### PR TITLE
fix(scoring): align time-input preview with save behavior

### DIFF
--- a/apps/wodsmith-start/src/lib/scoring/index.ts
+++ b/apps/wodsmith-start/src/lib/scoring/index.ts
@@ -14,8 +14,8 @@
  *   computeSortKey,
  * } from "@/lib/scoring"
  *
- * // Parse user input
- * const result = parseScore("1234", "time")
+ * // Parse user input — bare digits are raw seconds, matching encodeScore
+ * const result = parseScore("12:34", "time")
  * // → { isValid: true, encoded: 754000, formatted: "12:34" }
  *
  * // Encode for database

--- a/apps/wodsmith-start/src/lib/scoring/parse/index.ts
+++ b/apps/wodsmith-start/src/lib/scoring/parse/index.ts
@@ -35,8 +35,12 @@ export { parseTime, validateTimeInput } from "./time"
  * @param options - Optional parsing options
  *
  * @example
- * parseScore("1234", "time")
+ * parseScore("12:34", "time")
  * // → { isValid: true, encoded: 754000, formatted: "12:34" }
+ *
+ * parseScore("2000", "time")
+ * // → { isValid: true, encoded: 2000000, formatted: "33:20" }
+ * // (bare digits = raw seconds, matching encodeScore)
  *
  * parseScore("5+12", "rounds-reps")
  * // → { isValid: true, encoded: 500012, formatted: "5+12" }

--- a/apps/wodsmith-start/src/lib/scoring/parse/time.ts
+++ b/apps/wodsmith-start/src/lib/scoring/parse/time.ts
@@ -2,17 +2,16 @@
  * Smart time parsing: converts various input formats to standardized time
  */
 
-import { MS_PER_SECOND } from "../constants"
 import { decodeTime } from "../decode/time"
 import { encodeTime } from "../encode/time"
 import type { ParseResult } from "../types"
 
 export interface TimeParseOptions {
   /**
-   * How to interpret raw numbers without colons:
-   * - 'auto': Smart parsing (e.g., "1234" → "12:34")
-   * - 'seconds': Treat as raw seconds
-   * - 'ms': Treat as raw milliseconds
+   * How to interpret bare numeric input:
+   * - 'auto' (default) / 'seconds': Treat as raw seconds — matches `encodeTime` so
+   *   the live preview always agrees with what `encodeScore` will save.
+   * - 'ms': Treat as raw milliseconds.
    */
   precision?: "auto" | "seconds" | "ms"
 }
