### PR TITLE
Add missing submissions filter for broadcast audience targeting

### DIFF
--- a/apps/wodsmith-start/src/db/schemas/scores.ts
+++ b/apps/wodsmith-start/src/db/schemas/scores.ts
@@ -51,7 +51,10 @@ export const scoresTable = mysqlTable(
 
     // What was scored
     workoutId: varchar({ length: 255 }).notNull(),
-    competitionEventId: varchar({ length: 255 }), // NULL for personal logs
+    // References trackWorkoutsTable.id (NOT competitionEventsTable.id) despite
+    // the name. The column predates the event/workout split; all insert sites
+    // write the trackWorkoutId here. NULL for personal logs.
+    competitionEventId: varchar({ length: 255 }),
     scheduledWorkoutInstanceId: varchar({ length: 255 }),
 
     // Score classification

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/broadcasts.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/broadcasts.tsx
@@ -190,6 +190,7 @@ type AudienceFilterType =
   | "volunteers"
   | "volunteer_role"
   | "pending_teammates"
+  | "missing_submissions"
 
 const VOLUNTEER_ROLES = [
   { value: "judge", label: "Judge" },
@@ -236,7 +237,10 @@ function ComposeCard({
 
   // Determine which questions to show based on audience type
   const relevantQuestions = useMemo(() => {
-    const isAthleteAudience = filterType === "all" || filterType === "division"
+    const isAthleteAudience =
+      filterType === "all" ||
+      filterType === "division" ||
+      filterType === "missing_submissions"
     const isVolunteerAudience =
       filterType === "volunteers" || filterType === "volunteer_role"
     const isPublic = filterType === "public"
@@ -261,9 +265,11 @@ function ComposeCard({
                   divisionId,
                 }
               : { type: "pending_teammates" as const }
-            : {
-                type: filterType as "all" | "public" | "volunteers",
-              }
+            : filterType === "missing_submissions" && divisionId
+              ? { type: "missing_submissions" as const, divisionId }
+              : {
+                  type: filterType as "all" | "public" | "volunteers",
+                }
 
     if (questionFilters.length > 0) {
       return { ...base, questionFilters }
@@ -274,7 +280,8 @@ function ComposeCard({
   // Auto-fetch recipient count when filter is complete
   const filterReady =
     (filterType !== "division" || !!divisionId) &&
-    (filterType !== "volunteer_role" || !!volunteerRole)
+    (filterType !== "volunteer_role" || !!volunteerRole) &&
+    (filterType !== "missing_submissions" || !!divisionId)
 
   // Debounce the preview call
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -336,6 +343,11 @@ function ComposeCard({
     }
 
     if (filterType === "division" && !divisionId) {
+      toast.error("Please select a division")
+      return
+    }
+
+    if (filterType === "missing_submissions" && !divisionId) {
       toast.error("Please select a division")
       return
     }
@@ -421,6 +433,9 @@ function ComposeCard({
                 <SelectItem value="public">Everyone (Public)</SelectItem>
                 <SelectItem value="all">All Athletes</SelectItem>
                 <SelectItem value="division">Athletes by Division</SelectItem>
+                <SelectItem value="missing_submissions">
+                  Athletes Missing Submissions (by Division)
+                </SelectItem>
                 <SelectItem value="volunteers">All Volunteers</SelectItem>
                 <SelectItem value="volunteer_role">
                   Volunteers by Role
@@ -432,7 +447,8 @@ function ComposeCard({
             </Select>
 
             {(filterType === "division" ||
-              filterType === "pending_teammates") && (
+              filterType === "pending_teammates" ||
+              filterType === "missing_submissions") && (
               <Select
                 value={divisionId}
                 onValueChange={(v) => {

--- a/apps/wodsmith-start/src/server-fns/broadcast-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/broadcast-fns.ts
@@ -19,6 +19,7 @@ import {
   competitionBroadcastsTable,
 } from "@/db/schemas/broadcasts"
 import {
+  competitionEventsTable,
   competitionRegistrationAnswersTable,
   competitionRegistrationQuestionsTable,
   competitionRegistrationsTable,
@@ -26,6 +27,8 @@ import {
   REGISTRATION_STATUS,
   volunteerRegistrationAnswersTable,
 } from "@/db/schemas/competitions"
+import { eventDivisionMappingsTable } from "@/db/schemas/event-division-mappings"
+import { scoresTable } from "@/db/schemas/scores"
 import {
   INVITATION_STATUS,
   SYSTEM_ROLES_ENUM,
@@ -71,6 +74,7 @@ export const audienceFilterSchema = z
       "volunteers",
       "volunteer_role",
       "pending_teammates",
+      "missing_submissions",
     ]),
     divisionId: z.string().optional(),
     volunteerRole: z.string().optional(),
@@ -96,6 +100,14 @@ export const audienceFilterSchema = z
     {
       message:
         "Registration question filters are not supported for pending teammate invites (invitees have no registration answers)",
+    },
+  )
+  .refine(
+    (filter) =>
+      filter.type !== "missing_submissions" ||
+      (filter.divisionId && filter.divisionId.length > 0),
+    {
+      message: "Division ID is required when filtering by missing submissions",
     },
   )
 
@@ -615,6 +627,125 @@ async function partitionQuestionFilters(
 }
 
 // ============================================================================
+// Missing Submissions Filter
+// ============================================================================
+
+/**
+ * Return the set of trackWorkoutIds that athletes in `divisionId` are expected
+ * to have a score for. Honors event-division mappings — an event is required
+ * for the division when it's unmapped (applies to all) or explicitly mapped
+ * to this division. Sub-event mappings inherit from the parent event, matching
+ * the leaderboard rule used elsewhere in the app.
+ */
+async function getDivisionRequiredTrackWorkoutIds(params: {
+  competitionId: string
+  divisionId: string
+}): Promise<string[]> {
+  const db = getDb()
+
+  const events = await db
+    .select({
+      trackWorkoutId: competitionEventsTable.trackWorkoutId,
+    })
+    .from(competitionEventsTable)
+    .where(eq(competitionEventsTable.competitionId, params.competitionId))
+
+  if (events.length === 0) return []
+
+  const mappings = await db
+    .select({
+      trackWorkoutId: eventDivisionMappingsTable.trackWorkoutId,
+      divisionId: eventDivisionMappingsTable.divisionId,
+    })
+    .from(eventDivisionMappingsTable)
+    .where(eq(eventDivisionMappingsTable.competitionId, params.competitionId))
+
+  if (mappings.length === 0) {
+    return events.map((e) => e.trackWorkoutId)
+  }
+
+  const mappedEventIds = new Set(mappings.map((m) => m.trackWorkoutId))
+  const mappedToThisDivision = new Set(
+    mappings
+      .filter((m) => m.divisionId === params.divisionId)
+      .map((m) => m.trackWorkoutId),
+  )
+
+  return events
+    .filter((e) =>
+      !mappedEventIds.has(e.trackWorkoutId)
+        ? true
+        : mappedToThisDivision.has(e.trackWorkoutId),
+    )
+    .map((e) => e.trackWorkoutId)
+}
+
+/**
+ * Filter athlete recipients down to those who have NOT submitted a score for
+ * every required event in the division.
+ *
+ * Pending-invite recipients (userId=null) have zero submissions by definition
+ * and are kept whenever any event is required.
+ *
+ * `scoresTable.competitionEventId` actually stores the `trackWorkoutId`
+ * (see comment on [[apps/wodsmith-start/src/db/schemas/workouts.ts#competitionEventId]]),
+ * which is why we match scores against the trackWorkoutId set directly.
+ */
+async function applyMissingSubmissionsFilter(
+  recipients: Recipient[],
+  params: { competitionId: string; divisionId: string },
+): Promise<Recipient[]> {
+  if (recipients.length === 0) return recipients
+
+  const requiredTrackWorkoutIds = await getDivisionRequiredTrackWorkoutIds({
+    competitionId: params.competitionId,
+    divisionId: params.divisionId,
+  })
+
+  // No required events means every recipient is trivially "complete" — nobody
+  // qualifies as missing submissions.
+  if (requiredTrackWorkoutIds.length === 0) return []
+
+  const userIds = recipients
+    .map((r) => r.userId)
+    .filter((id): id is string => id !== null)
+
+  const submittedByUser = new Map<string, Set<string>>()
+  if (userIds.length > 0) {
+    const db = getDb()
+    const rows = await db
+      .select({
+        userId: scoresTable.userId,
+        competitionEventId: scoresTable.competitionEventId,
+      })
+      .from(scoresTable)
+      .where(
+        and(
+          inArray(scoresTable.userId, userIds),
+          inArray(scoresTable.competitionEventId, requiredTrackWorkoutIds),
+        ),
+      )
+
+    for (const r of rows) {
+      if (!r.competitionEventId) continue
+      let set = submittedByUser.get(r.userId)
+      if (!set) {
+        set = new Set()
+        submittedByUser.set(r.userId, set)
+      }
+      set.add(r.competitionEventId)
+    }
+  }
+
+  const requiredCount = requiredTrackWorkoutIds.length
+  return recipients.filter((r) => {
+    if (!r.userId) return true // pending invites are always incomplete
+    const submitted = submittedByUser.get(r.userId)
+    return !submitted || submitted.size < requiredCount
+  })
+}
+
+// ============================================================================
 // Organizer: Get Distinct Answer Values (for UI autocomplete)
 // ============================================================================
 
@@ -822,18 +953,22 @@ export const sendBroadcastFn = createServerFn({ method: "POST" })
     const includeAthletes =
       filterType === "all" ||
       filterType === "division" ||
-      filterType === "public"
+      filterType === "public" ||
+      filterType === "missing_submissions"
     const includeVolunteers =
       filterType === "public" ||
       filterType === "volunteers" ||
       filterType === "volunteer_role"
     const isPendingTeammates = filterType === "pending_teammates"
+    const isMissingSubmissions = filterType === "missing_submissions"
 
     if (includeAthletes || isPendingTeammates) {
       const audienceRows = await fetchAthleteAudienceRows({
         competitionId: data.competitionId,
         divisionId:
-          filterType === "division" || isPendingTeammates
+          filterType === "division" ||
+          isPendingTeammates ||
+          isMissingSubmissions
             ? (data.audienceFilter?.divisionId ?? null)
             : null,
       })
@@ -933,6 +1068,21 @@ export const sendBroadcastFn = createServerFn({ method: "POST" })
 
       athleteRecipients = filteredAthletes
       volunteerRecipients = filteredVolunteers
+    }
+
+    // Apply missing-submissions filter last so question-filter team inheritance
+    // isn't broken: the question filter looks up captain/solo registrations to
+    // decide which teammates/invites pass, and narrowing by missing submissions
+    // first could strip the captain (who submitted everything) while leaving a
+    // teammate whose captain is no longer in the pool to inherit from.
+    if (isMissingSubmissions && data.audienceFilter?.divisionId) {
+      athleteRecipients = await applyMissingSubmissionsFilter(
+        athleteRecipients,
+        {
+          competitionId: data.competitionId,
+          divisionId: data.audienceFilter.divisionId,
+        },
+      )
     }
 
     // Drop pending-invite athlete rows whose email collides with a volunteer
@@ -1352,12 +1502,14 @@ export const previewAudienceFn = createServerFn({ method: "GET" })
     const includeAthletes =
       filterType === "all" ||
       filterType === "division" ||
-      filterType === "public"
+      filterType === "public" ||
+      filterType === "missing_submissions"
     const includeVolunteers =
       filterType === "public" ||
       filterType === "volunteers" ||
       filterType === "volunteer_role"
     const isPendingTeammates = filterType === "pending_teammates"
+    const isMissingSubmissions = filterType === "missing_submissions"
 
     // Build the athlete-side recipient set via the shared helper so preview
     // and send stay in lock-step on audience expansion + dedup rules.
@@ -1366,7 +1518,9 @@ export const previewAudienceFn = createServerFn({ method: "GET" })
       const audienceRows = await fetchAthleteAudienceRows({
         competitionId: data.competitionId,
         divisionId:
-          filterType === "division" || isPendingTeammates
+          filterType === "division" ||
+          isPendingTeammates ||
+          isMissingSubmissions
             ? (data.audienceFilter?.divisionId ?? null)
             : null,
       })
@@ -1475,6 +1629,19 @@ export const previewAudienceFn = createServerFn({ method: "GET" })
               competition.competitionTeamId,
             )
           : volunteerRecipients
+    }
+
+    // Apply missing-submissions filter after question filters so team
+    // inheritance in applyAthleteQuestionFilters still has the captain row
+    // available to resolve teammate matches (kept in lock-step with send).
+    if (isMissingSubmissions && data.audienceFilter?.divisionId) {
+      athleteRecipients = await applyMissingSubmissionsFilter(
+        athleteRecipients,
+        {
+          competitionId: data.competitionId,
+          divisionId: data.audienceFilter.divisionId,
+        },
+      )
     }
 
     return {

--- a/apps/wodsmith-start/src/server/notifications/submission-window.ts
+++ b/apps/wodsmith-start/src/server/notifications/submission-window.ts
@@ -184,17 +184,22 @@ async function deleteNotificationReservation(params: {
 }
 
 /**
- * Check if a user has submitted a score for a competition event
+ * Check if a user has submitted a score for a competition event.
+ *
+ * NOTE: `scoresTable.competitionEventId` stores the `trackWorkoutId`, not
+ * `competitionEventsTable.id` — the column name is historical. Every insert
+ * site writes `data.trackWorkoutId` into this column, so we match on it here.
+ * Do not pass `competitionEventsTable.id`; the query will never match.
  */
 async function hasUserSubmittedScore(params: {
   userId: string
-  competitionEventId: string
+  trackWorkoutId: string
 }): Promise<boolean> {
   const db = getDb()
   const score = await db.query.scoresTable.findFirst({
     where: and(
       eq(scoresTable.userId, params.userId),
-      eq(scoresTable.competitionEventId, params.competitionEventId),
+      eq(scoresTable.competitionEventId, params.trackWorkoutId),
     ),
     columns: { id: true },
   })
@@ -716,10 +721,12 @@ export async function processSubmissionWindowNotifications(): Promise<ProcessedN
 
           // 5. Window just closed (within last 15 minutes)
           if (closesAt <= now && closesAt > fifteenMinutesAgo) {
-            // Check if user has actually submitted a score for this event
+            // Check if user has actually submitted a score for this event.
+            // scoresTable.competitionEventId stores the trackWorkoutId, not
+            // competitionEventsTable.id — see hasUserSubmittedScore comment.
             const hasSubmitted = await hasUserSubmittedScore({
               userId: user.id,
-              competitionEventId: event.id,
+              trackWorkoutId: event.trackWorkoutId,
             })
 
             const sent = await sendWindowClosedNotification({

--- a/apps/wodsmith-start/test/server-fns/broadcast-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/broadcast-fns.test.ts
@@ -229,4 +229,26 @@ describe("audienceFilterSchema", () => {
 		const result = audienceFilterSchema.safeParse({ type: "volunteer_role" })
 		expect(result.success).toBe(false)
 	})
+
+	it("requires divisionId when type=missing_submissions", () => {
+		const result = audienceFilterSchema.safeParse({ type: "missing_submissions" })
+		expect(result.success).toBe(false)
+	})
+
+	it("accepts missing_submissions with divisionId", () => {
+		const result = audienceFilterSchema.safeParse({
+			type: "missing_submissions",
+			divisionId: "div_rx",
+		})
+		expect(result.success).toBe(true)
+	})
+
+	it("accepts missing_submissions with questionFilters for further narrowing", () => {
+		const result = audienceFilterSchema.safeParse({
+			type: "missing_submissions",
+			divisionId: "div_rx",
+			questionFilters: [{ questionId: "q1", values: ["male"] }],
+		})
+		expect(result.success).toBe(true)
+	})
 })

--- a/lat.md/organizer-dashboard.md
+++ b/lat.md/organizer-dashboard.md
@@ -228,6 +228,18 @@ Optional `divisionId` narrows by inheriting `athleteTeamId`s from registrations 
 
 The filter is exposed in the audience type picker in [[apps/wodsmith-start/src/routes/compete/organizer/$competitionId/broadcasts.tsx]] and produces invite-only recipient rows that appear in email delivery but not in the athlete in-app broadcasts list, since [[apps/wodsmith-start/src/server-fns/broadcast-fns.ts#listAthleteBroadcastsFn]] filters by `userId`.
 
+### Missing submissions filter
+
+The `missing_submissions` audience type targets athletes in a specified division who have not submitted scores for every event required of that division — useful for nudging stragglers before a submission window closes on online competitions.
+
+Requires `divisionId` (enforced in [[apps/wodsmith-start/src/server-fns/broadcast-fns.ts#audienceFilterSchema]]). The division scopes both the audience (via `fetchAthleteAudienceRows`) and the set of required events. The filter resolves required events via [[apps/wodsmith-start/src/server-fns/broadcast-fns.ts#getDivisionRequiredTrackWorkoutIds]]: pulls all `competitionEventsTable` rows for the competition, then honors any [[apps/wodsmith-start/src/db/schemas/event-division-mappings.ts#eventDivisionMappingsTable]] entries — if mappings exist, an event is required only when unmapped or explicitly mapped to this division. If no mappings exist, every event is required for every division (backwards-compatible).
+
+[[apps/wodsmith-start/src/server-fns/broadcast-fns.ts#applyMissingSubmissionsFilter]] is the per-user check: for each recipient with a userId, batch-load their scores where `scoresTable.competitionEventId` (which actually stores `trackWorkoutId` — the column name predates the trackWorkoutsTable split) matches any required event, then keep the recipient if the distinct count is less than the total required. Pending-invite recipients have no user account and zero submissions by definition, so they're always kept whenever any event is required; this matches the division-scoped pending_teammates behavior where the organizer still wants to reach them.
+
+The filter runs *after* question filters in both [[apps/wodsmith-start/src/server-fns/broadcast-fns.ts#sendBroadcastFn]] and [[apps/wodsmith-start/src/server-fns/broadcast-fns.ts#previewAudienceFn]] so [[apps/wodsmith-start/src/server-fns/broadcast-fns.ts#applyAthleteQuestionFilters]] still has the captain row available for team inheritance. Reversing the order would strip a captain who had submitted all their scores and leave a teammate whose captain is no longer in the pool for the inheritance step to match against.
+
+Dedup across divisions is handled upstream by [[apps/wodsmith-start/src/server-fns/broadcast-fns.ts#buildBroadcastRecipients]] (user rows dedup by `userId`), so an athlete registered in multiple divisions filtered by "missing submissions in Division A" only appears once in the recipient list regardless of their Division B state.
+
 ## Danger Zone
 
 Destructive actions including competition deletion.


### PR DESCRIPTION
## Summary
Adds a new "missing submissions" audience filter type to the broadcast system, allowing organizers to target athletes in a specific division who haven't submitted scores for all required events. This is useful for sending reminder notifications before submission windows close.

## Key Changes

- **New filter type**: Added `missing_submissions` to `audienceFilterType` with required `divisionId` parameter
- **Event requirement resolution**: Implemented `getDivisionRequiredTrackWorkoutIds()` to determine which events are required for a division, respecting event-division mappings (unmapped events apply to all divisions; mapped events only apply to their specified divisions)
- **Submission checking**: Implemented `applyMissingSubmissionsFilter()` to identify athletes missing submissions by batch-loading their scores and comparing against required events
- **Filter ordering**: Applied missing submissions filter *after* question filters in both `sendBroadcastFn` and `previewAudienceFn` to preserve team inheritance logic (captains must remain in the pool for teammates to inherit their registration answers)
- **Pending invites**: Pending-invite recipients (userId=null) are always included when any event is required, matching the behavior of the existing `pending_teammates` filter
- **UI updates**: Added "Athletes Missing Submissions (by Division)" option to the audience type picker with appropriate validation
- **Schema documentation**: Clarified that `scoresTable.competitionEventId` stores `trackWorkoutId` (not `competitionEventsTable.id`) with comments in both broadcast-fns.ts and submission-window.ts to prevent future bugs
- **Tests**: Added validation tests for the new filter type requiring divisionId and supporting optional question filters

## Notable Implementation Details

- The filter respects event-division mappings: if mappings exist for a competition, only unmapped events (apply to all) or events explicitly mapped to the target division are considered required
- Batch queries optimize the submission check by loading all scores for relevant users in a single query
- The filter integrates seamlessly with existing question filters and team inheritance logic by running last in the recipient pipeline

https://claude.ai/code/session_01EGo1FxXpNr8M2jRR7RHfjT

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new “missing submissions” audience filter so organizers can target athletes in a division who haven’t submitted all required events. Also fixes a notification bug that mis-reported missed submissions.

- **New Features**
  - Added `missing_submissions` filter (requires `divisionId`); resolves required events using division mappings (unmapped = all divisions; mapped = only those divisions).
  - Batch-checks athlete scores against required track workouts; pending invites are included when any event is required.
  - Runs after question filters to preserve team inheritance in both send and preview flows.
  - UI: new picker option, validation, and recipient count preview.

- **Bug Fixes**
  - Fixed window-closed notification check to match scores by `trackWorkoutId` (the value stored in `scoresTable.competitionEventId`), not `competitionEventsTable.id`.
  - Updated helper signature and call sites, and documented the column’s semantics to prevent future mismatches.

<sup>Written for commit 8c490e81ab4c572b8a62ad8490f49aae397931af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

