### PR TITLE
fix: update tiebreak terminology in video submission form

### DIFF
--- a/apps/wodsmith-start/src/components/compete/video-submission-form.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-submission-form.tsx
@@ -1105,7 +1105,7 @@ export function VideoSubmissionForm({
                 <div className="space-y-2">
                   <Label htmlFor="tiebreak-input">
                     Tiebreak (
-                    {workout.tiebreakScheme === "time" ? "Time" : "Reps"})
+                    {workout.tiebreakScheme === "time" ? "Time" : "Reps/Weight"})
                   </Label>
                   <Input
                     id="tiebreak-input"
@@ -1122,7 +1122,7 @@ export function VideoSubmissionForm({
                   <p className="text-xs text-muted-foreground">
                     {workout.tiebreakScheme === "time"
                       ? "Time to complete specified reps/work"
-                      : "Reps completed for tiebreak"}
+                      : "Reps or weight completed for tiebreak"}
                   </p>
                 </div>
               )}


### PR DESCRIPTION
Changed the label and description for the tiebreak input to clarify that it can refer to either "Reps" or "Weight" instead of just "Reps". This improves the accuracy of the information presented to users when submitting their videos.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified tiebreak terminology in the video submission form: when the tiebreak scheme isn’t time, the label now shows "Reps/Weight" and the helper text says "Reps or weight completed." This helps athletes submit accurate tiebreaks.

<sup>Written for commit df7206ddf1cb31379dc85f9b65c6282f64a31c26. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated tiebreak input labels to display "Reps/Weight" instead of "Reps" and revised helper text to "Reps or weight completed for tiebreak".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->