### PR TITLE
Support multiple workouts in submission window open emails

### DIFF
--- a/apps/wodsmith-start/src/react-email/submission-window-opens.tsx
+++ b/apps/wodsmith-start/src/react-email/submission-window-opens.tsx
@@ -3,6 +3,7 @@ import {
   Container,
   Head,
   Heading,
+  Hr,
   Html,
   Link,
   Section,
@@ -10,12 +11,20 @@ import {
 } from "@react-email/components"
 import { SITE_DOMAIN } from "@/constants"
 
+export interface WorkoutInfo {
+  name: string
+  description?: string
+}
+
 export interface SubmissionWindowOpensProps {
   athleteName?: string
   competitionName?: string
   competitionSlug?: string
+  /** @deprecated Use `workouts` array instead */
   workoutName?: string
+  /** @deprecated Use `workouts` array instead */
   workoutDescription?: string
+  workouts?: WorkoutInfo[]
   submissionClosesAt?: string
   timezone?: string
 }
@@ -24,12 +33,22 @@ export const SubmissionWindowOpensEmail = ({
   athleteName = "Athlete",
   competitionName = "Competition",
   competitionSlug = "competition",
-  workoutName = "Workout 1",
+  workoutName,
   workoutDescription,
+  workouts: workoutsProp,
   submissionClosesAt,
   timezone = "UTC",
 }: SubmissionWindowOpensProps) => {
   const competitionUrl = `https://${SITE_DOMAIN}/compete/${competitionSlug}`
+
+  // Support both legacy single-workout and new multi-workout props
+  const workouts: WorkoutInfo[] =
+    workoutsProp && workoutsProp.length > 0
+      ? workoutsProp
+      : [{ name: workoutName || "Workout 1", description: workoutDescription }]
+
+  const isSingleWorkout = workouts.length === 1
+  const workoutLabel = isSingleWorkout ? "workout" : "workouts"
 
   return (
     <Html>
@@ -39,24 +58,41 @@ export const SubmissionWindowOpensEmail = ({
           <Heading style={preheader}>Submission Window Now Open!</Heading>
           <Text style={paragraph}>Hi {athleteName},</Text>
           <Text style={paragraph}>
-            The submission window for <strong>{workoutName}</strong> in{" "}
-            <strong>{competitionName}</strong> is now open. You can submit your
-            score!
+            The submission window for{" "}
+            {isSingleWorkout ? (
+              <>
+                <strong>{workouts[0].name}</strong> in{" "}
+              </>
+            ) : (
+              <>
+                {workouts.length} {workoutLabel} in{" "}
+              </>
+            )}
+            <strong>{competitionName}</strong> is now open. You can submit your{" "}
+            {isSingleWorkout ? "score" : "scores"}!
           </Text>
 
           <Section style={detailsBox}>
-            <Text style={detailsTitle}>Event Details</Text>
+            <Text style={detailsTitle}>
+              {isSingleWorkout ? "Event Details" : "Events Now Open"}
+            </Text>
             <Text style={detailRow}>
               <strong>Competition:</strong> {competitionName}
             </Text>
-            <Text style={detailRow}>
-              <strong>Event:</strong> {workoutName}
-            </Text>
-            {workoutDescription && (
-              <Text style={detailRow}>
-                <strong>Description:</strong> {workoutDescription}
-              </Text>
-            )}
+            {workouts.map((workout, index) => (
+              <Section key={workout.name}>
+                {!isSingleWorkout && index > 0 && <Hr style={divider} />}
+                <Text style={detailRow}>
+                  <strong>{isSingleWorkout ? "Event:" : `Event ${index + 1}:`}</strong>{" "}
+                  {workout.name}
+                </Text>
+                {workout.description && (
+                  <Text style={detailRow}>
+                    <strong>Description:</strong> {workout.description}
+                  </Text>
+                )}
+              </Section>
+            ))}
             {submissionClosesAt && (
               <Text style={detailRow}>
                 <strong>Submit By:</strong> {submissionClosesAt} ({timezone})
@@ -66,13 +102,15 @@ export const SubmissionWindowOpensEmail = ({
 
           <Section style={buttonContainer}>
             <Link style={button} href={competitionUrl}>
-              Submit Your Score
+              Submit Your {isSingleWorkout ? "Score" : "Scores"}
             </Link>
           </Section>
 
           <Text style={paragraph}>
-            Make sure to complete the workout and submit your score before the
-            window closes. Good luck!
+            Make sure to complete the{" "}
+            {isSingleWorkout ? "workout" : "workouts"} and submit your{" "}
+            {isSingleWorkout ? "score" : "scores"} before the window closes.
+            Good luck!
           </Text>
         </Container>
         <Text style={footer}>
@@ -88,8 +126,11 @@ SubmissionWindowOpensEmail.PreviewProps = {
   athleteName: "John Smith",
   competitionName: "CrossFit Open 2025",
   competitionSlug: "crossfit-open-2025",
-  workoutName: "25.1",
-  workoutDescription: "15-12-9 Thrusters and Bar Muscle-ups",
+  workouts: [
+    { name: "25.1", description: "15-12-9 Thrusters and Bar Muscle-ups" },
+    { name: "25.2", description: "5 Rounds: 10 Deadlifts, 20 Double-unders" },
+    { name: "25.3" },
+  ],
   submissionClosesAt: "Monday, March 17, 2025 at 5:00 PM",
   timezone: "America/Denver",
 } as SubmissionWindowOpensProps
@@ -152,6 +193,11 @@ const detailRow = {
   fontSize: "15px",
   lineHeight: "20px",
   margin: "8px 0",
+}
+
+const divider = {
+  borderColor: "#e2e8f0",
+  margin: "12px 0",
 }
 
 const buttonContainer = {

--- a/apps/wodsmith-start/src/server/notifications/submission-window.ts
+++ b/apps/wodsmith-start/src/server/notifications/submission-window.ts
@@ -24,7 +24,10 @@ import {
 } from "@/db/schema"
 import { logError, logInfo } from "@/lib/logging/posthog-otel-logger"
 import { SubmissionWindowClosedEmail } from "@/react-email/submission-window-closed"
-import { SubmissionWindowOpensEmail } from "@/react-email/submission-window-opens"
+import {
+  SubmissionWindowOpensEmail,
+  type WorkoutInfo,
+} from "@/react-email/submission-window-opens"
 import { SubmissionWindowReminderEmail } from "@/react-email/submission-window-reminder"
 import { sendEmail } from "@/utils/email"
 
@@ -206,17 +209,17 @@ async function hasUserSubmittedScore(params: {
 // ============================================================================
 
 /**
- * Send a "submission window opens" notification to an athlete
+ * Send a "submission window opens" notification to an athlete.
+ * Supports multiple workouts in a single email when events share the same window.
  */
 export async function sendWindowOpensNotification(params: {
   userId: string
   registrationId: string
   competitionId: string
-  competitionEventId: string
+  competitionEventIds: string[]
   competitionName: string
   competitionSlug: string
-  workoutName: string
-  workoutDescription?: string
+  workouts: WorkoutInfo[]
   submissionClosesAt?: string
   timezone: string
 }): Promise<boolean> {
@@ -224,11 +227,10 @@ export async function sendWindowOpensNotification(params: {
     userId,
     registrationId,
     competitionId,
-    competitionEventId,
+    competitionEventIds,
     competitionName,
     competitionSlug,
-    workoutName,
-    workoutDescription,
+    workouts,
     submissionClosesAt,
     timezone,
   } = params
@@ -241,23 +243,30 @@ export async function sendWindowOpensNotification(params: {
   if (!user?.email) {
     logError({
       message: "[Submission Notification] Cannot send window opens - no email",
-      attributes: { userId, registrationId, competitionEventId },
+      attributes: { userId, registrationId, competitionEventIds },
     })
     return false
   }
 
-  // Reserve the notification slot first (prevents race conditions)
-  const reserved = await reserveNotification({
-    competitionId,
-    competitionEventId,
-    registrationId,
-    userId,
-    type: SUBMISSION_WINDOW_NOTIFICATION_TYPES.WINDOW_OPENS,
-    sentToEmail: user.email,
-  })
+  // Reserve notification slots for all events in this window group.
+  // If at least one reservation succeeds, we need to send the email.
+  const reservedEventIds: string[] = []
+  for (const eventId of competitionEventIds) {
+    const reserved = await reserveNotification({
+      competitionId,
+      competitionEventId: eventId,
+      registrationId,
+      userId,
+      type: SUBMISSION_WINDOW_NOTIFICATION_TYPES.WINDOW_OPENS,
+      sentToEmail: user.email,
+    })
+    if (reserved) {
+      reservedEventIds.push(eventId)
+    }
+  }
 
-  if (!reserved) {
-    // Already sent by another process
+  if (reservedEventIds.length === 0) {
+    // All events already notified by another process
     return false
   }
 
@@ -267,15 +276,16 @@ export async function sendWindowOpensNotification(params: {
       ? formatDateTimeForDisplay(submissionClosesAt, timezone)
       : undefined
 
+    const workoutNames = workouts.map((w) => w.name).join(", ")
+
     await sendEmail({
       to: user.email,
-      subject: `Submission Window Open: ${workoutName} - ${competitionName}`,
+      subject: `Submission Window Open: ${workoutNames} - ${competitionName}`,
       template: SubmissionWindowOpensEmail({
         athleteName,
         competitionName,
         competitionSlug,
-        workoutName,
-        workoutDescription,
+        workouts,
         submissionClosesAt: formattedCloseTime,
         timezone,
       }),
@@ -287,25 +297,28 @@ export async function sendWindowOpensNotification(params: {
       attributes: {
         userId,
         registrationId,
-        competitionEventId,
+        competitionEventIds,
         competitionName,
-        workoutName,
+        workoutNames,
+        workoutCount: workouts.length,
       },
     })
 
     return true
   } catch (err) {
-    // Email failed - delete reservation to allow retry on next cron run
-    await deleteNotificationReservation({
-      competitionEventId,
-      registrationId,
-      type: SUBMISSION_WINDOW_NOTIFICATION_TYPES.WINDOW_OPENS,
-    })
+    // Email failed - delete reservations to allow retry on next cron run
+    for (const eventId of reservedEventIds) {
+      await deleteNotificationReservation({
+        competitionEventId: eventId,
+        registrationId,
+        type: SUBMISSION_WINDOW_NOTIFICATION_TYPES.WINDOW_OPENS,
+      })
+    }
     logError({
       message:
         "[Submission Notification] Failed to send window opens notification",
       error: err,
-      attributes: { userId, registrationId, competitionEventId },
+      attributes: { userId, registrationId, competitionEventIds },
     })
     return false
   }
@@ -607,11 +620,38 @@ export async function processSubmissionWindowNotifications(): Promise<ProcessedN
         ),
       )
 
+    // Time window calculations for 15-minute cron intervals
+    const fifteenMinutesMs = 15 * 60 * 1000
+    const oneHourMs = 60 * 60 * 1000
+    const twentyFourHoursMs = 24 * 60 * 60 * 1000
+
+    const fifteenMinutesAgo = new Date(now.getTime() - fifteenMinutesMs)
+    const fifteenMinutesFromNow = new Date(now.getTime() + fifteenMinutesMs)
+    const fortyFiveMinutesFromNow = new Date(now.getTime() + 45 * 60 * 1000)
+    const oneHourFromNow = new Date(now.getTime() + oneHourMs)
+    const twentyThreeHours45mFromNow = new Date(
+      now.getTime() + twentyFourHoursMs - fifteenMinutesMs,
+    )
+    const twentyFourHoursFromNow = new Date(now.getTime() + twentyFourHoursMs)
+
+    // Group events by competition + submissionOpensAt so we can send
+    // a single "window opens" email listing all workouts that share the same window
+    interface WindowOpenGroup {
+      competitionId: string
+      competitionName: string
+      competitionSlug: string
+      timezone: string
+      submissionClosesAt: string | undefined
+      eventIds: string[]
+      workouts: WorkoutInfo[]
+    }
+
+    const windowOpenGroups = new Map<string, WindowOpenGroup>()
+
     for (const { event, competition, workout } of events) {
       if (!event.submissionOpensAt) continue
 
       // Normalize datetime strings to UTC-aware ISO format
-      // Handles both SQLite format ("2026-01-27 00:36:37") and ISO with timezone
       const opensAt = new Date(normalizeToUtcDatetime(event.submissionOpensAt))
       const closesAt = event.submissionClosesAt
         ? new Date(normalizeToUtcDatetime(event.submissionClosesAt))
@@ -619,59 +659,63 @@ export async function processSubmissionWindowNotifications(): Promise<ProcessedN
 
       const timezone = competition.timezone || "America/Denver"
 
-      // Get all registrations for this competition
-      const registrations = await db
-        .select({
-          registration: competitionRegistrationsTable,
-          user: userTable,
-        })
-        .from(competitionRegistrationsTable)
-        .innerJoin(
-          userTable,
-          eq(competitionRegistrationsTable.userId, userTable.id),
-        )
-        .where(eq(competitionRegistrationsTable.eventId, competition.id))
-
-      // Time window calculations for 15-minute cron intervals
-      const fifteenMinutesMs = 15 * 60 * 1000
-      const oneHourMs = 60 * 60 * 1000
-      const twentyFourHoursMs = 24 * 60 * 60 * 1000
-
-      const fifteenMinutesAgo = new Date(now.getTime() - fifteenMinutesMs)
-      const fifteenMinutesFromNow = new Date(now.getTime() + fifteenMinutesMs)
-      const fortyFiveMinutesFromNow = new Date(now.getTime() + 45 * 60 * 1000)
-      const oneHourFromNow = new Date(now.getTime() + oneHourMs)
-      const twentyThreeHours45mFromNow = new Date(
-        now.getTime() + twentyFourHoursMs - fifteenMinutesMs,
-      )
-      const twentyFourHoursFromNow = new Date(now.getTime() + twentyFourHoursMs)
-
-      for (const { registration, user } of registrations) {
-        if (!user.email) continue
-
-        const baseParams = {
-          userId: user.id,
-          registrationId: registration.id,
-          competitionId: competition.id,
-          competitionEventId: event.id,
-          competitionName: competition.name,
-          competitionSlug: competition.slug,
-          workoutName: workout.name,
-          workoutDescription: workout.description || undefined,
-          timezone,
-        }
-
-        // 1. Window just opened (within last 15 minutes)
-        if (opensAt <= now && opensAt > fifteenMinutesAgo) {
-          const sent = await sendWindowOpensNotification({
-            ...baseParams,
-            submissionClosesAt: event.submissionClosesAt || undefined,
+      // 1. Window just opened (within last 15 minutes) — collect for grouped email
+      if (opensAt <= now && opensAt > fifteenMinutesAgo) {
+        const groupKey = `${competition.id}::${event.submissionOpensAt}`
+        const existing = windowOpenGroups.get(groupKey)
+        if (existing) {
+          existing.eventIds.push(event.id)
+          existing.workouts.push({
+            name: workout.name,
+            description: workout.description || undefined,
           })
-          if (sent) result.windowOpens++
+        } else {
+          windowOpenGroups.set(groupKey, {
+            competitionId: competition.id,
+            competitionName: competition.name,
+            competitionSlug: competition.slug,
+            timezone,
+            submissionClosesAt: event.submissionClosesAt || undefined,
+            eventIds: [event.id],
+            workouts: [
+              {
+                name: workout.name,
+                description: workout.description || undefined,
+              },
+            ],
+          })
         }
+      }
 
-        // Only process closing notifications if we have a close time
-        if (closesAt) {
+      // Per-event notifications for closing/closed (these remain per-event)
+      if (closesAt) {
+        const registrations = await db
+          .select({
+            registration: competitionRegistrationsTable,
+            user: userTable,
+          })
+          .from(competitionRegistrationsTable)
+          .innerJoin(
+            userTable,
+            eq(competitionRegistrationsTable.userId, userTable.id),
+          )
+          .where(eq(competitionRegistrationsTable.eventId, competition.id))
+
+        for (const { registration, user } of registrations) {
+          if (!user.email) continue
+
+          const baseParams = {
+            userId: user.id,
+            registrationId: registration.id,
+            competitionId: competition.id,
+            competitionEventId: event.id,
+            competitionName: competition.name,
+            competitionSlug: competition.slug,
+            workoutName: workout.name,
+            workoutDescription: workout.description || undefined,
+            timezone,
+          }
+
           // 2. Window closes in ~24 hours (23h45m - 24h window)
           if (
             closesAt <= twentyFourHoursFromNow &&
@@ -716,7 +760,6 @@ export async function processSubmissionWindowNotifications(): Promise<ProcessedN
 
           // 5. Window just closed (within last 15 minutes)
           if (closesAt <= now && closesAt > fifteenMinutesAgo) {
-            // Check if user has actually submitted a score for this event
             const hasSubmitted = await hasUserSubmittedScore({
               userId: user.id,
               competitionEventId: event.id,
@@ -729,6 +772,39 @@ export async function processSubmissionWindowNotifications(): Promise<ProcessedN
             if (sent) result.windowClosed++
           }
         }
+      }
+    }
+
+    // Process grouped window-opens notifications
+    // Each group is a set of events in the same competition that share the same submissionOpensAt
+    for (const group of windowOpenGroups.values()) {
+      const registrations = await db
+        .select({
+          registration: competitionRegistrationsTable,
+          user: userTable,
+        })
+        .from(competitionRegistrationsTable)
+        .innerJoin(
+          userTable,
+          eq(competitionRegistrationsTable.userId, userTable.id),
+        )
+        .where(eq(competitionRegistrationsTable.eventId, group.competitionId))
+
+      for (const { registration, user } of registrations) {
+        if (!user.email) continue
+
+        const sent = await sendWindowOpensNotification({
+          userId: user.id,
+          registrationId: registration.id,
+          competitionId: group.competitionId,
+          competitionEventIds: group.eventIds,
+          competitionName: group.competitionName,
+          competitionSlug: group.competitionSlug,
+          workouts: group.workouts,
+          submissionClosesAt: group.submissionClosesAt,
+          timezone: group.timezone,
+        })
+        if (sent) result.windowOpens++
       }
     }
 

--- a/apps/wodsmith-start/src/server/notifications/submission-window.ts
+++ b/apps/wodsmith-start/src/server/notifications/submission-window.ts
@@ -248,22 +248,49 @@ export async function sendWindowOpensNotification(params: {
     return false
   }
 
-  // Reserve notification slots for all events in this window group.
-  // If at least one reservation succeeds, we need to send the email.
-  const reservedEventIds: string[] = []
-  for (const eventId of competitionEventIds) {
-    const reserved = await reserveNotification({
-      competitionId,
-      competitionEventId: eventId,
-      registrationId,
-      userId,
-      type: SUBMISSION_WINDOW_NOTIFICATION_TYPES.WINDOW_OPENS,
-      sentToEmail: user.email,
-    })
-    if (reserved) {
-      reservedEventIds.push(eventId)
+  // Reserve notification slots for all events in this window group atomically.
+  // Uses a transaction so either all reservations succeed or none do,
+  // preventing duplicate grouped emails from concurrent cron runs.
+  const reservedEventIds = await db.transaction(async (tx) => {
+    const reserved: string[] = []
+    for (const eventId of competitionEventIds) {
+      const [existing] = await tx
+        .select({ id: submissionWindowNotificationsTable.id })
+        .from(submissionWindowNotificationsTable)
+        .where(
+          and(
+            eq(
+              submissionWindowNotificationsTable.competitionEventId,
+              eventId,
+            ),
+            eq(
+              submissionWindowNotificationsTable.registrationId,
+              registrationId,
+            ),
+            eq(
+              submissionWindowNotificationsTable.type,
+              SUBMISSION_WINDOW_NOTIFICATION_TYPES.WINDOW_OPENS,
+            ),
+          ),
+        )
+
+      if (existing) {
+        // This event was already reserved — another process owns this group
+        return []
+      }
+
+      await tx.insert(submissionWindowNotificationsTable).values({
+        competitionId,
+        competitionEventId: eventId,
+        registrationId,
+        userId,
+        type: SUBMISSION_WINDOW_NOTIFICATION_TYPES.WINDOW_OPENS,
+        sentToEmail: user.email,
+      })
+      reserved.push(eventId)
     }
-  }
+    return reserved
+  })
 
   if (reservedEventIds.length === 0) {
     // All events already notified by another process
@@ -661,7 +688,7 @@ export async function processSubmissionWindowNotifications(): Promise<ProcessedN
 
       // 1. Window just opened (within last 15 minutes) — collect for grouped email
       if (opensAt <= now && opensAt > fifteenMinutesAgo) {
-        const groupKey = `${competition.id}::${event.submissionOpensAt}`
+        const groupKey = `${competition.id}::${event.submissionOpensAt}::${event.submissionClosesAt ?? ""}`
         const existing = windowOpenGroups.get(groupKey)
         if (existing) {
           existing.eventIds.push(event.id)

--- a/apps/wodsmith-start/test/server/notifications/submission-window.test.ts
+++ b/apps/wodsmith-start/test/server/notifications/submission-window.test.ts
@@ -153,10 +153,9 @@ describe("Submission Window Notifications", () => {
 			mockDb.registerTable("submissionWindowNotificationsTable")
 			mockDb.setMockSingleValue(mockUser)
 
-			// reserveNotification checks submissionWindowNotificationsTable.findFirst()
-			// Return existing notification = already sent = reservation fails
-			const notifFindFirst = mockDb.query.submissionWindowNotificationsTable.findFirst as any
-			notifFindFirst.mockResolvedValueOnce({ id: "existing_notif" })
+			// The atomic transaction uses select().from().where() to check for existing reservations.
+			// Set mockReturnValue so the select chain returns an existing record.
+			mockDb.setMockReturnValue([{ id: "existing_notif" }])
 
 			const { sendWindowOpensNotification } = await import(
 				"@/server/notifications/submission-window"

--- a/apps/wodsmith-start/test/server/notifications/submission-window.test.ts
+++ b/apps/wodsmith-start/test/server/notifications/submission-window.test.ts
@@ -86,10 +86,10 @@ describe("Submission Window Notifications", () => {
 				userId: "user_123",
 				registrationId: "reg_123",
 				competitionId: "comp_123",
-				competitionEventId: "event_123",
+				competitionEventIds: ["event_123"],
 				competitionName: "Test Competition",
 				competitionSlug: "test-comp",
-				workoutName: "Test Workout",
+				workouts: [{ name: "Test Workout" }],
 				timezone: "America/Denver",
 			})
 
@@ -104,7 +104,49 @@ describe("Submission Window Notifications", () => {
 			)
 		})
 
-		it("does not send notification when reservation fails (already sent)", async () => {
+		it("sends single email with multiple workouts when events share a window", async () => {
+			// Arrange - user exists with email
+			const mockUser = { id: "user_123", email: "athlete@example.com", firstName: "John" }
+			mockDb.registerTable("userTable")
+			mockDb.registerTable("submissionWindowNotificationsTable")
+			mockDb.setMockSingleValue(mockUser)
+
+			// Both event reservations succeed (first time sending)
+			const notifFindFirst = mockDb.query.submissionWindowNotificationsTable.findFirst as any
+			notifFindFirst.mockResolvedValueOnce(null) // event_1 reservation succeeds
+			notifFindFirst.mockResolvedValueOnce(null) // event_2 reservation succeeds
+
+			const { sendWindowOpensNotification } = await import(
+				"@/server/notifications/submission-window"
+			)
+
+			// Act
+			const result = await sendWindowOpensNotification({
+				userId: "user_123",
+				registrationId: "reg_123",
+				competitionId: "comp_123",
+				competitionEventIds: ["event_1", "event_2"],
+				competitionName: "Test Competition",
+				competitionSlug: "test-comp",
+				workouts: [
+					{ name: "Workout 1", description: "10 Thrusters" },
+					{ name: "Workout 2", description: "20 Pull-ups" },
+				],
+				timezone: "America/Denver",
+			})
+
+			// Assert - only one email sent, containing both workout names
+			expect(result).toBe(true)
+			expect(mockSendEmail).toHaveBeenCalledTimes(1)
+			expect(mockSendEmail).toHaveBeenCalledWith(
+				expect.objectContaining({
+					to: "athlete@example.com",
+					subject: "Submission Window Open: Workout 1, Workout 2 - Test Competition",
+				}),
+			)
+		})
+
+		it("does not send notification when all reservations fail (already sent)", async () => {
 			// Arrange - user exists with email
 			const mockUser = { id: "user_123", email: "athlete@example.com", firstName: "John" }
 			mockDb.registerTable("userTable")
@@ -125,10 +167,10 @@ describe("Submission Window Notifications", () => {
 				userId: "user_123",
 				registrationId: "reg_123",
 				competitionId: "comp_123",
-				competitionEventId: "event_123",
+				competitionEventIds: ["event_123"],
 				competitionName: "Test Competition",
 				competitionSlug: "test-comp",
-				workoutName: "Test Workout",
+				workouts: [{ name: "Test Workout" }],
 				timezone: "America/Denver",
 			})
 
@@ -164,10 +206,10 @@ describe("Submission Window Notifications", () => {
 				userId: "user_123",
 				registrationId: "reg_123",
 				competitionId: "comp_123",
-				competitionEventId: "event_123",
+				competitionEventIds: ["event_123"],
 				competitionName: "Test Competition",
 				competitionSlug: "test-comp",
-				workoutName: "Test Workout",
+				workouts: [{ name: "Test Workout" }],
 				timezone: "America/Denver",
 			})
 
@@ -194,10 +236,10 @@ describe("Submission Window Notifications", () => {
 				userId: "user_123",
 				registrationId: "reg_123",
 				competitionId: "comp_123",
-				competitionEventId: "event_123",
+				competitionEventIds: ["event_123"],
 				competitionName: "Test Competition",
 				competitionSlug: "test-comp",
-				workoutName: "Test Workout",
+				workouts: [{ name: "Test Workout" }],
 				timezone: "America/Denver",
 			})
 


### PR DESCRIPTION
## Summary
This PR enables sending a single "submission window opens" email when multiple workouts in the same competition share the same submission window, improving the user experience by reducing email volume for events with multiple concurrent workouts.

## Key Changes

- **Updated `sendWindowOpensNotification` function** to accept multiple competition event IDs and workout information instead of a single event/workout
  - Changed `competitionEventId` parameter to `competitionEventIds: string[]`
  - Changed `workoutName`/`workoutDescription` parameters to `workouts: WorkoutInfo[]`
  - Updated notification reservation logic to handle multiple events and only send email if at least one reservation succeeds

- **Enhanced email template** (`SubmissionWindowOpensEmail`) to display multiple workouts
  - Added `WorkoutInfo` interface for structured workout data
  - Maintained backward compatibility with deprecated `workoutName`/`workoutDescription` props
  - Updated UI to show "X workouts" vs single workout with appropriate singular/plural text
  - Added visual separator (horizontal rule) between multiple workouts in the email

- **Refactored notification processing** in `processSubmissionWindowNotifications`
  - Introduced `WindowOpenGroup` interface to group events by competition + submission open time
  - Events sharing the same submission window are now collected and sent as a single grouped email
  - Per-event notifications (closing/closed) remain unchanged and are processed separately
  - Moved time window calculations outside the event loop for efficiency

- **Updated tests** to reflect new multi-event API
  - Added test case for sending single email with multiple workouts
  - Updated existing tests to use new parameter names and structures

## Implementation Details

- The grouping key for window-opens notifications is `${competitionId}::${submissionOpensAt}`, ensuring events in the same competition with identical submission times are grouped together
- Notification reservations are attempted for each event in a group; the email is sent if at least one succeeds
- On email failure, all successful reservations are cleaned up to allow retry on the next cron run
- The email subject line now lists all workout names joined by commas (e.g., "Submission Window Open: Workout 1, Workout 2 - Competition Name")

https://claude.ai/code/session_01NPjNVihbNaLUbBNU4ZETri

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send a single “submission window opens” email when multiple workouts in the same competition share the same window, listing all workouts in one message. Adds atomic reservation to prevent duplicate sends and groups by competition + open time + close time.

- **New Features**
  - Group events by competition + submission open time + close time; send one email with all workouts. Closing/closed reminders stay per-event.
  - Updated `SubmissionWindowOpensEmail` to render multiple workouts with pluralized copy, dividers, and a pluralized CTA; subject lists all workout names.
  - Reserve notifications for all events in a group in one transaction; skip if any event was already reserved and clean up all reservations on send failure.

- **Migration**
  - `sendWindowOpensNotification` now takes `competitionEventIds: string[]` and `workouts: WorkoutInfo[]` (replaces `competitionEventId`, `workoutName`, and `workoutDescription`).
  - `SubmissionWindowOpensEmail` supports `workouts`; single-workout props are still accepted but deprecated.

<sup>Written for commit 7c439ce93776b375f6d8475073c80407e8ca3804. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Submission window opening emails now support multiple workouts in a single notification.
  * Email messaging automatically adjusts between singular and plural phrasing based on the number of events included.

* **Chores**
  * Improved grouping of multiple events sharing the same submission window opening time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->