### PR TITLE
feat: per-sub-event score and video submission for online competitions

### DIFF
--- a/apps/wodsmith-start/scripts/seed/seeders/04-teams.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/04-teams.ts
@@ -137,5 +137,20 @@ export async function seed(client: Connection): Promise<void> {
 			current_plan_id: null,
 			parent_organization_id: null,
 		},
+		// Athlete team for online qualifier team division (Mike captain, Ryan teammate)
+		{
+			id: "team_online_team_mike_ryan",
+			name: "Team Send It",
+			slug: "team-send-it",
+			type: "competition_team",
+			description: "Mike & Ryan's team for Online Qualifier 2026",
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+			is_personal_team: 0,
+			personal_team_owner_id: null,
+			current_plan_id: null,
+			parent_organization_id: null,
+		},
 	])
 }

--- a/apps/wodsmith-start/scripts/seed/seeders/05-team-memberships.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/05-team-memberships.ts
@@ -81,5 +81,9 @@ export async function seed(client: Connection): Promise<void> {
 		mem("tmem_mike_online", "team_online_qualifier_2026", "usr_athlete_mike", "member"),
 		mem("tmem_sarah_online", "team_online_qualifier_2026", "usr_athlete_sarah", "member"),
 		mem("tmem_alex_online", "team_online_qualifier_2026", "usr_athlete_alex", "member"),
+		mem("tmem_ryan_online", "team_online_qualifier_2026", "usr_athlete_ryan", "member"),
+		// Athlete team memberships (competition_team type) for Team Send It
+		mem("tmem_mike_team_sendit", "team_online_team_mike_ryan", "usr_athlete_mike", "owner"),
+		mem("tmem_ryan_team_sendit", "team_online_team_mike_ryan", "usr_athlete_ryan", "member"),
 	])
 }

--- a/apps/wodsmith-start/scripts/seed/seeders/09-workouts.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/09-workouts.ts
@@ -102,6 +102,10 @@ export async function seed(client: Connection): Promise<void> {
 		wod("wod_online_fran", "Online Qualifier Event 1 - Fran", "For time:\n\n21-15-9 reps of:\n\u2022 Thrusters (95/65 lb)\n\u2022 Pull-ups\n\nTime cap: 10 minutes\n\nMovement Standards:\n- Thrusters: Full depth squat, bar finishes overhead with hips and knees fully extended\n- Pull-ups: Chin must break the horizontal plane of the bar", "time-with-cap", "private", BOX1_TEAM, 1, "wod_fran", 600),
 		wod("wod_online_karen", "Online Qualifier Event 2 - Karen", "For time:\n\n150 Wall Ball Shots (20/14 lb to 10/9 ft)\n\nTime cap: 15 minutes\n\nMovement Standards:\n- Wall Ball: Hip crease must pass below knee at bottom\n- Ball must hit target at or above required height", "time-with-cap", "private", BOX1_TEAM, 1, "wod_karen", 900),
 		wod("wod_online_amrap", "Online Qualifier Event 3 - Chipper AMRAP", "AMRAP 12 minutes:\n\n5 Deadlifts (225/155 lb)\n10 Box Jump Overs (24/20 in)\n15 Toes-to-Bar\n\nMovement Standards:\n- Deadlifts: Full hip and knee extension at top\n- Box Jump Overs: Two-foot takeoff, both feet must touch top of box\n- Toes-to-Bar: Both feet must touch the bar simultaneously", "rounds-reps", "private", BOX1_TEAM, 1, null, null),
+		// Online Qualifier Event 4 — parent event with 2 sub-events
+		wod("wod_online_couplet_parent", "Online Qualifier Event 4 - Couplet Challenge", "Two-part test: a sprint workout followed by a max lift. Sub-events scored independently.", "time", "private", BOX1_TEAM, 1, null, null, null),
+		wod("wod_online_couplet_sprint", "Sprint WOD", "For time:\n\n3 rounds:\n• 10 Power Cleans (135/95 lb)\n• 20 Box Jumps (24/20 in)\n\nTime cap: 8 minutes", "time-with-cap", "private", BOX1_TEAM, 1, null, 480, "min"),
+		wod("wod_online_couplet_max_clean", "Max Clean", "For max load:\n\n1 Rep Max Clean\n• 3 attempts, 90 seconds between attempts\n\nScore is heaviest successful lift.", "load", "private", BOX1_TEAM, 1, null, null, "max"),
 	])
 
 	// Workout tags

