### PR TITLE
fix: event-division mapper shows no divisions

### DIFF
--- a/apps/wodsmith-start/src/server-fns/competition-divisions-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-divisions-fns.ts
@@ -417,18 +417,25 @@ async function ensureCompetitionOwnedScalingGroup({
       }
 
       // Create default divisions
-      await createScalingLevel({
+      const openLevel = await createScalingLevel({
         scalingGroupId: newGroup.id,
         label: "Open",
         position: 0,
         tx,
       })
-      await createScalingLevel({
+      const scaledLevel = await createScalingLevel({
         scalingGroupId: newGroup.id,
         label: "Scaled",
         position: 1,
         tx,
       })
+
+      // Create competition_divisions rows
+      const defaultFee = competition.defaultRegistrationFeeCents ?? 0
+      await tx.insert(competitionDivisionsTable).values([
+        { competitionId, divisionId: openLevel.id, feeCents: defaultFee },
+        { competitionId, divisionId: scaledLevel.id, feeCents: defaultFee },
+      ])
 
       // Update competition settings
       const newSettings = stringifyCompetitionSettings({
@@ -482,14 +489,28 @@ async function ensureCompetitionOwnedScalingGroup({
     }
 
     // Clone levels
+    const clonedLevels: Array<{ id: string }> = []
     for (const level of templateLevels) {
-      await createScalingLevel({
+      const created = await createScalingLevel({
         scalingGroupId: newGroup.id,
         label: level.label,
         position: level.position,
         teamSize: level.teamSize,
         tx,
       })
+      clonedLevels.push(created)
+    }
+
+    // Create competition_divisions rows for cloned levels
+    const defaultFee = competition.defaultRegistrationFeeCents ?? 0
+    if (clonedLevels.length > 0) {
+      await tx.insert(competitionDivisionsTable).values(
+        clonedLevels.map((l) => ({
+          competitionId,
+          divisionId: l.id,
+          feeCents: defaultFee,
+        })),
+      )
     }
 
     // Update competition settings
@@ -942,6 +963,8 @@ export const initializeCompetitionDivisionsFn = createServerFn({
         throw new Error("Failed to create scaling group")
       }
 
+      const createdLevels: Array<{ id: string }> = []
+
       if (data.templateGroupId) {
         // Clone levels from template, optionally filtering to selected subset
         const levelsToClone = data.templateDivisionIds
@@ -951,28 +974,42 @@ export const initializeCompetitionDivisionsFn = createServerFn({
           : templateLevels
         for (let i = 0; i < levelsToClone.length; i++) {
           const level = levelsToClone[i]
-          await createScalingLevel({
+          const created = await createScalingLevel({
             scalingGroupId: newGroup.id,
             label: level.label,
             position: i,
             teamSize: level.teamSize,
             tx,
           })
+          createdLevels.push(created)
         }
       } else {
         // Create default divisions
-        await createScalingLevel({
+        const openLevel = await createScalingLevel({
           scalingGroupId: newGroup.id,
           label: "Open",
           position: 0,
           tx,
         })
-        await createScalingLevel({
+        const scaledLevel = await createScalingLevel({
           scalingGroupId: newGroup.id,
           label: "Scaled",
           position: 1,
           tx,
         })
+        createdLevels.push(openLevel, scaledLevel)
+      }
+
+      // Create competition_divisions rows
+      const defaultFee = competition.defaultRegistrationFeeCents ?? 0
+      if (createdLevels.length > 0) {
+        await tx.insert(competitionDivisionsTable).values(
+          createdLevels.map((l) => ({
+            competitionId: data.competitionId,
+            divisionId: l.id,
+            feeCents: defaultFee,
+          })),
+        )
       }
 
       // Update competition settings with new scaling group
@@ -1018,10 +1055,24 @@ export const addCompetitionDivisionFn = createServerFn({ method: "POST" })
       teamId: data.teamId,
     })
 
+    const db = getDb()
     const level = await createScalingLevel({
       scalingGroupId,
       label: data.label,
       teamSize: data.teamSize,
+    })
+
+    // Create competition_divisions row for the new division
+    const [competition] = await db
+      .select({ defaultRegistrationFeeCents: competitionsTable.defaultRegistrationFeeCents })
+      .from(competitionsTable)
+      .where(eq(competitionsTable.id, data.competitionId))
+    const defaultFee = competition?.defaultRegistrationFeeCents ?? 0
+
+    await db.insert(competitionDivisionsTable).values({
+      competitionId: data.competitionId,
+      divisionId: level.id,
+      feeCents: defaultFee,
     })
 
     return { divisionId: level.id }
@@ -1759,6 +1810,24 @@ async function switchCompetitionScalingGroupCore({
         await tx
           .delete(competitionDivisionsTable)
           .where(eq(competitionDivisionsTable.id, oldConfig.id))
+      }
+    }
+
+    // Ensure all new levels have competition_divisions rows
+    const defaultFee = competition.defaultRegistrationFeeCents ?? 0
+    for (const level of newLevels) {
+      const existing = await tx.query.competitionDivisionsTable.findFirst({
+        where: and(
+          eq(competitionDivisionsTable.competitionId, competitionId),
+          eq(competitionDivisionsTable.divisionId, level.id),
+        ),
+      })
+      if (!existing) {
+        await tx.insert(competitionDivisionsTable).values({
+          competitionId,
+          divisionId: level.id,
+          feeCents: defaultFee,
+        })
       }
     }
 

--- a/apps/wodsmith-start/src/server-fns/competition-divisions-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-divisions-fns.ts
@@ -1056,23 +1056,28 @@ export const addCompetitionDivisionFn = createServerFn({ method: "POST" })
     })
 
     const db = getDb()
-    const level = await createScalingLevel({
-      scalingGroupId,
-      label: data.label,
-      teamSize: data.teamSize,
-    })
+    const level = await db.transaction(async (tx) => {
+      const created = await createScalingLevel({
+        scalingGroupId,
+        label: data.label,
+        teamSize: data.teamSize,
+        tx,
+      })
 
-    // Create competition_divisions row for the new division
-    const [competition] = await db
-      .select({ defaultRegistrationFeeCents: competitionsTable.defaultRegistrationFeeCents })
-      .from(competitionsTable)
-      .where(eq(competitionsTable.id, data.competitionId))
-    const defaultFee = competition?.defaultRegistrationFeeCents ?? 0
+      // Create competition_divisions row for the new division
+      const [competition] = await tx
+        .select({ defaultRegistrationFeeCents: competitionsTable.defaultRegistrationFeeCents })
+        .from(competitionsTable)
+        .where(eq(competitionsTable.id, data.competitionId))
+      const defaultFee = competition?.defaultRegistrationFeeCents ?? 0
 
-    await db.insert(competitionDivisionsTable).values({
-      competitionId: data.competitionId,
-      divisionId: level.id,
-      feeCents: defaultFee,
+      await tx.insert(competitionDivisionsTable).values({
+        competitionId: data.competitionId,
+        divisionId: created.id,
+        feeCents: defaultFee,
+      })
+
+      return created
     })
 
     return { divisionId: level.id }

--- a/apps/wodsmith-start/src/server-fns/event-division-mapping-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/event-division-mapping-fns.ts
@@ -7,7 +7,7 @@
  */
 
 import { createServerFn } from "@tanstack/react-start"
-import { eq } from "drizzle-orm"
+import { and, eq } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import { competitionsTable } from "@/db/schemas/competitions"
@@ -116,26 +116,38 @@ export const getEventDivisionMappingsFn = createServerFn({ method: "GET" })
       }))
     }
 
-    // Get competition divisions from competition_divisions table joined to
-    // scaling_levels for label/metadata. This ensures divisionId values match
-    // what registrations use (competition_divisions.divisionId), not a
-    // potentially different scaling group in settings.
-    const compDivisions = await db
-      .select({
-        divisionId: competitionDivisionsTable.divisionId,
-        label: scalingLevelsTable.label,
-        teamSize: scalingLevelsTable.teamSize,
-        position: scalingLevelsTable.position,
-      })
-      .from(competitionDivisionsTable)
-      .innerJoin(
-        scalingLevelsTable,
-        eq(competitionDivisionsTable.divisionId, scalingLevelsTable.id),
-      )
-      .where(eq(competitionDivisionsTable.competitionId, data.competitionId))
-      .orderBy(scalingLevelsTable.position)
+    // Get competition divisions from scaling_levels via settings, left-joining
+    // competition_divisions for fee/capacity metadata. This works whether or
+    // not competition_divisions rows have been created yet.
+    const settings = competition.settings
+      ? (JSON.parse(competition.settings as string) as {
+          divisions?: { scalingGroupId?: string }
+        })
+      : null
+    const scalingGroupId = settings?.divisions?.scalingGroupId
 
-    const divisions: EventDivisionMappingData["divisions"] = compDivisions
+    let divisions: EventDivisionMappingData["divisions"] = []
+    if (scalingGroupId) {
+      const compDivisions = await db
+        .select({
+          divisionId: scalingLevelsTable.id,
+          label: scalingLevelsTable.label,
+          teamSize: scalingLevelsTable.teamSize,
+          position: scalingLevelsTable.position,
+        })
+        .from(scalingLevelsTable)
+        .leftJoin(
+          competitionDivisionsTable,
+          and(
+            eq(competitionDivisionsTable.divisionId, scalingLevelsTable.id),
+            eq(competitionDivisionsTable.competitionId, data.competitionId),
+          ),
+        )
+        .where(eq(scalingLevelsTable.scalingGroupId, scalingGroupId))
+        .orderBy(scalingLevelsTable.position)
+
+      divisions = compDivisions
+    }
 
     // Get existing mappings, filtering out stale rows that no longer match
     // current events or divisions (e.g. after programming track changes)
@@ -214,11 +226,21 @@ export const saveEventDivisionMappingsFn = createServerFn({ method: "POST" })
         for (const tw of trackWorkouts) validEventIds.add(tw.id)
       }
 
-      const compDivisions = await db
-        .select({ divisionId: competitionDivisionsTable.divisionId })
-        .from(competitionDivisionsTable)
-        .where(eq(competitionDivisionsTable.competitionId, data.competitionId))
-      const validDivisionIds = new Set(compDivisions.map((d) => d.divisionId))
+      // Resolve valid divisions from scaling_levels via settings
+      const settings = competition.settings
+        ? (JSON.parse(competition.settings as string) as {
+            divisions?: { scalingGroupId?: string }
+          })
+        : null
+      const sgId = settings?.divisions?.scalingGroupId
+      const validDivisionIds = new Set<string>()
+      if (sgId) {
+        const levels = await db
+          .select({ id: scalingLevelsTable.id })
+          .from(scalingLevelsTable)
+          .where(eq(scalingLevelsTable.scalingGroupId, sgId))
+        for (const l of levels) validDivisionIds.add(l.id)
+      }
 
       for (const m of data.mappings) {
         if (!validEventIds.has(m.trackWorkoutId) || !validDivisionIds.has(m.divisionId)) {


### PR DESCRIPTION
## Summary
- Changed event-division mapper from INNER JOIN on `competition_divisions` to LEFT JOIN on `scaling_levels` via `settings.divisions.scalingGroupId` — divisions now show up even when `competition_divisions` rows don't exist yet
- Added `competition_divisions` row creation in all code paths that assign divisions: `ensureCompetitionOwnedScalingGroup`, `initializeCompetitionDivisionsFn`, `addCompetitionDivisionFn`, and `switchCompetitionScalingGroupCore`
- Same fix applied to the save handler's validation query

## Root cause
`competition_divisions` rows were only created via the demo seeder, commerce flows, or manual description updates — not during normal division setup. The event-division mapper's INNER JOIN returned empty when those rows didn't exist.

## Test plan
- [ ] Create a new competition, add divisions, verify event-division mappings page shows divisions
- [ ] Verify existing competitions with `competition_divisions` rows still work
- [ ] Add a division to an existing competition, verify it appears in mappings
- [ ] Switch scaling groups on a competition, verify all new divisions get rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes empty event–division mappings by resolving divisions from `scaling_levels` and auto-creating `competition_divisions` rows across all flows. Also makes division creation atomic to prevent missing rows.

- **Bug Fixes**
  - Replaced INNER JOIN with LEFT JOIN from `scaling_levels` via `settings.divisions.scalingGroupId` so divisions always appear.
  - Auto-create `competition_divisions` rows (with default fee) when cloning/creating divisions and when switching scaling groups; `addCompetitionDivisionFn` now runs in a transaction to insert the level and row together.
  - Save handler validates division IDs against `scaling_levels` for the active scaling group.

<sup>Written for commit 8768e65c6073df7cc73b2a7fe84577c8872eeed3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved competition division initialization to ensure proper database consistency when creating or switching scaling groups.
  * Enhanced division management to guarantee all divisions are correctly linked to competitions with appropriate fee configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->