### PR TITLE
Require invitation flow for existing users in competition contexts

### DIFF
--- a/apps/wodsmith-start/src/server/registration.ts
+++ b/apps/wodsmith-start/src/server/registration.ts
@@ -203,51 +203,34 @@ async function inviteUserToTeamInternal({
       }
     }
 
-    // User exists but not a member - add directly to team
-    await db.insert(teamMembershipTable).values({
-      teamId,
-      userId: existingUser.id,
-      roleId,
-      isSystemRole,
-      invitedBy,
-      invitedAt: new Date(),
-      joinedAt: new Date(),
-      isActive: true,
-    })
-
-    // Also add to competition_event team if this is a competition team
     if (competitionContext) {
-      // Get competition to find the competition_event team
-      const competition = await db.query.competitionsTable.findFirst({
-        where: eq(competitionsTable.id, competitionContext.competitionId),
+      // For competition invites, always create an invitation and send email
+      // so the user is notified and can complete registration requirements
+      // (questions, waivers). The acceptance flow handles adding them to the team.
+      // Fall through to the invitation creation path below.
+    } else {
+      // Non-competition context: add existing user directly to team
+      await db.insert(teamMembershipTable).values({
+        teamId,
+        userId: existingUser.id,
+        roleId,
+        isSystemRole,
+        invitedBy,
+        invitedAt: new Date(),
+        joinedAt: new Date(),
+        isActive: true,
       })
-      if (competition?.competitionTeamId) {
-        // Check if already a member of competition_event team
-        const existingEventMembership =
-          await db.query.teamMembershipTable.findFirst({
-            where: and(
-              eq(teamMembershipTable.teamId, competition.competitionTeamId),
-              eq(teamMembershipTable.userId, existingUser.id),
-            ),
-          })
-        if (!existingEventMembership) {
-          await db.insert(teamMembershipTable).values({
-            teamId: competition.competitionTeamId,
-            userId: existingUser.id,
-            roleId: SYSTEM_ROLES_ENUM.MEMBER,
-            isSystemRole: true,
-            joinedAt: new Date(),
-            isActive: true,
-          })
-        }
+
+      await updateAllSessionsOfUser(existingUser.id)
+      return {
+        userJoined: true,
+        userId: existingUser.id,
+        invitationSent: false,
       }
     }
-
-    await updateAllSessionsOfUser(existingUser.id)
-    return { userJoined: true, userId: existingUser.id, invitationSent: false }
   }
 
-  // User doesn't exist - create invitation
+  // Create invitation (for new users, or existing users in competition context)
   const token = createId()
   const expiresAt = new Date()
   expiresAt.setDate(expiresAt.getDate() + 30) // 30 days for competition invites


### PR DESCRIPTION
## Summary
Modified the user invitation logic to ensure existing users invited to competition teams go through the invitation acceptance flow rather than being added directly. This allows them to complete required registration steps (questions, waivers) before joining the team.

## Key Changes
- **Conditional logic for existing users**: Split the flow based on context:
  - **Competition context**: Existing users now fall through to the invitation creation path instead of being added directly to the team
  - **Non-competition context**: Existing users are added directly to the team as before, with immediate session updates and return
  
- **Removed automatic team membership**: Eliminated the direct insertion into `teamMembershipTable` for existing users in competition contexts, along with the associated logic for adding them to the `competition_event` team

- **Simplified return path**: Non-competition invites now return immediately after adding the user, avoiding unnecessary invitation creation

## Implementation Details
- The change preserves backward compatibility for non-competition team invitations
- Competition invites now consistently use the invitation acceptance flow, ensuring users complete all required registration steps before team membership is finalized
- The 30-day invitation expiration window applies to both new users and existing users in competition contexts

https://claude.ai/code/session_0195edp7LRhJY25VXrFhNzMr

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require invitation acceptance for existing users when invited to competition teams, so they receive an email and complete registration (questions, waivers) before joining. Non-competition invites still add existing users immediately.

- **Bug Fixes**
  - Existing users in competition context now get an invitation with a 30-day expiry; team membership happens on acceptance.
  - Removed silent auto-add and the automatic join to the `competition_event` team.
  - Non-competition invites keep direct add behavior and update sessions immediately.

<sup>Written for commit ceb2e231f9f2ee683db0de37ebc3349af5507e4f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved team membership and invitation handling for more consistent user registration workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->