### PR TITLE
fix: require score on video submission form

### DIFF
--- a/apps/wodsmith-start/src/components/compete/video-submission-form.tsx
+++ b/apps/wodsmith-start/src/components/compete/video-submission-form.tsx
@@ -282,6 +282,7 @@ export function VideoSubmissionForm({
   )
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [hasAttemptedSubmit, setHasAttemptedSubmit] = useState(false)
   const [success, setSuccess] = useState<string | null>(null)
   const hasAnySubmission = existingSubmissions.length > 0
   const [hasSubmitted, setHasSubmitted] = useState(hasAnySubmission)
@@ -715,6 +716,7 @@ export function VideoSubmissionForm({
     e.preventDefault()
     setError(null)
     setSuccess(null)
+    setHasAttemptedSubmit(true)
 
     // For teams, require ALL video links; for individuals, require at least one
     if (teamSize > 1) {
@@ -751,29 +753,41 @@ export function VideoSubmissionForm({
       }
     }
 
-    // Validate score — multi-round or single
-    if (isMultiRound && workout) {
+    // Validate score — score is required for all submissions
+    if (isMultiRound) {
       const filledRounds = roundScoreInputs.filter((s) => s.trim())
-      if (filledRounds.length > 0 && filledRounds.length < roundsToScore) {
+      if (filledRounds.length === 0) {
         setError(
-          `Please enter scores for all ${roundsToScore} rounds, or leave them all empty`,
+          `Please enter scores for all ${roundsToScore} rounds`,
         )
         return
       }
-      for (let i = 0; i < roundScoreInputs.length; i++) {
-        const input = roundScoreInputs[i]
-        if (input.trim()) {
-          const result = parseScore(input, workout.scheme)
-          if (!result.isValid) {
-            setError(
-              `Round ${i + 1}: ${result.error || "Please check your score entry"}`,
-            )
-            return
+      if (filledRounds.length < roundsToScore) {
+        setError(
+          `Please enter scores for all ${roundsToScore} rounds`,
+        )
+        return
+      }
+      if (workout) {
+        for (let i = 0; i < roundScoreInputs.length; i++) {
+          const input = roundScoreInputs[i]
+          if (input.trim()) {
+            const result = parseScore(input, workout.scheme)
+            if (!result.isValid) {
+              setError(
+                `Round ${i + 1}: ${result.error || "Please check your score entry"}`,
+              )
+              return
+            }
           }
         }
       }
-    } else if (scoreInput.trim() && workout) {
-      if (!parseResult?.isValid) {
+    } else {
+      if (!scoreInput.trim()) {
+        setError("Please enter your score")
+        return
+      }
+      if (workout && !parseResult?.isValid) {
         setError(
           `Invalid score: ${parseResult?.error || "Please check your score entry"}`,
         )
@@ -1041,8 +1055,8 @@ export function VideoSubmissionForm({
                           placeholder={getPlaceholder(workout.scheme)}
                           className={cn(
                             "font-mono",
-                            roundResult?.error &&
-                              !roundResult?.isValid &&
+                            ((roundResult?.error && !roundResult?.isValid) ||
+                              (hasAttemptedSubmit && !input.trim())) &&
                               "border-destructive",
                           )}
                           disabled={isSubmitting}
@@ -1055,6 +1069,11 @@ export function VideoSubmissionForm({
                         {roundResult?.error && (
                           <p className="text-xs text-destructive">
                             {roundResult.error}
+                          </p>
+                        )}
+                        {hasAttemptedSubmit && !input.trim() && (
+                          <p className="text-xs text-destructive">
+                            Please enter a score for round {i + 1}
                           </p>
                         )}
                       </div>
@@ -1080,8 +1099,8 @@ export function VideoSubmissionForm({
                     placeholder={getPlaceholder(workout.scheme)}
                     className={cn(
                       "font-mono",
-                      parseResult?.error &&
-                        !parseResult?.isValid &&
+                      ((parseResult?.error && !parseResult?.isValid) ||
+                        (hasAttemptedSubmit && !scoreInput.trim())) &&
                         "border-destructive",
                     )}
                     disabled={isSubmitting}
@@ -1100,6 +1119,11 @@ export function VideoSubmissionForm({
                   {parseResult?.error && (
                     <p className="text-xs text-destructive">
                       {parseResult.error}
+                    </p>
+                  )}
+                  {hasAttemptedSubmit && !scoreInput.trim() && (
+                    <p className="text-xs text-destructive">
+                      Please enter your score
                     </p>
                   )}
                 </div>

--- a/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
@@ -915,6 +915,15 @@ export const submitVideoFn = createServerFn({ method: "POST" })
 
     const now = new Date()
 
+    // Validate score is present before saving anything
+    const hasRoundScores =
+      data.roundScores && data.roundScores.length > 0
+    const hasScore = data.score || hasRoundScores
+
+    if (!hasScore) {
+      throw new Error("A score is required when submitting")
+    }
+
     // Save or update video submission
     let submissionId: string
 
@@ -948,15 +957,7 @@ export const submitVideoFn = createServerFn({ method: "POST" })
       submissionId = id
     }
 
-    // Save claimed score (required — athletes must submit a score with their video)
-    const hasRoundScores =
-      data.roundScores && data.roundScores.length > 0
-    const hasScore = data.score || hasRoundScores
-
-    if (!hasScore) {
-      throw new Error("A score is required when submitting")
-    }
-
+    // Save claimed score (score is validated as required above)
     if (hasScore) {
       // Get workout details for encoding
       const workout = await getWorkoutDetails(data.trackWorkoutId)

--- a/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
@@ -948,10 +948,14 @@ export const submitVideoFn = createServerFn({ method: "POST" })
       submissionId = id
     }
 
-    // Save claimed score if provided (single score or round scores)
+    // Save claimed score (required — athletes must submit a score with their video)
     const hasRoundScores =
       data.roundScores && data.roundScores.length > 0
     const hasScore = data.score || hasRoundScores
+
+    if (!hasScore) {
+      throw new Error("A score is required when submitting")
+    }
 
     if (hasScore) {
       // Get workout details for encoding

--- a/apps/wodsmith-start/test/server-fns/video-submission-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/video-submission-fns.test.ts
@@ -563,6 +563,8 @@ describe("Video Submission Server Functions (TanStack)", () => {
 		it("creates new video submission successfully", async () => {
 			const registration = createTestRegistration()
 			const competition = createTestCompetition({ competitionType: "online" })
+			const workout = createTestWorkout({ id: "wk-1", scheme: "time" })
+			const trackWorkout = createTestTrackWorkout({ workoutId: "wk-1" })
 
 			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
 			limitMock
@@ -571,12 +573,18 @@ describe("Video Submission Server Functions (TanStack)", () => {
 				.mockResolvedValueOnce([]) // No event = allow submission
 				.mockResolvedValueOnce([{ teamSize: 1 }]) // getTeamSize
 				.mockResolvedValueOnce([]) // No existing submission
+				.mockResolvedValueOnce([{ ...trackWorkout, ...workout, trackId: "track-1" }]) // Workout details
+				.mockResolvedValueOnce([{ ownerTeamId: "team-1" }]) // Track for team ownership
+
+			const returningMock = mockDb.getChainMock().returning as ReturnType<typeof vi.fn>
+			returningMock.mockResolvedValueOnce([{ id: "sub-new" }])
 
 			const result = await submitVideoFn({
 				data: {
 					trackWorkoutId: "tw-1",
 					competitionId: "comp-1",
 					videoUrl: "https://youtube.com/watch?v=test",
+					score: "10:00",
 				},
 			})
 
@@ -590,6 +598,8 @@ describe("Video Submission Server Functions (TanStack)", () => {
 			const registration = createTestRegistration()
 			const competition = createTestCompetition({ competitionType: "online" })
 			const existingSubmission = createTestVideoSubmission({ id: "sub-existing" })
+			const workout = createTestWorkout({ id: "wk-1", scheme: "time" })
+			const trackWorkout = createTestTrackWorkout({ workoutId: "wk-1" })
 
 			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
 			limitMock
@@ -598,12 +608,15 @@ describe("Video Submission Server Functions (TanStack)", () => {
 				.mockResolvedValueOnce([])
 				.mockResolvedValueOnce([{ teamSize: 1 }]) // getTeamSize
 				.mockResolvedValueOnce([existingSubmission]) // Existing submission found
+				.mockResolvedValueOnce([{ ...trackWorkout, ...workout, trackId: "track-1" }]) // Workout details
+				.mockResolvedValueOnce([{ ownerTeamId: "team-1" }]) // Track for team ownership
 
 			const result = await submitVideoFn({
 				data: {
 					trackWorkoutId: "tw-1",
 					competitionId: "comp-1",
 					videoUrl: "https://youtube.com/watch?v=updated",
+					score: "10:00",
 				},
 			})
 
@@ -863,6 +876,8 @@ describe("Video Submission Server Functions (TanStack)", () => {
 				id: "sub-new",
 				notes: "Great performance!",
 			})
+			const workout = createTestWorkout({ id: "wk-1", scheme: "time" })
+			const trackWorkout = createTestTrackWorkout({ workoutId: "wk-1" })
 
 			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
 			limitMock
@@ -870,7 +885,9 @@ describe("Video Submission Server Functions (TanStack)", () => {
 				.mockResolvedValueOnce([competition])
 				.mockResolvedValueOnce([])
 				.mockResolvedValueOnce([{ teamSize: 1 }]) // getTeamSize
-				.mockResolvedValueOnce([])
+				.mockResolvedValueOnce([]) // No existing submission
+				.mockResolvedValueOnce([{ ...trackWorkout, ...workout, trackId: "track-1" }]) // Workout details
+				.mockResolvedValueOnce([{ ownerTeamId: "team-1" }]) // Track for team ownership
 
 			const returningMock = mockDb.getChainMock().returning as ReturnType<
 				typeof vi.fn
@@ -883,6 +900,7 @@ describe("Video Submission Server Functions (TanStack)", () => {
 					competitionId: "comp-1",
 					videoUrl: "https://youtube.com/watch?v=test",
 					notes: "Great performance!",
+					score: "10:00",
 				},
 			})
 
@@ -1303,6 +1321,8 @@ describe("Video Submission Server Functions (TanStack)", () => {
 		it("creates submission with divisionId and videoIndex", async () => {
 			const registration = createTestRegistration({ divisionId: "div-rx" })
 			const competition = createTestCompetition({ competitionType: "online" })
+			const workout = createTestWorkout({ id: "wk-1", scheme: "time" })
+			const trackWorkout = createTestTrackWorkout({ workoutId: "wk-1" })
 
 			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
 			limitMock
@@ -1311,6 +1331,8 @@ describe("Video Submission Server Functions (TanStack)", () => {
 				.mockResolvedValueOnce([]) // No event = allow submission
 				.mockResolvedValueOnce([{ teamSize: 3 }]) // Team of 3
 				.mockResolvedValueOnce([]) // No existing submission at this index
+				.mockResolvedValueOnce([{ ...trackWorkout, ...workout, trackId: "track-1" }]) // Workout details
+				.mockResolvedValueOnce([{ ownerTeamId: "team-1" }]) // Track for team ownership
 
 			const result = await submitVideoFn({
 				data: {
@@ -1319,6 +1341,7 @@ describe("Video Submission Server Functions (TanStack)", () => {
 					divisionId: "div-rx",
 					videoUrl: "https://youtube.com/watch?v=test",
 					videoIndex: 1,
+					score: "10:00",
 				},
 			})
 
@@ -1330,6 +1353,8 @@ describe("Video Submission Server Functions (TanStack)", () => {
 		it("allows videoIndex 0 (default) for individual athletes", async () => {
 			const registration = createTestRegistration()
 			const competition = createTestCompetition({ competitionType: "online" })
+			const workout = createTestWorkout({ id: "wk-1", scheme: "time" })
+			const trackWorkout = createTestTrackWorkout({ workoutId: "wk-1" })
 
 			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
 			limitMock
@@ -1338,6 +1363,8 @@ describe("Video Submission Server Functions (TanStack)", () => {
 				.mockResolvedValueOnce([]) // No event = allow submission
 				.mockResolvedValueOnce([{ teamSize: 1 }]) // Individual
 				.mockResolvedValueOnce([]) // No existing submission
+				.mockResolvedValueOnce([{ ...trackWorkout, ...workout, trackId: "track-1" }]) // Workout details
+				.mockResolvedValueOnce([{ ownerTeamId: "team-1" }]) // Track for team ownership
 
 			const result = await submitVideoFn({
 				data: {
@@ -1345,6 +1372,7 @@ describe("Video Submission Server Functions (TanStack)", () => {
 					competitionId: "comp-1",
 					videoUrl: "https://youtube.com/watch?v=test",
 					videoIndex: 0,
+					score: "10:00",
 				},
 			})
 

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -158,7 +158,7 @@ Organizers create waiver templates per competition. Athletes sign waivers during
 
 Athletes can submit video evidence of their workout performance for remote judging.
 
-Submissions link to a score and include a video URL (e.g., Vimeo). Judges can verify or reject submissions. Community voting is supported via `videoVotesTable`. Event ownership validation in [[apps/wodsmith-start/src/server-fns/submission-verification-fns.ts]] uses `verifyEventBelongsToCompetition` which checks `competition_events` first, then falls back to `track_workouts` → `programming_tracks` for sub-events without submission windows.
+Submissions link to a score and include a video URL (e.g., Vimeo). A valid score is **required** — both [[apps/wodsmith-start/src/components/compete/video-submission-form.tsx#VideoSubmissionForm]] and [[apps/wodsmith-start/src/server-fns/video-submission-fns.ts#submitVideoFn]] reject submissions without a score to prevent athletes from entering scores in the notes field instead. Judges can verify or reject submissions. Community voting is supported via `videoVotesTable`. Event ownership validation in [[apps/wodsmith-start/src/server-fns/submission-verification-fns.ts]] uses `verifyEventBelongsToCompetition` which checks `competition_events` first, then falls back to `track_workouts` → `programming_tracks` for sub-events without submission windows.
 
 ### Supported Video Platforms
 


### PR DESCRIPTION
## Summary
- Score is now **required** when submitting a video for online competitions — athletes can no longer submit with a blank score field
- Client-side validation blocks submission and shows inline error messages with red border styling on empty score inputs
- Server-side validation in `submitVideoFn` throws if neither `score` nor `roundScores` is provided
- Applies to both single-round and multi-round workouts, and to both regular and sub-event submission forms (same `VideoSubmissionForm` component)

## Test plan
- [ ] Submit a video with a blank score — should see "Please enter your score" inline error with red border
- [ ] Submit a multi-round workout with empty rounds — should see per-round error messages
- [ ] Submit with a valid score — should succeed as before
- [ ] Submit with an invalid score format — existing parse error still shows
- [ ] Test on a sub-event submission form — same validation applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require a score on all video submissions to prevent blank-score uploads. Client and server validation block empty scores and avoid orphaned video records.

- **Bug Fixes**
  - Block submit when score is empty; show inline errors and destructive borders after attempted submit.
  - Multi-round: require all rounds; show per-round errors if any are missing.
  - Server: `submitVideoFn` validates score before saving and rejects submissions without `score` or `roundScores`.
  - Tests: updated to include a score in all video submissions.
  - Docs: domain docs now state a score is required.

<sup>Written for commit cb963389f63fc1fc9d0f2940d2870ea3e1d4f647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

