### PR TITLE
fix: deduplicate broadcast recipients by userId to prevent duplicate key error

### DIFF
--- a/apps/wodsmith-start/src/server-fns/broadcast-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/broadcast-fns.ts
@@ -8,7 +8,7 @@
 
 import { createServerFn } from "@tanstack/react-start"
 import { render } from "@react-email/render"
-import { and, count, desc, eq, inArray, ne } from "drizzle-orm"
+import { and, count, countDistinct, desc, eq, inArray, ne } from "drizzle-orm"
 import { env } from "cloudflare:workers"
 import { z } from "zod"
 import { getDb } from "@/db"
@@ -552,14 +552,20 @@ export const sendBroadcastFn = createServerFn({ method: "POST" })
 				)
 				.where(and(...conditions))
 
-			recipients.push(
-				...athleteRows.map((r) => ({
-					registrationId: r.id as string | null,
-					userId: r.userId,
-					email: r.email,
-					firstName: r.firstName,
-				})),
-			)
+			// Deduplicate athletes by userId — a user may have multiple registrations
+			// (e.g. across divisions) but should only receive one broadcast recipient row
+			const seenAthleteUserIds = new Set<string>()
+			for (const r of athleteRows) {
+				if (!seenAthleteUserIds.has(r.userId)) {
+					seenAthleteUserIds.add(r.userId)
+					recipients.push({
+						registrationId: r.id as string | null,
+						userId: r.userId,
+						email: r.email,
+						firstName: r.firstName,
+					})
+				}
+			}
 		}
 
 		if (includeVolunteers) {
@@ -1096,14 +1102,19 @@ export const previewAudienceFn = createServerFn({ method: "GET" })
 					)
 					.where(and(...conditions))
 
-				recipients.push(
-					...athleteRows.map((r) => ({
-						registrationId: r.id as string | null,
-						userId: r.userId,
-						email: r.email,
-						firstName: r.firstName,
-					})),
-				)
+				// Deduplicate athletes by userId — a user may have multiple registrations
+				const seenAthleteUserIds = new Set<string>()
+				for (const r of athleteRows) {
+					if (!seenAthleteUserIds.has(r.userId)) {
+						seenAthleteUserIds.add(r.userId)
+						recipients.push({
+							registrationId: r.id as string | null,
+							userId: r.userId,
+							email: r.email,
+							firstName: r.firstName,
+						})
+					}
+				}
 			}
 
 			if (includeVolunteers) {
@@ -1207,10 +1218,10 @@ export const previewAudienceFn = createServerFn({ method: "GET" })
 				)
 			}
 			const [result] = await db
-				.select({ count: count() })
+				.select({ count: countDistinct(competitionRegistrationsTable.userId) })
 				.from(competitionRegistrationsTable)
 				.where(and(...conditions))
-			athleteCount = result?.count ?? 0
+			athleteCount = Number(result?.count ?? 0)
 		}
 
 		if (includeVolunteers) {


### PR DESCRIPTION
When a user has multiple registrations in the same competition (e.g. across
divisions), the athlete query returns duplicate userId entries. The bulk INSERT
into competition_broadcast_recipients then violates the unique index on
(broadcastId, userId), causing a MySQL 1062 duplicate entry error.

Fix deduplication in both sendBroadcastFn and previewAudienceFn by tracking
seen userIds before adding athletes to the recipients list. Also fix the
preview fast-path count to use countDistinct(userId) instead of count(*).

https://claude.ai/code/session_01WYqJKoJKtoHLMXMDrFkVLp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate broadcast recipients when an athlete has multiple registrations by deduplicating on userId and fixing preview counts. This removes MySQL 1062 errors and keeps audience size accurate.

- **Bug Fixes**
  - Deduplicate athletes by userId in `sendBroadcastFn` and `previewAudienceFn` before building recipients.
  - Use `countDistinct(userId)` for the preview fast path and coerce to number, aligning counts with actual recipients.

<sup>Written for commit 3595a6e5b63a759bd03612c4cb34b8b8069d0403. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed athlete audience preview count to accurately reflect unique users instead of total registrations when displaying audience size estimates
  * Resolved duplicate athlete recipient entries in broadcast communications, ensuring each user receives messages exactly once even with multiple active registrations
  * Improved recipient deduplication logic for more accurate broadcast delivery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->