### PR TITLE
fix: allow platform admins to access coupon page

### DIFF
--- a/apps/wodsmith-start/src/server-fns/coupon-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/coupon-fns.ts
@@ -60,11 +60,13 @@ export const createCouponFn = createServerFn({ method: "POST" })
   .handler(async ({ data: input }) => {
     const session = await requireVerifiedEmail()
 
-    const canManage = session.teams?.find(
-      (t) =>
-        t.id === input.teamId &&
-        (t.role.id === "admin" || t.role.id === "owner"),
-    )
+    const canManage =
+      session.user?.role === "admin" ||
+      session.teams?.find(
+        (t) =>
+          t.id === input.teamId &&
+          (t.role.id === "admin" || t.role.id === "owner"),
+      )
     if (!canManage) throw new Error("Unauthorized")
 
     getEvlog()?.set({ action: "create_coupon", coupon: { competitionId: input.competitionId }, teamId: input.teamId })
@@ -142,11 +144,13 @@ export const listCouponsFn = createServerFn({ method: "GET" })
   .handler(async ({ data: input }) => {
     const session = await requireVerifiedEmail()
 
-    const canManage = session.teams?.find(
-      (t) =>
-        t.id === input.teamId &&
-        (t.role.id === "admin" || t.role.id === "owner"),
-    )
+    const canManage =
+      session.user?.role === "admin" ||
+      session.teams?.find(
+        (t) =>
+          t.id === input.teamId &&
+          (t.role.id === "admin" || t.role.id === "owner"),
+      )
     if (!canManage) throw new Error("Unauthorized")
 
     const db = getDb()
@@ -230,11 +234,13 @@ export const deactivateCouponFn = createServerFn({ method: "POST" })
   .handler(async ({ data: input }) => {
     const session = await requireVerifiedEmail()
 
-    const canManage = session.teams?.find(
-      (t) =>
-        t.id === input.teamId &&
-        (t.role.id === "admin" || t.role.id === "owner"),
-    )
+    const canManage =
+      session.user?.role === "admin" ||
+      session.teams?.find(
+        (t) =>
+          t.id === input.teamId &&
+          (t.role.id === "admin" || t.role.id === "owner"),
+      )
     if (!canManage) throw new Error("Unauthorized")
 
     getEvlog()?.set({ action: "deactivate_coupon", coupon: { id: input.couponId }, teamId: input.teamId })

--- a/lat.md/organizer-dashboard.md
+++ b/lat.md/organizer-dashboard.md
@@ -140,7 +140,7 @@ Fetches revenue stats and Stripe connection status in parallel. Uses `RevenueSta
 
 Discount codes that reduce registration fees for athletes.
 
-Requires `PRODUCT_COUPONS` entitlement. `CouponsPage` handles creating and deactivating coupons with code, discount amount, usage limits, and expiration. Uses `createCouponFn`, `listCouponsFn`, `deactivateCouponFn`.
+Requires `PRODUCT_COUPONS` entitlement. `CouponsPage` handles creating and deactivating coupons with code, discount amount, usage limits, and expiration. Uses `createCouponFn`, `listCouponsFn`, `deactivateCouponFn`. All three server functions authorize both platform admins (`session.user.role === "admin"`) and team admin/owner members.
 
 ## Sponsors
 


### PR DESCRIPTION
## Summary
- `createCouponFn`, `listCouponsFn`, and `deactivateCouponFn` only checked team admin/owner membership, rejecting platform admins not on the organizing team
- Added `session.user?.role === "admin"` check to all three functions, matching the parent route layout's authorization pattern

## Test plan
- [ ] Log in as a platform admin who is NOT a member of an organizing team
- [ ] Navigate to that team's competition coupon page — should load successfully
- [ ] Verify creating and deactivating coupons works as platform admin
- [ ] Verify team admin/owner access is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed authorization on coupon server functions so platform admins can access and manage coupons without being on the team. Added `session.user?.role === "admin"` checks and updated organizer docs.

- **Bug Fixes**
  - Authorized platform admins in `createCouponFn`, `listCouponsFn`, and `deactivateCouponFn` (matches parent route layout).
  - Platform admins can load the coupon page and create/deactivate coupons; team admin/owner access unchanged.
  - Updated `organizer-dashboard.md` to document both admin paths.

<sup>Written for commit 32d04a499607212fa69ebe0aebbd0e6cb52528a4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

