### PR TITLE
fix: don't reject teammate video slots without a score

### DIFF
--- a/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
@@ -918,12 +918,16 @@ export const submitVideoFn = createServerFn({ method: "POST" })
 
     const now = new Date()
 
-    // Validate score is present before saving anything
+    // Validate score is present before saving anything.
+    // For team divisions the captain submits all videos in one form action;
+    // the score is only sent with the first slot (videoIndex 0) and shared
+    // across the team's submission, so subsequent slots intentionally arrive
+    // without a score and must not be rejected here.
     const hasRoundScores =
       data.roundScores && data.roundScores.length > 0
     const hasScore = data.score || hasRoundScores
 
-    if (!hasScore) {
+    if (data.videoIndex === 0 && !hasScore) {
       throw new Error("A score is required when submitting")
     }
 

--- a/apps/wodsmith-start/test/server-fns/video-submission-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/video-submission-fns.test.ts
@@ -1353,6 +1353,57 @@ describe("Video Submission Server Functions (TanStack)", () => {
 			expect(mockDb.insert).toHaveBeenCalled()
 		})
 
+		it("allows team videoIndex > 0 without a score (captain's first slot carries the team score)", async () => {
+			const registration = createTestRegistration({ divisionId: "div-rx" })
+			const competition = createTestCompetition({ competitionType: "online" })
+
+			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
+			limitMock
+				.mockResolvedValueOnce([registration])
+				.mockResolvedValueOnce([competition])
+				.mockResolvedValueOnce([]) // No event = allow submission
+				.mockResolvedValueOnce([{ teamSize: 3 }]) // Team of 3
+				.mockResolvedValueOnce([]) // No existing submission at this index
+
+			const result = await submitVideoFn({
+				data: {
+					trackWorkoutId: "tw-1",
+					competitionId: "comp-1",
+					divisionId: "div-rx",
+					videoUrl: "https://youtube.com/watch?v=test",
+					videoIndex: 1,
+					// no score — only the captain's first slot (videoIndex 0) sends it
+				},
+			})
+
+			expect(result.success).toBe(true)
+			expect(result.isUpdate).toBe(false)
+		})
+
+		it("rejects videoIndex 0 submission with no score", async () => {
+			const registration = createTestRegistration()
+			const competition = createTestCompetition({ competitionType: "online" })
+
+			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
+			limitMock
+				.mockResolvedValueOnce([registration])
+				.mockResolvedValueOnce([competition])
+				.mockResolvedValueOnce([]) // No event = allow submission
+				.mockResolvedValueOnce([{ teamSize: 1 }]) // Individual
+				.mockResolvedValueOnce([]) // No existing submission
+
+			await expect(
+				submitVideoFn({
+					data: {
+						trackWorkoutId: "tw-1",
+						competitionId: "comp-1",
+						videoUrl: "https://youtube.com/watch?v=test",
+						videoIndex: 0,
+					},
+				}),
+			).rejects.toThrow("A score is required when submitting")
+		})
+
 		it("allows videoIndex 0 (default) for individual athletes", async () => {
 			const registration = createTestRegistration()
 			const competition = createTestCompetition({ competitionType: "online" })

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -158,7 +158,7 @@ Organizers create waiver templates per competition. Athletes sign waivers during
 
 Athletes can submit video evidence of their workout performance for remote judging.
 
-Submissions link to a score and include a video URL (e.g., Vimeo). A valid score is **required** — both [[apps/wodsmith-start/src/components/compete/video-submission-form.tsx#VideoSubmissionForm]] and [[apps/wodsmith-start/src/server-fns/video-submission-fns.ts#submitVideoFn]] reject submissions without a score to prevent athletes from entering scores in the notes field instead. Judges can verify or reject submissions. Community voting is supported via `videoVotesTable`. Event ownership validation in [[apps/wodsmith-start/src/server-fns/submission-verification-fns.ts]] uses `verifyEventBelongsToCompetition` which checks `competition_events` first, then falls back to `track_workouts` → `programming_tracks` for sub-events without submission windows.
+Submissions link to a score and include a video URL (e.g., Vimeo). A valid score is **required** — both [[apps/wodsmith-start/src/components/compete/video-submission-form.tsx#VideoSubmissionForm]] and [[apps/wodsmith-start/src/server-fns/video-submission-fns.ts#submitVideoFn]] reject submissions without a score to prevent athletes from entering scores in the notes field instead. The server-side check is gated on `videoIndex === 0` so that a team captain submitting multiple teammate videos in one form action — where the score is intentionally only sent with the first slot — is not rejected on subsequent slots. Judges can verify or reject submissions. Community voting is supported via `videoVotesTable`. Event ownership validation in [[apps/wodsmith-start/src/server-fns/submission-verification-fns.ts]] uses `verifyEventBelongsToCompetition` which checks `competition_events` first, then falls back to `track_workouts` → `programming_tracks` for sub-events without submission windows.
 
 ### Supported Video Platforms
 
@@ -190,7 +190,7 @@ Individual athletes (teamSize = 1) are always treated as their own captain. Both
 
 Team divisions allow up to `teamSize` video submissions per event, tracked via a `videoIndex` column on `videoSubmissionsTable`.
 
-The unique constraint is `(registrationId, trackWorkoutId, videoIndex)`. Videos are optional — teams can submit fewer than `teamSize`. The score is submitted once per team (tied to the captain's userId).
+The unique constraint is `(registrationId, trackWorkoutId, videoIndex)`. Videos are optional — teams can submit fewer than `teamSize`. The score is submitted once per team (tied to the captain's userId): the form sends the score (and `roundScores`) only with the first slot's `submitVideoFn` call (`videoIndex === 0`); subsequent teammate slots arrive with no score by design, and the server's score-required check matches that contract by gating on `videoIndex === 0`.
 
 ### Round Breakdown Display
 


### PR DESCRIPTION
## Summary

- PR #401 added a server-side score-required check in `submitVideoFn`, but the video-submission form sends the score only with the captain's first slot (`videoIndex=0`); teammate slots (`videoIndex>0`) are intentionally submitted without a score, so the new check rejected them with *"A score is required when submitting"* and broke team-division submissions end to end.
- Gate the server check on `data.videoIndex === 0` so the captain's submission is still defended but follow-up teammate slots pass through. Document the client/server contract in `lat.md/domain.md`.
- Added regression tests: teammate slot accepts no score; first slot still rejects no score.

## Test plan

- [ ] `pnpm test test/server-fns/video-submission-fns.test.ts` — all 60 tests pass locally
- [ ] `pnpm type-check` clean
- [ ] Manual: as a team captain, fill all `teamSize` video URLs + a score on the form, submit → all slots persist, score saves once, no error toast
- [ ] Manual: as an individual athlete, submit with empty score → still blocked client-side; server still rejects on `videoIndex=0` if bypassed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes team video submissions by only requiring a score for the captain’s first slot (`videoIndex === 0`). Teammate slots without a score now submit correctly while captain score validation stays enforced.

- **Bug Fixes**
  - Gate server score check in `submitVideoFn` to `videoIndex === 0`.
  - Add tests for teammate slot (no score → allowed) and first slot (no score → rejected).
  - Update `lat.md/domain.md` to document the team submission contract.

<sup>Written for commit a7a09d258202a4efd08fb93798e20befa9b13031. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

