### PR TITLE
feat: add division cutoff rank with leaderboard line

### DIFF
--- a/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
@@ -74,6 +74,7 @@ interface CompetitionLeaderboardTableProps {
   }>
   selectedEventId: string | null // null = overall view
   scoringAlgorithm: ScoringAlgorithm
+  cutoffRank: number | null
 }
 
 function getRankIcon(rank: number) {
@@ -426,6 +427,7 @@ export function CompetitionLeaderboardTable({
   events,
   selectedEventId,
   scoringAlgorithm,
+  cutoffRank,
 }: CompetitionLeaderboardTableProps) {
   // Compute the correct default sort column based on view mode
   const defaultSortColumn = selectedEventId ? "eventRank" : "overallRank"
@@ -825,14 +827,30 @@ export function CompetitionLeaderboardTable({
           </div>
         ) : (
           <div>
-            {tableData.map((entry) => (
-              <MobileLeaderboardRow
-                key={entry.registrationId}
-                entry={entry}
-                events={events}
-                scoringAlgorithm={scoringAlgorithm}
-              />
-            ))}
+            {tableData.map((entry, idx) => {
+              const nextEntry = tableData[idx + 1]
+              const showCutoff =
+                cutoffRank != null &&
+                !selectedEventId &&
+                entry.overallRank <= cutoffRank &&
+                (!nextEntry || nextEntry.overallRank > cutoffRank)
+              return (
+                <Fragment key={entry.registrationId}>
+                  <MobileLeaderboardRow
+                    entry={entry}
+                    events={events}
+                    scoringAlgorithm={scoringAlgorithm}
+                  />
+                  {showCutoff && (
+                    <div
+                      className="h-[3px] bg-orange-500"
+                      role="separator"
+                      aria-label="Division cutoff line"
+                    />
+                  )}
+                </Fragment>
+              )
+            })}
           </div>
         )}
       </div>
@@ -885,18 +903,37 @@ export function CompetitionLeaderboardTable({
                 </TableCell>
               </TableRow>
             ) : (
-              table.getRowModel().rows.map((row) => (
-                <TableRow key={row.id} className="table-row">
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id} className="table-cell">
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
-                      )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))
+              table.getRowModel().rows.map((row, rowIdx) => {
+                const entry = row.original
+                const rows = table.getRowModel().rows
+                const nextRow = rows[rowIdx + 1]
+                const showCutoff =
+                  cutoffRank != null &&
+                  !selectedEventId &&
+                  entry.overallRank <= cutoffRank &&
+                  (!nextRow || nextRow.original.overallRank > cutoffRank)
+                return (
+                  <Fragment key={row.id}>
+                    <TableRow className="table-row">
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id} className="table-cell">
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                    {showCutoff && (
+                      <tr aria-hidden="true">
+                        <td colSpan={columns.length} className="p-0">
+                          <div className="h-[3px] bg-orange-500" />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })
             )}
           </TableBody>
         </Table>

--- a/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
@@ -842,11 +842,7 @@ export function CompetitionLeaderboardTable({
                     scoringAlgorithm={scoringAlgorithm}
                   />
                   {showCutoff && (
-                    <div
-                      className="h-[3px] bg-orange-500"
-                      role="separator"
-                      aria-label="Division cutoff line"
-                    />
+                    <div className="h-[3px] bg-orange-500" />
                   )}
                 </Fragment>
               )

--- a/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
@@ -921,7 +921,7 @@ export function CompetitionLeaderboardTable({
                       ))}
                     </TableRow>
                     {showCutoff && (
-                      <tr aria-hidden="true">
+                      <tr>
                         <td colSpan={columns.length} className="p-0">
                           <div className="h-[3px] bg-orange-500" />
                         </td>

--- a/apps/wodsmith-start/src/components/divisions/organizer-division-item.tsx
+++ b/apps/wodsmith-start/src/components/divisions/organizer-division-item.tsx
@@ -38,6 +38,8 @@ export interface OrganizerDivisionItemProps {
   description: string | null
   maxSpots: number | null
   defaultMaxSpots: number | null
+  cutoffRank: number | null
+  defaultCutoffRank: number | null
   index: number
   registrationCount: number
   isOnly: boolean
@@ -45,6 +47,7 @@ export interface OrganizerDivisionItemProps {
   onLabelSave: (value: string) => void
   onDescriptionSave: (value: string | null) => void
   onMaxSpotsSave: (value: number | null) => void
+  onCutoffRankSave: (value: number | null) => void
   onRemove: () => void
   onDrop: (sourceIndex: number, targetIndex: number) => void
 }
@@ -55,6 +58,8 @@ export function OrganizerDivisionItem({
   description,
   maxSpots,
   defaultMaxSpots,
+  cutoffRank,
+  defaultCutoffRank,
   index,
   registrationCount,
   isOnly,
@@ -62,6 +67,7 @@ export function OrganizerDivisionItem({
   onLabelSave,
   onDescriptionSave,
   onMaxSpotsSave,
+  onCutoffRankSave,
   onRemove,
   onDrop,
 }: OrganizerDivisionItemProps) {
@@ -74,6 +80,7 @@ export function OrganizerDivisionItem({
   const labelRef = useRef(label)
   const [localDescription, setLocalDescription] = useState(description ?? "")
   const [localMaxSpots, setLocalMaxSpots] = useState(maxSpots?.toString() ?? "")
+  const [localCutoffRank, setLocalCutoffRank] = useState(cutoffRank?.toString() ?? "")
   const [isExpanded, setIsExpanded] = useState(false)
 
   // Sync local state when prop changes (e.g., after server update)
@@ -89,6 +96,10 @@ export function OrganizerDivisionItem({
   useEffect(() => {
     setLocalMaxSpots(maxSpots?.toString() ?? "")
   }, [maxSpots])
+
+  useEffect(() => {
+    setLocalCutoffRank(cutoffRank?.toString() ?? "")
+  }, [cutoffRank])
 
   const canDelete = registrationCount === 0 && !isOnly
 
@@ -316,6 +327,48 @@ export function OrganizerDivisionItem({
                   {defaultMaxSpots
                     ? "Leave blank to use competition default"
                     : "Leave blank for unlimited"}
+                </span>
+              </div>
+              <div className="flex items-center gap-3">
+                <label
+                  htmlFor={`cutoffRank-${id}`}
+                  className="text-sm text-muted-foreground whitespace-nowrap"
+                >
+                  Cutoff rank:
+                </label>
+                <Input
+                  id={`cutoffRank-${id}`}
+                  type="number"
+                  min={1}
+                  value={localCutoffRank}
+                  onChange={(e) => setLocalCutoffRank(e.target.value)}
+                  onBlur={() => {
+                    const newVal =
+                      localCutoffRank.trim() === ""
+                        ? null
+                        : parseInt(localCutoffRank, 10)
+                    if (newVal !== cutoffRank) {
+                      if (
+                        newVal !== null &&
+                        (Number.isNaN(newVal) || newVal < 1)
+                      ) {
+                        setLocalCutoffRank(cutoffRank?.toString() ?? "")
+                        return
+                      }
+                      onCutoffRankSave(newVal)
+                    }
+                  }}
+                  placeholder={
+                    defaultCutoffRank
+                      ? `${defaultCutoffRank} (default)`
+                      : "No cutoff"
+                  }
+                  className="w-32 text-sm"
+                />
+                <span className="text-xs text-muted-foreground">
+                  {defaultCutoffRank
+                    ? "Leave blank to use competition default"
+                    : "Leave blank for no cutoff line"}
                 </span>
               </div>
               <Textarea

--- a/apps/wodsmith-start/src/components/divisions/organizer-division-manager.tsx
+++ b/apps/wodsmith-start/src/components/divisions/organizer-division-manager.tsx
@@ -38,6 +38,7 @@ import {
   switchCompetitionScalingGroupFn,
   updateCompetitionDivisionFn,
   updateDivisionCapacityFn,
+  updateDivisionCutoffFn,
   updateDivisionDescriptionFn,
 } from "@/server-fns/competition-divisions-fns"
 import { OrganizerDivisionItem } from "./organizer-division-item"
@@ -51,6 +52,7 @@ interface Division {
   description: string | null
   feeCents: number | null
   maxSpots: number | null
+  cutoffRank: number | null
 }
 
 interface ScalingGroupWithLevels {
@@ -74,6 +76,7 @@ interface OrganizerDivisionManagerProps {
   scalingGroupTitle: string | null
   scalingGroups: ScalingGroupWithLevels[]
   defaultMaxSpotsPerDivision: number | null
+  defaultCutoffRank: number | null
 }
 
 export function OrganizerDivisionManager({
@@ -84,6 +87,7 @@ export function OrganizerDivisionManager({
   scalingGroupTitle,
   scalingGroups,
   defaultMaxSpotsPerDivision,
+  defaultCutoffRank,
 }: OrganizerDivisionManagerProps) {
   const router = useRouter()
   const [divisions, setDivisions] = useState(initialDivisions)
@@ -249,6 +253,43 @@ export function OrganizerDivisionManager({
         prev.map((d) =>
           d.id === divisionId
             ? { ...d, maxSpots: original?.maxSpots ?? newMaxSpots }
+            : d,
+        ),
+      )
+    }
+  }
+
+  const handleCutoffRankSave = async (
+    divisionId: string,
+    newCutoffRank: number | null,
+  ) => {
+    const original = initialDivisions.find((d) => d.id === divisionId)
+    if (original && original.cutoffRank === newCutoffRank) return
+
+    setDivisions((prev) =>
+      prev.map((d) =>
+        d.id === divisionId ? { ...d, cutoffRank: newCutoffRank } : d,
+      ),
+    )
+
+    try {
+      await updateDivisionCutoffFn({
+        data: {
+          teamId,
+          competitionId,
+          divisionId,
+          cutoffRank: newCutoffRank,
+        },
+      })
+      toast.success("Division cutoff updated")
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update cutoff",
+      )
+      setDivisions((prev) =>
+        prev.map((d) =>
+          d.id === divisionId
+            ? { ...d, cutoffRank: original?.cutoffRank ?? newCutoffRank }
             : d,
         ),
       )
@@ -421,6 +462,8 @@ export function OrganizerDivisionManager({
                   description={division.description}
                   maxSpots={division.maxSpots}
                   defaultMaxSpots={defaultMaxSpotsPerDivision}
+                  cutoffRank={division.cutoffRank}
+                  defaultCutoffRank={defaultCutoffRank}
                   index={index}
                   registrationCount={division.registrationCount}
                   isOnly={divisions.length === 1}
@@ -431,6 +474,9 @@ export function OrganizerDivisionManager({
                   }
                   onMaxSpotsSave={(spots) =>
                     handleMaxSpotsSave(division.id, spots)
+                  }
+                  onCutoffRankSave={(rank) =>
+                    handleCutoffRankSave(division.id, rank)
                   }
                   onRemove={() => handleRemove(division.id)}
                   onDrop={handleDrop}

--- a/apps/wodsmith-start/src/components/leaderboard-page-content.tsx
+++ b/apps/wodsmith-start/src/components/leaderboard-page-content.tsx
@@ -75,6 +75,9 @@ export function LeaderboardPageContent({
   const selectedEventId = searchParams.event ?? null
   const selectedAffiliate = searchParams.affiliate ?? "all"
 
+  // Get cutoff rank for the selected division
+  const cutoffRank = divisions?.find((d) => d.id === selectedDivision)?.cutoffRank ?? null
+
   const [leaderboard, setLeaderboard] = useState<CompetitionLeaderboardEntry[]>(
     [],
   )
@@ -569,6 +572,7 @@ export function LeaderboardPageContent({
             events={events}
             selectedEventId={effectiveEventId}
             scoringAlgorithm={scoringAlgorithm}
+            cutoffRank={cutoffRank}
           />
         ) : (
           <CompetitionLeaderboardTable
@@ -576,6 +580,7 @@ export function LeaderboardPageContent({
             events={events}
             selectedEventId={effectiveEventId}
             scoringAlgorithm={scoringAlgorithm}
+            cutoffRank={cutoffRank}
           />
         )}
       </div>

--- a/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
@@ -1189,11 +1189,7 @@ export function OnlineCompetitionLeaderboardTable({
                     currentUserId={currentUserId}
                   />
                   {showCutoff && (
-                    <div
-                      className="h-[3px] bg-orange-500"
-                      role="separator"
-                      aria-label="Division cutoff line"
-                    />
+                    <div className="h-[3px] bg-orange-500" />
                   )}
                 </Fragment>
               )

--- a/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
@@ -1299,7 +1299,7 @@ export function OnlineCompetitionLeaderboardTable({
                       />
                     )}
                     {showCutoff && (
-                      <tr aria-hidden="true">
+                      <tr>
                         <td colSpan={columns.length} className="p-0">
                           <div className="h-[3px] bg-orange-500" />
                         </td>

--- a/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
@@ -81,6 +81,7 @@ interface OnlineCompetitionLeaderboardTableProps {
   }>
   selectedEventId: string | null
   scoringAlgorithm: ScoringAlgorithm
+  cutoffRank: number | null
 }
 
 function getRankIcon(rank: number) {
@@ -684,6 +685,7 @@ export function OnlineCompetitionLeaderboardTable({
   events,
   selectedEventId,
   scoringAlgorithm,
+  cutoffRank,
 }: OnlineCompetitionLeaderboardTableProps) {
   const session = useSession()
   const isLoggedIn = !!session?.userId
@@ -1169,17 +1171,33 @@ export function OnlineCompetitionLeaderboardTable({
           </div>
         ) : (
           <div>
-            {tableData.map((entry) => (
-              <MobileOnlineLeaderboardRow
-                key={entry.registrationId}
-                entry={entry}
-                events={events}
-                scoringAlgorithm={scoringAlgorithm}
-                voteCounts={voteCounts}
-                isLoggedIn={isLoggedIn}
-                currentUserId={currentUserId}
-              />
-            ))}
+            {tableData.map((entry, idx) => {
+              const nextEntry = tableData[idx + 1]
+              const showCutoff =
+                cutoffRank != null &&
+                !selectedEventId &&
+                entry.overallRank <= cutoffRank &&
+                (!nextEntry || nextEntry.overallRank > cutoffRank)
+              return (
+                <Fragment key={entry.registrationId}>
+                  <MobileOnlineLeaderboardRow
+                    entry={entry}
+                    events={events}
+                    scoringAlgorithm={scoringAlgorithm}
+                    voteCounts={voteCounts}
+                    isLoggedIn={isLoggedIn}
+                    currentUserId={currentUserId}
+                  />
+                  {showCutoff && (
+                    <div
+                      className="h-[3px] bg-orange-500"
+                      role="separator"
+                      aria-label="Division cutoff line"
+                    />
+                  )}
+                </Fragment>
+              )
+            })}
           </div>
         )}
       </div>
@@ -1239,43 +1257,61 @@ export function OnlineCompetitionLeaderboardTable({
                 </TableCell>
               </TableRow>
             ) : (
-              table.getRowModel().rows.map((row) => (
-                <Fragment key={row.id}>
-                  <TableRow
-                    key={row.id}
-                    className={cn(
-                      "table-row",
-                      row.getIsExpanded() && "border-b-0",
-                      hasExpandableContent(row.original, selectedEventId) &&
-                        "cursor-pointer",
+              table.getRowModel().rows.map((row, rowIdx) => {
+                const entry = row.original
+                const rows = table.getRowModel().rows
+                const nextRow = rows[rowIdx + 1]
+                const showCutoff =
+                  cutoffRank != null &&
+                  !selectedEventId &&
+                  entry.overallRank <= cutoffRank &&
+                  (!nextRow || nextRow.original.overallRank > cutoffRank)
+                return (
+                  <Fragment key={row.id}>
+                    <TableRow
+                      className={cn(
+                        "table-row",
+                        row.getIsExpanded() && "border-b-0",
+                        hasExpandableContent(row.original, selectedEventId) &&
+                          "cursor-pointer",
+                      )}
+                      onClick={() => {
+                        if (
+                          hasExpandableContent(row.original, selectedEventId)
+                        ) {
+                          row.toggleExpanded()
+                        }
+                      }}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id} className="table-cell">
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                    {row.getIsExpanded() && (
+                      <ExpandedVideoRow
+                        row={row}
+                        selectedEventId={selectedEventId}
+                        columnsCount={columns.length}
+                        voteCounts={voteCounts}
+                        isLoggedIn={isLoggedIn}
+                        currentUserId={currentUserId}
+                      />
                     )}
-                    onClick={() => {
-                      if (hasExpandableContent(row.original, selectedEventId)) {
-                        row.toggleExpanded()
-                      }
-                    }}
-                  >
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id} className="table-cell">
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                  {row.getIsExpanded() && (
-                    <ExpandedVideoRow
-                      row={row}
-                      selectedEventId={selectedEventId}
-                      columnsCount={columns.length}
-                      voteCounts={voteCounts}
-                      isLoggedIn={isLoggedIn}
-                      currentUserId={currentUserId}
-                    />
-                  )}
-                </Fragment>
-              ))
+                    {showCutoff && (
+                      <tr aria-hidden="true">
+                        <td colSpan={columns.length} className="p-0">
+                          <div className="h-[3px] bg-orange-500" />
+                        </td>
+                      </tr>
+                    )}
+                  </Fragment>
+                )
+              })
             )}
           </TableBody>
         </Table>

--- a/apps/wodsmith-start/src/db/schemas/commerce.ts
+++ b/apps/wodsmith-start/src/db/schemas/commerce.ts
@@ -158,6 +158,8 @@ export const competitionDivisionsTable = mysqlTable(
     description: text(),
     // Max spots for this division (null = use competition default)
     maxSpots: int(),
+    // Cutoff rank for this division (null = use competition default)
+    cutoffRank: int(),
   },
   (table) => [
     // Each division can only have one config per competition

--- a/apps/wodsmith-start/src/db/schemas/competitions.ts
+++ b/apps/wodsmith-start/src/db/schemas/competitions.ts
@@ -129,6 +129,8 @@ export const competitionsTable = mysqlTable(
     defaultMaxSpotsPerDivision: int(),
     // Capacity: max total registrations across all divisions (null = unlimited)
     maxTotalRegistrations: int({ unsigned: true }),
+    // Cutoff: default leaderboard cutoff rank per division (null = no cutoff line)
+    defaultCutoffRank: int(),
     // Primary address for the competition
     primaryAddressId: varchar({ length: 255 }),
   },

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/capacity-settings-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/capacity-settings-form.tsx
@@ -23,6 +23,7 @@ interface Props {
     organizingTeamId: string
     defaultMaxSpotsPerDivision: number | null
     maxTotalRegistrations: number | null
+    defaultCutoffRank: number | null
   }
 }
 
@@ -34,6 +35,9 @@ export function CapacitySettingsForm({ competition }: Props) {
   )
   const [maxTotal, setMaxTotal] = useState<string>(
     competition.maxTotalRegistrations?.toString() ?? "",
+  )
+  const [cutoffRank, setCutoffRank] = useState<string>(
+    competition.defaultCutoffRank?.toString() ?? "",
   )
 
   const updateCapacity = useServerFn(updateCompetitionDefaultCapacityFn)
@@ -63,12 +67,24 @@ export function CapacitySettingsForm({ competition }: Props) {
         return
       }
 
+      const parsedCutoff = cutoffRank.trim() === "" ? null : parseInt(cutoffRank, 10)
+
+      if (
+        parsedCutoff !== null &&
+        (Number.isNaN(parsedCutoff) || parsedCutoff < 1)
+      ) {
+        toast.error("Cutoff rank must be 1 or higher")
+        setIsSubmitting(false)
+        return
+      }
+
       await updateCapacity({
         data: {
           competitionId: competition.id,
           teamId: competition.organizingTeamId,
           defaultMaxSpotsPerDivision: parsedValue,
           maxTotalRegistrations: parsedTotal,
+          defaultCutoffRank: parsedCutoff,
         },
       })
       toast.success("Capacity settings updated")
@@ -85,9 +101,12 @@ export function CapacitySettingsForm({ competition }: Props) {
     if (parsed !== null && Number.isNaN(parsed)) return false
     const parsedTotal = maxTotal.trim() === "" ? null : Number(maxTotal)
     if (parsedTotal !== null && (!Number.isFinite(parsedTotal) || !Number.isInteger(parsedTotal))) return false
+    const parsedCutoff = cutoffRank.trim() === "" ? null : parseInt(cutoffRank, 10)
+    if (parsedCutoff !== null && Number.isNaN(parsedCutoff)) return false
     return (
       parsed !== competition.defaultMaxSpotsPerDivision ||
-      parsedTotal !== competition.maxTotalRegistrations
+      parsedTotal !== competition.maxTotalRegistrations ||
+      parsedCutoff !== competition.defaultCutoffRank
     )
   })()
 
@@ -99,7 +118,7 @@ export function CapacitySettingsForm({ competition }: Props) {
           <CardTitle>Capacity Settings</CardTitle>
         </div>
         <CardDescription>
-          Set registration limits for this competition.
+          Set registration limits and leaderboard cutoff for this competition.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
@@ -143,6 +162,28 @@ export function CapacitySettingsForm({ competition }: Props) {
           <p className="text-xs text-muted-foreground">
             Athletes will see available spots and cannot register when a
             division is full.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="cutoffRank">Default cutoff rank</Label>
+          <div className="flex items-center gap-4">
+            <Input
+              id="cutoffRank"
+              type="number"
+              min={1}
+              placeholder="No cutoff"
+              value={cutoffRank}
+              onChange={(e) => setCutoffRank(e.target.value)}
+              className="w-full sm:w-32"
+            />
+            <span className="text-sm text-muted-foreground">
+              Leave blank for no cutoff line
+            </span>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            An orange line will appear on the leaderboard after this rank
+            position across all divisions.
           </p>
         </div>
 

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/divisions.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/divisions.tsx
@@ -64,6 +64,7 @@ export const Route = createFileRoute(
       scalingGroups: scalingGroupsResult.groups,
       defaultMaxSpotsPerDivision:
         divisionsResult.defaultMaxSpotsPerDivision ?? null,
+      defaultCutoffRank: divisionsResult.defaultCutoffRank ?? null,
       seriesMappingStatus,
     }
   },
@@ -76,6 +77,7 @@ function DivisionsPage() {
     scalingGroupTitle,
     scalingGroups,
     defaultMaxSpotsPerDivision,
+    defaultCutoffRank,
     seriesMappingStatus,
   } = Route.useLoaderData()
   // Get competition from parent layout loader data
@@ -98,6 +100,7 @@ function DivisionsPage() {
             organizingTeamId: competition.organizingTeamId,
             defaultMaxSpotsPerDivision,
             maxTotalRegistrations: competition.maxTotalRegistrations,
+            defaultCutoffRank,
           }}
         />
       )}
@@ -111,6 +114,7 @@ function DivisionsPage() {
         scalingGroupTitle={scalingGroupTitle}
         scalingGroups={scalingGroups}
         defaultMaxSpotsPerDivision={defaultMaxSpotsPerDivision}
+        defaultCutoffRank={defaultCutoffRank}
       />
     </div>
   )

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/settings.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/settings.tsx
@@ -56,6 +56,7 @@ function SettingsPage() {
             organizingTeamId: competition.organizingTeamId,
             defaultMaxSpotsPerDivision: competition.defaultMaxSpotsPerDivision,
             maxTotalRegistrations: competition.maxTotalRegistrations,
+            defaultCutoffRank: competition.defaultCutoffRank,
           }}
         />
       </section>

--- a/apps/wodsmith-start/src/server-fns/competition-detail-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-detail-fns.ts
@@ -210,6 +210,7 @@ export const getCompetitionByIdFn = createServerFn({ method: "GET" })
         defaultMaxSpotsPerDivision:
           competitionsTable.defaultMaxSpotsPerDivision,
         maxTotalRegistrations: competitionsTable.maxTotalRegistrations,
+        defaultCutoffRank: competitionsTable.defaultCutoffRank,
         primaryAddressId: competitionsTable.primaryAddressId,
         createdAt: competitionsTable.createdAt,
         updatedAt: competitionsTable.updatedAt,

--- a/apps/wodsmith-start/src/server-fns/competition-divisions-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-divisions-fns.ts
@@ -112,6 +112,7 @@ export interface PublicCompetitionDivision {
   maxSpots: number | null
   spotsAvailable: number | null
   isFull: boolean
+  cutoffRank: number | null
 }
 
 export interface CompetitionDivisionWithCounts {
@@ -122,6 +123,7 @@ export interface CompetitionDivisionWithCounts {
   description: string | null
   feeCents: number | null
   maxSpots: number | null
+  cutoffRank: number | null
   teamSize: number
 }
 
@@ -205,6 +207,7 @@ const updateCompetitionDefaultCapacityInputSchema = z.object({
   teamId: z.string().min(1, "Team ID is required"),
   defaultMaxSpotsPerDivision: z.number().int().min(1).nullable().optional(),
   maxTotalRegistrations: z.number().int().min(1).nullable().optional(),
+  defaultCutoffRank: z.number().int().min(1).nullable().optional(),
 })
 
 const getCompetitionSpotsAvailableInputSchema = z.object({
@@ -217,6 +220,13 @@ const updateDivisionCapacityInputSchema = z.object({
   teamId: z.string().min(1, "Team ID is required"),
   divisionId: z.string().min(1, "Division ID is required"),
   maxSpots: z.number().int().min(1).nullable(),
+})
+
+const updateDivisionCutoffInputSchema = z.object({
+  competitionId: z.string().min(1, "Competition ID is required"),
+  teamId: z.string().min(1, "Team ID is required"),
+  divisionId: z.string().min(1, "Division ID is required"),
+  cutoffRank: z.number().int().min(1).nullable(),
 })
 
 const getDivisionSpotsAvailableInputSchema = z.object({
@@ -621,6 +631,7 @@ export const getPublicCompetitionDivisionsFn = createServerFn({ method: "GET" })
           description: competitionDivisionsTable.description,
           feeCents: competitionDivisionsTable.feeCents,
           maxSpots: competitionDivisionsTable.maxSpots,
+          cutoffRank: competitionDivisionsTable.cutoffRank,
           registrationCount: sql<number>`cast(count(${competitionRegistrationsTable.id}) as unsigned)`,
         })
         .from(scalingLevelsTable)
@@ -648,6 +659,7 @@ export const getPublicCompetitionDivisionsFn = createServerFn({ method: "GET" })
           competitionDivisionsTable.description,
           competitionDivisionsTable.feeCents,
           competitionDivisionsTable.maxSpots,
+          competitionDivisionsTable.cutoffRank,
         )
         .orderBy(scalingLevelsTable.position),
       // Count pending purchases (reservations) per division
@@ -696,6 +708,7 @@ export const getPublicCompetitionDivisionsFn = createServerFn({ method: "GET" })
         maxSpots: capacity.effectiveMax,
         spotsAvailable: capacity.spotsAvailable,
         isFull: capacity.isFull,
+        cutoffRank: d.cutoffRank ?? competition.defaultCutoffRank ?? null,
       }
     })
 
@@ -775,6 +788,7 @@ export const getCompetitionDivisionsWithCountsFn = createServerFn({
         description: competitionDivisionsTable.description,
         feeCents: competitionDivisionsTable.feeCents,
         maxSpots: competitionDivisionsTable.maxSpots,
+        cutoffRank: competitionDivisionsTable.cutoffRank,
         teamSize: scalingLevelsTable.teamSize,
         registrationCount: sql<number>`cast(count(${competitionRegistrationsTable.id}) as unsigned)`,
       })
@@ -801,6 +815,7 @@ export const getCompetitionDivisionsWithCountsFn = createServerFn({
         competitionDivisionsTable.description,
         competitionDivisionsTable.feeCents,
         competitionDivisionsTable.maxSpots,
+        competitionDivisionsTable.cutoffRank,
       )
       .orderBy(scalingLevelsTable.position)
 
@@ -808,11 +823,13 @@ export const getCompetitionDivisionsWithCountsFn = createServerFn({
       scalingGroupId,
       scalingGroupTitle: scalingGroup?.title ?? null,
       defaultMaxSpotsPerDivision: competition.defaultMaxSpotsPerDivision,
+      defaultCutoffRank: competition.defaultCutoffRank,
       divisions: divisions.map((d) => ({
         ...d,
         description: d.description ?? null,
         feeCents: d.feeCents ?? competition.defaultRegistrationFeeCents ?? null,
         maxSpots: d.maxSpots ?? null,
+        cutoffRank: d.cutoffRank ?? null,
       })) as CompetitionDivisionWithCounts[],
     }
   })
@@ -1349,7 +1366,7 @@ export const updateCompetitionDefaultCapacityFn = createServerFn({
       TEAM_PERMISSIONS.MANAGE_PROGRAMMING,
     )
 
-    getEvlog()?.set({ action: "update_competition_default_capacity", competition: { id: data.competitionId }, capacity: { defaultMaxSpotsPerDivision: data.defaultMaxSpotsPerDivision, maxTotalRegistrations: data.maxTotalRegistrations }, teamId: data.teamId })
+    getEvlog()?.set({ action: "update_competition_default_capacity", competition: { id: data.competitionId }, capacity: { defaultMaxSpotsPerDivision: data.defaultMaxSpotsPerDivision, maxTotalRegistrations: data.maxTotalRegistrations, defaultCutoffRank: data.defaultCutoffRank }, teamId: data.teamId })
 
     // Verify competition exists and belongs to team
     const [competition] = await db
@@ -1371,6 +1388,9 @@ export const updateCompetitionDefaultCapacityFn = createServerFn({
     }
     if (data.maxTotalRegistrations !== undefined) {
       updateData.maxTotalRegistrations = data.maxTotalRegistrations
+    }
+    if (data.defaultCutoffRank !== undefined) {
+      updateData.defaultCutoffRank = data.defaultCutoffRank
     }
 
     await db
@@ -1445,6 +1465,71 @@ export const updateDivisionCapacityFn = createServerFn({ method: "POST" })
         divisionId: data.divisionId,
         feeCents: defaultFee,
         maxSpots: data.maxSpots,
+      })
+    }
+
+    return { success: true }
+  })
+
+/**
+ * Update cutoff rank for a specific division (override)
+ */
+export const updateDivisionCutoffFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    updateDivisionCutoffInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const db = getDb()
+
+    const session = await getSessionFromCookie()
+    if (!session?.userId) {
+      throw new Error("Not authenticated")
+    }
+
+    await requireTeamPermission(
+      data.teamId,
+      TEAM_PERMISSIONS.MANAGE_PROGRAMMING,
+    )
+
+    getEvlog()?.set({ action: "update_division_cutoff", division: { id: data.divisionId, competitionId: data.competitionId, cutoffRank: data.cutoffRank }, teamId: data.teamId })
+
+    const { scalingGroupId } = await ensureCompetitionOwnedScalingGroup({
+      competitionId: data.competitionId,
+      teamId: data.teamId,
+    })
+
+    const [division] = await db
+      .select()
+      .from(scalingLevelsTable)
+      .where(eq(scalingLevelsTable.id, data.divisionId))
+
+    if (!division || division.scalingGroupId !== scalingGroupId) {
+      throw new Error("Division not found in this competition")
+    }
+
+    const existing = await db.query.competitionDivisionsTable.findFirst({
+      where: and(
+        eq(competitionDivisionsTable.competitionId, data.competitionId),
+        eq(competitionDivisionsTable.divisionId, data.divisionId),
+      ),
+    })
+
+    if (existing) {
+      await db
+        .update(competitionDivisionsTable)
+        .set({ cutoffRank: data.cutoffRank, updatedAt: new Date() })
+        .where(eq(competitionDivisionsTable.id, existing.id))
+    } else {
+      const competition = await db.query.competitionsTable.findFirst({
+        where: eq(competitionsTable.id, data.competitionId),
+      })
+      const defaultFee = competition?.defaultRegistrationFeeCents ?? 0
+
+      await db.insert(competitionDivisionsTable).values({
+        competitionId: data.competitionId,
+        divisionId: data.divisionId,
+        feeCents: defaultFee,
+        cutoffRank: data.cutoffRank,
       })
     }
 

--- a/apps/wodsmith-start/src/server-fns/competition-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-fns.ts
@@ -190,6 +190,7 @@ export const getPublicCompetitionsFn = createServerFn({ method: "GET" })
         defaultMaxSpotsPerDivision:
           competitionsTable.defaultMaxSpotsPerDivision,
         maxTotalRegistrations: competitionsTable.maxTotalRegistrations,
+        defaultCutoffRank: competitionsTable.defaultCutoffRank,
         primaryAddressId: competitionsTable.primaryAddressId,
         createdAt: competitionsTable.createdAt,
         updatedAt: competitionsTable.updatedAt,
@@ -263,6 +264,7 @@ export const getPublicCompetitionsFn = createServerFn({ method: "GET" })
         defaultLaneShiftPattern: row.defaultLaneShiftPattern,
         defaultMaxSpotsPerDivision: row.defaultMaxSpotsPerDivision,
         maxTotalRegistrations: row.maxTotalRegistrations,
+        defaultCutoffRank: row.defaultCutoffRank,
         primaryAddressId: row.primaryAddressId,
         createdAt: row.createdAt,
         updatedAt: row.updatedAt,
@@ -338,6 +340,7 @@ export const getOrganizerCompetitionsFn = createServerFn({ method: "GET" })
         defaultMaxSpotsPerDivision:
           competitionsTable.defaultMaxSpotsPerDivision,
         maxTotalRegistrations: competitionsTable.maxTotalRegistrations,
+        defaultCutoffRank: competitionsTable.defaultCutoffRank,
         primaryAddressId: competitionsTable.primaryAddressId,
         createdAt: competitionsTable.createdAt,
         updatedAt: competitionsTable.updatedAt,
@@ -413,6 +416,7 @@ export const getOrganizerCompetitionsFn = createServerFn({ method: "GET" })
       defaultLaneShiftPattern: row.defaultLaneShiftPattern,
       defaultMaxSpotsPerDivision: row.defaultMaxSpotsPerDivision,
       maxTotalRegistrations: row.maxTotalRegistrations,
+      defaultCutoffRank: row.defaultCutoffRank,
       primaryAddressId: row.primaryAddressId,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
@@ -481,6 +485,7 @@ export const getCompetitionBySlugFn = createServerFn({ method: "GET" })
         defaultMaxSpotsPerDivision:
           competitionsTable.defaultMaxSpotsPerDivision,
         maxTotalRegistrations: competitionsTable.maxTotalRegistrations,
+        defaultCutoffRank: competitionsTable.defaultCutoffRank,
         primaryAddressId: competitionsTable.primaryAddressId,
         createdAt: competitionsTable.createdAt,
         updatedAt: competitionsTable.updatedAt,
@@ -548,6 +553,7 @@ export const getCompetitionBySlugFn = createServerFn({ method: "GET" })
       defaultLaneShiftPattern: row.defaultLaneShiftPattern,
       defaultMaxSpotsPerDivision: row.defaultMaxSpotsPerDivision,
       maxTotalRegistrations: row.maxTotalRegistrations,
+      defaultCutoffRank: row.defaultCutoffRank,
       primaryAddressId: row.primaryAddressId,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,

--- a/apps/wodsmith-start/test/components/leaderboard-page-content.test.tsx
+++ b/apps/wodsmith-start/test/components/leaderboard-page-content.test.tsx
@@ -79,6 +79,7 @@ const mockDivisions = [
 		maxSpots: null,
 		spotsAvailable: null,
 		isFull: false,
+		cutoffRank: null,
 	},
 	{
 		id: "div-2",
@@ -90,6 +91,7 @@ const mockDivisions = [
 		maxSpots: null,
 		spotsAvailable: null,
 		isFull: false,
+		cutoffRank: null,
 	},
 ]
 

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -45,7 +45,7 @@ Defined in `competitionEventsTable`. Each event references a `workoutId` and bel
 
 Divisions segment athletes within a competition (e.g., "RX Male", "Scaled Female", "Masters 40+").
 
-Stored in competition `settings` JSON. Athletes register into a specific division. Division-specific registration fees can override the competition default.
+Stored in competition `settings` JSON. Athletes register into a specific division. Division-specific registration fees, capacity (max spots), and leaderboard cutoff rank can each override the competition default.
 
 ### Heats
 

--- a/lat.md/organizer-dashboard.md
+++ b/lat.md/organizer-dashboard.md
@@ -24,7 +24,13 @@ Fetches competition groups for the organizing team. Uses `OrganizerCompetitionEd
 
 Organizers configure which divisions athletes can register into, sourced from the team's scaling groups.
 
-Fetches divisions with registration counts, scaling groups, and series mapping status in parallel. Uses `OrganizerDivisionManager` for CRUD on divisions. Also includes `CapacitySettingsForm` for per-division and default max spots configuration. For series competitions, shows mapping status indicating whether divisions are synced from the series template.
+Fetches divisions with registration counts, scaling groups, and series mapping status in parallel. Uses `OrganizerDivisionManager` for CRUD on divisions. Also includes `CapacitySettingsForm` for per-division and default max spots configuration, as well as a default cutoff rank that draws an orange line on the leaderboard. For series competitions, shows mapping status indicating whether divisions are synced from the series template.
+
+### Cutoff Rank
+
+Configures a leaderboard cutoff line — a bold orange line rendered after the Nth-ranked athlete.
+
+Uses the same two-level fallback as capacity: `competitionsTable.defaultCutoffRank` is the competition-wide default, `competitionDivisionsTable.cutoffRank` is the per-division override (null = use default). The effective cutoff flows to the public leaderboard via `getPublicCompetitionDivisionsFn` and renders in both `CompetitionLeaderboardTable` and `OnlineCompetitionLeaderboardTable` (desktop + mobile). Only shown on overall view, hidden in single-event view.
 
 ## Event Management
 


### PR DESCRIPTION
## Summary

- Adds a configurable **cutoff rank** that renders a bold orange line on the leaderboard after the Nth-ranked athlete (e.g., "top 10 advance to finals")
- Uses the same **competition-default + per-division override** pattern as capacity (maxSpots)
- Two new DB columns: `competitionsTable.defaultCutoffRank` and `competitionDivisionsTable.cutoffRank`

## Changes

**Schema:**
- `defaultCutoffRank: int()` on `competitionsTable` — competition-wide default
- `cutoffRank: int()` on `competitionDivisionsTable` — per-division override (null = use default)

**Server functions:**
- Extended `updateCompetitionDefaultCapacityFn` to accept `defaultCutoffRank`
- New `updateDivisionCutoffFn` for per-division cutoff overrides
- Extended `getCompetitionDivisionsWithCountsFn` and `getPublicCompetitionDivisionsFn` to return cutoff data

**Organizer UI:**
- New "Default cutoff rank" input in `CapacitySettingsForm`
- Per-division cutoff rank input in `OrganizerDivisionItem` collapsible section

**Leaderboard:**
- 3px orange line in `CompetitionLeaderboardTable` and `OnlineCompetitionLeaderboardTable`
- Both desktop table and mobile list views
- Only shown on overall view (hidden in single-event view)
- Handles ties correctly — line appears after all athletes with rank <= cutoff

## Test plan

- [ ] `pnpm db:push` to apply schema changes
- [ ] Set competition default cutoff on organizer divisions page, verify save
- [ ] Set per-division override, verify it takes precedence
- [ ] View leaderboard — orange line at correct rank position
- [ ] Test: ties at boundary, cutoff > total entries, null cutoff, single event view
- [ ] Test mobile view
- [ ] Test online competition leaderboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a configurable leaderboard cutoff rank that draws a bold orange line after the Nth-ranked athlete. Uses a competition default with per-division overrides, shows only on overall view, and handles ties.

- **New Features**
  - Schema: `competitionsTable.defaultCutoffRank`, `competitionDivisionsTable.cutoffRank`.
  - Server: extended `updateCompetitionDefaultCapacityFn` to accept `defaultCutoffRank`; added `updateDivisionCutoffFn`; cutoff returned by `getCompetitionDivisionsWithCountsFn` and `getPublicCompetitionDivisionsFn`.
  - Organizer UI: default cutoff input in `CapacitySettingsForm`; per-division cutoff input in `OrganizerDivisionItem` (wired via `OrganizerDivisionManager`).
  - Leaderboard: 3px orange cutoff line in `CompetitionLeaderboardTable` and `OnlineCompetitionLeaderboardTable` (desktop + mobile). Only on overall view; line appears after all athletes at the cutoff to account for ties.

- **Migration**
  - Run `pnpm db:push` to add new columns.
  - Optionally set a competition default or per-division cutoff; leave blank to disable the line.

<sup>Written for commit 0634494a14adc85425061edbf8b47fb615c78175. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Leaderboard cutoff rank configuration added: organizers can now set a default cutoff rank at the competition level and customize the cutoff for individual divisions
  * Leaderboards display a bold orange separator line at the cutoff rank boundary (visible in overall rankings only, not in event-specific views)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->