### PR TITLE
Hide score adjustments from leaderboard UI unless penalized

### DIFF
--- a/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
@@ -174,22 +174,19 @@ function CappedRoundsIndicator({
   )
 }
 
-/** Clickable icon for any score modification (penalty or direct adjust) */
+/** Clickable icon shown only for minor/major penalties */
 function PenaltyIndicator({
   result,
 }: {
   result: CompetitionLeaderboardEntry["eventResults"][number]
 }) {
-  if (!result.penaltyType && !result.isDirectlyModified) return null
+  if (!result.penaltyType) return null
 
-  const label = result.penaltyType
-    ? `${result.penaltyType === "major" ? "Major" : "Minor"} Penalty`
-    : "Score Adjusted"
-
+  const label = `${result.penaltyType === "major" ? "Major" : "Minor"} Penalty`
   const detail =
     result.penaltyPercentage != null
       ? `${result.penaltyPercentage}% deduction applied`
-      : "This score was modified by an organizer."
+      : "A penalty was applied to this score."
 
   return (
     <Popover>

--- a/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
@@ -217,20 +217,18 @@ function CappedRoundsIndicator({
   )
 }
 
-/** Subtle warning icon indicating a penalty or score adjustment */
+/** Subtle warning icon shown only for minor/major penalties */
 function PenaltyIndicator({
   result,
 }: {
   result: CompetitionLeaderboardEntry["eventResults"][number]
 }) {
-  if (!result.penaltyType && !result.isDirectlyModified) return null
+  if (!result.penaltyType) return null
 
-  const label = result.penaltyType
-    ? `${result.penaltyType === "major" ? "Major" : "Minor"} Penalty${result.penaltyPercentage != null ? ` (${result.penaltyPercentage}%)` : ""}`
-    : "Score Adjusted"
+  const label = `${result.penaltyType === "major" ? "Major" : "Minor"} Penalty${result.penaltyPercentage != null ? ` (${result.penaltyPercentage}%)` : ""}`
 
   return (
-    <span title={label}>
+    <span title={label} aria-label={label}>
       <AlertTriangle className="h-3 w-3 text-muted-foreground" />
     </span>
   )
@@ -304,7 +302,7 @@ function hasExpandableContent(
   return entry.eventResults.some(
     (r) =>
       r.trackWorkoutId === selectedEventId &&
-      (r.videoUrl || r.penaltyType || r.isDirectlyModified),
+      (r.videoUrl || r.penaltyType),
   )
 }
 
@@ -412,11 +410,9 @@ function ExpandedVideoRow({
     ? entry.eventResults.filter(
         (r) =>
           r.trackWorkoutId === selectedEventId &&
-          (r.videoUrl || r.penaltyType || r.isDirectlyModified),
+          (r.videoUrl || r.penaltyType),
       )
-    : entry.eventResults.filter(
-        (r) => r.videoUrl || r.penaltyType || r.isDirectlyModified,
-      )
+    : entry.eventResults.filter((r) => r.videoUrl || r.penaltyType)
 
   if (resultsToShow.length === 0) return null
 
@@ -436,19 +432,13 @@ function ExpandedVideoRow({
                   </span>
                 )}
 
-                {/* Penalty / adjustment notices */}
+                {/* Penalty notice */}
                 {result.penaltyType && (
                   <div className="inline-flex items-center gap-1.5 rounded-md bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-600 dark:text-amber-400">
                     <AlertTriangle className="h-3 w-3" />
                     {result.penaltyType === "major" ? "Major" : "Minor"} Penalty
                     {result.penaltyPercentage != null &&
                       ` · ${result.penaltyPercentage}% deduction`}
-                  </div>
-                )}
-                {!result.penaltyType && result.isDirectlyModified && (
-                  <div className="inline-flex items-center gap-1.5 rounded-md bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-600 dark:text-amber-400">
-                    <AlertTriangle className="h-3 w-3" />
-                    Score adjusted by organizer
                   </div>
                 )}
 
@@ -651,9 +641,7 @@ function MobileOnlineLeaderboardRow({
           {entry.eventResults.some((r) => r.videoUrl) && (
             <Video className="h-4 w-4 text-muted-foreground shrink-0" />
           )}
-          {entry.eventResults.some(
-            (r) => r.penaltyType || r.isDirectlyModified,
-          ) && (
+          {entry.eventResults.some((r) => r.penaltyType) && (
             <AlertTriangle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
           )}
 
@@ -719,12 +707,6 @@ function MobileOnlineLeaderboardRow({
                             Penalty
                             {result.penaltyPercentage != null &&
                               ` · ${result.penaltyPercentage}% deduction`}
-                          </span>
-                        )}
-                        {!result.penaltyType && result.isDirectlyModified && (
-                          <span className="text-[10px] text-muted-foreground inline-flex items-center gap-1">
-                            <AlertTriangle className="h-2.5 w-2.5" />
-                            Score adjusted by organizer
                           </span>
                         )}
                       </div>

--- a/apps/wodsmith-start/test/components/leaderboard-page-content.test.tsx
+++ b/apps/wodsmith-start/test/components/leaderboard-page-content.test.tsx
@@ -559,7 +559,7 @@ describe("LeaderboardPageContent", () => {
 			expect(indicators.length).toBeGreaterThan(0)
 		})
 
-		it("shows indicator for directly modified score", async () => {
+		it("does not show indicator for directly modified score without penalty", async () => {
 			const entries = [
 				createMockEntry({
 					eventResults: [
@@ -600,8 +600,8 @@ describe("LeaderboardPageContent", () => {
 				expect(screen.getAllByText("4:50").length).toBeGreaterThan(0)
 			})
 
-			const indicators = screen.getAllByLabelText("Score Adjusted")
-			expect(indicators.length).toBeGreaterThan(0)
+			expect(screen.queryByLabelText(/penalty/i)).not.toBeInTheDocument()
+			expect(screen.queryByLabelText(/adjusted/i)).not.toBeInTheDocument()
 		})
 
 		it("shows penalty details in popover on click", async () => {
@@ -654,7 +654,7 @@ describe("LeaderboardPageContent", () => {
 			})
 		})
 
-		it("shows organizer message for directly modified scores in popover", async () => {
+		it("does not show popover for directly modified scores without penalty", async () => {
 			const entries = [
 				createMockEntry({
 					eventResults: [
@@ -695,13 +695,10 @@ describe("LeaderboardPageContent", () => {
 				expect(screen.getAllByText("4:50").length).toBeGreaterThan(0)
 			})
 
-			const indicator = screen.getAllByLabelText("Score Adjusted")[0]
-			fireEvent.click(indicator)
-
-			await waitFor(() => {
-				expect(screen.getByText("Score Adjusted")).toBeInTheDocument()
-				expect(screen.getByText("This score was modified by an organizer.")).toBeInTheDocument()
-			})
+			expect(screen.queryByLabelText("Score Adjusted")).not.toBeInTheDocument()
+			expect(
+				screen.queryByText("This score was modified by an organizer."),
+			).not.toBeInTheDocument()
 		})
 	})
 

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -238,6 +238,8 @@ The adjust inputs mirror the athlete submission form: `parseScore` validates ent
 
 The Adjust Score form's penalty-tiebreak state is seeded from `submission.score.tiebreakValue` (the decoded display string) rather than the empty string, so editing other fields without touching the tiebreak input preserves the existing value. Without that seed, the server would receive `tieBreakScore: undefined`, fail the `if (data.tieBreakScore && score.tiebreakScheme)` truthiness check, and persist `tiebreakValue: null`, silently erasing a previously-entered tiebreak.
 
+The public leaderboard only surfaces a warning icon — and the accompanying expanded notice — for scores carrying a Minor or Major penalty. Plain score adjustments (`isDirectlyModified` with `penaltyType: null`) are treated as data-entry corrections and intentionally render without any warning badge so athletes aren't alarmed by routine fixes. Both [[apps/wodsmith-start/src/components/competition-leaderboard-table.tsx#PenaltyIndicator]] and [[apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx#PenaltyIndicator]] gate on `penaltyType` alone, and the online table's expanded row / mobile collapsible suppress the "Score adjusted by organizer" line for the same reason.
+
 ### Manual Score Entry
 
 When an athlete uploads a video without filling in the score field, the sidebar renders [[apps/wodsmith-start/src/components/compete/enter-score-form.tsx#EnterScoreForm]] instead of the placeholder, letting the reviewer create the missing score in one step.


### PR DESCRIPTION
## Summary
Refactors the leaderboard penalty indicator logic to only display warnings for scores with Minor or Major penalties. Plain score adjustments (marked `isDirectlyModified` without a `penaltyType`) are now treated as routine data-entry corrections and no longer show warning badges or expanded notices to athletes.

## Key Changes
- **PenaltyIndicator component**: Changed condition from `!result.penaltyType && !result.isDirectlyModified` to `!result.penaltyType` alone, removing the "Score Adjusted" label and popover detail
- **Expanded row filtering**: Removed `r.isDirectlyModified` from all conditions that determine which results show expandable content, so only penalty-bearing scores trigger the expanded view
- **Mobile leaderboard**: Removed the "Score adjusted by organizer" notice from the collapsible result details
- **Test updates**: Updated test expectations to verify that directly-modified scores without penalties no longer display any indicator or popover
- **Documentation**: Added clarification to domain.md explaining that plain adjustments are intentionally hidden to avoid alarming athletes with routine fixes

## Implementation Details
- Both `competition-leaderboard-table.tsx` and `online-competition-leaderboard-table.tsx` were updated consistently
- The `aria-label` attribute was added to the online table's PenaltyIndicator for accessibility
- Popover detail text changed from "This score was modified by an organizer" to "A penalty was applied to this score" to reflect the new semantics
- All filtering logic now uses a single condition: `r.videoUrl || r.penaltyType` (removing the third `r.isDirectlyModified` clause)

https://claude.ai/code/session_017n7WQe67Crk3vgyLMQck9j

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide score adjustment warnings unless a Minor or Major penalty is present. Plain organizer adjustments no longer show badges, popovers, or expanded notices.

- **Bug Fixes**
  - `PenaltyIndicator` now renders only when `penaltyType` is set; removes the "Score Adjusted" label and popover.
  - Expanded rows and mobile details gate on `videoUrl` or `penaltyType` (removed `isDirectlyModified` from conditions).
  - Added `aria-label` to the online table indicator and updated copy to "A penalty was applied to this score."
  - Updated tests and `domain.md` to reflect the new behavior.

<sup>Written for commit d7d42ec1fab6f90660384b010e817681da8c1b6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

