### PR TITLE
Add multi-round workout support and update team partner labels

### DIFF
--- a/apps/wodsmith-start/scripts/seed/seeders/09-workouts.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/09-workouts.ts
@@ -106,6 +106,8 @@ export async function seed(client: Connection): Promise<void> {
 		wod("wod_online_couplet_parent", "Online Qualifier Event 4 - Couplet Challenge", "Two-part test: a sprint workout followed by a max lift. Sub-events scored independently.", "time", "private", BOX1_TEAM, 1, null, null, null),
 		wod("wod_online_couplet_sprint", "Sprint WOD", "For time:\n\n3 rounds:\n• 10 Power Cleans (135/95 lb)\n• 20 Box Jumps (24/20 in)\n\nTime cap: 8 minutes", "time-with-cap", "private", BOX1_TEAM, 1, null, 480, "min"),
 		wod("wod_online_couplet_max_clean", "Max Clean", "For max load:\n\n1 Rep Max Clean\n• 3 attempts, 90 seconds between attempts\n\nScore is heaviest successful lift.", "load", "private", BOX1_TEAM, 1, null, null, "max"),
+		// Online Qualifier Event 5 — multi-round scoring (rounds_to_score = 3)
+		wod("wod_online_triple_amrap", "Online Qualifier Event 5 - Triple AMRAP", "3 rounds, each scored individually:\n\nRound 1: 3 min AMRAP of 10 Thrusters (95/65 lb) + 10 Toes-to-Bar\nRound 2: 3 min AMRAP of 10 Power Cleans (135/95 lb) + 10 Bar-Facing Burpees\nRound 3: 3 min AMRAP of 10 Shoulder-to-Overhead (135/95 lb) + 10 Chest-to-Bar Pull-ups\n\n1 min rest between rounds. Score each round separately.", "rounds-reps", "private", BOX1_TEAM, 3, null, 660, "max"),
 	])
 
 	// Workout tags

--- a/apps/wodsmith-start/scripts/seed/seeders/10-programming.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/10-programming.ts
@@ -139,4 +139,9 @@ export async function seed(client: Connection): Promise<void> {
 		{ id: "tw_online_event4_sprint", track_id: "track_online_qualifier_2026", workout_id: "wod_online_couplet_sprint", track_order: 4.01, parent_event_id: "tw_online_event4_parent", notes: null, points_multiplier: 100, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "tw_online_event4_clean", track_id: "track_online_qualifier_2026", workout_id: "wod_online_couplet_max_clean", track_order: 4.02, parent_event_id: "tw_online_event4_parent", notes: null, points_multiplier: 100, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
 	])
+
+	// Online Qualifier Event 5 — multi-round scoring (3 rounds scored individually)
+	await batchInsert(client, "track_workouts", [
+		{ id: "tw_online_event5", track_id: "track_online_qualifier_2026", workout_id: "wod_online_triple_amrap", track_order: 5, notes: "Event 5: Triple AMRAP — 3 rounds scored individually, testing per-round score inputs.", points_multiplier: 100, heat_status: "draft", event_status: "published", created_at: ts, updated_at: ts, update_counter: 0 },
+	])
 }

--- a/apps/wodsmith-start/scripts/seed/seeders/11-competition.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/11-competition.ts
@@ -177,5 +177,7 @@ export async function seed(client: Connection): Promise<void> {
 		{ id: "cevt_online_event4_parent", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event4_parent", submission_opens_at: pastDatetime(1), submission_closes_at: futureDatetime(6), created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "cevt_online_event4_sprint", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event4_sprint", submission_opens_at: pastDatetime(1), submission_closes_at: futureDatetime(6), created_at: ts, updated_at: ts, update_counter: 0 },
 		{ id: "cevt_online_event4_clean", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event4_clean", submission_opens_at: pastDatetime(1), submission_closes_at: futureDatetime(6), created_at: ts, updated_at: ts, update_counter: 0 },
+		// Event 5: Triple AMRAP — multi-round scoring, window currently open
+		{ id: "cevt_online_event5", competition_id: "comp_online_qualifier_2026", track_workout_id: "tw_online_event5", submission_opens_at: pastDatetime(1), submission_closes_at: futureDatetime(6), created_at: ts, updated_at: ts, update_counter: 0 },
 	])
 }

--- a/apps/wodsmith-start/scripts/seed/seeders/14-video-submissions.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/14-video-submissions.ts
@@ -12,6 +12,18 @@ function timeSortKey(ms: number): string {
 	return key.toString().padStart(38, "0")
 }
 
+const SEGMENT_MAX = 2n ** 40n - 1n
+
+/**
+ * Compute sort key for a desc-direction score (higher is better).
+ * For "scored" status (statusOrder=0):
+ *   sortKey = (SEGMENT_MAX - BigInt(value)) << 80n
+ */
+function descSortKey(value: number): string {
+	const key = (SEGMENT_MAX - BigInt(value)) << 80n
+	return key.toString().padStart(38, "0")
+}
+
 const VIDEO_URL = "https://youtube.com/watch?v=mp_HF-63eFs&themeRefresh=1"
 const TEAM_ID = "team_cokkpu1klwo0ulfhl1iwzpvnbox1"
 const ADMIN_USER_ID = "usr_demo1admin"
