### PR TITLE
feat: add WodProof video URL support

### DIFF
--- a/apps/wodsmith-start/src/components/compete/video-player-embed.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-player-embed.tsx
@@ -251,7 +251,7 @@ function WodProofPlayer({
 
     video.addEventListener("canplay", handleCanPlay)
     return () => video.removeEventListener("canplay", handleCanPlay)
-  }, [videoId])
+  }, [])
 
   if (error) {
     return (
@@ -284,6 +284,7 @@ function WodProofPlayer({
         className,
       )}
     >
+      {/* biome-ignore lint/a11y/useMediaCaption: workout videos don't have captions */}
       <video
         ref={videoRef}
         src={getWodProofVideoUrl(videoId)}
@@ -362,7 +363,7 @@ export function VideoPlayerEmbed({
  */
 export function supportsInteractivePlayer(url: string): boolean {
   const parsed = parseVideoUrl(url)
-  return parsed !== null && parsed.supportsEmbed
+  return parsed?.supportsEmbed ?? false
 }
 
 /**

--- a/apps/wodsmith-start/src/components/compete/video-player-embed.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-player-embed.tsx
@@ -217,14 +217,22 @@ export function VideoPlayerEmbed({
 }: VideoPlayerEmbedProps) {
   const parsed = parseVideoUrl(url)
 
-  if (!parsed) {
+  // No parse result or platform without embed support (e.g., WodProof)
+  if (!parsed || !parsed.supportsEmbed) {
+    const platformLabel =
+      parsed?.platform === "wodproof" ? "WodProof" : undefined
     return (
       <div
         className={cn(
-          "relative aspect-video w-full overflow-hidden rounded-lg bg-muted flex items-center justify-center p-4",
+          "relative aspect-video w-full overflow-hidden rounded-lg bg-muted flex flex-col items-center justify-center gap-3 p-4",
           className,
         )}
       >
+        {platformLabel && (
+          <span className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-medium text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
+            {platformLabel}
+          </span>
+        )}
         <a
           href={isSafeUrl(url) ? url : "#"}
           target="_blank"
@@ -232,7 +240,7 @@ export function VideoPlayerEmbed({
           className="inline-flex items-center gap-2 text-primary hover:underline text-sm"
         >
           <ExternalLink className="h-4 w-4" />
-          Open video in new tab
+          {platformLabel ? `Open in ${platformLabel}` : "Open video in new tab"}
         </a>
       </div>
     )
@@ -264,7 +272,7 @@ export function VideoPlayerEmbed({
  */
 export function supportsInteractivePlayer(url: string): boolean {
   const parsed = parseVideoUrl(url)
-  return parsed?.platform === "youtube" || parsed?.platform === "vimeo"
+  return parsed !== null && parsed.supportsEmbed
 }
 
 /**
@@ -278,5 +286,7 @@ export function getVideoPlatformName(url: string): string | null {
       return "YouTube"
     case "vimeo":
       return "Vimeo"
+    case "wodproof":
+      return "WodProof"
   }
 }

--- a/apps/wodsmith-start/src/components/compete/video-player-embed.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-player-embed.tsx
@@ -10,7 +10,11 @@
 import { ExternalLink } from "lucide-react"
 import { useEffect, useId, useRef } from "react"
 import { cn } from "@/lib/utils"
-import { parseVideoUrl, type VideoPlatform } from "@/schemas/video-url"
+import {
+  getWodProofVideoUrl,
+  parseVideoUrl,
+  type VideoPlatform,
+} from "@/schemas/video-url"
 import { isSafeUrl } from "@/utils/url"
 
 // ── Common player interface ──────────────────────────────────────────
@@ -208,6 +212,62 @@ function VimeoPlayer({
   )
 }
 
+// ── WodProof Player ─────────────────────────────────────────────────
+
+function WodProofPlayer({
+  videoId,
+  className,
+  onPlayerReady,
+}: {
+  videoId: string
+  className?: string
+  onPlayerReady?: (player: VideoPlayerRef) => void
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const onReadyRef = useRef(onPlayerReady)
+  onReadyRef.current = onPlayerReady
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) return
+
+    const handleCanPlay = () => {
+      const ref: VideoPlayerRef = {
+        platform: "wodproof",
+        pauseVideo: () => video.pause(),
+        playVideo: () => {
+          video.play()
+        },
+        getCurrentTime: () => video.currentTime,
+        seekTo: (seconds) => {
+          video.currentTime = seconds
+        },
+      }
+      onReadyRef.current?.(ref)
+    }
+
+    video.addEventListener("canplay", handleCanPlay)
+    return () => video.removeEventListener("canplay", handleCanPlay)
+  }, [videoId])
+
+  return (
+    <div
+      className={cn(
+        "relative aspect-video w-full overflow-hidden rounded-lg bg-black",
+        className,
+      )}
+    >
+      <video
+        ref={videoRef}
+        src={getWodProofVideoUrl(videoId)}
+        controls
+        playsInline
+        className="absolute inset-0 h-full w-full"
+      />
+    </div>
+  )
+}
+
 // ── Unified component ────────────────────────────────────────────────
 
 export function VideoPlayerEmbed({
@@ -217,10 +277,8 @@ export function VideoPlayerEmbed({
 }: VideoPlayerEmbedProps) {
   const parsed = parseVideoUrl(url)
 
-  // No parse result or platform without embed support (e.g., WodProof)
+  // No parse result or platform without embed support
   if (!parsed || !parsed.supportsEmbed) {
-    const platformLabel =
-      parsed?.platform === "wodproof" ? "WodProof" : undefined
     return (
       <div
         className={cn(
@@ -228,11 +286,6 @@ export function VideoPlayerEmbed({
           className,
         )}
       >
-        {platformLabel && (
-          <span className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-medium text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
-            {platformLabel}
-          </span>
-        )}
         <a
           href={isSafeUrl(url) ? url : "#"}
           target="_blank"
@@ -240,7 +293,7 @@ export function VideoPlayerEmbed({
           className="inline-flex items-center gap-2 text-primary hover:underline text-sm"
         >
           <ExternalLink className="h-4 w-4" />
-          {platformLabel ? `Open in ${platformLabel}` : "Open video in new tab"}
+          Open video in new tab
         </a>
       </div>
     )
@@ -260,6 +313,14 @@ export function VideoPlayerEmbed({
         <VimeoPlayer
           videoId={parsed.videoId}
           privacyHash={parsed.privacyHash}
+          className={className}
+          onPlayerReady={onPlayerReady}
+        />
+      )
+    case "wodproof":
+      return (
+        <WodProofPlayer
+          videoId={parsed.videoId}
           className={className}
           onPlayerReady={onPlayerReady}
         />

--- a/apps/wodsmith-start/src/components/compete/video-player-embed.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-player-embed.tsx
@@ -8,7 +8,7 @@
  */
 
 import { ExternalLink } from "lucide-react"
-import { useEffect, useId, useRef } from "react"
+import { useEffect, useId, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 import {
   getWodProofVideoUrl,
@@ -216,16 +216,19 @@ function VimeoPlayer({
 
 function WodProofPlayer({
   videoId,
+  originalUrl,
   className,
   onPlayerReady,
 }: {
   videoId: string
+  originalUrl: string
   className?: string
   onPlayerReady?: (player: VideoPlayerRef) => void
 }) {
   const videoRef = useRef<HTMLVideoElement>(null)
   const onReadyRef = useRef(onPlayerReady)
   onReadyRef.current = onPlayerReady
+  const [error, setError] = useState(false)
 
   useEffect(() => {
     const video = videoRef.current
@@ -250,6 +253,30 @@ function WodProofPlayer({
     return () => video.removeEventListener("canplay", handleCanPlay)
   }, [videoId])
 
+  if (error) {
+    return (
+      <div
+        className={cn(
+          "relative aspect-video w-full overflow-hidden rounded-lg bg-muted flex flex-col items-center justify-center gap-3 p-4",
+          className,
+        )}
+      >
+        <span className="text-sm text-muted-foreground">
+          Video could not be loaded
+        </span>
+        <a
+          href={isSafeUrl(originalUrl) ? originalUrl : "#"}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 text-primary hover:underline text-sm"
+        >
+          <ExternalLink className="h-4 w-4" />
+          Open in WodProof
+        </a>
+      </div>
+    )
+  }
+
   return (
     <div
       className={cn(
@@ -263,6 +290,7 @@ function WodProofPlayer({
         controls
         playsInline
         className="absolute inset-0 h-full w-full"
+        onError={() => setError(true)}
       />
     </div>
   )
@@ -321,6 +349,7 @@ export function VideoPlayerEmbed({
       return (
         <WodProofPlayer
           videoId={parsed.videoId}
+          originalUrl={parsed.originalUrl}
           className={className}
           onPlayerReady={onPlayerReady}
         />

--- a/apps/wodsmith-start/src/components/compete/video-submission-preview.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-submission-preview.tsx
@@ -5,8 +5,6 @@ import {
   CheckCircle2,
   Clock,
   Edit3,
-  ExternalLink,
-  FileText,
   Trophy,
 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
@@ -18,12 +16,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { VideoEmbed } from "@/components/video-embed"
 import { Separator } from "@/components/ui/separator"
 import type { ReviewStatus } from "@/db/schemas/video-submissions"
 import type { ScoreType, WorkoutScheme } from "@/lib/scoring"
-import { isSafeUrl } from "@/utils/url"
 import { SubmissionStatusBadge } from "./submission-status-badge"
-import { YouTubeEmbed, isYouTubeUrl } from "./youtube-embed"
 
 interface SubmissionData {
   id: string
@@ -121,7 +118,6 @@ function VideoPreviewItem({
   timezone?: string | null
   label?: string
 }) {
-  const isYouTube = isYouTubeUrl(submission.videoUrl)
   const hasUpdated =
     new Date(submission.updatedAt).getTime() !==
     new Date(submission.submittedAt).getTime()
@@ -140,35 +136,7 @@ function VideoPreviewItem({
           )}
         </div>
       )}
-      {isYouTube ? (
-        <YouTubeEmbed
-          url={submission.videoUrl}
-          title={workout?.name || "Workout submission"}
-        />
-      ) : (
-        <div className="rounded-lg border bg-muted/50 p-4">
-          <div className="flex items-center gap-3">
-            <FileText className="h-5 w-5 text-muted-foreground" />
-            <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium truncate">
-                {submission.videoUrl}
-              </p>
-              <p className="text-xs text-muted-foreground">
-                External video link
-              </p>
-            </div>
-            <a
-              href={isSafeUrl(submission.videoUrl) ? submission.videoUrl : "#"}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1.5 text-sm text-primary hover:underline shrink-0"
-            >
-              <ExternalLink className="h-4 w-4" />
-              Open
-            </a>
-          </div>
-        </div>
-      )}
+      <VideoEmbed url={submission.videoUrl} />
       {submission.notes && (
         <div className="rounded-lg bg-muted/50 p-4">
           <p className="text-xs text-muted-foreground uppercase tracking-wider mb-2">

--- a/apps/wodsmith-start/src/components/compete/video-submission-preview.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-submission-preview.tsx
@@ -109,12 +109,10 @@ function getSchemeLabel(scheme: WorkoutScheme): string {
 
 function VideoPreviewItem({
   submission,
-  workout,
   timezone,
   label,
 }: {
   submission: SubmissionData
-  workout?: VideoSubmissionPreviewProps["workout"]
   timezone?: string | null
   label?: string
 }) {
@@ -221,7 +219,6 @@ export function VideoSubmissionPreview({
           <VideoPreviewItem
             key={submission.id}
             submission={submission}
-            workout={workout}
             timezone={timezone}
             label={
               isTeam

--- a/apps/wodsmith-start/src/components/ui/video-url-input.tsx
+++ b/apps/wodsmith-start/src/components/ui/video-url-input.tsx
@@ -231,8 +231,19 @@ const VideoUrlInput = React.forwardRef<HTMLInputElement, VideoUrlInputProps>(
             {isValid && parsedUrl && (
               <>
                 {showPlatformBadge && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400">
-                    {parsedUrl.platform === "youtube" ? "YouTube" : "Vimeo"}
+                  <span
+                    className={cn(
+                      "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium",
+                      parsedUrl.supportsEmbed
+                        ? "bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400"
+                        : "bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400",
+                    )}
+                  >
+                    {parsedUrl.platform === "youtube"
+                      ? "YouTube"
+                      : parsedUrl.platform === "vimeo"
+                        ? "Vimeo"
+                        : "WodProof"}
                   </span>
                 )}
                 {showPreviewLink && (

--- a/apps/wodsmith-start/src/components/video-embed.tsx
+++ b/apps/wodsmith-start/src/components/video-embed.tsx
@@ -7,7 +7,7 @@
 
 import { useMemo } from "react"
 import { ExternalLink, VideoOff } from "lucide-react"
-import { parseVideoUrl } from "@/schemas/video-url"
+import { getWodProofVideoUrl, parseVideoUrl } from "@/schemas/video-url"
 import { isSafeUrl } from "@/utils/url"
 
 interface VideoEmbedProps {
@@ -64,7 +64,24 @@ export function VideoEmbed({
     )
   }
 
-  // Platform without embed support (e.g., WodProof) — show external link
+  // WodProof — render native video player
+  if (videoInfo.platform === "wodproof") {
+    return (
+      <div
+        className={`relative overflow-hidden rounded-lg bg-black ${className}`}
+        style={{ aspectRatio }}
+      >
+        <video
+          src={getWodProofVideoUrl(videoInfo.videoId)}
+          controls
+          playsInline
+          className="absolute inset-0 h-full w-full"
+        />
+      </div>
+    )
+  }
+
+  // Platform without embed support — show external link
   if (!videoInfo.supportsEmbed) {
     return (
       <div
@@ -72,9 +89,6 @@ export function VideoEmbed({
         style={{ aspectRatio }}
       >
         <div className="text-muted-foreground flex flex-col items-center gap-2">
-          <span className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-medium text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
-            {videoInfo.platform === "wodproof" ? "WodProof" : videoInfo.platform}
-          </span>
           <span className="text-sm">
             This video must be viewed on the platform
           </span>
@@ -86,7 +100,7 @@ export function VideoEmbed({
           className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
         >
           <ExternalLink className="h-4 w-4" />
-          Open in WodProof
+          Open video
         </a>
       </div>
     )

--- a/apps/wodsmith-start/src/components/video-embed.tsx
+++ b/apps/wodsmith-start/src/components/video-embed.tsx
@@ -160,6 +160,7 @@ function WodProofVideoEmbed({
       className={`relative overflow-hidden rounded-lg bg-black ${className}`}
       style={{ aspectRatio }}
     >
+      {/* biome-ignore lint/a11y/useMediaCaption: workout videos don't have captions */}
       <video
         src={getWodProofVideoUrl(videoInfo.videoId)}
         controls

--- a/apps/wodsmith-start/src/components/video-embed.tsx
+++ b/apps/wodsmith-start/src/components/video-embed.tsx
@@ -5,7 +5,7 @@
  * Uses the shared parseVideoUrl parser from @/schemas/video-url.
  */
 
-import { useMemo } from "react"
+import { useMemo, useState } from "react"
 import { ExternalLink, VideoOff } from "lucide-react"
 import { getWodProofVideoUrl, parseVideoUrl } from "@/schemas/video-url"
 import { isSafeUrl } from "@/utils/url"
@@ -64,20 +64,14 @@ export function VideoEmbed({
     )
   }
 
-  // WodProof — render native video player
+  // WodProof — render native video player with fallback to external link
   if (videoInfo.platform === "wodproof") {
     return (
-      <div
-        className={`relative overflow-hidden rounded-lg bg-black ${className}`}
-        style={{ aspectRatio }}
-      >
-        <video
-          src={getWodProofVideoUrl(videoInfo.videoId)}
-          controls
-          playsInline
-          className="absolute inset-0 h-full w-full"
-        />
-      </div>
+      <WodProofVideoEmbed
+        videoInfo={videoInfo}
+        className={className}
+        aspectRatio={aspectRatio}
+      />
     )
   }
 
@@ -117,6 +111,61 @@ export function VideoEmbed({
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowFullScreen
         className="absolute inset-0 h-full w-full"
+      />
+    </div>
+  )
+}
+
+/**
+ * WodProof video player with fallback to external link on load error
+ */
+function WodProofVideoEmbed({
+  videoInfo,
+  className = "",
+  aspectRatio = "16/9",
+}: {
+  videoInfo: { videoId: string; originalUrl: string }
+  className?: string
+  aspectRatio?: string
+}) {
+  const [error, setError] = useState(false)
+
+  if (error) {
+    return (
+      <div
+        className={`bg-muted flex flex-col items-center justify-center gap-3 rounded-lg p-6 ${className}`}
+        style={{ aspectRatio }}
+      >
+        <div className="text-muted-foreground flex flex-col items-center gap-2">
+          <VideoOff className="h-12 w-12" />
+          <span className="text-sm">Video could not be loaded</span>
+        </div>
+        <a
+          href={
+            isSafeUrl(videoInfo.originalUrl) ? videoInfo.originalUrl : "#"
+          }
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <ExternalLink className="h-4 w-4" />
+          Open in WodProof
+        </a>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-lg bg-black ${className}`}
+      style={{ aspectRatio }}
+    >
+      <video
+        src={getWodProofVideoUrl(videoInfo.videoId)}
+        controls
+        playsInline
+        className="absolute inset-0 h-full w-full"
+        onError={() => setError(true)}
       />
     </div>
   )

--- a/apps/wodsmith-start/src/components/video-embed.tsx
+++ b/apps/wodsmith-start/src/components/video-embed.tsx
@@ -1,12 +1,12 @@
 /**
  * Video Embed Component
  *
- * Renders an embedded video player for YouTube or Vimeo URLs.
+ * Renders an embedded video player for YouTube, Vimeo, or WodProof URLs.
  * Uses the shared parseVideoUrl parser from @/schemas/video-url.
  */
 
 import { useMemo } from "react"
-import { VideoOff } from "lucide-react"
+import { ExternalLink, VideoOff } from "lucide-react"
 import { parseVideoUrl } from "@/schemas/video-url"
 import { isSafeUrl } from "@/utils/url"
 
@@ -64,6 +64,34 @@ export function VideoEmbed({
     )
   }
 
+  // Platform without embed support (e.g., WodProof) — show external link
+  if (!videoInfo.supportsEmbed) {
+    return (
+      <div
+        className={`bg-muted flex flex-col items-center justify-center gap-3 rounded-lg p-6 ${className}`}
+        style={{ aspectRatio }}
+      >
+        <div className="text-muted-foreground flex flex-col items-center gap-2">
+          <span className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-2.5 py-0.5 text-xs font-medium text-orange-700 dark:bg-orange-900/30 dark:text-orange-400">
+            {videoInfo.platform === "wodproof" ? "WodProof" : videoInfo.platform}
+          </span>
+          <span className="text-sm">
+            This video must be viewed on the platform
+          </span>
+        </div>
+        <a
+          href={isSafeUrl(videoInfo.originalUrl) ? videoInfo.originalUrl : "#"}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          <ExternalLink className="h-4 w-4" />
+          Open in WodProof
+        </a>
+      </div>
+    )
+  }
+
   return (
     <div
       className={`relative overflow-hidden rounded-lg ${className}`}
@@ -116,13 +144,13 @@ export function VideoThumbnail({
     )
   }
 
-  // Vimeo placeholder
+  // Vimeo / WodProof / other — platform label placeholder
   return (
     <div
       className={`bg-muted flex items-center justify-center rounded ${className}`}
     >
       <span className="text-muted-foreground text-xs capitalize">
-        {videoInfo.platform}
+        {videoInfo.platform === "wodproof" ? "WodProof" : videoInfo.platform}
       </span>
     </div>
   )

--- a/apps/wodsmith-start/src/schemas/video-url.ts
+++ b/apps/wodsmith-start/src/schemas/video-url.ts
@@ -82,36 +82,47 @@ const VIMEO_PATTERNS = [
 /**
  * WodProof URL patterns:
  *
- * WodProof is a closed platform with no public API or embed support.
- * Videos are shared as opaque cloud links generated from the mobile app.
- * We accept these URLs and display them as external links until a formal
- * integration is established.
+ * WodProof videos are shared as cloud links from the mobile app.
+ * The cloud URL format is: https://wodproofapp.com/cloud/?v=VIDEO_ID
+ * The actual MP4 is hosted at: https://s3.us-east-1.amazonaws.com/wodproof-cloud/VIDEO_ID.mp4
+ *
+ * We extract the video ID from the `v` query parameter and construct
+ * the S3 URL for direct <video> element playback.
  *
  * Known domain patterns:
- * - wodproofapp.com/* (main site and potential cloud links)
- * - backend.wodproofapp.com/* (backend/API — unlikely as share links)
+ * - wodproofapp.com/cloud/?v=ID (cloud share links)
+ * - wodproofapp.com/* (other paths)
  * - *.wodproof.com/* (any subdomain)
- *
- * Since WodProof doesn't publish their video URL format, we match broadly
- * on the domain and extract the path as the identifier.
  */
 const WODPROOF_PATTERNS = [
-  // wodproofapp.com with any path (main domain)
+  // wodproofapp.com with any path (main domain, www only)
   /^(?:https?:\/\/)?(?:www\.)?wodproofapp\.com\/(.+)$/,
-  // Any subdomain of wodproofapp.com with path
-  /^(?:https?:\/\/)?([a-z0-9-]+\.)?wodproofapp\.com\/(.+)$/,
   // wodproof.com (alternate domain) with path
   /^(?:https?:\/\/)?(?:www\.)?wodproof\.com\/(.+)$/,
 ] as const
 
 /**
- * Check if a URL is from WodProof
- * Returns the path portion as an identifier (opaque — no known video ID format)
+ * Extract the video ID from a WodProof URL.
+ * For cloud URLs (wodproofapp.com/cloud/?v=ID), extracts the `v` query parameter.
+ * For other WodProof URLs, falls back to the path as an identifier.
  */
 function extractWodProofId(url: string): string | null {
   for (const pattern of WODPROOF_PATTERNS) {
     const match = url.match(pattern)
     if (match) {
+      // Try to extract `v` query parameter from cloud URLs
+      try {
+        const parsed = new URL(
+          url.startsWith("http") ? url : `https://${url}`,
+        )
+        const videoId = parsed.searchParams.get("v")
+        if (videoId) {
+          return videoId
+        }
+      } catch {
+        // Fall through to path-based extraction
+      }
+
       // Use the last captured group (the path) as the ID
       const path = match[match.length - 1]
       if (path && path.length > 0) {
@@ -120,6 +131,14 @@ function extractWodProofId(url: string): string | null {
     }
   }
   return null
+}
+
+/**
+ * Construct the direct S3 MP4 URL for a WodProof video.
+ * WodProof stores videos at: https://s3.us-east-1.amazonaws.com/wodproof-cloud/{videoId}.mp4
+ */
+export function getWodProofVideoUrl(videoId: string): string {
+  return `https://s3.us-east-1.amazonaws.com/wodproof-cloud/${videoId}.mp4`
 }
 
 /**
@@ -197,10 +216,9 @@ export function parseVideoUrl(url: string): ParsedVideoUrl | null {
       platform: "wodproof",
       videoId: wodproofId,
       originalUrl: trimmedUrl,
-      // WodProof has no embed API — link opens in new tab
-      embedUrl: trimmedUrl,
+      embedUrl: getWodProofVideoUrl(wodproofId),
       thumbnailUrl: "",
-      supportsEmbed: false,
+      supportsEmbed: true,
     }
   }
 

--- a/apps/wodsmith-start/src/schemas/video-url.ts
+++ b/apps/wodsmith-start/src/schemas/video-url.ts
@@ -2,7 +2,7 @@
  * Video URL Validation Schema
  *
  * Validates video URLs for online competition submissions.
- * Supports YouTube and Vimeo URL formats with video ID extraction.
+ * Supports YouTube, Vimeo, and WodProof URL formats with video ID extraction.
  */
 
 import { z } from "zod"
@@ -10,7 +10,7 @@ import { z } from "zod"
 /**
  * Supported video platforms
  */
-export const VIDEO_PLATFORMS = ["youtube", "vimeo"] as const
+export const VIDEO_PLATFORMS = ["youtube", "vimeo", "wodproof"] as const
 export type VideoPlatform = (typeof VIDEO_PLATFORMS)[number]
 
 /**
@@ -24,6 +24,8 @@ export interface ParsedVideoUrl {
   thumbnailUrl: string
   /** Privacy hash for unlisted Vimeo videos */
   privacyHash?: string
+  /** Whether this platform supports inline embedding (iframe/player) */
+  supportsEmbed: boolean
 }
 
 /**
@@ -78,6 +80,49 @@ const VIMEO_PATTERNS = [
 ] as const
 
 /**
+ * WodProof URL patterns:
+ *
+ * WodProof is a closed platform with no public API or embed support.
+ * Videos are shared as opaque cloud links generated from the mobile app.
+ * We accept these URLs and display them as external links until a formal
+ * integration is established.
+ *
+ * Known domain patterns:
+ * - wodproofapp.com/* (main site and potential cloud links)
+ * - backend.wodproofapp.com/* (backend/API — unlikely as share links)
+ * - *.wodproof.com/* (any subdomain)
+ *
+ * Since WodProof doesn't publish their video URL format, we match broadly
+ * on the domain and extract the path as the identifier.
+ */
+const WODPROOF_PATTERNS = [
+  // wodproofapp.com with any path (main domain)
+  /^(?:https?:\/\/)?(?:www\.)?wodproofapp\.com\/(.+)$/,
+  // Any subdomain of wodproofapp.com with path
+  /^(?:https?:\/\/)?([a-z0-9-]+\.)?wodproofapp\.com\/(.+)$/,
+  // wodproof.com (alternate domain) with path
+  /^(?:https?:\/\/)?(?:www\.)?wodproof\.com\/(.+)$/,
+] as const
+
+/**
+ * Check if a URL is from WodProof
+ * Returns the path portion as an identifier (opaque — no known video ID format)
+ */
+function extractWodProofId(url: string): string | null {
+  for (const pattern of WODPROOF_PATTERNS) {
+    const match = url.match(pattern)
+    if (match) {
+      // Use the last captured group (the path) as the ID
+      const path = match[match.length - 1]
+      if (path && path.length > 0) {
+        return path.replace(/[?#].*$/, "") // strip query/hash
+      }
+    }
+  }
+  return null
+}
+
+/**
  * Extract video ID from YouTube URL
  */
 function extractYouTubeId(url: string): string | null {
@@ -122,6 +167,7 @@ export function parseVideoUrl(url: string): ParsedVideoUrl | null {
       originalUrl: trimmedUrl,
       embedUrl: `https://www.youtube.com/embed/${youtubeId}`,
       thumbnailUrl: `https://img.youtube.com/vi/${youtubeId}/maxresdefault.jpg`,
+      supportsEmbed: true,
     }
   }
 
@@ -140,6 +186,21 @@ export function parseVideoUrl(url: string): ParsedVideoUrl | null {
       // Vimeo thumbnails require API access, use placeholder
       thumbnailUrl: `https://vumbnail.com/${vimeoResult.id}.jpg`,
       privacyHash: vimeoResult.hash,
+      supportsEmbed: true,
+    }
+  }
+
+  // Try WodProof
+  const wodproofId = extractWodProofId(trimmedUrl)
+  if (wodproofId) {
+    return {
+      platform: "wodproof",
+      videoId: wodproofId,
+      originalUrl: trimmedUrl,
+      // WodProof has no embed API — link opens in new tab
+      embedUrl: trimmedUrl,
+      thumbnailUrl: "",
+      supportsEmbed: false,
     }
   }
 
@@ -157,7 +218,7 @@ export function isSupportedVideoUrl(url: string): boolean {
  * Get a human-readable list of supported platforms
  */
 export function getSupportedPlatformsText(): string {
-  return "YouTube or Vimeo"
+  return "YouTube, Vimeo, or WodProof"
 }
 
 /**

--- a/apps/wodsmith-start/src/server-fns/video-validation-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/video-validation-fns.ts
@@ -130,6 +130,28 @@ async function checkVimeoAccessibility(videoId: string): Promise<boolean> {
 }
 
 /**
+ * Check if a WodProof video is accessible by sending a HEAD request to the S3 URL
+ */
+async function checkWodProofAccessibility(videoId: string): Promise<boolean> {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), OEMBED_TIMEOUT_MS)
+
+  try {
+    const s3Url = `https://s3.us-east-1.amazonaws.com/wodproof-cloud/${videoId}.mp4`
+    const response = await fetch(s3Url, {
+      method: "HEAD",
+      signal: controller.signal,
+    })
+
+    clearTimeout(timeoutId)
+    return response.ok
+  } catch {
+    clearTimeout(timeoutId)
+    return false
+  }
+}
+
+/**
  * Check video accessibility based on platform
  */
 async function checkVideoAccessibility(
@@ -140,6 +162,8 @@ async function checkVideoAccessibility(
       return checkYouTubeAccessibility(parsed.videoId)
     case "vimeo":
       return checkVimeoAccessibility(parsed.videoId)
+    case "wodproof":
+      return checkWodProofAccessibility(parsed.videoId)
     default:
       return false
   }

--- a/apps/wodsmith-start/test/components/video-submission-preview.test.tsx
+++ b/apps/wodsmith-start/test/components/video-submission-preview.test.tsx
@@ -35,22 +35,11 @@ vi.mock("lucide-react", () => {
 	}
 })
 
-// Mock YouTube embed components
-vi.mock("@/components/compete/youtube-embed", () => ({
-	YouTubeEmbed: ({ url, title }: { url: string; title?: string }) => (
-		<div data-testid="youtube-embed" data-url={url} data-title={title} />
+// Mock VideoEmbed component
+vi.mock("@/components/video-embed", () => ({
+	VideoEmbed: ({ url }: { url: string | null }) => (
+		<div data-testid="video-embed" data-url={url} />
 	),
-	isYouTubeUrl: (url: string) => {
-		try {
-			const parsed = new URL(url)
-			return (
-				parsed.hostname.includes("youtube.com") ||
-				parsed.hostname.includes("youtu.be")
-			)
-		} catch {
-			return false
-		}
-	},
 }))
 
 // Mock url utility
@@ -112,7 +101,7 @@ function createDefaultWorkout(
 
 describe("VideoSubmissionPreview", () => {
 	describe("video display", () => {
-		it("renders YouTube embed for YouTube URLs", () => {
+		it("renders VideoEmbed for YouTube URLs", () => {
 			render(
 				<VideoSubmissionPreview
 					submissions={[createDefaultSubmission()]}
@@ -121,10 +110,14 @@ describe("VideoSubmissionPreview", () => {
 				/>,
 			)
 
-			expect(screen.getByTestId("youtube-embed")).toBeTruthy()
+			const embed = screen.getByTestId("video-embed")
+			expect(embed).toBeTruthy()
+			expect(embed.getAttribute("data-url")).toBe(
+				"https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+			)
 		})
 
-		it("renders external link for non-YouTube URLs", () => {
+		it("renders VideoEmbed for Vimeo URLs", () => {
 			render(
 				<VideoSubmissionPreview
 					submissions={[createDefaultSubmission({
@@ -135,39 +128,29 @@ describe("VideoSubmissionPreview", () => {
 				/>,
 			)
 
-			expect(screen.queryByTestId("youtube-embed")).toBeNull()
-			expect(screen.getByText("External video link")).toBeTruthy()
-			expect(screen.getByText("Open")).toBeTruthy()
+			const embed = screen.getByTestId("video-embed")
+			expect(embed).toBeTruthy()
+			expect(embed.getAttribute("data-url")).toBe(
+				"https://vimeo.com/123456",
+			)
 		})
 
-		it("uses safe URL href for external links", () => {
+		it("renders VideoEmbed for WodProof URLs", () => {
 			render(
 				<VideoSubmissionPreview
 					submissions={[createDefaultSubmission({
-						videoUrl: "https://vimeo.com/123456",
+						videoUrl: "https://wodproofapp.com/cloud/?v=abc123test",
 					})]}
 					teamSize={1}
 					canEdit={false}
 				/>,
 			)
 
-			const link = screen.getByText("Open").closest("a")
-			expect(link?.href).toContain("vimeo.com/123456")
-		})
-
-		it("uses # href for unsafe external URLs", () => {
-			render(
-				<VideoSubmissionPreview
-					submissions={[createDefaultSubmission({
-						videoUrl: "javascript:alert(1)",
-					})]}
-					teamSize={1}
-					canEdit={false}
-				/>,
+			const embed = screen.getByTestId("video-embed")
+			expect(embed).toBeTruthy()
+			expect(embed.getAttribute("data-url")).toBe(
+				"https://wodproofapp.com/cloud/?v=abc123test",
 			)
-
-			const link = screen.getByText("Open").closest("a")
-			expect(link?.getAttribute("href")).toBe("#")
 		})
 	})
 

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -136,6 +136,12 @@ Athletes can submit video evidence of their workout performance for remote judgi
 
 Submissions link to a score and include a video URL (e.g., Vimeo). Judges can verify or reject submissions. Community voting is supported via `videoVotesTable`.
 
+### Supported Video Platforms
+
+YouTube, Vimeo, and WodProof URLs are validated and parsed by [[apps/wodsmith-start/src/schemas/video-url.ts#parseVideoUrl]].
+
+YouTube and Vimeo use iframe embeds. WodProof cloud URLs (`wodproofapp.com/cloud/?v=ID`) are resolved to direct S3 MP4 URLs via [[apps/wodsmith-start/src/schemas/video-url.ts#getWodProofVideoUrl]] and rendered with a native `<video>` element in both the athlete-facing [[apps/wodsmith-start/src/components/video-embed.tsx#VideoEmbed]] and the interactive [[apps/wodsmith-start/src/components/compete/video-player-embed.tsx#VideoPlayerEmbed]] components.
+
 ### Multi-Division Submission
 
 Athletes registered in multiple divisions see a division picker on the submission form. Single-division athletes see a static badge.


### PR DESCRIPTION
## Summary
- Adds WodProof (`wodproofapp.com`, `wodproof.com`) as a recognized video platform for online competition submissions
- WodProof URLs are accepted and validated, but displayed as external links (not embedded) since WodProof has no public embed API
- Introduces `supportsEmbed` flag on `ParsedVideoUrl` so all embed components gracefully handle link-only platforms
- Platform badge shows orange for WodProof (vs green for YouTube/Vimeo) to indicate external-only viewing

## Files changed
- `src/schemas/video-url.ts` — URL patterns, parsing, platform type
- `src/components/video-embed.tsx` — Static embed fallback for non-embeddable platforms
- `src/components/compete/video-player-embed.tsx` — Interactive player fallback
- `src/components/ui/video-url-input.tsx` — Platform badge styling

## Test plan
- [ ] Paste a WodProof URL (e.g. `https://wodproofapp.com/some/video/path`) into the video submission form — should show orange "WodProof" badge
- [ ] Paste YouTube/Vimeo URLs — should still work as before with green badge and inline embed
- [ ] Verify WodProof videos render as "Open in WodProof" external link in submission review pages
- [ ] Verify unsupported URLs still show the existing error message

> **Note:** WodProof has no public API or embed support. We've emailed `contact@wodproofapp.com` about a formal integration. This PR is the bare-bones acceptance of their URLs until we hear back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds WodProof video support with inline playback via a native player. WodProof cloud URLs are parsed to S3 MP4s, validated server-side, and play alongside YouTube/Vimeo with a fallback link on load errors.

- **New Features**
  - Parse `wodproofapp.com`/`wodproof.com` URLs and build S3 MP4 with `getWodProofVideoUrl`; server-side HEAD check for access.
  - Add native `<video>` playback for WodProof in `VideoEmbed` and `VideoPlayerEmbed`; `supportsInteractivePlayer` now uses `supportsEmbed`.
  - Platform badge shows green for embeddable platforms (YouTube, Vimeo, WodProof); supported platforms text updated.
  - Submission preview uses `VideoEmbed` for all platforms.

- **Bug Fixes**
  - If a WodProof MP4 fails to load, show an error state with an “Open in WodProof” link in both embeds.
  - Remove unused `workout` prop from `VideoPreviewItem` after switching to `VideoEmbed`.
  - Resolve lint issues: suppress `useMediaCaption` for workout videos, fix effect deps, and use optional chaining in `supportsInteractivePlayer`.
  - Update tests to use `VideoEmbed` and cover WodProof URLs.

<sup>Written for commit 2073e572f4a0216b62871692ef50025c58fc3d74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WodProof video platform support with native in-app playback.

* **Improvements**
  * Platform badges/labels now indicate embed capability and show "WodProof" when applicable.
  * Better handling and layout for non-embeddable videos with a clear external-link fallback.
  * Improved URL parsing and accessibility checks so more videos render or fall back reliably.

* **Documentation**
  * Updated docs to list supported platforms and embedding/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->