### PR TITLE
chore: upgrade pnpm 9 to 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"apps/*",
 		"packages/*"
 	],
-	"packageManager": "pnpm@9.12.1+sha512.e5a7e52a4183a02d5931057f7a0dbff9d5e9ce3161e33fa68ae392125b79282a8a8a470a51dfc8a0ed86221442eb2fb57019b0990ed24fab519bf0e1bc5ccfc4",
+	"packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
 	"engines": {
 		"node": ">=24"
 	}


### PR DESCRIPTION
## Summary
- Upgrade pnpm from 9.12.1 to 10.33.0
- Fixes `[DEP0169] url.parse()` deprecation warning on Node 24 (pnpm 9 used the deprecated API internally)
- Lockfile format is compatible — no lockfile changes needed

## Test plan
- [x] `pnpm install` — no warnings
- [x] `pnpm test` — 84 files, 2437 tests passing
- [ ] CI confirms pnpm 10 works with `pnpm/action-setup@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `pnpm` from 9.12.1 to 10.33.0 to remove the Node 24 `[DEP0169] url.parse()` deprecation warning during install. Lockfile format is compatible, so no lockfile changes are needed.

<sup>Written for commit 2885729a593bfd6fe6eab8ee41a6a78a3f9ede76. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package manager version to improve project tooling and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->