@@ -20,29 +19,26 @@ export interface TimeParseOptions {
 /**
  * Parse a time input string with smart formatting.
  *
- * Supports multiple input formats:
- * - Standard: "12:34" or "12:34.567" or "1:02:34.567"
- * - Period-delimited: "12.34.567" (MM.SS.ms) or "1.02.34.567" (H.MM.SS.ms)
- * - Digits only: "1234" → "12:34"
+ * Mirrors `encodeTime` so the live preview always matches what `encodeScore`
+ * will persist on save — there is no separate "smart digit padding" path.
  *
- * Smart parsing rules (when precision is 'auto'):
- * - Input with colons: parse as MM:SS or HH:MM:SS
- * - Input with 2+ periods: treat as period-delimited time (MM.SS.ms or H.MM.SS.ms)
- * - Input with 1 period: treat as time.milliseconds (e.g., "1234.567" → "12:34.567")
- * - 1-2 digits: treat as seconds (e.g., "45" → "0:45")
- * - 3 digits: treat as M:SS (e.g., "345" → "3:45")
- * - 4 digits: treat as MM:SS (e.g., "1234" → "12:34")
- * - 5 digits: treat as H:MM:SS (e.g., "10234" → "1:02:34")
- * - 6+ digits: treat as HH:MM:SS or more
+ * Supported formats:
+ * - Colon-delimited: "MM:SS", "MM:SS.fff", "HH:MM:SS", "HH:MM:SS.fff"
+ * - Period-delimited (3+ parts): "MM.SS.fff", "H.MM.SS.fff"
+ * - Decimal seconds (single period): "12.34" → 12.34 sec, "1234.567" → 1234.567 sec
+ * - Bare digits: treated as raw seconds — "2000" → 33:20, "45" → 0:45
+ *
+ * The `precision` option only matters for explicit overrides:
+ * - 'auto' (default) and 'seconds' both treat bare numbers as raw seconds
+ * - 'ms' treats bare integers as raw milliseconds
  *
  * @example
- * parseTime("1234")        // → { encoded: 754000, formatted: "12:34" }
  * parseTime("12:34")       // → { encoded: 754000, formatted: "12:34" }
  * parseTime("12:34.567")   // → { encoded: 754567, formatted: "12:34.567" }
  * parseTime("12.34.567")   // → { encoded: 754567, formatted: "12:34.567" }
  * parseTime("1.02.34.567") // → { encoded: 3754567, formatted: "1:02:34.567" }
- * parseTime("45")          // → { encoded: 45000, formatted: "0:45" }
- * parseTime("345")         // → { encoded: 225000, formatted: "3:45" }
+ * parseTime("45")          // → { encoded: 45000,  formatted: "0:45" }
+ * parseTime("2000")        // → { encoded: 2000000, formatted: "33:20" }
  */
 export function parseTime(
   input: string,
@@ -60,117 +56,7 @@ export function parseTime(
 
   const precision = options?.precision ?? "auto"
 
-  // If input already has colons, parse directly
-  if (trimmed.includes(":")) {
-    const encoded = encodeTime(trimmed)
-    if (encoded === null) {
-      return {
-        isValid: false,
-        encoded: null,
-        formatted: trimmed,
-        error: "Invalid time format",
-      }
-    }
-    return {
-      isValid: true,
-      encoded,
-      formatted: decodeTime(encoded),
-    }
-  }
-
-  // Handle period-delimited input (e.g., "12.34.567" or "1.02.34.567")
-  if (trimmed.includes(".")) {
-    const parts = trimmed.split(".")
-
-    // If 3+ parts, treat as period-delimited time: MM.SS.ms or H.MM.SS.ms
-    if (parts.length >= 3) {
-      // Last part is always milliseconds
-      const msPart = parts[parts.length - 1] ?? "0"
-      const timeParts = parts.slice(0, -1)
-
-      // Convert to colon format: join time parts with colons
-      const colonFormat = timeParts.join(":")
-      const withMs = `${colonFormat}.${msPart}`
-
-      const encoded = encodeTime(withMs)
-      if (encoded === null) {
-        return {
-          isValid: false,
-          encoded: null,
-          formatted: trimmed,
-          error: "Invalid time format",
-        }
-      }
-      return {
-        isValid: true,
-        encoded,
-        formatted: decodeTime(encoded),
-      }
-    }
-
-    // If 2 parts (one period), treat as time.milliseconds
-    const [wholePart, decimalPart] = parts
-    if (!wholePart) {
-      return {
-        isValid: false,
-        encoded: null,
-        formatted: trimmed,
-        error: "Invalid time format",
-      }
-    }
-
-    // Parse the whole part as time, then add milliseconds
-    const {
-      isValid,
-      encoded: wholeEncoded,
-      error,
-    } = parseTime(wholePart, options)
-    if (!isValid || wholeEncoded === null) {
-      return { isValid: false, encoded: null, formatted: trimmed, error }
-    }
-
-    // Add milliseconds
-    const ms = Number.parseInt(
-      (decimalPart ?? "0").padEnd(3, "0").slice(0, 3),
-      10,
-    )
-    if (Number.isNaN(ms)) {
-      return {
-        isValid: false,
-        encoded: null,
-        formatted: trimmed,
-        error: "Invalid milliseconds",
-      }
-    }
-
-    const encoded = wholeEncoded + ms
-    return {
-      isValid: true,
-      encoded,
-      formatted: decodeTime(encoded),
-    }
-  }
-
-  // No colons - smart parse based on precision option
-  if (precision === "seconds") {
-    const seconds = Number.parseFloat(trimmed)
-    if (Number.isNaN(seconds) || seconds < 0) {
-      return {
-        isValid: false,
-        encoded: null,
-        formatted: trimmed,
-        error: "Invalid number",
-      }
-    }
-    const encoded = Math.round(seconds * MS_PER_SECOND)
-    return {
-      isValid: true,
-      encoded,
-      formatted: decodeTime(encoded),
-    }
-  }
-
-  if (precision === "ms") {
+  if (precision === "ms" && !trimmed.includes(":") && !trimmed.includes(".")) {
     const ms = Number.parseInt(trimmed, 10)
     if (Number.isNaN(ms) || ms < 0) {
       return {
@@ -187,71 +73,12 @@ export function parseTime(
     }
   }
 
-  // Auto precision - smart parsing
-  return parseTimeAuto(trimmed)
-}
-
-/**
- * Smart auto-parse for time without colons.
- */
-function parseTimeAuto(input: string): ParseResult {
-  // Remove any non-digit characters
-  const digits = input.replace(/\D/g, "")
-  if (!digits) {
-    return {
-      isValid: false,
-      encoded: null,
-      formatted: input,
-      error: "No digits found",
-    }
-  }
-
-  let formatted: string
-
-  switch (digits.length) {
-    case 1:
-    case 2:
-      // 1-2 digits: treat as seconds (e.g., "45" → "0:45")
-      formatted = `0:${digits.padStart(2, "0")}`
-      break
-
-    case 3:
-      // 3 digits: M:SS (e.g., "345" → "3:45")
-      formatted = `${digits[0]}:${digits.slice(1)}`
-      break
-
-    case 4:
-      // 4 digits: MM:SS (e.g., "1234" → "12:34")
-      formatted = `${digits.slice(0, 2)}:${digits.slice(2)}`
-      break
-
-    case 5:
-      // 5 digits: H:MM:SS (e.g., "10234" → "1:02:34")
-      formatted = `${digits[0]}:${digits.slice(1, 3)}:${digits.slice(3)}`
-      break
-
-    case 6:
-      // 6 digits: HH:MM:SS (e.g., "010234" → "1:02:34")
-      formatted = `${digits.slice(0, 2)}:${digits.slice(2, 4)}:${digits.slice(4)}`
-      break
-
-    default: {
-      // 7+ digits: parse as HH...H:MM:SS
-      const hours = digits.slice(0, -4)
-      const minutes = digits.slice(-4, -2)
-      const seconds = digits.slice(-2)
-      formatted = `${hours}:${minutes}:${seconds}`
-      break
-    }
-  }
-
-  // Now encode the formatted time
-  const encoded = encodeTime(formatted)
+  const encoded = encodeTime(trimmed)
   if (encoded === null) {
     return {
       isValid: false,
       encoded: null,
-      formatted: input,
+      formatted: trimmed,
       error: "Invalid time format",
     }
   }

--- a/apps/wodsmith-start/test/lib/scoring/parse-time.test.ts
+++ b/apps/wodsmith-start/test/lib/scoring/parse-time.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { encodeScore, parseScore } from "@/lib/scoring"
+
+describe("parseScore time — preview matches save", () => {
+  it("treats bare 4-digit input as raw seconds, not MM:SS", () => {
+    const previewed = parseScore("2000", "time")
+    expect(previewed.isValid).toBe(true)
+    expect(previewed.encoded).toBe(2_000_000)
+    expect(previewed.formatted).toBe("33:20")
+    expect(previewed.encoded).toBe(encodeScore("2000", "time"))
+  })
+
+  it("treats bare 3-digit input as raw seconds", () => {
+    const previewed = parseScore("345", "time")
+    expect(previewed.isValid).toBe(true)
+    expect(previewed.encoded).toBe(345_000)
+    expect(previewed.encoded).toBe(encodeScore("345", "time"))
+  })
+
+  it("preserves 1-2 digit inputs (still raw seconds)", () => {
+    expect(parseScore("45", "time").encoded).toBe(45_000)
+    expect(parseScore("45", "time").formatted).toBe("0:45")
+    expect(parseScore("45", "time").encoded).toBe(encodeScore("45", "time"))
+  })
+
+  it("still parses colon-delimited input correctly", () => {
+    const result = parseScore("12:34", "time")
+    expect(result.isValid).toBe(true)
+    expect(result.encoded).toBe(754_000)
+    expect(result.formatted).toBe("12:34")
+    expect(result.encoded).toBe(encodeScore("12:34", "time"))
+  })
+
+  it("still parses colon + ms input correctly", () => {
+    const result = parseScore("12:34.567", "time")
+    expect(result.isValid).toBe(true)
+    expect(result.encoded).toBe(754_567)
+    expect(result.encoded).toBe(encodeScore("12:34.567", "time"))
+  })
+
+  it("treats single-period input as decimal seconds (preview matches save)", () => {
+    const previewed = parseScore("1234.567", "time")
+    expect(previewed.isValid).toBe(true)
+    expect(previewed.encoded).toBe(1_234_567)
+    expect(previewed.encoded).toBe(encodeScore("1234.567", "time"))
+  })
+
+  it("still parses period-delimited time (3+ parts) correctly", () => {
+    const result = parseScore("12.34.567", "time")
+    expect(result.isValid).toBe(true)
+    expect(result.encoded).toBe(754_567)
+    expect(result.encoded).toBe(encodeScore("12.34.567", "time"))
+  })
+})

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -106,6 +106,12 @@ Key design:
 - Tiebreak values stored separately for time-capped workouts
 - Score rounds (`scoreRoundsTable`) store per-round breakdowns for multi-round workouts
 
+### Time input parsing matches save semantics
+
+Bare numeric input on a time score (no colon — e.g. `2000`) is treated as **raw seconds** in both the live preview and the save path, so the two can never disagree.
+
+[[apps/wodsmith-start/src/lib/scoring/parse/time.ts#parseTime]] defers to [[apps/wodsmith-start/src/lib/scoring/encode/time.ts#encodeTime]] for any non-colon input. An earlier version smart-padded bare digits as MM:SS (`2000` → `20:00` in preview) while the save persisted `33:20`, which confused athletes typing on a phone. Colon-delimited input (`12:34`, `1:02:34.567`) is unchanged. Use `precision: "ms"` only when explicitly persisting raw milliseconds.
+
 ### Missing scores tie at worst place
 
 Athletes registered in a division who never submitted a score for an event are awarded the same points as if they finished one place behind every recorded score in their division.


### PR DESCRIPTION
## Summary

- Live score preview ran input through `parseTime`'s smart digit-padding (e.g. \`\"2000\"\` → \`\"20:00\"`) while the save path used `encodeTime` (which treats bare digits as raw seconds: \`\"2000\"\` → \`33:20.000\`). Athletes typing on a phone saw one value and got a different one persisted, with no warning. Reported by @ianjones.
- Collapse `parseTime` to defer to `encodeTime` for any non-colon input so preview and save share one source of truth. Remove the dead `parseTimeAuto` helper and the duplicated single-period branch.
- Colon-delimited input (\`\"12:34\"\`, \`\"1:02:34.567\"\`) and 3+ part period-delimited time (\`\"12.34.567\"\`) are unchanged.

### Behavior shift (preview side only — save was already this way)

| Input | Before (preview) | After (preview = save) |
|------:|-----------------:|------------------------:|
| \`45\` | 0:45 | 0:45 |
| \`345\` | 3:45 | **5:45** |
| \`1234\` | 12:34 | **20:34** |
| \`2000\` | 20:00 | **33:20** |
| \`12:34\` | 12:34 | 12:34 |
| \`12:34.567\` | 12:34.567 | 12:34.567 |

⚠️ **User-visible change** for athletes who got used to typing bare digits and seeing them auto-formatted as MM:SS — but their save was always wrong. Now the preview tells the truth.

## Test plan

- [ ] \`pnpm test test/lib/scoring/\` — 217 tests pass locally (7 new in \`parse-time.test.ts\` asserting \`parseScore(x, \"time\") === encodeScore(x, \"time\")\` across bare digits, colons, and periods)
- [ ] \`pnpm type-check\` clean
- [ ] Manual: open a time-scored event submission form, type \`2000\` → preview reads \`33:20\`, save persists \`33:20\` (no longer disagrees)
- [ ] Manual: type \`12:34\` → preview and save both \`12:34\` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns time-input preview with save behavior by treating bare digits as raw seconds (e.g., "2000" → "33:20"). Removes MM:SS auto-padding in preview so athletes see exactly what will be saved.

- **Bug Fixes**
  - `parseTime` now defers to `encodeTime` for non-colon input; bare numbers are seconds (preview = save).
  - Colon-delimited and 3+ part period-delimited inputs are unchanged; single-period input remains decimal seconds.
  - Removed `parseTimeAuto` and redundant single-period logic; updated docs and examples.
  - Added tests asserting `parseScore(x, "time") === encodeScore(x, "time")` across bare digits, colons, and periods.

<sup>Written for commit f95b9b19daa896e406ead1e37c873bedbc4432f3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent time input parsing behavior between preview and save paths; bare numeric inputs (e.g., "2000") now uniformly treated as raw seconds.

* **Documentation**
  * Updated time parsing documentation and examples to reflect consistent input handling for bare digits, colon-delimited, and decimal formats.

* **Tests**
  * Added comprehensive test suite validating time parsing behavior across multiple input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->