@@ -309,6 +321,213 @@ export async function seed(client: Connection): Promise<void> {
 			user_id: "usr_athlete_sarah",
 			video_url: VIDEO_URL,
 			notes: null,
+			submitted_at: pastDatetime(0),
+			review_status: "pending",
+			status_updated_at: null,
+			reviewer_notes: null,
+			reviewed_at: null,
+			reviewed_by: null,
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+	])
+
+	// ─── Scores for Event 5 (Triple AMRAP, rounds-reps, rounds_to_score=3) ──
+	// Tests per-round score inputs. rounds-reps encoding: rounds * 100_000 + reps
+	// Mike: R1=2+15 (200015), R2=2+10 (200010), R3=2+12 (200012) → total 6+37 (600037)
+	// John: R1=1+18 (100018), R2=1+15 (100015), R3=1+12 (100012) → total 3+45 (300045)
+	// Sarah: R1=2+12 (200012), R2=2+8 (200008), R3=1+18 (100018) → total 5+38 (500038)
+	// Team Send It (Mike captain): R1=2+10 (200010), R2=1+15 (100015), R3=2+8 (200008) → total 5+33 (500033)
+
+	await batchInsert(client, "scores", [
+		{
+			id: "score_mike_online_event5",
+			user_id: "usr_athlete_mike",
+			team_id: TEAM_ID,
+			workout_id: "wod_online_triple_amrap",
+			competition_event_id: "tw_online_event5",
+			scheme: "rounds-reps",
+			score_type: "max",
+			score_value: 600037,
+			status: "scored",
+			status_order: 0,
+			sort_key: descSortKey(600037),
+			scaling_level_id: "slvl_online_rx",
+			as_rx: 1,
+			notes: "Consistent pacing across all 3 rounds",
+			recorded_at: pastDatetime(0),
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		{
+			id: "score_john_online_event5",
+			user_id: "usr_demo3member",
+			team_id: TEAM_ID,
+			workout_id: "wod_online_triple_amrap",
+			competition_event_id: "tw_online_event5",
+			scheme: "rounds-reps",
+			score_type: "max",
+			score_value: 300045,
+			status: "scored",
+			status_order: 0,
+			sort_key: descSortKey(300045),
+			scaling_level_id: "slvl_online_rx",
+			as_rx: 1,
+			notes: null,
+			recorded_at: pastDatetime(0),
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		{
+			id: "score_sarah_online_event5",
+			user_id: "usr_athlete_sarah",
+			team_id: TEAM_ID,
+			workout_id: "wod_online_triple_amrap",
+			competition_event_id: "tw_online_event5",
+			scheme: "rounds-reps",
+			score_type: "max",
+			score_value: 500038,
+			status: "scored",
+			status_order: 0,
+			sort_key: descSortKey(500038),
+			scaling_level_id: "slvl_online_rx",
+			as_rx: 1,
+			notes: "Round 2 power cleans were rough",
+			recorded_at: pastDatetime(0),
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		{
+			id: "score_mike_online_event5_team",
+			user_id: "usr_athlete_mike",
+			team_id: TEAM_ID,
+			workout_id: "wod_online_triple_amrap",
+			competition_event_id: "tw_online_event5",
+			scheme: "rounds-reps",
+			score_type: "max",
+			score_value: 500033,
+			status: "scored",
+			status_order: 0,
+			sort_key: descSortKey(500033),
+			scaling_level_id: "slvl_online_team_rx",
+			as_rx: 1,
+			notes: "Team effort — alternated rounds",
+			recorded_at: pastDatetime(0),
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+	])
+
+	// ─── Score rounds for Event 5 (per-round breakdown) ──────────────────
+	await batchInsert(client, "score_rounds", [
+		// Mike individual: R1=2+15, R2=2+10, R3=2+12
+		{ id: "sr_mike_e5_r1", score_id: "score_mike_online_event5", round_number: 1, value: 200015, status: "scored", created_at: ts },
+		{ id: "sr_mike_e5_r2", score_id: "score_mike_online_event5", round_number: 2, value: 200010, status: "scored", created_at: ts },
+		{ id: "sr_mike_e5_r3", score_id: "score_mike_online_event5", round_number: 3, value: 200012, status: "scored", created_at: ts },
+		// John: R1=1+18, R2=1+15, R3=1+12
+		{ id: "sr_john_e5_r1", score_id: "score_john_online_event5", round_number: 1, value: 100018, status: "scored", created_at: ts },
+		{ id: "sr_john_e5_r2", score_id: "score_john_online_event5", round_number: 2, value: 100015, status: "scored", created_at: ts },
+		{ id: "sr_john_e5_r3", score_id: "score_john_online_event5", round_number: 3, value: 100012, status: "scored", created_at: ts },
+		// Sarah: R1=2+12, R2=2+8, R3=1+18
+		{ id: "sr_sarah_e5_r1", score_id: "score_sarah_online_event5", round_number: 1, value: 200012, status: "scored", created_at: ts },
+		{ id: "sr_sarah_e5_r2", score_id: "score_sarah_online_event5", round_number: 2, value: 200008, status: "scored", created_at: ts },
+		{ id: "sr_sarah_e5_r3", score_id: "score_sarah_online_event5", round_number: 3, value: 100018, status: "scored", created_at: ts },
+		// Team Send It (Mike captain): R1=2+10, R2=1+15, R3=2+8
+		{ id: "sr_mike_team_e5_r1", score_id: "score_mike_online_event5_team", round_number: 1, value: 200010, status: "scored", created_at: ts },
+		{ id: "sr_mike_team_e5_r2", score_id: "score_mike_online_event5_team", round_number: 2, value: 100015, status: "scored", created_at: ts },
+		{ id: "sr_mike_team_e5_r3", score_id: "score_mike_online_event5_team", round_number: 3, value: 200008, status: "scored", created_at: ts },
+	])
+
+	// ─── Video submissions for Event 5 ───────────────────────────────────
+	// Individual athletes: 1 video each. Team: 2 videos (partner 1 + partner 2)
+	await batchInsert(client, "video_submissions", [
+		{
+			id: "vsub_mike_online_event5",
+			registration_id: "creg_mike_online",
+			track_workout_id: "tw_online_event5",
+			video_index: 0,
+			user_id: "usr_athlete_mike",
+			video_url: VIDEO_URL,
+			notes: "All 3 rounds filmed continuously",
+			submitted_at: pastDatetime(0),
+			review_status: "pending",
+			status_updated_at: null,
+			reviewer_notes: null,
+			reviewed_at: null,
+			reviewed_by: null,
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		{
+			id: "vsub_john_online_event5",
+			registration_id: "creg_john_online",
+			track_workout_id: "tw_online_event5",
+			video_index: 0,
+			user_id: "usr_demo3member",
+			video_url: VIDEO_URL,
+			notes: null,
+			submitted_at: pastDatetime(0),
+			review_status: "pending",
+			status_updated_at: null,
+			reviewer_notes: null,
+			reviewed_at: null,
+			reviewed_by: null,
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		{
+			id: "vsub_sarah_online_event5",
+			registration_id: "creg_sarah_online",
+			track_workout_id: "tw_online_event5",
+			video_index: 0,
+			user_id: "usr_athlete_sarah",
+			video_url: VIDEO_URL,
+			notes: "Timer visible, full body in frame for all rounds",
+			submitted_at: pastDatetime(0),
+			review_status: "pending",
+			status_updated_at: null,
+			reviewer_notes: null,
+			reviewed_at: null,
+			reviewed_by: null,
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		// Team Send It — Partner 1 video (Mike, captain)
+		{
+			id: "vsub_mike_team_online_event5_p1",
+			registration_id: "creg_mike_online_team",
+			track_workout_id: "tw_online_event5",
+			video_index: 0,
+			user_id: "usr_athlete_mike",
+			video_url: VIDEO_URL,
+			notes: "Partner 1 (Mike) camera angle — all 3 rounds",
+			submitted_at: pastDatetime(0),
+			review_status: "pending",
+			status_updated_at: null,
+			reviewer_notes: null,
+			reviewed_at: null,
+			reviewed_by: null,
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		// Team Send It — Partner 2 video (Ryan)
+		{
+			id: "vsub_mike_team_online_event5_p2",
+			registration_id: "creg_mike_online_team",
+			track_workout_id: "tw_online_event5",
+			video_index: 1,
+			user_id: "usr_athlete_mike",
+			video_url: VIDEO_URL,
+			notes: "Partner 2 (Ryan) camera angle — all 3 rounds",
 			submitted_at: pastDatetime(0),
 			review_status: "pending",
 			status_updated_at: null,

--- a/apps/wodsmith-start/src/components/compete/video-submission-form.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-submission-form.tsx
@@ -76,6 +76,7 @@ interface VideoSubmissionInitialData {
     timeCap: number | null
     tiebreakScheme: string | null
     repsPerRound: number | null
+    roundsToScore: number | null
   } | null
   existingScore?: {
     scoreValue: number | null
@@ -83,6 +84,11 @@ interface VideoSubmissionInitialData {
     status: string | null
     secondaryValue: number | null
     tiebreakValue: number | null
+    roundScores?: Array<{
+      roundNumber: number
+      value: number
+      displayScore: string | null
+    }>
   } | null
 }
 
@@ -213,9 +219,9 @@ interface VideoSlotState {
   existingSubmission: VideoSubmissionData | null
 }
 
-/** Returns a human-readable label for a video slot based on index */
+/** Returns a human-readable label for a video slot based on partner index */
 function videoSlotLabel(index: number): string {
-  return index === 0 ? "Captain" : `Teammate ${index + 1}`
+  return `Partner ${index + 1}`
 }
 
 function createInitialSlots(
@@ -295,11 +301,23 @@ export function VideoSubmissionForm({
     }
     return tiebreakValue.toString()
   })
+  // Per-round score inputs for multi-round workouts
+  const [roundScoreInputs, setRoundScoreInputs] = useState<string[]>(() => {
+    const roundsToScore = currentData?.workout?.roundsToScore ?? 1
+    if (roundsToScore <= 1) return []
+    const existingRounds = currentData?.existingScore?.roundScores ?? []
+    return Array.from({ length: roundsToScore }, (_, i) => {
+      const existing = existingRounds.find((r) => r.roundNumber === i + 1)
+      return existing?.displayScore ?? ""
+    })
+  })
   const successTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const submitVideo = useServerFn(submitVideoFn)
   const fetchSubmission = useServerFn(getVideoSubmissionFn)
 
   const workout = currentData?.workout
+  const roundsToScore = workout?.roundsToScore ?? 1
+  const isMultiRound = roundsToScore > 1
 
   // Handle division switch — fetch submission data for the new division
   const handleDivisionChange = useCallback(
@@ -343,6 +361,21 @@ export function VideoSubmissionForm({
         } else {
           setTiebreakScore("")
         }
+        // Reset round score inputs for the new division's workout
+        const newRoundsToScore = result.workout?.roundsToScore ?? 1
+        if (newRoundsToScore > 1) {
+          const existingRounds = result.existingScore?.roundScores ?? []
+          setRoundScoreInputs(
+            Array.from({ length: newRoundsToScore }, (_, i) => {
+              const existing = existingRounds.find(
+                (r) => r.roundNumber === i + 1,
+              )
+              return existing?.displayScore ?? ""
+            }),
+          )
+        } else {
+          setRoundScoreInputs([])
+        }
         setHasSubmitted(subs.length > 0)
         setIsEditing(subs.length === 0)
       } catch {
@@ -367,8 +400,17 @@ export function VideoSubmissionForm({
   }, [success])
 
   // Derived state — parseResult is a pure function of scoreInput + scheme
+  // For multi-round, parse each round independently
+  const roundParseResults: (ParseResult | null)[] = isMultiRound && workout
+    ? roundScoreInputs.map((input) =>
+        input.trim() ? parseScore(input, workout.scheme) : null,
+      )
+    : []
+
   const parseResult: ParseResult | null =
-    workout && scoreInput.trim() ? parseScore(scoreInput, workout.scheme) : null
+    !isMultiRound && workout && scoreInput.trim()
+      ? parseScore(scoreInput, workout.scheme)
+      : null
 
   // Derive status from whether time meets or exceeds time cap
   const scoreStatus: "scored" | "cap" = (() => {
@@ -615,6 +657,20 @@ export function VideoSubmissionForm({
     setError(null)
     setSuccess(null)
 
+    // For teams, require ALL video links; for individuals, require at least one
+    if (teamSize > 1) {
+      const missingSlots = videoSlots
+        .map((slot, index) => ({ slot, index }))
+        .filter(({ slot }) => !slot.url.trim())
+      if (missingSlots.length > 0) {
+        const labels = missingSlots
+          .map(({ index }) => videoSlotLabel(index))
+          .join(", ")
+        setError(`Missing video links for: ${labels}`)
+        return
+      }
+    }
+
     // Find slots that have a video URL to submit
     const slotsToSubmit = videoSlots
       .map((slot, index) => ({ slot, index }))
@@ -636,8 +692,28 @@ export function VideoSubmissionForm({
       }
     }
 
-    // Validate score — reuse derived parseResult
-    if (scoreInput.trim() && workout) {
+    // Validate score — multi-round or single
+    if (isMultiRound && workout) {
+      const filledRounds = roundScoreInputs.filter((s) => s.trim())
+      if (filledRounds.length > 0 && filledRounds.length < roundsToScore) {
+        setError(
+          `Please enter scores for all ${roundsToScore} rounds, or leave them all empty`,
+        )
+        return
+      }
+      for (let i = 0; i < roundScoreInputs.length; i++) {
+        const input = roundScoreInputs[i]
+        if (input.trim()) {
+          const result = parseScore(input, workout.scheme)
+          if (!result.isValid) {
+            setError(
+              `Round ${i + 1}: ${result.error || "Please check your score entry"}`,
+            )
+            return
+          }
+        }
+      }
+    } else if (scoreInput.trim() && workout) {
       if (!parseResult?.isValid) {
         setError(
           `Invalid score: ${parseResult?.error || "Please check your score entry"}`,
@@ -657,6 +733,13 @@ export function VideoSubmissionForm({
         videoIndex: number
       }> = []
 
+      // Build round scores array for multi-round workouts
+      const roundScoresPayload = isMultiRound
+        ? roundScoreInputs
+            .filter((s) => s.trim())
+            .map((s) => ({ score: s.trim() }))
+        : undefined
+
       for (const { slot, index } of slotsToSubmit) {
         const isFirstSlot = index === slotsToSubmit[0].index
         const result = await submitVideo({
@@ -668,16 +751,24 @@ export function VideoSubmissionForm({
             notes: slot.notes.trim() || undefined,
             videoIndex: index,
             // Only send score with the first video slot
-            score: isFirstSlot ? scoreInput.trim() || undefined : undefined,
+            score: isFirstSlot && !isMultiRound
+              ? scoreInput.trim() || undefined
+              : undefined,
             scoreStatus:
-              isFirstSlot && scoreInput.trim() ? scoreStatus : undefined,
+              isFirstSlot && !isMultiRound && scoreInput.trim()
+                ? scoreStatus
+                : undefined,
             secondaryScore:
-              isFirstSlot && scoreStatus === "cap"
+              isFirstSlot && !isMultiRound && scoreStatus === "cap"
                 ? secondaryScore.trim() || undefined
                 : undefined,
             tiebreakScore: isFirstSlot
               ? tiebreakScore.trim() || undefined
               : undefined,
+            roundScores:
+              isFirstSlot && roundScoresPayload?.length
+                ? roundScoresPayload
+                : undefined,
           },
         })
         results.push({ ...result, videoIndex: index })
@@ -731,7 +822,26 @@ export function VideoSubmissionForm({
         }
         setSubmissionsData(newSubmissions)
 
-        if (scoreInput.trim() && workout && parseResult) {
+        if (isMultiRound && roundScoresPayload?.length && workout) {
+          // For multi-round, we don't compute the aggregate client-side —
+          // just store the round display values for preview
+          setScoreData({
+            scoreValue: null,
+            displayScore: roundScoreInputs.filter((s) => s.trim()).join(" + "),
+            status: "scored",
+            secondaryValue: null,
+            tiebreakValue: tiebreakScore
+              ? parseTiebreakValue(tiebreakScore, workout.tiebreakScheme)
+              : null,
+            roundScores: roundScoreInputs
+              .filter((s) => s.trim())
+              .map((s, i) => ({
+                roundNumber: i + 1,
+                value: 0,
+                displayScore: s.trim(),
+              })),
+          })
+        } else if (scoreInput.trim() && workout && parseResult) {
           setScoreData({
             scoreValue: parseResult.encoded,
             displayScore: parseResult.formatted ?? scoreInput,
@@ -798,7 +908,7 @@ export function VideoSubmissionForm({
               {hasSubmitted
                 ? "Update your submission below"
                 : teamSize > 1
-                  ? `Submit your team's score and up to ${teamSize} videos`
+                  ? `Submit your team's score and ${teamSize} partner videos`
                   : "Submit your score and video for this event"}
             </CardDescription>
           </div>
@@ -822,49 +932,104 @@ export function VideoSubmissionForm({
           {/* Score Section */}
           {workout && (
             <>
-              <div className="space-y-2">
-                <Label htmlFor="score-input">
-                  {teamSize > 1 ? "Team " : "Your "}
-                  {getSchemeLabel(workout.scheme)}
-                </Label>
-                <Input
-                  id="score-input"
-                  value={scoreInput}
-                  onChange={(e) => setScoreInput(e.target.value)}
-                  placeholder={getPlaceholder(workout.scheme)}
-                  className={cn(
-                    "font-mono",
-                    parseResult?.error &&
-                      !parseResult?.isValid &&
-                      "border-destructive",
+              {isMultiRound ? (
+                /* Per-round score inputs for multi-round workouts */
+                <div className="space-y-3">
+                  <Label>
+                    {getSchemeLabel(workout.scheme)} per Round
+                  </Label>
+                  {roundScoreInputs.map((input, i) => {
+                    const roundResult = roundParseResults[i]
+                    return (
+                      <div key={i} className="space-y-1">
+                        <Label
+                          htmlFor={`round-score-${i}`}
+                          className="text-sm font-normal text-muted-foreground"
+                        >
+                          Round {i + 1}
+                        </Label>
+                        <Input
+                          id={`round-score-${i}`}
+                          value={input}
+                          onChange={(e) => {
+                            const updated = [...roundScoreInputs]
+                            updated[i] = e.target.value
+                            setRoundScoreInputs(updated)
+                          }}
+                          placeholder={getPlaceholder(workout.scheme)}
+                          className={cn(
+                            "font-mono",
+                            roundResult?.error &&
+                              !roundResult?.isValid &&
+                              "border-destructive",
+                          )}
+                          disabled={isSubmitting}
+                        />
+                        {roundResult?.isValid && (
+                          <p className="text-xs text-green-600 dark:text-green-400">
+                            Parsed as: {roundResult.formatted}
+                          </p>
+                        )}
+                        {roundResult?.error && (
+                          <p className="text-xs text-destructive">
+                            {roundResult.error}
+                          </p>
+                        )}
+                      </div>
+                    )
+                  })}
+                  {getHelpText(workout.scheme, workout.timeCap) && (
+                    <p className="text-xs text-muted-foreground">
+                      {getHelpText(workout.scheme, workout.timeCap)}
+                    </p>
                   )}
-                  disabled={isSubmitting}
-                />
-                {getHelpText(workout.scheme, workout.timeCap) && (
-                  <p className="text-xs text-muted-foreground">
-                    {getHelpText(workout.scheme, workout.timeCap)}
-                  </p>
-                )}
-                {parseResult?.isValid && (
-                  <p className="text-xs text-green-600 dark:text-green-400">
-                    Parsed as: {parseResult.formatted}
-                    {scoreStatus === "cap" && " (Time Cap)"}
-                  </p>
-                )}
-                {parseResult?.error && (
-                  <p className="text-xs text-destructive">
-                    {parseResult.error}
-                  </p>
-                )}
-              </div>
+                </div>
+              ) : (
+                /* Single score input */
+                <div className="space-y-2">
+                  <Label htmlFor="score-input">
+                    {teamSize > 1 ? "Team " : "Your "}
+                    {getSchemeLabel(workout.scheme)}
+                  </Label>
+                  <Input
+                    id="score-input"
+                    value={scoreInput}
+                    onChange={(e) => setScoreInput(e.target.value)}
+                    placeholder={getPlaceholder(workout.scheme)}
+                    className={cn(
+                      "font-mono",
+                      parseResult?.error &&
+                        !parseResult?.isValid &&
+                        "border-destructive",
+                    )}
+                    disabled={isSubmitting}
+                  />
+                  {getHelpText(workout.scheme, workout.timeCap) && (
+                    <p className="text-xs text-muted-foreground">
+                      {getHelpText(workout.scheme, workout.timeCap)}
+                    </p>
+                  )}
+                  {parseResult?.isValid && (
+                    <p className="text-xs text-green-600 dark:text-green-400">
+                      Parsed as: {parseResult.formatted}
+                      {scoreStatus === "cap" && " (Time Cap)"}
+                    </p>
+                  )}
+                  {parseResult?.error && (
+                    <p className="text-xs text-destructive">
+                      {parseResult.error}
+                    </p>
+                  )}
+                </div>
+              )}
 
               {/* Secondary Score (reps at cap) - shown when time equals time cap */}
-              {scoreStatus === "cap" && (
+              {!isMultiRound && scoreStatus === "cap" && (
                 <p className="text-xs text-amber-600 dark:text-amber-400">
                   You hit the time cap. Enter the reps you completed below.
                 </p>
               )}
-              {showSecondaryInput && (
+              {!isMultiRound && showSecondaryInput && (
                 <div className="space-y-2">
                   <Label htmlFor="secondary-input">Reps Completed at Cap</Label>
                   <Input
@@ -913,61 +1078,86 @@ export function VideoSubmissionForm({
             </>
           )}
 
-          {/* Video URL Inputs */}
-          {videoSlots.map((slot, index) => (
-            <div key={index} className="space-y-2">
-              <Label htmlFor={`videoUrl-${index}`}>
-                {teamSize > 1
-                  ? `${videoSlotLabel(index)}'s Video`
-                  : "Video URL"}
-              </Label>
-              <VideoUrlInput
-                id={`videoUrl-${index}`}
-                value={slot.url}
-                onChange={(url) => updateSlot(index, { url })}
-                onValidationChange={(validation) =>
-                  updateSlot(index, { validation })
-                }
-                required={false}
-                disabled={isSubmitting}
-                showPlatformBadge
-                showPreviewLink
-              />
-              {index === 0 && (
-                <p className="text-xs text-muted-foreground">
-                  Upload your video to {getSupportedPlatformsText()} (unlisted
-                  is fine) and paste the link
+          {/* Partner Submission Links — separate section for teams */}
+          {teamSize > 1 && (
+            <div className="space-y-3">
+              <div>
+                <Label className="text-base">Partner Submission Links</Label>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Each partner must provide a video link. Upload to{" "}
+                  {getSupportedPlatformsText()} (unlisted is fine) and paste the
+                  link.
                 </p>
-              )}
+              </div>
+              {videoSlots.map((slot, index) => (
+                <div key={index} className="space-y-2">
+                  <Label htmlFor={`videoUrl-${index}`}>
+                    {videoSlotLabel(index)}&apos;s Video
+                  </Label>
+                  <VideoUrlInput
+                    id={`videoUrl-${index}`}
+                    value={slot.url}
+                    onChange={(url) => updateSlot(index, { url })}
+                    onValidationChange={(validation) =>
+                      updateSlot(index, { validation })
+                    }
+                    required
+                    disabled={isSubmitting}
+                    showPlatformBadge
+                    showPreviewLink
+                  />
+                  <Textarea
+                    placeholder={`Notes for ${videoSlotLabel(index).toLowerCase()}'s video`}
+                    value={slot.notes}
+                    onChange={(e) =>
+                      updateSlot(index, { notes: e.target.value })
+                    }
+                    rows={1}
+                    disabled={isSubmitting}
+                    maxLength={1000}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
 
-              {/* Per-slot notes */}
-              {teamSize > 1 && (
+          {/* Individual video submission */}
+          {teamSize === 1 && (
+            <>
+              {videoSlots.map((slot, index) => (
+                <div key={index} className="space-y-2">
+                  <Label htmlFor={`videoUrl-${index}`}>Video URL</Label>
+                  <VideoUrlInput
+                    id={`videoUrl-${index}`}
+                    value={slot.url}
+                    onChange={(url) => updateSlot(index, { url })}
+                    onValidationChange={(validation) =>
+                      updateSlot(index, { validation })
+                    }
+                    required={false}
+                    disabled={isSubmitting}
+                    showPlatformBadge
+                    showPreviewLink
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Upload your video to {getSupportedPlatformsText()} (unlisted
+                    is fine) and paste the link
+                  </p>
+                </div>
+              ))}
+              <div className="space-y-2">
+                <Label htmlFor="notes">Notes (Optional)</Label>
                 <Textarea
-                  placeholder={`Notes for ${videoSlotLabel(index).toLowerCase()}'s video`}
-                  value={slot.notes}
-                  onChange={(e) => updateSlot(index, { notes: e.target.value })}
-                  rows={1}
+                  id="notes"
+                  placeholder="Any additional information about your submission..."
+                  value={videoSlots[0]?.notes ?? ""}
+                  onChange={(e) => updateSlot(0, { notes: e.target.value })}
+                  rows={2}
                   disabled={isSubmitting}
                   maxLength={1000}
                 />
-              )}
-            </div>
-          ))}
-
-          {/* Single notes field for individual submissions */}
-          {teamSize === 1 && (
-            <div className="space-y-2">
-              <Label htmlFor="notes">Notes (Optional)</Label>
-              <Textarea
-                id="notes"
-                placeholder="Any additional information about your submission..."
-                value={videoSlots[0]?.notes ?? ""}
-                onChange={(e) => updateSlot(0, { notes: e.target.value })}
-                rows={2}
-                disabled={isSubmitting}
-                maxLength={1000}
-              />
-            </div>
+              </div>
+            </>
           )}
 
           {/* Error Message */}

--- a/apps/wodsmith-start/src/components/compete/video-submission-preview.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-submission-preview.tsx
@@ -222,9 +222,7 @@ export function VideoSubmissionPreview({
             timezone={timezone}
             label={
               isTeam
-                ? submission.videoIndex === 0
-                  ? "Captain"
-                  : `Teammate ${submission.videoIndex + 1}`
+                ? `Partner ${submission.videoIndex + 1}`
                 : undefined
             }
           />

--- a/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
@@ -5,7 +5,7 @@
  */
 
 import { createServerFn } from "@tanstack/react-start"
-import { and, asc, count, eq, inArray, isNotNull, ne } from "drizzle-orm"
+import { and, asc, count, eq, inArray, isNotNull, ne, sql } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import {
@@ -19,7 +19,7 @@ import {
   trackWorkoutsTable,
 } from "@/db/schemas/programming"
 import { scalingLevelsTable } from "@/db/schemas/scaling"
-import { scoresTable } from "@/db/schemas/scores"
+import { scoreRoundsTable, scoresTable } from "@/db/schemas/scores"
 import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
 import { userTable } from "@/db/schemas/users"
 import type { ReviewStatus } from "@/db/schemas/video-submissions"
@@ -33,6 +33,7 @@ import { workouts } from "@/db/schemas/workouts"
 import {
   computeSortKey,
   decodeScore,
+  encodeRounds,
   encodeScore,
   getDefaultScoreType,
   parseScore,
@@ -75,6 +76,10 @@ const submitVideoInputSchema = z.object({
   scoreStatus: z.enum(["scored", "cap"]).optional(),
   secondaryScore: z.string().optional(),
   tiebreakScore: z.string().optional(),
+  // Per-round scores for multi-round workouts
+  roundScores: z
+    .array(z.object({ score: z.string() }))
+    .optional(),
 })
 
 // ============================================================================
@@ -300,6 +305,7 @@ async function getWorkoutDetails(trackWorkoutId: string) {
       timeCap: workouts.timeCap,
       tiebreakScheme: workouts.tiebreakScheme,
       repsPerRound: workouts.repsPerRound,
+      roundsToScore: workouts.roundsToScore,
       trackId: trackWorkoutsTable.trackId,
     })
     .from(trackWorkoutsTable)
@@ -405,6 +411,11 @@ export const getVideoSubmissionFn = createServerFn({ method: "GET" })
       status: string | null
       secondaryValue: number | null
       tiebreakValue: number | null
+      roundScores: Array<{
+        roundNumber: number
+        value: number
+        displayScore: string | null
+      }>
     } | null = null
 
     // Score belongs to the captain (or the individual athlete)
@@ -423,6 +434,7 @@ export const getVideoSubmissionFn = createServerFn({ method: "GET" })
 
     const [score] = await db
       .select({
+        id: scoresTable.id,
         scoreValue: scoresTable.scoreValue,
         status: scoresTable.status,
         secondaryValue: scoresTable.secondaryValue,
@@ -443,12 +455,41 @@ export const getVideoSubmissionFn = createServerFn({ method: "GET" })
         )
       }
 
+      // Load round scores if this is a multi-round workout
+      let roundScores: Array<{
+        roundNumber: number
+        value: number
+        displayScore: string | null
+      }> = []
+
+      if (workout && (workout.roundsToScore ?? 1) > 1) {
+        const rounds = await db
+          .select({
+            roundNumber: scoreRoundsTable.roundNumber,
+            value: scoreRoundsTable.value,
+          })
+          .from(scoreRoundsTable)
+          .where(eq(scoreRoundsTable.scoreId, score.id))
+          .orderBy(asc(scoreRoundsTable.roundNumber))
+
+        roundScores = rounds.map((r) => ({
+          roundNumber: r.roundNumber,
+          value: r.value,
+          displayScore: score.scheme
+            ? decodeScore(r.value, score.scheme as WorkoutScheme, {
+                compact: false,
+              })
+            : null,
+        }))
+      }
+
       existingScore = {
         scoreValue: score.scoreValue,
         displayScore,
         status: score.status,
         secondaryValue: score.secondaryValue,
         tiebreakValue: score.tiebreakValue,
+        roundScores,
       }
     }
 
@@ -478,6 +519,7 @@ export const getVideoSubmissionFn = createServerFn({ method: "GET" })
             timeCap: workout.timeCap,
             tiebreakScheme: workout.tiebreakScheme,
             repsPerRound: workout.repsPerRound,
+            roundsToScore: workout.roundsToScore,
           }
         : null,
       existingScore,
@@ -691,8 +733,12 @@ export const submitVideoFn = createServerFn({ method: "POST" })
       submissionId = id
     }
 
-    // Save claimed score if provided
-    if (data.score) {
+    // Save claimed score if provided (single score or round scores)
+    const hasRoundScores =
+      data.roundScores && data.roundScores.length > 0
+    const hasScore = data.score || hasRoundScores
+
+    if (hasScore) {
       // Get workout details for encoding
       const workout = await getWorkoutDetails(data.trackWorkoutId)
 
@@ -704,16 +750,34 @@ export const submitVideoFn = createServerFn({ method: "POST" })
       const scoreType =
         (workout.scoreType as ScoreType) || getDefaultScoreType(scheme)
 
-      // Parse and validate the score
-      const parseResult = parseScore(data.score, scheme)
-      if (!parseResult.isValid) {
-        throw new Error(
-          `Invalid score format: ${parseResult.error || "Please check your entry"}`,
-        )
-      }
+      // Encode the score — multi-round or single
+      let encodedValue: number | null = null
+      let encodedRounds: number[] = []
 
-      // Encode the score
-      let encodedValue: number | null = encodeScore(data.score, scheme)
+      if (hasRoundScores && data.roundScores) {
+        // Multi-round: validate and encode each round, then aggregate
+        for (const rs of data.roundScores) {
+          const roundResult = parseScore(rs.score, scheme)
+          if (!roundResult.isValid) {
+            throw new Error(
+              `Invalid round score: ${roundResult.error || "Please check your entry"}`,
+            )
+          }
+        }
+        const roundInputs = data.roundScores.map((rs) => ({ raw: rs.score }))
+        const roundsResult = encodeRounds(roundInputs, scheme, scoreType)
+        encodedValue = roundsResult.aggregated
+        encodedRounds = roundsResult.rounds
+      } else if (data.score) {
+        // Single score: parse and encode directly
+        const parseResult = parseScore(data.score, scheme)
+        if (!parseResult.isValid) {
+          throw new Error(
+            `Invalid score format: ${parseResult.error || "Please check your entry"}`,
+          )
+        }
+        encodedValue = encodeScore(data.score, scheme)
+      }
 
       // Derive status server-side (ignore client-provided scoreStatus)
       // For time-with-cap, any time >= cap is treated as capped
@@ -834,6 +898,41 @@ export const submitVideoFn = createServerFn({ method: "POST" })
             updatedAt: now,
           },
         })
+
+      // Save round scores if multi-round
+      if (encodedRounds.length > 0) {
+        // Look up the score ID for the upserted score
+        const [upsertedScore] = await db
+          .select({ id: scoresTable.id })
+          .from(scoresTable)
+          .where(
+            and(
+              eq(scoresTable.competitionEventId, data.trackWorkoutId),
+              eq(scoresTable.userId, session.userId),
+              registration.divisionId
+                ? eq(scoresTable.scalingLevelId, registration.divisionId)
+                : sql`1=1`,
+            ),
+          )
+          .limit(1)
+
+        if (upsertedScore) {
+          // Delete existing rounds
+          await db
+            .delete(scoreRoundsTable)
+            .where(eq(scoreRoundsTable.scoreId, upsertedScore.id))
+
+          // Insert new rounds
+          const roundsToInsert = encodedRounds.map((value, index) => ({
+            scoreId: upsertedScore.id,
+            roundNumber: index + 1,
+            value,
+            status: null,
+          }))
+
+          await db.insert(scoreRoundsTable).values(roundsToInsert)
+        }
+      }
     }
 
     return {

--- a/apps/wodsmith-start/test/components/video-submission-form.test.tsx
+++ b/apps/wodsmith-start/test/components/video-submission-form.test.tsx
@@ -168,6 +168,7 @@ function createInitialData(overrides?: Partial<{
 		timeCap: number | null
 		tiebreakScheme: string | null
 		repsPerRound: number | null
+		roundsToScore: number | null
 	} | null
 	existingScore: null
 }>) {
@@ -351,8 +352,8 @@ describe("VideoSubmissionForm", () => {
 			)
 
 			expect(screen.getByText(/Submitted videos \(2 of 3\)/)).toBeTruthy()
-			expect(screen.getByText(/Captain:/)).toBeTruthy()
-			expect(screen.getByText(/Teammate 2:/)).toBeTruthy()
+			expect(screen.getByText(/Partner 1:/)).toBeTruthy()
+			expect(screen.getByText(/Partner 2:/)).toBeTruthy()
 		})
 	})
 
@@ -370,9 +371,9 @@ describe("VideoSubmissionForm", () => {
 			)
 
 			expect(screen.getByText("Submit Team Result")).toBeTruthy()
-			expect(screen.getByText("Captain's Video")).toBeTruthy()
-			expect(screen.getByText("Teammate 2's Video")).toBeTruthy()
-			expect(screen.getByText("Teammate 3's Video")).toBeTruthy()
+			expect(screen.getByText("Partner 1's Video")).toBeTruthy()
+			expect(screen.getByText("Partner 2's Video")).toBeTruthy()
+			expect(screen.getByText("Partner 3's Video")).toBeTruthy()
 		})
 
 		it("shows individual video URL label for teamSize 1", () => {
@@ -407,6 +408,7 @@ describe("VideoSubmissionForm", () => {
 							timeCap: null,
 							tiebreakScheme: null,
 							repsPerRound: null,
+							roundsToScore: 1,
 						},
 					})}
 				/>,

--- a/apps/wodsmith-start/test/components/video-submission-preview.test.tsx
+++ b/apps/wodsmith-start/test/components/video-submission-preview.test.tsx
@@ -512,7 +512,7 @@ describe("VideoSubmissionPreview", () => {
 	})
 
 	describe("team display", () => {
-		it("shows Captain and Teammate labels for team submissions", () => {
+		it("shows Partner labels for team submissions", () => {
 			render(
 				<VideoSubmissionPreview
 					submissions={[
@@ -528,8 +528,8 @@ describe("VideoSubmissionPreview", () => {
 				/>,
 			)
 
-			expect(screen.getByText("Captain")).toBeTruthy()
-			expect(screen.getByText("Teammate 2")).toBeTruthy()
+			expect(screen.getByText("Partner 1")).toBeTruthy()
+			expect(screen.getByText("Partner 2")).toBeTruthy()
 		})
 
 		it("shows team submission count in description", () => {
@@ -600,7 +600,7 @@ describe("VideoSubmissionPreview", () => {
 				/>,
 			)
 
-			expect(screen.queryByText("Captain")).toBeNull()
+			expect(screen.queryByText("Partner 1")).toBeNull()
 		})
 	})
 })


### PR DESCRIPTION
## Summary
This PR adds support for multi-round workouts where athletes submit individual scores for each round, and updates team submission terminology from "Captain/Teammate" to "Partner" labels for consistency.

## Key Changes

### Multi-Round Workout Support
- Added `roundsToScore` field to workout data structure to indicate number of rounds
- Implemented per-round score input UI that displays separate input fields for each round when `roundsToScore > 1`
- Added `roundScores` array to score data to store individual round results with display values
- Created `encodeRounds()` function to parse and aggregate multi-round scores server-side
- Updated score validation to handle both single-score and multi-round submission flows
- Modified submission payload to include `roundScores` array for multi-round workouts
- Added `scoreRoundsTable` queries to load and persist individual round scores in the database

### Team Partner Labeling
- Changed `videoSlotLabel()` function to use "Partner 1", "Partner 2", etc. instead of "Captain" and "Teammate" terminology
- Updated all UI text references from "Captain's Video" / "Teammate's Video" to "Partner's Video"
- Reorganized team video submission section with clearer "Partner Submission Links" heading
- Updated test expectations to reflect new partner labels

### Form Validation & UX
- Added validation requiring all team partners to provide video links (previously optional)
- Added validation for multi-round submissions: either all rounds must have scores or all must be empty
- Improved error messaging for multi-round score validation with round-specific error reporting
- Updated submission description text from "up to N videos" to "N partner videos" for teams

### Data Structure Updates
- Extended `VideoSubmissionInitialData` interface with `roundsToScore` in workout data
- Extended `existingScore` object with `roundScores` array containing round number, value, and display score
- Updated server function schemas to accept and process `roundScores` array in submissions

## Implementation Details
- Multi-round and single-score flows are mutually exclusive based on `isMultiRound` derived state
- Round scores are only sent with the first video slot submission (consistent with existing score handling)
- Server-side aggregation of round scores is deferred to backend computation rather than client-side
- Existing single-round submissions remain unchanged; multi-round support is additive

https://claude.ai/code/session_01P1kyaKeMvM6eJ4xSEBQHEK

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi‑round scoring with per‑round inputs and server aggregation, and updates team flows to use “Partner N” labels with required links from every partner. Single‑round workflows remain unchanged, and Event 5 is seeded to test the new flow.

- **New Features**
  - Multi‑round scoring: per‑round inputs when `workout.roundsToScore > 1`, round validation, server aggregation via `encodeRounds`, and per‑round storage in `scoreRoundsTable`. Existing `roundScores` are loaded and shown.
  - API/Schema: submissions accept `roundScores[]`; responses include `workout.roundsToScore` and `existingScore.roundScores`.
  - UX: time‑cap secondary reps only for single‑score events; per‑round preview for multi‑round; team form uses “Partner N” labels, a “Partner Submission Links” section, and requires a video from each partner.
  - Seed data: added Online Qualifier Event 5 (Triple AMRAP, `rounds_to_score=3`) with per‑round `score_rounds` and partner `video_submissions` to exercise the new flows.

<sup>Written for commit c4735aca4894267d84b49c2bce7183cb96b1bda3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-round scoring: per-round inputs, validation, submission, and preview of round breakdowns for eligible workouts.
  * UI: partner-focused wording and a dedicated "Partner Submission Links" section; submit card text updated to reflect partner video count.

* **Bug Fixes**
  * Stronger team validation: requires all partner video URLs before submission.

* **Tests**
  * Updated tests to reflect partner labeling and multi-round scoring.

* **Chores**
  * Added new seeded workout/event and sample multi-round submissions for Event 5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->