### PR TITLE
feat: refresh expired competition team invites

### DIFF
--- a/apps/wodsmith-start/src/routes/compete/$slug/teams/$registrationId/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/teams/$registrationId/index.tsx
@@ -11,6 +11,7 @@ import {
   notFound,
   redirect,
   useNavigate,
+  useRouter,
 } from "@tanstack/react-router"
 import { eq } from "drizzle-orm"
 import {
@@ -21,6 +22,7 @@ import {
   Copy,
   Crown,
   Mail,
+  RefreshCw,
   Users,
 } from "lucide-react"
 import { useEffect, useState } from "react"
@@ -42,6 +44,7 @@ import type { Waiver, WaiverSignature } from "@/db/schemas/waivers"
 import {
   getRegistrationDetailsFn,
   getTeamRosterFn,
+  refreshCompetitionTeamInviteFn,
   type RegistrationDetails,
   type TeamRosterResult,
 } from "@/server-fns/registration-fns"
@@ -416,6 +419,7 @@ function TeamManagementPage() {
 
   const { welcome } = Route.useSearch()
   const navigate = useNavigate()
+  const router = useRouter()
   const [showWelcomeModal, setShowWelcomeModal] = useState(false)
 
   // Show welcome modal when ?welcome=true is in URL
@@ -452,6 +456,28 @@ function TeamManagementPage() {
       toast.success("Invite link copied to clipboard")
     } catch {
       toast.error("Failed to copy invite link")
+    }
+  }
+
+  const [refreshingInviteId, setRefreshingInviteId] = useState<string | null>(
+    null,
+  )
+
+  const handleRefreshInvite = async (inviteId: string) => {
+    setRefreshingInviteId(inviteId)
+    try {
+      await refreshCompetitionTeamInviteFn({
+        data: {
+          invitationId: inviteId,
+          registrationId: registration.id,
+        },
+      })
+      toast.success("Invite refreshed and email resent")
+      router.invalidate()
+    } catch {
+      toast.error("Failed to refresh invite")
+    } finally {
+      setRefreshingInviteId(null)
     }
   }
 
@@ -683,6 +709,8 @@ function TeamManagementPage() {
                 <div className="space-y-2">
                   {pending.map((invite) => {
                     const pendingAffiliate = getPendingAffiliate(invite.email)
+                    const isExpired =
+                      invite.expiresAt && new Date(invite.expiresAt) < new Date()
                     return (
                       <div
                         key={invite.id}
@@ -710,19 +738,48 @@ function TeamManagementPage() {
                           </div>
                         </div>
                         <div className="flex items-center gap-2">
-                          {isRegisteredUser && invite.token && (
+                          {isRegisteredUser && isExpired && (
                             <Button
-                              variant="ghost"
+                              variant="outline"
                               size="sm"
-                              onClick={() => copyInviteLink(invite.token!)}
+                              onClick={() => handleRefreshInvite(invite.id)}
+                              disabled={refreshingInviteId === invite.id}
                             >
-                              <Copy className="w-4 h-4 mr-1" />
-                              Copy Link
+                              <RefreshCw
+                                className={`w-4 h-4 mr-1 ${refreshingInviteId === invite.id ? "animate-spin" : ""}`}
+                              />
+                              {refreshingInviteId === invite.id
+                                ? "Refreshing..."
+                                : "Resend Invite"}
                             </Button>
                           )}
-                          <Badge variant="outline" className="text-yellow-600">
-                            Pending
-                          </Badge>
+                          {isRegisteredUser &&
+                            !isExpired &&
+                            invite.token && (
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => copyInviteLink(invite.token!)}
+                              >
+                                <Copy className="w-4 h-4 mr-1" />
+                                Copy Link
+                              </Button>
+                            )}
+                          {isExpired ? (
+                            <Badge
+                              variant="outline"
+                              className="text-destructive"
+                            >
+                              Expired
+                            </Badge>
+                          ) : (
+                            <Badge
+                              variant="outline"
+                              className="text-yellow-600"
+                            >
+                              Pending
+                            </Badge>
+                          )}
                         </div>
                       </div>
                     )

--- a/apps/wodsmith-start/src/server-fns/registration-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/registration-fns.ts
@@ -10,6 +10,7 @@
  * - Payment flow states (pending, completed, cancelled) are logged
  */
 
+import { createId } from "@paralleldrive/cuid2"
 import { createServerFn } from "@tanstack/react-start"
 import { and, eq, inArray, isNull, ne, or, sql } from "drizzle-orm"
 import type Stripe from "stripe"
@@ -877,6 +878,7 @@ interface PendingInviteData {
   email: string
   token: string | null
   invitedAt: Date | null
+  expiresAt: Date | null
 }
 
 export interface TeamRosterResult {
@@ -1152,6 +1154,7 @@ export const getTeamRosterFn = createServerFn({ method: "GET" })
       email: i.email,
       token: i.token,
       invitedAt: i.createdAt ? new Date(i.createdAt) : null,
+      expiresAt: i.expiresAt ? new Date(i.expiresAt) : null,
     }))
 
     return {
@@ -2053,4 +2056,110 @@ export const createManualRegistrationFn = createServerFn({ method: "POST" })
       divisionFeeCents,
       isNewAthlete,
     }
+  })
+
+// ============================================================================
+// Refresh Competition Team Invite
+// ============================================================================
+
+const refreshInviteSchema = z.object({
+  invitationId: z.string().min(1),
+  registrationId: z.string().min(1),
+})
+
+/**
+ * Regenerate a competition team invite token and resend the email.
+ * Only the team captain (registration owner) can refresh invites.
+ */
+export const refreshCompetitionTeamInviteFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) => refreshInviteSchema.parse(data))
+  .handler(async ({ data }) => {
+    const session = await requireVerifiedEmail()
+    const db = getDb()
+
+    // Verify the registration exists and the caller is the captain
+    const registration =
+      await db.query.competitionRegistrationsTable.findFirst({
+        where: eq(competitionRegistrationsTable.id, data.registrationId),
+        with: {
+          competition: {
+            columns: { id: true, name: true, slug: true },
+          },
+          division: {
+            columns: { id: true, label: true },
+          },
+        },
+      })
+
+    if (!registration) {
+      throw new Error("Registration not found")
+    }
+
+    if (registration.userId !== session.userId) {
+      throw new Error("Only the team captain can refresh invites")
+    }
+
+    // Get the invitation
+    const invitation = await db.query.teamInvitationTable.findFirst({
+      where: and(
+        eq(teamInvitationTable.id, data.invitationId),
+        eq(
+          teamInvitationTable.teamId,
+          registration.athleteTeamId ?? "",
+        ),
+      ),
+    })
+
+    if (!invitation) {
+      throw new Error("Invitation not found")
+    }
+
+    if (invitation.acceptedAt) {
+      throw new Error("Invitation has already been accepted")
+    }
+
+    // Generate new token and extend expiry to 30 days
+    const newToken = createId()
+    const newExpiresAt = new Date()
+    newExpiresAt.setDate(newExpiresAt.getDate() + 30)
+
+    await db
+      .update(teamInvitationTable)
+      .set({
+        token: newToken,
+        expiresAt: newExpiresAt,
+        updatedAt: new Date(),
+      })
+      .where(eq(teamInvitationTable.id, invitation.id))
+
+    // Resend the invite email
+    const competition = Array.isArray(registration.competition)
+      ? registration.competition[0]
+      : registration.competition
+    const division = Array.isArray(registration.division)
+      ? registration.division[0]
+      : registration.division
+
+    const inviter = await db.query.userTable.findFirst({
+      where: eq(userTable.id, session.userId),
+      columns: { firstName: true, lastName: true },
+    })
+    const inviterName = inviter
+      ? `${inviter.firstName || ""} ${inviter.lastName || ""}`.trim() ||
+        "Your team captain"
+      : "Your team captain"
+
+    const { sendCompetitionTeamInviteEmail } = await import("@/utils/email")
+    await sendCompetitionTeamInviteEmail({
+      email: invitation.email,
+      invitationToken: newToken,
+      teamName: registration.teamName ?? "Team",
+      competitionName: competition?.name ?? "the competition",
+      divisionName: division?.label ?? "Division",
+      inviterName,
+    })
+
+    return { success: true, newToken }
   })

--- a/apps/wodsmith-start/src/server-fns/registration-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/registration-fns.ts
@@ -2101,7 +2101,8 @@ export const refreshCompetitionTeamInviteFn = createServerFn({
       throw new Error("Only the team captain can refresh invites")
     }
 
-    // Get the invitation
+    // Get the invitation (only pending invites can be refreshed)
+    const { INVITATION_STATUS } = await import("@/db/schema")
     const invitation = await db.query.teamInvitationTable.findFirst({
       where: and(
         eq(teamInvitationTable.id, data.invitationId),
@@ -2109,6 +2110,7 @@ export const refreshCompetitionTeamInviteFn = createServerFn({
           teamInvitationTable.teamId,
           registration.athleteTeamId ?? "",
         ),
+        eq(teamInvitationTable.status, INVITATION_STATUS.PENDING),
       ),
     })
 
@@ -2118,6 +2120,11 @@ export const refreshCompetitionTeamInviteFn = createServerFn({
 
     if (invitation.acceptedAt) {
       throw new Error("Invitation has already been accepted")
+    }
+
+    // Only allow refreshing expired invitations
+    if (!invitation.expiresAt || new Date(invitation.expiresAt) >= new Date()) {
+      throw new Error("Only expired invitations can be refreshed")
     }
 
     // Generate new token and extend expiry to 30 days

--- a/apps/wodsmith-start/src/server-fns/team-settings-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/team-settings-fns.ts
@@ -784,7 +784,7 @@ export const inviteUserFn = createServerFn({ method: "POST" })
     // User doesn't exist, create an invitation
     const token = createId()
     const expiresAt = new Date()
-    expiresAt.setDate(expiresAt.getDate() + 7) // Valid for 7 days
+    expiresAt.setDate(expiresAt.getDate() + 30) // Valid for 30 days
 
     // Check if there's an existing invitation
     const existingInvitation = await db.query.teamInvitationTable.findFirst({

--- a/apps/wodsmith-start/src/server/team-members.ts
+++ b/apps/wodsmith-start/src/server/team-members.ts
@@ -139,7 +139,7 @@ export async function inviteUserToTeam({
   // User doesn't exist, create an invitation
   const token = createId()
   const expiresAt = new Date()
-  expiresAt.setDate(expiresAt.getDate() + 7) // Valid for 7 days
+  expiresAt.setDate(expiresAt.getDate() + 30) // Valid for 30 days
 
   // Check if there's an existing invitation
   const existingInvitation = await db.query.teamInvitationTable.findFirst({

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -55,7 +55,7 @@ Each division becomes a separate line item in Stripe Checkout and a separate `co
 
 Team divisions (teamSize > 1) require a team name and teammate emails during registration.
 
-The captain (registering user) creates the team. A `competition_team` is created in the `teamTable` with `competitionMetadata` JSON storing `competitionId` and `divisionId`. Teammates are invited via `inviteUserToTeamInternal`: existing users are added directly to the team; new users receive an email invitation with a 30-day token. Teammates are also added to the `competition_event` team. Captains can refresh expired invites via [[apps/wodsmith-start/src/server-fns/registration-fns.ts#refreshCompetitionTeamInviteFn]], which generates a new token, extends the expiry by 30 days, and resends the email.
+The captain (registering user) creates the team. A `competition_team` is created in the `teamTable` with `competitionMetadata` JSON storing `competitionId` and `divisionId`. Teammates are invited via [[apps/wodsmith-start/src/server/registration.ts#inviteUserToTeamInternal]]: existing users are added directly to the team; new users receive an email invitation with a 30-day token. Teammates are also added to the `competition_event` team. Captains can refresh expired invites via [[apps/wodsmith-start/src/server-fns/registration-fns.ts#refreshCompetitionTeamInviteFn]], which generates a new token, extends the expiry by 30 days, and resends the email.
 
 ## Capacity Management
 

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -55,7 +55,7 @@ Each division becomes a separate line item in Stripe Checkout and a separate `co
 
 Team divisions (teamSize > 1) require a team name and teammate emails during registration.
 
-The captain (registering user) creates the team. A `competition_team` is created in the `teamTable` with `competitionMetadata` JSON storing `competitionId` and `divisionId`. Teammates are invited via `inviteUserToTeamInternal`: existing users are added directly to the team; new users receive an email invitation with a 30-day token. Teammates are also added to the `competition_event` team.
+The captain (registering user) creates the team. A `competition_team` is created in the `teamTable` with `competitionMetadata` JSON storing `competitionId` and `divisionId`. Teammates are invited via `inviteUserToTeamInternal`: existing users are added directly to the team; new users receive an email invitation with a 30-day token. Teammates are also added to the `competition_event` team. Captains can refresh expired invites via [[apps/wodsmith-start/src/server-fns/registration-fns.ts#refreshCompetitionTeamInviteFn]], which generates a new token, extends the expiry by 30 days, and resends the email.
 
 ## Capacity Management
 


### PR DESCRIPTION
## Summary
- Captains can now resend expired teammate invitations from the team roster page via a "Resend Invite" button that regenerates the token, extends expiry by 30 days, and resends the email
- Expired invites show a red "Expired" badge and hide the non-functional "Copy Link" button
- Extended all invite expiration from 7 → 30 days (team-members, team-settings, competition invites were already 30d)

## Test plan
- [ ] Register a team for a competition with a teammate email that doesn't have an account
- [ ] Manually expire the invite in the DB (`UPDATE team_invitations SET expiresAt = NOW() - INTERVAL 1 DAY WHERE ...`)
- [ ] Visit the team roster page as the captain — verify "Expired" badge and "Resend Invite" button appear
- [ ] Click "Resend Invite" — verify toast success, page refreshes, invite shows "Pending" again with working "Copy Link"
- [ ] Open the new invite link — verify it loads the accept invite page (not expired)
- [ ] Verify non-captain team members do not see the "Resend Invite" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a captain-only “Resend Invite” flow for expired competition team invites, generating a new token, extending expiry to 30 days, and resending the email. Also standardizes invite expirations to 30 days and clarifies the UI for expired vs pending invites.

- **New Features**
  - Team roster: “Resend Invite” button for expired invites; shows spinner and invalidates the route on success.
  - UI: Expired invites show a red “Expired” badge and hide “Copy Link”; pending invites keep “Copy Link”.
  - Server: Added `refreshCompetitionTeamInviteFn` to validate captain, regenerate the token, extend expiry by 30 days, send the email, and expose `expiresAt` in the roster.
  - Expiration: Updated invite expiry from 7 → 30 days in `apps/wodsmith-start/src/server-fns/team-settings-fns.ts` and `apps/wodsmith-start/src/server/team-members.ts`; docs updated.

- **Bug Fixes**
  - Hardened refresh endpoint: only expired + pending invitations can be refreshed; live links and cancelled invites are rejected.

<sup>Written for commit 2822588e4566bf5bfd10d0638d353af4d4cd42f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Captains can refresh expired team invitations via a “Resend Invite” action that regenerates the invite and resends the email.
  * Expired invitations now show an “Expired” badge.

* **Improvements**
  * Invitation validity increased from 7 to 30 days; refreshed invites extend expiry by 30 days.
  * Refresh actions show progress state and surface success/error toasts.

* **Documentation**
  * Team registration docs updated to describe invite refresh behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->