--- a/apps/wodsmith-start/scripts/seed/seeders/10-programming.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/10-programming.ts
@@ -130,5 +130,13 @@ export async function seed(client: Connection): Promise<void> {
 		{ id: "tw_online_event1", track_id: "track_online_qualifier_2026", workout_id: "wod_online_fran", track_order: 1, notes: "Event 1: Complete Fran and submit your video within the submission window.", points_multiplier: 100, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "tw_online_event2", track_id: "track_online_qualifier_2026", workout_id: "wod_online_karen", track_order: 2, notes: "Event 2: Complete Karen and submit your video within the submission window.", points_multiplier: 100, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "tw_online_event3", track_id: "track_online_qualifier_2026", workout_id: "wod_online_amrap", track_order: 3, notes: "Event 3: Complete the AMRAP and submit your video within the submission window.", points_multiplier: 150, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
+		// Event 4: Parent (no sub-events in this batch — sub-events need parent_event_id column)
+		{ id: "tw_online_event4_parent", track_id: "track_online_qualifier_2026", workout_id: "wod_online_couplet_parent", track_order: 4, notes: "Event 4: Couplet Challenge — sprint WOD + max clean, scored per sub-event.", points_multiplier: 100, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
+	])
+
+	// Online Qualifier sub-events (separate batch for parent_event_id column)
+	await batchInsert(client, "track_workouts", [
+		{ id: "tw_online_event4_sprint", track_id: "track_online_qualifier_2026", workout_id: "wod_online_couplet_sprint", track_order: 4.01, parent_event_id: "tw_online_event4_parent", notes: null, points_multiplier: 100, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
+		{ id: "tw_online_event4_clean", track_id: "track_online_qualifier_2026", workout_id: "wod_online_couplet_max_clean", track_order: 4.02, parent_event_id: "tw_online_event4_parent", notes: null, points_multiplier: 100, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
 	])
 }

--- a/apps/wodsmith-start/scripts/seed/seeders/11-competition.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/11-competition.ts
@@ -53,6 +53,7 @@ export async function seed(client: Connection): Promise<void> {
 		{ id: "slvl_online_rx", scaling_group_id: "sgrp_online_qualifier_2026", label: "RX", position: 0, team_size: 1, created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "slvl_online_scaled", scaling_group_id: "sgrp_online_qualifier_2026", label: "Scaled", position: 1, team_size: 1, created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "slvl_online_masters", scaling_group_id: "sgrp_online_qualifier_2026", label: "Masters 40+", position: 2, team_size: 1, created_at: ts, updated_at: ts, update_counter: 0 },
+		{ id: "slvl_online_team_rx", scaling_group_id: "sgrp_online_qualifier_2026", label: "Team RX", position: 3, team_size: 2, created_at: ts, updated_at: ts, update_counter: 0 },
 	])
 
 	// Competitions
@@ -153,7 +154,7 @@ export async function seed(client: Connection): Promise<void> {
 		reg("creg_kaitlyn_winter", "comp_winter_throwdown_2025", "usr_athlete_kaitlyn", "tmem_kaitlyn_winter_throwdown", "slvl_winter_scaled", "2024-12-31 17:00:00", "2024-12-31 17:01:00"),
 		// Masters 40+
 		reg("creg_chris_winter", "comp_winter_throwdown_2025", "usr_athlete_chris", "tmem_chris_winter_throwdown", "slvl_winter_masters_40", "2024-12-28 09:00:00", "2024-12-28 09:01:00"),
-		// Online Qualifier registrations
+		// Online Qualifier registrations (individual)
 		{ id: "creg_john_online", event_id: "comp_online_qualifier_2026", user_id: "usr_demo3member", team_member_id: "tmem_john_online", division_id: "slvl_online_rx", registered_at: ts, payment_status: "PAID", paid_at: ts, created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "creg_jane_online", event_id: "comp_online_qualifier_2026", user_id: "usr_demo4member", team_member_id: "tmem_jane_online", division_id: "slvl_online_scaled", registered_at: ts, payment_status: "PAID", paid_at: ts, created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "creg_mike_online", event_id: "comp_online_qualifier_2026", user_id: "usr_athlete_mike", team_member_id: "tmem_mike_online", division_id: "slvl_online_rx", registered_at: ts, payment_status: "PAID", paid_at: ts, created_at: ts, updated_at: ts, update_counter: 0 },
@@ -161,10 +162,20 @@ export async function seed(client: Connection): Promise<void> {
 		{ id: "creg_alex_online", event_id: "comp_online_qualifier_2026", user_id: "usr_athlete_alex", team_member_id: "tmem_alex_online", division_id: "slvl_online_masters", registered_at: ts, payment_status: "PAID", paid_at: ts, created_at: ts, updated_at: ts, update_counter: 0 },
 	])
 
+	// Online Qualifier team registrations (Team Send It: Mike captain, Ryan teammate)
+	await batchInsert(client, "competition_registrations", [
+		{ id: "creg_mike_online_team", event_id: "comp_online_qualifier_2026", user_id: "usr_athlete_mike", team_member_id: "tmem_mike_team_sendit", division_id: "slvl_online_team_rx", team_name: "Team Send It", captain_user_id: "usr_athlete_mike", athlete_team_id: "team_online_team_mike_ryan", registered_at: datetimeToUnix(ts), payment_status: "PAID", paid_at: datetimeToUnix(ts), created_at: ts, updated_at: ts, update_counter: 0 },
+		{ id: "creg_ryan_online_team", event_id: "comp_online_qualifier_2026", user_id: "usr_athlete_ryan", team_member_id: "tmem_ryan_team_sendit", division_id: "slvl_online_team_rx", team_name: "Team Send It", captain_user_id: "usr_athlete_mike", athlete_team_id: "team_online_team_mike_ryan", registered_at: datetimeToUnix(ts), payment_status: "PAID", paid_at: datetimeToUnix(ts), created_at: ts, updated_at: ts, update_counter: 0 },
+	])
+
 	// Competition events (submission windows for online qualifier)
 	await batchInsert(client, "competition_events", [
 		{ id: "cevt_online_event1", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event1", submission_opens_at: pastDatetime(8), submission_closes_at: pastDatetime(1), created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "cevt_online_event2", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event2", submission_opens_at: pastDatetime(1), submission_closes_at: futureDatetime(6), created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "cevt_online_event3", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event3", submission_opens_at: futureDatetime(6), submission_closes_at: futureDatetime(13), created_at: ts, updated_at: ts, update_counter: 0 },
+		// Event 4: Couplet Challenge — parent + sub-events share the same active window
+		{ id: "cevt_online_event4_parent", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event4_parent", submission_opens_at: pastDatetime(1), submission_closes_at: futureDatetime(6), created_at: ts, updated_at: ts, update_counter: 0 },
+		{ id: "cevt_online_event4_sprint", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event4_sprint", submission_opens_at: pastDatetime(1), submission_closes_at: futureDatetime(6), created_at: ts, updated_at: ts, update_counter: 0 },
+		{ id: "cevt_online_event4_clean", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event4_clean", submission_opens_at: pastDatetime(1), submission_closes_at: futureDatetime(6), created_at: ts, updated_at: ts, update_counter: 0 },
 	])
 }

--- a/apps/wodsmith-start/src/components/compete/submission-window.tsx
+++ b/apps/wodsmith-start/src/components/compete/submission-window.tsx
@@ -10,6 +10,7 @@ interface Workout {
   id: string
   name: string
   trackWorkoutId: string
+  children?: { id: string; name: string }[]
 }
 
 interface SubmissionWindowProps {
@@ -209,18 +210,32 @@ export function SubmissionWindow({
               {workouts.map((workout) => (
                 <div
                   key={workout.id}
-                  className="flex items-center justify-between rounded-md border bg-card p-3"
+                  className="rounded-md border bg-card p-3"
                 >
-                  <span className="text-sm font-medium">{workout.name}</span>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => onRemoveWorkout(workout.trackWorkoutId)}
-                    aria-label={`Remove ${workout.name}`}
-                  >
-                    <X className="h-4 w-4" />
-                  </Button>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium">{workout.name}</span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => onRemoveWorkout(workout.trackWorkoutId)}
+                      aria-label={`Remove ${workout.name}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </Button>
+                  </div>
+                  {workout.children && workout.children.length > 0 && (
+                    <div className="mt-2 ml-4 space-y-1">
+                      {workout.children.map((child) => (
+                        <div
+                          key={child.id}
+                          className="text-xs text-muted-foreground"
+                        >
+                          └ {child.name}
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/apps/wodsmith-start/src/components/compete/submission-windows-manager.tsx
+++ b/apps/wodsmith-start/src/components/compete/submission-windows-manager.tsx
@@ -17,6 +17,7 @@ interface WorkoutWithType {
   name: string
   workoutType: string
   trackOrder: number
+  parentEventId: string | null
 }
 
 interface CompetitionEvent {
@@ -61,6 +62,23 @@ export function SubmissionWindowsManager({
 
   const upsertEvents = useServerFn(upsertCompetitionEventsFn)
 
+  // Separate parent (top-level) workouts from sub-events
+  const parentWorkouts = useMemo(
+    () => workouts.filter((w) => !w.parentEventId),
+    [workouts],
+  )
+  const childrenByParent = useMemo(() => {
+    const map = new Map<string, WorkoutWithType[]>()
+    for (const w of workouts) {
+      if (w.parentEventId) {
+        const children = map.get(w.parentEventId) || []
+        children.push(w)
+        map.set(w.parentEventId, children)
+      }
+    }
+    return map
+  }, [workouts])
+
   // Initialize state from server data
   useEffect(() => {
     // Prevent double initialization in strict mode
@@ -81,9 +99,20 @@ export function SubmissionWindowsManager({
       }
     >()
 
+    // Only track parent (top-level) workouts in assignments — sub-events
+    // are automatically included with their parent
+    const subEventIds = new Set(
+      workouts.filter((w) => w.parentEventId).map((w) => w.id),
+    )
+
     for (const event of initialEvents) {
       // Skip events with no submission window configured
       if (!event.submissionOpensAt && !event.submissionClosesAt) {
+        continue
+      }
+
+      // Skip sub-events — they inherit their parent's window
+      if (subEventIds.has(event.trackWorkoutId)) {
         continue
       }
 
@@ -122,7 +151,7 @@ export function SubmissionWindowsManager({
     // Mark as clean since we just loaded from server
     markClean()
     setIsInitialized(true)
-  }, [initialEvents, setWindows, assignWorkout, markClean, reset])
+  }, [initialEvents, setWindows, assignWorkout, markClean, reset, workouts])
 
   // Monitor for drag-drop events
   useEffect(() => {
@@ -214,6 +243,16 @@ export function SubmissionWindowsManager({
             submissionOpensAt: window.submissionOpensAt,
             submissionClosesAt: window.submissionClosesAt,
           })
+          // Include child sub-events with same window times
+          const children = childrenByParent.get(workoutId) || []
+          for (const child of children) {
+            assignedIds.add(child.id)
+            events.push({
+              trackWorkoutId: child.id,
+              submissionOpensAt: window.submissionOpensAt,
+              submissionClosesAt: window.submissionClosesAt,
+            })
+          }
         }
       }
 
@@ -312,7 +351,7 @@ export function SubmissionWindowsManager({
       <div className="grid gap-6 lg:grid-cols-[300px_1fr]">
         <div className="space-y-4">
           <UnassignedWorkoutsPool
-            workouts={workouts}
+            workouts={parentWorkouts}
             assignedWorkoutIds={assignedWorkoutIds}
             instanceId={instanceId}
           />
@@ -331,14 +370,19 @@ export function SubmissionWindowsManager({
             windows.map((window) => {
               const windowWorkouts = (workoutAssignments.get(window.id) || [])
                 .map((workoutId) => {
-                  const workout = workouts.find((w) => w.id === workoutId)
-                  return workout
-                    ? {
-                        id: workout.id,
-                        name: workout.name,
-                        trackWorkoutId: workout.id,
-                      }
-                    : null
+                  const workout = parentWorkouts.find(
+                    (w) => w.id === workoutId,
+                  )
+                  if (!workout) return null
+                  const children = (
+                    childrenByParent.get(workoutId) || []
+                  ).map((c) => ({ id: c.id, name: c.name }))
+                  return {
+                    id: workout.id,
+                    name: workout.name,
+                    trackWorkoutId: workout.id,
+                    children,
+                  }
                 })
                 .filter((w): w is NonNullable<typeof w> => w !== null)
 

--- a/apps/wodsmith-start/src/components/compete/unassigned-workouts-pool.tsx
+++ b/apps/wodsmith-start/src/components/compete/unassigned-workouts-pool.tsx
@@ -16,6 +16,7 @@ interface WorkoutWithType {
   name: string
   workoutType: string
   trackOrder: number
+  parentEventId: string | null
 }
 
 interface UnassignedWorkoutsPoolProps {

--- a/apps/wodsmith-start/src/routes/compete/$slug/workouts/$eventId.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/workouts/$eventId.tsx
@@ -136,20 +136,6 @@ export const Route = createFileRoute("/compete/$slug/workouts/$eventId")({
       })
       .filter((d): d is { divisionId: string; label: string } => d !== null)
 
-    // For online competitions, fetch video submission scoped to the first registered division
-    const initialSubmissionDivisionId =
-      athleteRegisteredDivisionIds[0] ?? undefined
-    const videoSubmissionResult =
-      competition.competitionType === "online"
-        ? await getVideoSubmissionFn({
-            data: {
-              trackWorkoutId: eventId,
-              competitionId: competition.id,
-              divisionId: initialSubmissionDivisionId,
-            },
-          })
-        : null
-
     // Defer heat schedule fetch - not needed for initial render
     const deferredEventHeats =
       eventResult.event.heatStatus === "published"
@@ -163,6 +149,47 @@ export const Route = createFileRoute("/compete/$slug/workouts/$eventId")({
     const childEvents = allWorkoutsResult.workouts
       .filter((w) => w.parentEventId === eventId)
       .sort((a, b) => a.trackOrder - b.trackOrder)
+
+    // For online competitions, fetch video submissions
+    const initialSubmissionDivisionId =
+      athleteRegisteredDivisionIds[0] ?? undefined
+    const hasChildEvents = childEvents.length > 0
+
+    // If event has children, fetch submissions per child; otherwise fetch for this event
+    let videoSubmissionResult: Awaited<
+      ReturnType<typeof getVideoSubmissionFn>
+    > | null = null
+    const childVideoSubmissions: Record<
+      string,
+      Awaited<ReturnType<typeof getVideoSubmissionFn>>
+    > = {}
+
+    if (competition.competitionType === "online") {
+      if (hasChildEvents) {
+        const childResults = await Promise.all(
+          childEvents.map((child) =>
+            getVideoSubmissionFn({
+              data: {
+                trackWorkoutId: child.id,
+                competitionId: competition.id,
+                divisionId: initialSubmissionDivisionId,
+              },
+            }),
+          ),
+        )
+        for (let i = 0; i < childEvents.length; i++) {
+          childVideoSubmissions[childEvents[i].id] = childResults[i]
+        }
+      } else {
+        videoSubmissionResult = await getVideoSubmissionFn({
+          data: {
+            trackWorkoutId: eventId,
+            competitionId: competition.id,
+            divisionId: initialSubmissionDivisionId,
+          },
+        })
+      }
+    }
 
     // If this is a sub-event, find the parent event for context
     const parentEvent = eventResult.event.parentEventId
@@ -209,6 +236,7 @@ export const Route = createFileRoute("/compete/$slug/workouts/$eventId")({
       athleteRegisteredDivisionId: athleteRegisteredDivisionIds[0] ?? null,
       venue: venueResult.venue,
       videoSubmission: videoSubmissionResult,
+      childVideoSubmissions,
       deferredEventHeats,
       childEvents,
       childDivisionDescriptions,
@@ -270,6 +298,7 @@ function EventDetailsPage() {
     athleteRegisteredDivisionId,
     venue,
     videoSubmission,
+    childVideoSubmissions,
     deferredEventHeats,
     childEvents,
     childDivisionDescriptions,
@@ -282,6 +311,13 @@ function EventDetailsPage() {
   const workout = event.workout
   const formattedTimeCap = workout.timeCap ? formatTime(workout.timeCap) : null
   const schemeLabel = getSchemeLabel(workout.scheme, workout.timeCap)
+
+  // For sidebar submission window display, use the first child's data for parent events
+  const sidebarSubmission =
+    videoSubmission ??
+    (childEvents.length > 0
+      ? Object.values(childVideoSubmissions)[0] ?? null
+      : null)
 
   // Sort division descriptions by position
   const sortedDivisions = [...divisionDescriptions].sort(
@@ -421,39 +457,55 @@ function EventDetailsPage() {
                     child.workout.scheme,
                     child.workout.timeCap,
                   )
+                  const childSubmission =
+                    childVideoSubmissions[child.id] ?? null
 
                   return (
-                    <div key={child.id} className="space-y-2">
-                      <div className="flex items-center gap-2">
-                        <h3 className="text-base font-semibold">
-                          {child.workout.name}
-                        </h3>
-                        <Badge variant="secondary" className="text-xs">
-                          {childScheme}
-                        </Badge>
-                        {child.pointsMultiplier &&
-                          child.pointsMultiplier !== 100 && (
-                            <span className="text-xs text-muted-foreground">
-                              {child.pointsMultiplier / 100}x points
-                            </span>
-                          )}
-                      </div>
-                      <div className="font-mono text-sm whitespace-pre-wrap leading-relaxed">
-                        {child.workout.description || "Details coming soon."}
-                      </div>
-                      {childScale && (
-                        <div className="flex items-start gap-2 mt-1">
-                          <Badge
-                            variant="secondary"
-                            className="shrink-0 text-xs"
-                          >
-                            {childDivisionDesc?.divisionLabel || "Division"}
+                    <div key={child.id} className="space-y-4">
+                      <div className="space-y-2">
+                        <div className="flex items-center gap-2">
+                          <h3 className="text-base font-semibold">
+                            {child.workout.name}
+                          </h3>
+                          <Badge variant="secondary" className="text-xs">
+                            {childScheme}
                           </Badge>
-                          <p className="font-mono text-sm whitespace-pre-wrap text-muted-foreground">
-                            {childScale}
-                          </p>
+                          {child.pointsMultiplier &&
+                            child.pointsMultiplier !== 100 && (
+                              <span className="text-xs text-muted-foreground">
+                                {child.pointsMultiplier / 100}x points
+                              </span>
+                            )}
                         </div>
-                      )}
+                        <div className="font-mono text-sm whitespace-pre-wrap leading-relaxed">
+                          {child.workout.description || "Details coming soon."}
+                        </div>
+                        {childScale && (
+                          <div className="flex items-start gap-2 mt-1">
+                            <Badge
+                              variant="secondary"
+                              className="shrink-0 text-xs"
+                            >
+                              {childDivisionDesc?.divisionLabel || "Division"}
+                            </Badge>
+                            <p className="font-mono text-sm whitespace-pre-wrap text-muted-foreground">
+                              {childScale}
+                            </p>
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Per-sub-event submission form for online competitions */}
+                      {competition.competitionType === "online" &&
+                        childSubmission && (
+                          <VideoSubmissionForm
+                            trackWorkoutId={child.id}
+                            competitionId={competition.id}
+                            timezone={competition.timezone}
+                            registeredDivisions={athleteRegisteredDivisions}
+                            initialData={childSubmission}
+                          />
+                        )}
                     </div>
                   )
                 })}
@@ -468,16 +520,18 @@ function EventDetailsPage() {
               />
             )}
 
-            {/* Video & Score Submission Form - Below description for online competitions */}
-            {competition.competitionType === "online" && videoSubmission && (
-              <VideoSubmissionForm
-                trackWorkoutId={event.id}
-                competitionId={competition.id}
-                timezone={competition.timezone}
-                registeredDivisions={athleteRegisteredDivisions}
-                initialData={videoSubmission}
-              />
-            )}
+            {/* Video & Score Submission Form - For events without sub-events */}
+            {competition.competitionType === "online" &&
+              videoSubmission &&
+              childEvents.length === 0 && (
+                <VideoSubmissionForm
+                  trackWorkoutId={event.id}
+                  competitionId={competition.id}
+                  timezone={competition.timezone}
+                  registeredDivisions={athleteRegisteredDivisions}
+                  initialData={videoSubmission}
+                />
+              )}
           </div>
         </div>
       </div>
@@ -486,7 +540,7 @@ function EventDetailsPage() {
       <aside className="space-y-4 lg:sticky lg:top-4 lg:self-start">
         {/* Submission Info Card - For online competitions */}
         {competition.competitionType === "online" &&
-          videoSubmission?.submissionWindow && (
+          sidebarSubmission?.submissionWindow && (
             <Card>
               <CardHeader className="pb-3">
                 <CardTitle className="text-lg">Submission Window</CardTitle>
@@ -500,7 +554,7 @@ function EventDetailsPage() {
                     </p>
                     <p className="font-medium text-sm">
                       {formatHeatTime(
-                        new Date(videoSubmission.submissionWindow.opensAt),
+                        new Date(sidebarSubmission.submissionWindow.opensAt),
                         competition.timezone,
                       )}
                     </p>
@@ -514,19 +568,19 @@ function EventDetailsPage() {
                     </p>
                     <p className="font-medium text-sm">
                       {formatHeatTime(
-                        new Date(videoSubmission.submissionWindow.closesAt),
+                        new Date(sidebarSubmission.submissionWindow.closesAt),
                         competition.timezone,
                       )}
                     </p>
                   </div>
                 </div>
-                {videoSubmission.canSubmit ? (
+                {sidebarSubmission.canSubmit ? (
                   <p className="text-xs text-green-600 dark:text-green-400 font-medium">
                     Submission window is open
                   </p>
                 ) : (
                   <p className="text-xs text-muted-foreground">
-                    {videoSubmission.reason}
+                    {sidebarSubmission.reason}
                   </p>
                 )}
               </CardContent>

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/quick-actions-events.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/quick-actions-events.tsx
@@ -61,18 +61,14 @@ export function QuickActionsEvents({
       return next
     })
     try {
-      // Update parent and all children
-      await Promise.all(
-        allIds.map((id) =>
-          updateCompetitionWorkout({
-            data: {
-              trackWorkoutId: id,
-              teamId: organizingTeamId,
-              eventStatus: newStatus,
-            },
-          }),
-        ),
-      )
+      // Server cascades eventStatus to child sub-events automatically
+      await updateCompetitionWorkout({
+        data: {
+          trackWorkoutId,
+          teamId: organizingTeamId,
+          eventStatus: newStatus,
+        },
+      })
       await router.invalidate()
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to update event")
@@ -102,18 +98,20 @@ export function QuickActionsEvents({
 
     setIsPublishingAll(true)
     try {
+      // Server cascades eventStatus to child sub-events automatically,
+      // so we only need to update parent events
       await Promise.all(
-        allDraftIds.map((id) =>
+        draftParents.map((parent) =>
           updateCompetitionWorkout({
             data: {
-              trackWorkoutId: id,
+              trackWorkoutId: parent.id,
               teamId: organizingTeamId,
               eventStatus: "published",
             },
           }),
         ),
       )
-      toast.success(`Published ${draftParents.length} event(s)`)
+      toast.success(`Published ${allDraftIds.length} event(s)`)
       await router.invalidate()
     } catch (err) {
       toast.error(

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/quick-actions-events.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/quick-actions-events.tsx
@@ -49,43 +49,71 @@ export function QuickActionsEvents({
     trackWorkoutId: string,
     newStatus: "draft" | "published",
   ) => {
-    setPendingEvents((prev) => new Set(prev).add(trackWorkoutId))
+    // Find child events that need the same status update
+    const childEvents = events.filter(
+      (e) => e.parentEventId === trackWorkoutId,
+    )
+    const allIds = [trackWorkoutId, ...childEvents.map((e) => e.id)]
+
+    setPendingEvents((prev) => {
+      const next = new Set(prev)
+      for (const id of allIds) next.add(id)
+      return next
+    })
     try {
-      await updateCompetitionWorkout({
-        data: {
-          trackWorkoutId,
-          teamId: organizingTeamId,
-          eventStatus: newStatus,
-        },
-      })
+      // Update parent and all children
+      await Promise.all(
+        allIds.map((id) =>
+          updateCompetitionWorkout({
+            data: {
+              trackWorkoutId: id,
+              teamId: organizingTeamId,
+              eventStatus: newStatus,
+            },
+          }),
+        ),
+      )
       await router.invalidate()
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "Failed to update event")
     } finally {
       setPendingEvents((prev) => {
         const next = new Set(prev)
-        next.delete(trackWorkoutId)
+        for (const id of allIds) next.delete(id)
         return next
       })
     }
   }
 
   const handlePublishAll = async () => {
-    const draftEvents = topLevelEvents.filter((e) => e.eventStatus !== "published")
-    if (draftEvents.length === 0) return
+    // Collect all draft events including children of draft parents
+    const draftParents = topLevelEvents.filter(
+      (e) => e.eventStatus !== "published",
+    )
+    if (draftParents.length === 0) return
+
+    const allDraftIds = draftParents.flatMap((parent) => {
+      const children = events.filter(
+        (e) =>
+          e.parentEventId === parent.id && e.eventStatus !== "published",
+      )
+      return [parent.id, ...children.map((c) => c.id)]
+    })
 
     setIsPublishingAll(true)
     try {
-      for (const event of draftEvents) {
-        await updateCompetitionWorkout({
-          data: {
-            trackWorkoutId: event.id,
-            teamId: organizingTeamId,
-            eventStatus: "published",
-          },
-        })
-      }
-      toast.success(`Published ${draftEvents.length} event(s)`)
+      await Promise.all(
+        allDraftIds.map((id) =>
+          updateCompetitionWorkout({
+            data: {
+              trackWorkoutId: id,
+              teamId: organizingTeamId,
+              eventStatus: "published",
+            },
+          }),
+        ),
+      )
+      toast.success(`Published ${draftParents.length} event(s)`)
       await router.invalidate()
     } catch (err) {
       toast.error(

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/results.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/results.tsx
@@ -104,23 +104,60 @@ export const Route = createFileRoute(
     const divisions = divisionsResult.divisions
 
     // For online competitions, fetch submission stats for each event
+    // Show sub-events individually (scores are per sub-event), group under parent for context
     if (isOnline) {
+      // Build a flat list of reviewable events: sub-events if parent has children, otherwise the event itself
+      const reviewableEvents: Array<{
+        event: (typeof events)[number]
+        parentName: string | null
+      }> = []
+      for (const event of events) {
+        if (event.parentEventId) continue // handled below via parent
+        const children = events.filter(
+          (e) => e.parentEventId === event.id,
+        )
+        if (children.length > 0) {
+          for (const child of children) {
+            reviewableEvents.push({
+              event: child,
+              parentName: event.workout.name,
+            })
+          }
+        } else {
+          reviewableEvents.push({ event, parentName: null })
+        }
+      }
+
       const eventSubmissionStats = await Promise.all(
-        events.map(async (event) => {
-          const { submissions } = await getEventSubmissionsFn({
-            data: {
-              competitionId: params.competitionId,
-              trackWorkoutId: event.id,
-            },
-          })
-          const withVideo = submissions.filter((s) => s.hasVideo).length
-          return {
-            eventId: event.id,
-            eventName: event.workout.name,
-            trackOrder: event.trackOrder,
-            totalSubmissions: submissions.length,
-            withVideo,
-            withoutVideo: submissions.length - withVideo,
+        reviewableEvents.map(async ({ event, parentName }) => {
+          try {
+            const { submissions } = await getEventSubmissionsFn({
+              data: {
+                competitionId: params.competitionId,
+                trackWorkoutId: event.id,
+              },
+            })
+            const withVideo = submissions.filter((s) => s.hasVideo).length
+            return {
+              eventId: event.id,
+              eventName: event.workout.name,
+              parentName,
+              trackOrder: event.trackOrder,
+              totalSubmissions: submissions.length,
+              withVideo,
+              withoutVideo: submissions.length - withVideo,
+            }
+          } catch {
+            // Event may not have a competition_events row yet
+            return {
+              eventId: event.id,
+              eventName: event.workout.name,
+              parentName,
+              trackOrder: event.trackOrder,
+              totalSubmissions: 0,
+              withVideo: 0,
+              withoutVideo: 0,
+            }
           }
         }),
       )
@@ -233,6 +270,7 @@ function OnlineSubmissionsOverview({
     eventSubmissionStats: Array<{
       eventId: string
       eventName: string
+      parentName: string | null
       trackOrder: number
       totalSubmissions: number
       withVideo: number
@@ -333,7 +371,16 @@ function OnlineSubmissionsOverview({
                     <TableCell className="font-medium">
                       #{formatTrackOrder(stat.trackOrder)}
                     </TableCell>
-                    <TableCell>{stat.eventName}</TableCell>
+                    <TableCell>
+                      <div>
+                        {stat.eventName}
+                        {stat.parentName && (
+                          <span className="text-xs text-muted-foreground ml-1.5">
+                            ({stat.parentName})
+                          </span>
+                        )}
+                      </div>
+                    </TableCell>
                     <TableCell className="text-center">
                       {stat.totalSubmissions}
                     </TableCell>

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/results.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/results.tsx
@@ -147,17 +147,23 @@ export const Route = createFileRoute(
               withVideo,
               withoutVideo: submissions.length - withVideo,
             }
-          } catch {
+          } catch (error) {
             // Event may not have a competition_events row yet
-            return {
-              eventId: event.id,
-              eventName: event.workout.name,
-              parentName,
-              trackOrder: event.trackOrder,
-              totalSubmissions: 0,
-              withVideo: 0,
-              withoutVideo: 0,
+            if (
+              error instanceof Error &&
+              error.message === "Event not found in this competition"
+            ) {
+              return {
+                eventId: event.id,
+                eventName: event.workout.name,
+                parentName,
+                trackOrder: event.trackOrder,
+                totalSubmissions: 0,
+                withVideo: 0,
+                withoutVideo: 0,
+              }
             }
+            throw error
           }
         }),
       )

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/submission-windows.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/submission-windows.tsx
@@ -63,6 +63,7 @@ function SubmissionWindowsPage() {
     name: event.workout?.name || `Event #${event.trackOrder}`,
     workoutType: event.workout?.scheme || "for-time",
     trackOrder: event.trackOrder,
+    parentEventId: event.parentEventId ?? null,
   }))
 
   return (

--- a/apps/wodsmith-start/src/server-fns/competition-detail-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-detail-fns.ts
@@ -453,18 +453,28 @@ export const getUserCompetitionRegistrationsFn = createServerFn({
         )
     }
 
-    // Merge and deduplicate (a captain appears in both direct and team sets)
-    const seenIds = new Set<string>()
-    const allRegistrations: typeof directRegistrations = []
+    // Merge and deduplicate by division.
+    // Direct registrations (user's own rows) take priority.
+    // Team query may return teammate rows in the same division — skip those.
+    const divisionMap = new Map<string | null, (typeof directRegistrations)[0]>()
 
-    for (const reg of [...directRegistrations, ...teamRegistrations]) {
-      if (!seenIds.has(reg.id)) {
-        seenIds.add(reg.id)
-        allRegistrations.push(reg)
+    for (const reg of directRegistrations) {
+      divisionMap.set(reg.divisionId, reg)
+    }
+
+    for (const reg of teamRegistrations) {
+      if (!divisionMap.has(reg.divisionId)) {
+        divisionMap.set(reg.divisionId, reg)
+      } else if (
+        reg.userId === data.userId &&
+        divisionMap.get(reg.divisionId)!.userId !== data.userId
+      ) {
+        // Prefer the user's own row over a teammate's row
+        divisionMap.set(reg.divisionId, reg)
       }
     }
 
-    return { registrations: allRegistrations }
+    return { registrations: Array.from(divisionMap.values()) }
   })
 
 /**

--- a/apps/wodsmith-start/src/server-fns/submission-verification-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/submission-verification-fns.ts
@@ -1039,8 +1039,14 @@ export const getEventDetailsForVerificationFn = createServerFn({
         data.competitionId,
         data.trackWorkoutId,
       )
-    } catch {
-      return { event: null }
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message === "Event not found in this competition"
+      ) {
+        return { event: null }
+      }
+      throw error
     }
 
     // Get the track workout with workout details

--- a/apps/wodsmith-start/src/server-fns/submission-verification-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/submission-verification-fns.ts
@@ -14,7 +14,10 @@ import {
   competitionRegistrationsTable,
   competitionsTable,
 } from "@/db/schemas/competitions"
-import { trackWorkoutsTable } from "@/db/schemas/programming"
+import {
+  programmingTracksTable,
+  trackWorkoutsTable,
+} from "@/db/schemas/programming"
 import { scalingLevelsTable } from "@/db/schemas/scaling"
 import { scoresTable, scoreVerificationLogsTable } from "@/db/schemas/scores"
 import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
@@ -33,6 +36,70 @@ import {
 import { getSessionFromCookie } from "@/utils/auth"
 import { autochunk } from "@/utils/batch-query"
 import { requireTeamPermission } from "@/utils/team-auth"
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Verify a track workout belongs to a competition.
+ * First checks `competition_events` (events with submission windows configured).
+ * Falls back to `track_workouts` → `programming_tracks` for sub-events or
+ * events without submission windows.
+ */
+async function verifyEventBelongsToCompetition(
+  db: ReturnType<typeof getDb>,
+  competitionId: string,
+  trackWorkoutId: string,
+): Promise<{
+  submissionOpensAt: string | null
+  submissionClosesAt: string | null
+}> {
+  // Try competition_events first (has submission window data)
+  const [competitionEvent] = await db
+    .select({
+      id: competitionEventsTable.id,
+      submissionOpensAt: competitionEventsTable.submissionOpensAt,
+      submissionClosesAt: competitionEventsTable.submissionClosesAt,
+    })
+    .from(competitionEventsTable)
+    .where(
+      and(
+        eq(competitionEventsTable.competitionId, competitionId),
+        eq(competitionEventsTable.trackWorkoutId, trackWorkoutId),
+      ),
+    )
+    .limit(1)
+
+  if (competitionEvent) {
+    return {
+      submissionOpensAt: competitionEvent.submissionOpensAt,
+      submissionClosesAt: competitionEvent.submissionClosesAt,
+    }
+  }
+
+  // Fall back: verify via track_workouts → programming_tracks → competitions
+  const [trackEvent] = await db
+    .select({ id: trackWorkoutsTable.id })
+    .from(trackWorkoutsTable)
+    .innerJoin(
+      programmingTracksTable,
+      eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+    )
+    .where(
+      and(
+        eq(trackWorkoutsTable.id, trackWorkoutId),
+        eq(programmingTracksTable.competitionId, competitionId),
+      ),
+    )
+    .limit(1)
+
+  if (!trackEvent) {
+    throw new Error("Event not found in this competition")
+  }
+
+  return { submissionOpensAt: null, submissionClosesAt: null }
+}
 
 // ============================================================================
 // Types
@@ -197,20 +264,11 @@ export const verifySubmissionScoreFn = createServerFn({ method: "POST" })
       getEvlog()?.set({ action: data.action === "verify" ? "verify_submission" : data.action === "adjust" ? "adjust_submission" : "reject_submission", verification: { competitionId: data.competitionId, scoreId: data.scoreId, trackWorkoutId: data.trackWorkoutId } })
 
       // Verify the event belongs to this competition
-      const [competitionEvent] = await db
-        .select({ id: competitionEventsTable.id })
-        .from(competitionEventsTable)
-        .where(
-          and(
-            eq(competitionEventsTable.competitionId, data.competitionId),
-            eq(competitionEventsTable.trackWorkoutId, data.trackWorkoutId),
-          ),
-        )
-        .limit(1)
-
-      if (!competitionEvent) {
-        throw new Error("Event not found in this competition")
-      }
+      await verifyEventBelongsToCompetition(
+        db,
+        data.competitionId,
+        data.trackWorkoutId,
+      )
 
       // Load the score (including current values for audit log)
       const [score] = await db
@@ -570,25 +628,12 @@ export const getSubmissionDetailFn = createServerFn({ method: "GET" })
         TEAM_PERMISSIONS.MANAGE_COMPETITIONS,
       )
 
-      // Verify the event belongs to this competition and get submission window
-      const [competitionEvent] = await db
-        .select({
-          id: competitionEventsTable.id,
-          submissionOpensAt: competitionEventsTable.submissionOpensAt,
-          submissionClosesAt: competitionEventsTable.submissionClosesAt,
-        })
-        .from(competitionEventsTable)
-        .where(
-          and(
-            eq(competitionEventsTable.competitionId, data.competitionId),
-            eq(competitionEventsTable.trackWorkoutId, data.trackWorkoutId),
-          ),
-        )
-        .limit(1)
-
-      if (!competitionEvent) {
-        throw new Error("Event not found in this competition")
-      }
+      // Verify the event belongs to this competition
+      const eventWindow = await verifyEventBelongsToCompetition(
+        db,
+        data.competitionId,
+        data.trackWorkoutId,
+      )
 
       // Get the score with user info
       const [score] = await db
@@ -651,8 +696,8 @@ export const getSubmissionDetailFn = createServerFn({ method: "GET" })
           timeCap: trackWorkout.workoutTimeCap,
         },
         submissionWindow: {
-          opensAt: competitionEvent?.submissionOpensAt ?? null,
-          closesAt: competitionEvent?.submissionClosesAt ?? null,
+          opensAt: eventWindow.submissionOpensAt,
+          closesAt: eventWindow.submissionClosesAt,
         },
       }
 
@@ -829,20 +874,11 @@ export const getEventSubmissionsFn = createServerFn({ method: "GET" })
     )
 
     // Verify the event belongs to this competition
-    const [competitionEvent] = await db
-      .select({ id: competitionEventsTable.id })
-      .from(competitionEventsTable)
-      .where(
-        and(
-          eq(competitionEventsTable.competitionId, data.competitionId),
-          eq(competitionEventsTable.trackWorkoutId, data.trackWorkoutId),
-        ),
-      )
-      .limit(1)
-
-    if (!competitionEvent) {
-      throw new Error("Event not found in this competition")
-    }
+    await verifyEventBelongsToCompetition(
+      db,
+      data.competitionId,
+      data.trackWorkoutId,
+    )
 
     // Get all scores for this event
     const scores = await db
@@ -996,22 +1032,14 @@ export const getEventDetailsForVerificationFn = createServerFn({
     )
 
     // Verify the event belongs to this competition and get submission window
-    const [competitionEvent] = await db
-      .select({
-        id: competitionEventsTable.id,
-        submissionOpensAt: competitionEventsTable.submissionOpensAt,
-        submissionClosesAt: competitionEventsTable.submissionClosesAt,
-      })
-      .from(competitionEventsTable)
-      .where(
-        and(
-          eq(competitionEventsTable.competitionId, data.competitionId),
-          eq(competitionEventsTable.trackWorkoutId, data.trackWorkoutId),
-        ),
+    let eventWindow: { submissionOpensAt: string | null; submissionClosesAt: string | null }
+    try {
+      eventWindow = await verifyEventBelongsToCompetition(
+        db,
+        data.competitionId,
+        data.trackWorkoutId,
       )
-      .limit(1)
-
-    if (!competitionEvent) {
+    } catch {
       return { event: null }
     }
 
@@ -1047,8 +1075,8 @@ export const getEventDetailsForVerificationFn = createServerFn({
           timeCap: trackWorkout.workoutTimeCap,
         },
         submissionWindow: {
-          opensAt: competitionEvent?.submissionOpensAt ?? null,
-          closesAt: competitionEvent?.submissionClosesAt ?? null,
+          opensAt: eventWindow.submissionOpensAt,
+          closesAt: eventWindow.submissionClosesAt,
         },
       },
     }

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -146,7 +146,7 @@ Switching divisions fetches that division's submission data via [[apps/wodsmith-
 
 Events with sub-events (parent/child hierarchy) show a separate submission form per child event on the parent workout page.
 
-The loader in [[apps/wodsmith-start/src/routes/compete/$slug/workouts/$eventId.tsx]] fetches video submissions for each child event in parallel via `getVideoSubmissionFn`. Each child renders its own [[apps/wodsmith-start/src/components/compete/video-submission-form.tsx#VideoSubmissionForm]] with the child's `trackWorkoutId`. Team divisions get the same multi-video slot behavior per sub-event. The parent event itself has no submission form when children exist — all scoring is per sub-event.
+The loader in [[apps/wodsmith-start/src/routes/compete/$slug/workouts/$eventId.tsx#Route]] fetches video submissions for each child event in parallel via [[apps/wodsmith-start/src/server-fns/video-submission-fns.ts#getVideoSubmissionFn]]. Each child renders its own [[apps/wodsmith-start/src/components/compete/video-submission-form.tsx#VideoSubmissionForm]] with the child's `trackWorkoutId`. Team divisions get the same multi-video slot behavior per sub-event. The parent event itself has no submission form when children exist — all scoring is per sub-event.
 
 ### Captain-Only Submission
 

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -134,7 +134,7 @@ Organizers create waiver templates per competition. Athletes sign waivers during
 
 Athletes can submit video evidence of their workout performance for remote judging.
 
-Submissions link to a score and include a video URL (e.g., Vimeo). Judges can verify or reject submissions. Community voting is supported via `videoVotesTable`.
+Submissions link to a score and include a video URL (e.g., Vimeo). Judges can verify or reject submissions. Community voting is supported via `videoVotesTable`. Event ownership validation in [[apps/wodsmith-start/src/server-fns/submission-verification-fns.ts]] uses `verifyEventBelongsToCompetition` which checks `competition_events` first, then falls back to `track_workouts` → `programming_tracks` for sub-events without submission windows.
 
 ### Multi-Division Submission
 

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -142,6 +142,12 @@ Athletes registered in multiple divisions see a division picker on the submissio
 
 Switching divisions fetches that division's submission data via [[apps/wodsmith-start/src/server-fns/video-submission-fns.ts#getVideoSubmissionFn]] with the `divisionId` parameter. Scores and video submissions are scoped per-division so each registration gets its own submission state. The picker lives in [[apps/wodsmith-start/src/components/compete/video-submission-form.tsx#VideoSubmissionForm]].
 
+### Sub-Event Submissions
+
+Events with sub-events (parent/child hierarchy) show a separate submission form per child event on the parent workout page.
+
+The loader in [[apps/wodsmith-start/src/routes/compete/$slug/workouts/$eventId.tsx]] fetches video submissions for each child event in parallel via `getVideoSubmissionFn`. Each child renders its own [[apps/wodsmith-start/src/components/compete/video-submission-form.tsx#VideoSubmissionForm]] with the child's `trackWorkoutId`. Team divisions get the same multi-video slot behavior per sub-event. The parent event itself has no submission form when children exist — all scoring is per sub-event.
+
 ### Captain-Only Submission
 
 For team divisions (teamSize > 1), only the team captain can submit videos and scores. Non-captain team members see a read-only view of the team's submissions. Individual athletes (teamSize = 1) are always treated as their own captain.

--- a/lat.md/organizer-dashboard.md
+++ b/lat.md/organizer-dashboard.md
@@ -30,7 +30,7 @@ Fetches divisions with registration counts, scaling groups, and series mapping s
 
 Events link workouts to the competition. Each event represents a workout athletes will perform and be scored on.
 
-Fetches events, divisions, movements, and sponsors in parallel. Uses `OrganizerEventManager` for creating, editing, reordering, and deleting events. Events can have per-division workout descriptions, attached resources, and judging sheets. Supports parent/sub-event hierarchy for multi-workout events.
+Fetches events, divisions, movements, and sponsors in parallel. Uses `OrganizerEventManager` for creating, editing, reordering, and deleting events. Events can have per-division workout descriptions, attached resources, and judging sheets. Supports parent/sub-event hierarchy for multi-workout events. Publishing or unpublishing a parent event cascades to all its child sub-events via [[apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/quick-actions-events.tsx]].
 
 ## Heat Scheduling
 
@@ -70,7 +70,7 @@ Organizers enter scores for each athlete per event, or review video submissions 
 
 For **in-person competitions**: `ResultsEntryForm` provides a per-event, per-division score entry grid. Organizers select an event and division, then enter scores for each athlete. Supports publishing/unpublishing division results.
 
-For **online competitions**: Shows a submissions overview with links to individual video verification pages at `/events/{eventId}/submissions/`. Displays submission counts and verification status per event.
+For **online competitions**: Shows a submissions overview with links to individual video verification pages at `/events/{eventId}/submissions/`. Displays submission counts and verification status per event. Parent events with sub-events aggregate submission stats from their children. Events without `competition_events` rows (no submission window configured) are handled gracefully.
 
 ## Submission Windows
 

--- a/lat.md/organizer-dashboard.md
+++ b/lat.md/organizer-dashboard.md
@@ -70,13 +70,13 @@ Organizers enter scores for each athlete per event, or review video submissions 
 
 For **in-person competitions**: `ResultsEntryForm` provides a per-event, per-division score entry grid. Organizers select an event and division, then enter scores for each athlete. Supports publishing/unpublishing division results.
 
-For **online competitions**: Shows a submissions overview with links to individual video verification pages at `/events/{eventId}/submissions/`. Displays submission counts and verification status per event. Parent events with sub-events aggregate submission stats from their children. Events without `competition_events` rows (no submission window configured) are handled gracefully.
+For **online competitions**: Shows a submissions overview with links to individual video verification pages at `/events/{eventId}/submissions/`. Each child sub-event is listed as its own row with submission counts and verification status; the parent event name is shown as contextual metadata alongside each child row. Events without `competition_events` rows (no submission window configured) are handled gracefully.
 
 ## Submission Windows
 
 Manages time windows during which athletes can submit video evidence for online competitions.
 
-Only available when `competitionType === "online"`. Fetches workouts and competition events. Each event can have a submission window with open/close dates. Uses `SubmissionWindowsManager` component.
+Only available when `competitionType === "online"`. Fetches workouts and competition events. Each event can have a submission window with open/close dates. Uses `SubmissionWindowsManager` component. Only parent (top-level) events appear in the unassigned pool and are draggable; sub-events are automatically assigned to the same window as their parent and displayed as children on the window card.
 
 ## Volunteers
 


### PR DESCRIPTION
## Summary

- When a parent event has sub-events, each child event now renders its own `VideoSubmissionForm` on the workout page
- Athletes can submit scores and videos independently per sub-event, with full support for multi-division switching and team multi-video slots
- Parent events with children no longer show a single submission form — all scoring is per sub-event
- Sidebar submission window card falls back to the first child's data for parent events

## Test plan

- [ ] Navigate to an online competition parent event with sub-events — verify each sub-event shows its own submission form
- [ ] Submit a score and video for one sub-event, confirm it saves independently
- [ ] Switch divisions in a sub-event form — verify submission data refreshes correctly
- [ ] Test with a team division (teamSize > 1) — verify multiple video slots appear per sub-event
- [ ] Verify non-captain team members see read-only view per sub-event
- [ ] Navigate to a regular event (no sub-events) — verify single submission form still works
- [ ] Navigate directly to a sub-event page — verify single submission form works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-sub-event score and video submission for online competitions. Parent pages render a form per child event, and organizer tools now manage windows and publishing at the parent level with automatic child inclusion.

- **New Features**
  - One `VideoSubmissionForm` per sub-event; child submissions fetched in parallel; single form only when no children; sidebar window uses the first child on parent views.
  - Submission windows: only parent events are draggable; assigning a parent auto-assigns all children and displays them under the parent on the window card.
  - Organizer results list sub-events individually with parent name for context. Seed data adds a team division and a parent event with two sub-events to demo the flow.

- **Bug Fixes**
  - Publishing/unpublishing a parent cascades to all child sub-events; pending state and toast counts include children.
  - Event ownership validation falls back to `track_workouts` → `programming_tracks` when no `competition_events` row exists; submission stats return zero counts instead of errors for those cases.
  - Deduplicate competition registrations by `divisionId`, preferring direct rows over teammate rows.

<sup>Written for commit 14e378ca614b6a834dae47076ac186f68586277a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Online competitions with sub-events now show per-sub-event video submission forms, parent form only when no children; sidebar uses the appropriate submission window per child.
  * Submission windows UI now groups sub-events under parent workouts; unassigned pool shows only parent workouts.
  * Added seeded online qualifier teams, workouts, programming, and registrations.

* **Bug Fixes**
  * Submission stats loader handles missing backend lookups gracefully.
  * Publish/unpublish and toggle actions cascade to direct child events.

* **Documentation**
  * Updated docs on sub-event submissions, event ownership/verification, and organizer dashboard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->