### PR TITLE
fix: show registration-time affiliate on organizer athletes page

### DIFF
--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/athletes.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/athletes.tsx
@@ -555,11 +555,18 @@ function AthletesPage() {
     }
 
     // Parse registration metadata for per-user affiliates
-    const registrationMetadata = registration.metadata
-      ? (typeof registration.metadata === "string"
-          ? JSON.parse(registration.metadata)
-          : registration.metadata)
-      : null
+    let registrationMetadata: Record<string, unknown> | null = null
+    if (registration.metadata) {
+      if (typeof registration.metadata === "string") {
+        try {
+          registrationMetadata = JSON.parse(registration.metadata)
+        } catch {
+          // Invalid JSON, fall back to null
+        }
+      } else {
+        registrationMetadata = registration.metadata as Record<string, unknown>
+      }
+    }
     const metadataAffiliates =
       registrationMetadata?.affiliates as Record<string, string | null> | undefined
 

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/athletes.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/athletes.tsx
@@ -554,8 +554,24 @@ function AthletesPage() {
         })
     }
 
+    // Parse registration metadata for per-user affiliates
+    const registrationMetadata = registration.metadata
+      ? (typeof registration.metadata === "string"
+          ? JSON.parse(registration.metadata)
+          : registration.metadata)
+      : null
+    const metadataAffiliates =
+      registrationMetadata?.affiliates as Record<string, string | null> | undefined
+
     // Create a row for each member
     allMembers.forEach((member, memberIndex) => {
+      const userId = member.user?.id ?? ""
+      // Prefer affiliate from registration metadata, fall back to user profile
+      const affiliateName =
+        metadataAffiliates?.[userId] ??
+        (member.user as { affiliateName?: string | null })?.affiliateName ??
+        null
+
       athleteRows.push({
         registrationId: registration.id,
         registrationStatus: registration.status,
@@ -565,14 +581,12 @@ function AthletesPage() {
         ordinal: rowIndex,
         ordinalLabel: memberIndex === 0 ? String(rowIndex) : "",
         athlete: {
-          id: member.user?.id ?? "",
+          id: userId,
           firstName: member.user?.firstName ?? null,
           lastName: member.user?.lastName ?? null,
           email: member.user?.email ?? null,
           avatar: member.user?.avatar ?? null,
-          affiliateName:
-            (member.user as { affiliateName?: string | null })?.affiliateName ??
-            null,
+          affiliateName,
         },
         isCaptain: member.isCaptain,
         status: "registered",


### PR DESCRIPTION
## Summary
- The organizer athletes page was displaying the affiliate from the user's **current profile** (`users.affiliate_name`), not what they entered at registration time
- Changed to read from `registration.metadata.affiliates[userId]` first, falling back to user profile if no registration metadata exists
- Affects both the table display and CSV export (both flow through the same `AthleteRow` data)

## Context
Queried MWFC Online Qualifier 2026 (260 registrations): 253 have affiliate in both places, 5 of those differ between profile and registration metadata — those 5 were showing the wrong (current profile) value to organizers.

## Test plan
- [ ] Load organizer athletes page for a competition with registrations
- [ ] Verify affiliate column shows registration-time affiliate values
- [ ] Export CSV and verify affiliate column matches the table
- [ ] Check a registration where user changed their profile affiliate after registering — should show original registration value

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the affiliate entered at registration on the organizer athletes page, not the current profile affiliate. Applies to both the table and CSV export for accurate historical records.

- **Bug Fixes**
  - Prefer affiliate from `registration.metadata.affiliates[userId]`, falling back to `users.affiliate_name` when missing.
  - Parse `registration.metadata` whether string or object and feed the value into `AthleteRow` used by both views.
  - Guard `JSON.parse` with try-catch to handle malformed metadata without breaking the page or CSV export.

<sup>Written for commit 87cad9f422805d3542e43f784c52eb3533d66b90. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of athlete affiliate data in competition registrations: registration metadata is now parsed and affiliate overrides from metadata are respected, ensuring accurate affiliate names shown in the organizer dashboard and participant lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->