### PR TITLE
fix: enforce parent event-division mappings on sub-events in submission panel

### DIFF
--- a/apps/wodsmith-start/src/components/compete/athlete-score-submission-panel.tsx
+++ b/apps/wodsmith-start/src/components/compete/athlete-score-submission-panel.tsx
@@ -131,7 +131,8 @@ export function AthleteScoreSubmissionPanel({
   }, [eventDivisionMappings, division?.id])
 
   // Filter parents and children by division mappings.
-  // Children with explicit mappings can survive even if the parent is mapped out.
+  // Sub-events inherit their parent's mapping — only top-level events are mapped in the matrix.
+  // Children with their own explicit mappings are filtered individually as a secondary filter.
   const { filteredParents, filteredChildEventsMap } = useMemo(() => {
     const isVisible = (id: string) =>
       eventsWithMappings.size === 0 || !eventsWithMappings.has(id) || mappedToSelectedDiv.has(id)
@@ -149,8 +150,11 @@ export function AthleteScoreSubmissionPanel({
         continue
       }
 
-      // Filter children first — children with explicit mappings survive
-      // even if parent is mapped out
+      // Parent with children: check parent's mapping first.
+      // If the parent is explicitly mapped to other divisions, skip it and all children.
+      if (!isVisible(parent.id)) continue
+
+      // Then filter children individually (children with their own explicit mappings)
       const visibleChildren = children.filter((c) => isVisible(c.id))
       if (visibleChildren.length > 0) {
         visibleParents.push(parent)

--- a/apps/wodsmith-start/src/components/compete/athlete-score-submission-panel.tsx
+++ b/apps/wodsmith-start/src/components/compete/athlete-score-submission-panel.tsx
@@ -130,9 +130,8 @@ export function AthleteScoreSubmissionPanel({
     }
   }, [eventDivisionMappings, division?.id])
 
-  // Filter parents and children by division mappings.
-  // Sub-events inherit their parent's mapping — only top-level events are mapped in the matrix.
-  // Children with their own explicit mappings are filtered individually as a secondary filter.
+  // Filter by division mappings. Only top-level events are mapped;
+  // sub-events inherit their parent's visibility.
   const { filteredParents, filteredChildEventsMap } = useMemo(() => {
     const isVisible = (id: string) =>
       eventsWithMappings.size === 0 || !eventsWithMappings.has(id) || mappedToSelectedDiv.has(id)
@@ -150,16 +149,12 @@ export function AthleteScoreSubmissionPanel({
         continue
       }
 
-      // Parent with children: check parent's mapping first.
-      // If the parent is explicitly mapped to other divisions, skip it and all children.
+      // Parent with children: check parent's mapping.
+      // Only top-level events are mapped; children inherit the parent's visibility.
       if (!isVisible(parent.id)) continue
 
-      // Then filter children individually (children with their own explicit mappings)
-      const visibleChildren = children.filter((c) => isVisible(c.id))
-      if (visibleChildren.length > 0) {
-        visibleParents.push(parent)
-        childMap.set(parent.id, visibleChildren)
-      }
+      visibleParents.push(parent)
+      childMap.set(parent.id, children)
     }
 
     return { filteredParents: visibleParents, filteredChildEventsMap: childMap }


### PR DESCRIPTION
## Summary
- Sub-events in the athlete score submission panel were not inheriting their parent event's division mapping, causing all children to appear for every division
- Added a `isVisible(parent.id)` check before processing children so that if a parent is mapped to other divisions only, it and all its children are skipped
- Children with their own explicit mappings are still filtered individually as a secondary step

## Test plan
- [ ] Register an athlete in Division A for a competition with event-division mappings
- [ ] Verify the submission panel only shows events mapped to Division A (not Division B events)
- [ ] Verify sub-events of a parent mapped to Division B only do not appear for Division A athletes
- [ ] Verify competitions with no event-division mappings still show all events to all divisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the athlete score submission panel so sub-events inherit their parent event’s division mapping. Parents mapped to other divisions are skipped with all children; competitions without mappings still show all events.

- **Refactors**
  - Removed dead child-event mapping filter; only top-level events are in `event_division_mappings`.

<sup>Written for commit d954ad0e812ad25ba9e81c6de3d6e54774ef6f14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event visibility filtering so that when a parent division is hidden, its child events are also hidden; leaf divisions remain shown/hidden based on their own visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->