### PR TITLE
Exclude removed registrations from leaderboard queries

### DIFF
--- a/apps/wodsmith-start/src/server-fns/leaderboard-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/leaderboard-fns.ts
@@ -8,12 +8,13 @@
  */
 
 import { createServerFn } from "@tanstack/react-start"
-import { and, eq } from "drizzle-orm"
+import { and, eq, ne } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import {
   competitionRegistrationsTable,
   competitionsTable,
+  REGISTRATION_STATUS,
 } from "@/db/schemas/competitions"
 import {
   programmingTracksTable,
@@ -158,15 +159,27 @@ export const getLeaderboardDataFn = createServerFn({ method: "GET" })
         })
       : []
 
-    // Get registrations for this competition
+    // Get registrations for this competition.
+    // Exclude REMOVED registrations so athletes removed from the competition
+    // don't appear on the leaderboard.
     const registrations = await db.query.competitionRegistrationsTable.findMany(
       {
         where: data.divisionId
           ? and(
               eq(competitionRegistrationsTable.eventId, data.competitionId),
               eq(competitionRegistrationsTable.divisionId, data.divisionId),
+              ne(
+                competitionRegistrationsTable.status,
+                REGISTRATION_STATUS.REMOVED,
+              ),
             )
-          : eq(competitionRegistrationsTable.eventId, data.competitionId),
+          : and(
+              eq(competitionRegistrationsTable.eventId, data.competitionId),
+              ne(
+                competitionRegistrationsTable.status,
+                REGISTRATION_STATUS.REMOVED,
+              ),
+            ),
         with: {
           user: true,
           division: true,

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -86,6 +86,8 @@ Organizers can soft-delete registrations via `removeRegistrationFn`, setting sta
 
 Cascading cleanup: deactivates team memberships (captain in event team + all members in athlete team), cancels pending invitations, deletes heat assignments, and deletes scores for the registered user(s) across all competition events. Requires `MANAGE_COMPETITIONS` permission.
 
+Leaderboard and downstream queries (competition leaderboard, series leaderboard, legacy [[apps/wodsmith-start/src/server-fns/leaderboard-fns.ts#getLeaderboardDataFn]], heats, divisions, broadcasts, video submissions) filter out `REMOVED` registrations so removed athletes never appear in standings or counts.
+
 ## Division Transfer
 
 Organizers can move a registration between divisions via `transferRegistrationDivisionFn`.


### PR DESCRIPTION
## Summary
Updated the leaderboard query to filter out registrations with `REMOVED` status, ensuring that athletes who have been removed from a competition do not appear in leaderboard standings.

## Key Changes
- Added `ne` (not equal) operator import from `drizzle-orm`
- Imported `REGISTRATION_STATUS` constant from competitions schema
- Modified `getLeaderboardDataFn` to exclude `REMOVED` registrations in both division-specific and competition-wide queries
- Updated documentation to clarify that removed registrations are filtered across all downstream queries (leaderboard, heats, divisions, broadcasts, video submissions)

## Implementation Details
- The filter applies to both query paths: when a `divisionId` is provided and when querying all divisions
- Uses `ne(competitionRegistrationsTable.status, REGISTRATION_STATUS.REMOVED)` to exclude removed athletes
- Maintains consistency with the soft-delete pattern already established in the codebase for registration removal

https://claude.ai/code/session_01Y2QLeDfCv5VJwxXB2N4odj

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude `REMOVED` registrations from the legacy leaderboard query so removed athletes never appear in standings. This aligns `getLeaderboardDataFn` with the main leaderboard and series queries for consistent counts across the app.

- **Bug Fixes**
  - Filter `REGISTRATION_STATUS.REMOVED` using `ne` from `drizzle-orm` in division-specific and competition-wide queries.
  - Updated docs to note that leaderboard, heats, divisions, broadcasts, and video submissions exclude removed registrations.

<sup>Written for commit a2a058e23b4a30f46ff886b5d0c7b50f896a708f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed athletes are now correctly excluded from leaderboard displays and standings calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->