### PR TITLE
feat(invites): ADR-0011 Phase 2A — schema, tokens, issue + bespoke helpers

### DIFF
--- a/apps/wodsmith-start/scripts/seed/cleanup.ts
+++ b/apps/wodsmith-start/scripts/seed/cleanup.ts
@@ -7,6 +7,7 @@ import type { Connection } from "mysql2/promise"
 export async function cleanup(client: Connection): Promise<void> {
 	const tables = [
 		// Competition invites (before competitions)
+		"competition_invites",
 		"competition_invite_sources",
 		// Broadcasts (before competitions)
 		"competition_broadcast_recipients",

--- a/apps/wodsmith-start/scripts/seed/seeders/20-competition-invites.ts
+++ b/apps/wodsmith-start/scripts/seed/seeders/20-competition-invites.ts
@@ -1,5 +1,13 @@
+import { createHash } from "node:crypto"
 import type { Connection } from "mysql2/promise"
-import { batchInsert, futureDate, now, pastDate } from "../helpers"
+import {
+	batchInsert,
+	futureDate,
+	futureDatetime,
+	now,
+	pastDate,
+	pastDatetime,
+} from "../helpers"
 import {
 	computeSortKey,
 	sortKeyToString,
@@ -326,6 +334,242 @@ export async function seed(client: Connection): Promise<void> {
 		{ sourceDivisionId: "slvl_mwfc_a_mrx", championshipDivisionId: "slvl_inv_champ_mrx" },
 		{ sourceDivisionId: "slvl_mwfc_a_wrx", championshipDivisionId: "slvl_inv_champ_wrx" },
 		{ sourceDivisionId: "slvl_mwfc_a_sc", championshipDivisionId: "slvl_inv_champ_sc" },
+	])
+
+	// ════════════════════════════════════════════════════════════════════
+	// 4. Phase 2 invite rows — one per lifecycle state so dev can inspect
+	//    every row-shape in db:studio without manual edits.
+	//
+	//    Tokens are deterministic so the organizer can actually click a
+	//    claim link. They are clearly marked as seed-only — do not ship
+	//    these to prod.
+	// ════════════════════════════════════════════════════════════════════
+
+	function sha256Hex(value: string): string {
+		return createHash("sha256").update(value).digest("hex")
+	}
+
+	function tokenArtifacts(plaintext: string) {
+		return {
+			hash: sha256Hex(plaintext),
+			last4: plaintext.slice(-4),
+		}
+	}
+
+	const SEED_PENDING_TOKEN = "seed-invite-mike-pending-men-rx-phase2"
+	const SEED_EXPIRED_TOKEN = "seed-invite-ryan-expired-men-rx-phase2"
+	const mikeToken = tokenArtifacts(SEED_PENDING_TOKEN)
+	const ryanToken = tokenArtifacts(SEED_EXPIRED_TOKEN)
+
+	console.log(
+		`    seed tokens — pending: ${SEED_PENDING_TOKEN} / expired: ${SEED_EXPIRED_TOKEN}`,
+	)
+
+	await batchInsert(client, "competition_invites", [
+		// 1. Pending source-derived invite for mike (Men's RX, top 1 from Qualifier).
+		{
+			id: "cinv_seed_pending_mike",
+			championship_competition_id: "comp_inv_championship",
+			round_id: "",
+			origin: "source",
+			source_id: "cisrc_seed_qualifier",
+			source_competition_id: "comp_inv_qualifier",
+			source_placement: 1,
+			source_placement_label: "1st — Regional Qualifier",
+			bespoke_reason: null,
+			championship_division_id: "slvl_inv_champ_mrx",
+			email: "mike@wodsmith.com",
+			user_id: "usr_athlete_mike",
+			invitee_first_name: "Mike",
+			invitee_last_name: null,
+			claim_token_hash: mikeToken.hash,
+			claim_token_last4: mikeToken.last4,
+			expires_at: futureDatetime(14),
+			send_attempt: 1,
+			status: "pending",
+			paid_at: null,
+			declined_at: null,
+			revoked_at: null,
+			revoked_by_user_id: null,
+			claimed_registration_id: null,
+			email_delivery_status: "sent",
+			email_last_error: null,
+			active_marker: "active",
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		// 2. Accepted + paid invite for ryan (Men's RX, top 2 from Qualifier).
+		//    Shows the happy-path terminal state: claimTokenHash nulled,
+		//    paidAt set, claimedRegistrationId linked. activeMarker stays
+		//    "active" so a second claim short-circuits to "already registered".
+		{
+			id: "cinv_seed_accepted_ryan",
+			championship_competition_id: "comp_inv_championship",
+			round_id: "",
+			origin: "source",
+			source_id: "cisrc_seed_qualifier",
+			source_competition_id: "comp_inv_qualifier",
+			source_placement: 2,
+			source_placement_label: "2nd — Regional Qualifier",
+			bespoke_reason: null,
+			championship_division_id: "slvl_inv_champ_mrx",
+			email: "ryan@wodsmith.com",
+			user_id: "usr_athlete_ryan",
+			invitee_first_name: "Ryan",
+			invitee_last_name: null,
+			claim_token_hash: null, // nulled on terminal transition
+			claim_token_last4: null,
+			expires_at: futureDatetime(14),
+			send_attempt: 1,
+			status: "accepted_paid",
+			paid_at: now(),
+			declined_at: null,
+			revoked_at: null,
+			revoked_by_user_id: null,
+			claimed_registration_id: null, // real reg wired up in Phase 2 sub-arc C
+			email_delivery_status: "sent",
+			email_last_error: null,
+			active_marker: "active", // stays active for paid
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		// 3. Expired invite for a third Men's RX athlete. activeMarker nulled
+		//    so the slot can be re-invited without colliding on the unique index.
+		{
+			id: "cinv_seed_expired_alex",
+			championship_competition_id: "comp_inv_championship",
+			round_id: "",
+			origin: "source",
+			source_id: "cisrc_seed_qualifier",
+			source_competition_id: "comp_inv_qualifier",
+			source_placement: 3,
+			source_placement_label: "3rd — Regional Qualifier",
+			bespoke_reason: null,
+			championship_division_id: "slvl_inv_champ_mrx",
+			email: "alex@wodsmith.com",
+			user_id: "usr_athlete_alex",
+			invitee_first_name: "Alex",
+			invitee_last_name: null,
+			claim_token_hash: null,
+			claim_token_last4: null,
+			expires_at: pastDatetime(2),
+			send_attempt: 1,
+			status: "expired",
+			paid_at: null,
+			declined_at: null,
+			revoked_at: null,
+			revoked_by_user_id: null,
+			claimed_registration_id: null,
+			email_delivery_status: "sent",
+			email_last_error: null,
+			active_marker: null, // nulled on terminal transition
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		// 4. Declined invite for sarah (Women's RX top 1).
+		{
+			id: "cinv_seed_declined_sarah",
+			championship_competition_id: "comp_inv_championship",
+			round_id: "",
+			origin: "source",
+			source_id: "cisrc_seed_qualifier",
+			source_competition_id: "comp_inv_qualifier",
+			source_placement: 1,
+			source_placement_label: "1st — Regional Qualifier",
+			bespoke_reason: null,
+			championship_division_id: "slvl_inv_champ_wrx",
+			email: "sarah@wodsmith.com",
+			user_id: "usr_athlete_sarah",
+			invitee_first_name: "Sarah",
+			invitee_last_name: null,
+			claim_token_hash: null,
+			claim_token_last4: null,
+			expires_at: futureDatetime(14),
+			send_attempt: 1,
+			status: "declined",
+			paid_at: null,
+			declined_at: now(),
+			revoked_at: null,
+			revoked_by_user_id: null,
+			claimed_registration_id: null,
+			email_delivery_status: "sent",
+			email_last_error: null,
+			active_marker: null,
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		// 5. Draft bespoke invite — organizer staged but hasn't sent yet.
+		//    activeMarker = "active" so the unique-active index blocks
+		//    duplicate staging; claim token is still NULL.
+		{
+			id: "cinv_seed_bespoke_draft_champion",
+			championship_competition_id: "comp_inv_championship",
+			round_id: "",
+			origin: "bespoke",
+			source_id: null,
+			source_competition_id: null,
+			source_placement: null,
+			source_placement_label: null,
+			bespoke_reason: "Past champion",
+			championship_division_id: "slvl_inv_champ_mrx",
+			email: "returning-champ@example.com",
+			user_id: null,
+			invitee_first_name: "Returning",
+			invitee_last_name: "Champion",
+			claim_token_hash: null,
+			claim_token_last4: null,
+			expires_at: null,
+			send_attempt: 0,
+			status: "pending",
+			paid_at: null,
+			declined_at: null,
+			revoked_at: null,
+			revoked_by_user_id: null,
+			claimed_registration_id: null,
+			email_delivery_status: "skipped",
+			email_last_error: null,
+			active_marker: "active",
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
+		// 6. Bespoke invite already sent to a sponsored athlete (pending).
+		{
+			id: "cinv_seed_bespoke_sent_sponsor",
+			championship_competition_id: "comp_inv_championship",
+			round_id: "",
+			origin: "bespoke",
+			source_id: null,
+			source_competition_id: null,
+			source_placement: null,
+			source_placement_label: null,
+			bespoke_reason: "Sponsored athlete",
+			championship_division_id: "slvl_inv_champ_wrx",
+			email: "sponsor-athlete@example.com",
+			user_id: null,
+			invitee_first_name: "Sponsored",
+			invitee_last_name: "Athlete",
+			claim_token_hash: ryanToken.hash, // reuse deterministic seed token
+			claim_token_last4: ryanToken.last4,
+			expires_at: futureDatetime(14),
+			send_attempt: 1,
+			status: "pending",
+			paid_at: null,
+			declined_at: null,
+			revoked_at: null,
+			revoked_by_user_id: null,
+			claimed_registration_id: null,
+			email_delivery_status: "sent",
+			email_last_error: null,
+			active_marker: "active",
+			created_at: ts,
+			updated_at: ts,
+			update_counter: 0,
+		},
 	])
 
 	await batchInsert(client, "competition_invite_sources", [

--- a/apps/wodsmith-start/src/db/schemas/common.ts
+++ b/apps/wodsmith-start/src/db/schemas/common.ts
@@ -139,3 +139,4 @@ export const createBroadcastRecipientId = () => `brcpt_${ulid()}`
 
 // Competition invite ID generators
 export const createCompetitionInviteSourceId = () => `cisrc_${ulid()}`
+export const createCompetitionInviteId = () => `cinv_${ulid()}`

--- a/apps/wodsmith-start/src/db/schemas/competition-invites.ts
+++ b/apps/wodsmith-start/src/db/schemas/competition-invites.ts
@@ -4,22 +4,28 @@
  * Tables powering ADR-0011 "Competition Invites" — the organizer-facing
  * qualification-source → roster → invite-round system.
  *
- * This file starts in Phase 1 with just `competition_invite_sources`, which
- * declares where a championship competition draws its invitees from
- * (another single competition, or a series). Later phases add rounds,
- * per-athlete invites, and email templates.
+ * Phase 1 shipped `competition_invite_sources`. Phase 2 adds
+ * `competition_invites` — the per-athlete invite row carrying the
+ * email-locked claim token, status, and origin attribution. Rounds
+ * (Phase 3) and email templates (Phase 4) follow.
  */
 // @lat: [[competition-invites#Sources schema]]
 
 import type { InferSelectModel } from "drizzle-orm"
 import {
+  datetime,
   index,
   int,
   mysqlTable,
   text,
+  uniqueIndex,
   varchar,
 } from "drizzle-orm/mysql-core"
-import { commonColumns, createCompetitionInviteSourceId } from "./common"
+import {
+  commonColumns,
+  createCompetitionInviteId,
+  createCompetitionInviteSourceId,
+} from "./common"
 
 // ============================================================================
 // Source Kinds
@@ -93,3 +99,204 @@ export const competitionInviteSourcesTable = mysqlTable(
 export type CompetitionInviteSource = InferSelectModel<
   typeof competitionInviteSourcesTable
 >
+
+// ============================================================================
+// Invite Origin
+// ============================================================================
+
+export const COMPETITION_INVITE_ORIGIN = {
+  SOURCE: "source",
+  BESPOKE: "bespoke",
+} as const
+
+export type CompetitionInviteOrigin =
+  (typeof COMPETITION_INVITE_ORIGIN)[keyof typeof COMPETITION_INVITE_ORIGIN]
+
+// ============================================================================
+// Invite Status
+// ============================================================================
+
+/**
+ * `pending` — invite issued, token live, waiting for the athlete to claim.
+ * `accepted_paid` — the athlete finished Stripe Checkout and their
+ *   `competition_registrations` row exists; set by the Stripe workflow.
+ * `declined` — athlete explicitly declined via the decline route.
+ * `expired` — cron-sweep transitioned a past-deadline pending invite.
+ * `revoked` — organizer or an R2 send revoked the R1 invite.
+ *
+ * No intermediate `accepted` state — the Stripe-in-flight window is still
+ * `pending` until the webhook confirms payment. See ADR-0011 "Capacity Math".
+ */
+export const COMPETITION_INVITE_STATUS = {
+  PENDING: "pending",
+  ACCEPTED_PAID: "accepted_paid",
+  DECLINED: "declined",
+  EXPIRED: "expired",
+  REVOKED: "revoked",
+} as const
+
+export type CompetitionInviteStatus =
+  (typeof COMPETITION_INVITE_STATUS)[keyof typeof COMPETITION_INVITE_STATUS]
+
+// ============================================================================
+// Invite Email Delivery Status
+// ============================================================================
+
+export const COMPETITION_INVITE_EMAIL_DELIVERY_STATUS = {
+  QUEUED: "queued",
+  SENT: "sent",
+  FAILED: "failed",
+  SKIPPED: "skipped",
+} as const
+
+export type CompetitionInviteEmailDeliveryStatus =
+  (typeof COMPETITION_INVITE_EMAIL_DELIVERY_STATUS)[keyof typeof COMPETITION_INVITE_EMAIL_DELIVERY_STATUS]
+
+/**
+ * Literal value stored in `activeMarker` while the invite is in an active
+ * state (`pending` or `accepted_paid`). Nulled the moment the invite
+ * transitions to `declined`, `expired`, or `revoked`. Combined with the
+ * unique index on `(championshipCompetitionId, email, championshipDivisionId,
+ * activeMarker)`, this enforces at most one active invite per
+ * (championship, division, email) while still allowing historical rows to
+ * accumulate (MySQL treats multiple NULLs as distinct in unique indexes).
+ */
+export const COMPETITION_INVITE_ACTIVE_MARKER = "active" as const
+
+// ============================================================================
+// Competition Invites
+// ============================================================================
+
+/**
+ * A per-athlete invite. Carries the email-locked claim token (hashed),
+ * status, origin attribution (source vs bespoke), and round attribution.
+ *
+ * Phase 2: `roundId` is `varchar(255) NOT NULL` with an empty-string
+ * sentinel default. Rounds are introduced in Phase 3 along with a backfill
+ * that rewrites every Phase-2 row to a synthetic "Round 1 — Backfill".
+ *
+ * Token model:
+ * - Only the SHA-256 hash of the URL-safe plaintext token lives here.
+ * - `claimTokenLast4` is support-facing ("did this athlete click the right
+ *   link?") and is rotated alongside the hash on every re-send.
+ * - Terminal transitions (`declined`, `expired`, `revoked`, `accepted_paid`)
+ *   set `claimTokenHash = NULL`. The unique index on the hash permits
+ *   multiple NULLs (MySQL semantics) so this is safe.
+ * - The `sendAttempt` counter is included in the Resend `Idempotency-Key`
+ *   so a reused `invite.id` does not get silently deduplicated when the
+ *   organizer extends / re-issues.
+ */
+export const competitionInvitesTable = mysqlTable(
+  "competition_invites",
+  {
+    ...commonColumns,
+    id: varchar({ length: 255 })
+      .primaryKey()
+      .$defaultFn(() => createCompetitionInviteId())
+      .notNull(),
+    // The championship receiving this invite. Shortened to 64 so the
+    // active-invite unique index below fits under MySQL's 3072-byte key
+    // limit; we issue ULIDs (~30 chars with prefix) so 64 is ample.
+    championshipCompetitionId: varchar({ length: 64 }).notNull(),
+    // The round this invite was sent in. Phase 2 uses an empty-string
+    // sentinel; Phase 3 introduces `competition_invite_rounds` and
+    // backfills real IDs.
+    roundId: varchar({ length: 255 }).default("").notNull(),
+    // "source" | "bespoke" — discriminator for how the invite came to exist.
+    origin: varchar({ length: 20 })
+      .$type<CompetitionInviteOrigin>()
+      .notNull(),
+    // `competition_invite_sources.id` — which source qualified them.
+    // NULL when origin = "bespoke".
+    sourceId: varchar({ length: 255 }),
+    // Resolved source competition for source invites (for kind=competition
+    // this equals source's competition, for kind=series this is the
+    // specific comp within the series). NULL when origin = "bespoke".
+    sourceCompetitionId: varchar({ length: 255 }),
+    // 1-based rank in the source for display. NULL for series-global rows
+    // and for bespoke invites.
+    sourcePlacement: int(),
+    // Denormalized human label, e.g. "Series GLB · 1st unqualified". For
+    // bespoke invites this can carry the organizer's note so the roster
+    // row has something to show in the source column.
+    sourcePlacementLabel: varchar({ length: 255 }),
+    // Free-text categorization when origin = "bespoke" ("Sponsored
+    // athlete", "Past champion", "Wildcard"). Surfaces as a small chip in
+    // the roster. Distinct from the salutation.
+    bespokeReason: varchar({ length: 255 }),
+    // The target division on the championship. Same 64-byte cap as
+    // `championshipCompetitionId` so the active-invite unique index stays
+    // within MySQL's 3072-byte key limit.
+    championshipDivisionId: varchar({ length: 64 }).notNull(),
+    // Lowercased, trimmed at write. This is the invite-locked email.
+    email: varchar({ length: 255 }).notNull(),
+    // The WODsmith user account, if one exists at issue time or is
+    // resolved later by the claim flow.
+    userId: varchar({ length: 255 }),
+    // Denormalized for email salutation; falls back to `email` if NULL.
+    inviteeFirstName: varchar({ length: 255 }),
+    inviteeLastName: varchar({ length: 255 }),
+    // SHA-256 of the URL-safe plaintext token. Rotated on each re-send.
+    // NULLed on terminal transitions.
+    claimTokenHash: varchar({ length: 64 }),
+    // Last 4 chars of the plaintext token for organizer support queries.
+    // Rotated alongside `claimTokenHash`.
+    claimTokenLast4: varchar({ length: 8 }),
+    // Hard expiry. Mirrors round.rsvpDeadlineAt at send time, but stored
+    // per-invite so per-invite extensions work.
+    expiresAt: datetime(),
+    // Incremented every time the invite is re-sent. Used in the Resend
+    // Idempotency-Key so re-sends with the same invite.id actually dispatch.
+    sendAttempt: int().default(0).notNull(),
+    // Invite lifecycle status. See COMPETITION_INVITE_STATUS.
+    status: varchar({ length: 20 })
+      .$type<CompetitionInviteStatus>()
+      .default("pending")
+      .notNull(),
+    // Set when status transitions to "accepted_paid".
+    paidAt: datetime(),
+    // Set when status transitions to "declined".
+    declinedAt: datetime(),
+    // Set when status transitions to "revoked".
+    revokedAt: datetime(),
+    revokedByUserId: varchar({ length: 255 }),
+    // The competition_registrations.id that resulted from payment.
+    claimedRegistrationId: varchar({ length: 255 }),
+    // Mirrors broadcast pattern: "queued" | "sent" | "failed" | "skipped".
+    emailDeliveryStatus: varchar({ length: 20 })
+      .$type<CompetitionInviteEmailDeliveryStatus>()
+      .default("queued")
+      .notNull(),
+    emailLastError: text(),
+    // Literal "active" while status IN (pending, accepted_paid); NULL on
+    // terminal transitions. Powers the unique-active-invite index below.
+    activeMarker: varchar({ length: 8 }),
+  },
+  (table) => [
+    // At most one *active* invite per (championship, division, email).
+    // MySQL treats multiple NULLs as distinct, so terminal rows
+    // (activeMarker IS NULL) don't collide with a fresh re-invite.
+    uniqueIndex("competition_invites_active_invite_idx").on(
+      table.championshipCompetitionId,
+      table.email,
+      table.championshipDivisionId,
+      table.activeMarker,
+    ),
+    // Tokens are globally unique while live. Multiple NULLs coexist so
+    // historical terminal rows can accumulate.
+    uniqueIndex("competition_invites_claim_token_hash_idx").on(
+      table.claimTokenHash,
+    ),
+    index("competition_invites_round_idx").on(table.roundId),
+    index("competition_invites_source_idx").on(table.sourceId),
+    index("competition_invites_origin_idx").on(table.origin),
+    index("competition_invites_status_idx").on(table.status),
+    index("competition_invites_email_idx").on(table.email),
+    index("competition_invites_championship_idx").on(
+      table.championshipCompetitionId,
+    ),
+    index("competition_invites_user_idx").on(table.userId),
+  ],
+)
+
+export type CompetitionInvite = InferSelectModel<typeof competitionInvitesTable>

--- a/apps/wodsmith-start/src/lib/competition-invites/tokens.ts
+++ b/apps/wodsmith-start/src/lib/competition-invites/tokens.ts
@@ -1,0 +1,68 @@
+/**
+ * Competition invite claim tokens — generation, hashing, display helpers.
+ *
+ * A claim token is a 32-byte URL-safe random string. Only the SHA-256 hash
+ * lives in `competition_invites.claimTokenHash`; the plaintext exists only
+ * in the email delivered to the invited address. We also store the last 4
+ * characters of the plaintext so organizer support can confirm "did this
+ * athlete click the right link?" without reading a usable credential.
+ *
+ * Pure functions — no DB, no KV, no I/O beyond Web Crypto. Safe to call
+ * from server functions, workflows, queue consumers, and tests.
+ */
+// @lat: [[competition-invites#Token helpers]]
+
+import { encodeBase64urlNoPadding, encodeHexLowerCase } from "@oslojs/encoding"
+
+export interface InviteClaimTokenArtifacts {
+  /** URL-safe plaintext. Only put this in an outgoing email. */
+  token: string
+  /** SHA-256 of the plaintext, lowercase hex. Safe to store in the DB. */
+  hash: string
+  /** Last 4 characters of the plaintext. Support-facing, non-credential. */
+  last4: string
+}
+
+const TOKEN_BYTE_LENGTH = 32
+
+/**
+ * Generate a cryptographically random 32-byte URL-safe token. Uses Web
+ * Crypto `getRandomValues` + unpadded base64url so the result is always a
+ * safe URL path segment and every character carries entropy.
+ */
+export function generateInviteClaimTokenPlaintext(): string {
+  const bytes = new Uint8Array(TOKEN_BYTE_LENGTH)
+  crypto.getRandomValues(bytes)
+  return encodeBase64urlNoPadding(bytes)
+}
+
+/**
+ * Compute the SHA-256 hash of a plaintext token. The return is lowercase
+ * hex so it fits a `varchar(64)` column and compares case-sensitively
+ * against the stored value without normalization.
+ */
+export async function hashInviteClaimToken(token: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(token),
+  )
+  return encodeHexLowerCase(new Uint8Array(digest))
+}
+
+/**
+ * Last-4 extraction for organizer support. Does not leak enough of the
+ * token to reconstruct it.
+ */
+export function inviteClaimTokenLast4(token: string): string {
+  return token.slice(-4)
+}
+
+/**
+ * One-shot: plaintext + hash + last4. Prefer this at issue time so the
+ * three artifacts are always derived from the same plaintext.
+ */
+export async function generateInviteClaimToken(): Promise<InviteClaimTokenArtifacts> {
+  const token = generateInviteClaimTokenPlaintext()
+  const hash = await hashInviteClaimToken(token)
+  return { token, hash, last4: inviteClaimTokenLast4(token) }
+}

--- a/apps/wodsmith-start/src/server/competition-invites/bespoke.ts
+++ b/apps/wodsmith-start/src/server/competition-invites/bespoke.ts
@@ -1,0 +1,375 @@
+/**
+ * Bespoke invite staging helpers (Phase 2).
+ *
+ * Bespoke invites are first-class invites with no source attribution — the
+ * organizer types an email directly (or pastes a list) and a draft row is
+ * staged in `competition_invites`. A draft row has:
+ *   - `origin = "bespoke"`
+ *   - `status = "pending"`
+ *   - `activeMarker = "active"` — enforces the unique-active index so the
+ *     organizer cannot add the same (email, division) twice.
+ *   - `roundId = ""` (Phase 2 sentinel)
+ *   - `claimTokenHash = NULL` — no token issued until the row is picked
+ *     into a send.
+ *
+ * Two entry points:
+ *  - {@link createBespokeInvite} — single-email path.
+ *  - {@link createBespokeInvitesBulk} — CSV/TSV paste path. Accepts
+ *    email-only lines too. Caps at 500 rows per submission (ADR-0011
+ *    OQ#8 = 500). Duplicates and invalid rows come back as structured
+ *    results, not exceptions, so the organizer UI can render row-level
+ *    feedback.
+ *
+ * Both paths reject when the target division's registration fee is $0 —
+ * free competitions are not eligible for invites in the MVP.
+ */
+// @lat: [[competition-invites#Bespoke helpers]]
+
+import { and, eq, inArray } from "drizzle-orm"
+import { getDb } from "@/db"
+import { createCompetitionInviteId } from "@/db/schemas/common"
+import {
+  COMPETITION_INVITE_ACTIVE_MARKER,
+  COMPETITION_INVITE_EMAIL_DELIVERY_STATUS,
+  COMPETITION_INVITE_ORIGIN,
+  COMPETITION_INVITE_STATUS,
+  type CompetitionInvite,
+  competitionInvitesTable,
+} from "@/db/schemas/competition-invites"
+import { getRegistrationFee } from "@/server/commerce/fee-calculator"
+import {
+  FreeCompetitionNotEligibleError,
+  InviteIssueValidationError,
+  normalizeInviteEmail,
+} from "./issue"
+
+// ============================================================================
+// Bulk cap (ADR-0011 OQ#8)
+// ============================================================================
+
+export const BESPOKE_BULK_MAX_ROWS = 500
+
+// ============================================================================
+// Single-add
+// ============================================================================
+
+export interface CreateBespokeInviteInput {
+  championshipCompetitionId: string
+  championshipDivisionId: string
+  email: string
+  inviteeFirstName?: string | null
+  inviteeLastName?: string | null
+  bespokeReason?: string | null
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+async function assertDivisionIsPaid(params: {
+  competitionId: string
+  divisionId: string
+}): Promise<void> {
+  const fee = await getRegistrationFee(params.competitionId, params.divisionId)
+  if (fee <= 0) {
+    throw new FreeCompetitionNotEligibleError(params)
+  }
+}
+
+export async function createBespokeInvite(
+  input: CreateBespokeInviteInput,
+): Promise<CompetitionInvite> {
+  const email = normalizeInviteEmail(input.email)
+  if (!EMAIL_PATTERN.test(email)) {
+    throw new InviteIssueValidationError(`Invalid email: ${input.email}`)
+  }
+
+  await assertDivisionIsPaid({
+    competitionId: input.championshipCompetitionId,
+    divisionId: input.championshipDivisionId,
+  })
+
+  const db = getDb()
+
+  const existing = await db
+    .select()
+    .from(competitionInvitesTable)
+    .where(
+      and(
+        eq(
+          competitionInvitesTable.championshipCompetitionId,
+          input.championshipCompetitionId,
+        ),
+        eq(
+          competitionInvitesTable.championshipDivisionId,
+          input.championshipDivisionId,
+        ),
+        eq(competitionInvitesTable.email, email),
+        eq(
+          competitionInvitesTable.activeMarker,
+          COMPETITION_INVITE_ACTIVE_MARKER,
+        ),
+      ),
+    )
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  if (existing) {
+    throw new InviteIssueValidationError(
+      `${email} already has an active invite for this championship division`,
+    )
+  }
+
+  const id = createCompetitionInviteId()
+  const now = new Date()
+  const row: CompetitionInvite = {
+    id,
+    championshipCompetitionId: input.championshipCompetitionId,
+    roundId: "",
+    origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+    sourceId: null,
+    sourceCompetitionId: null,
+    sourcePlacement: null,
+    sourcePlacementLabel: null,
+    bespokeReason: input.bespokeReason ?? null,
+    championshipDivisionId: input.championshipDivisionId,
+    email,
+    userId: null,
+    inviteeFirstName: input.inviteeFirstName ?? null,
+    inviteeLastName: input.inviteeLastName ?? null,
+    claimTokenHash: null,
+    claimTokenLast4: null,
+    expiresAt: null,
+    sendAttempt: 0,
+    status: COMPETITION_INVITE_STATUS.PENDING,
+    paidAt: null,
+    declinedAt: null,
+    revokedAt: null,
+    revokedByUserId: null,
+    claimedRegistrationId: null,
+    emailDeliveryStatus: COMPETITION_INVITE_EMAIL_DELIVERY_STATUS.SKIPPED,
+    emailLastError: null,
+    activeMarker: COMPETITION_INVITE_ACTIVE_MARKER,
+    createdAt: now,
+    updatedAt: now,
+    updateCounter: 0,
+  }
+
+  await db.insert(competitionInvitesTable).values(row)
+  return row
+}
+
+// ============================================================================
+// Bulk paste (CSV / TSV / one-email-per-line)
+// ============================================================================
+
+export interface BulkRowInput {
+  /** 1-based index in the original paste body. */
+  rowNumber: number
+  email: string
+  inviteeFirstName?: string | null
+  inviteeLastName?: string | null
+  bespokeReason?: string | null
+}
+
+export interface BulkInvalidRow {
+  rowNumber: number
+  rawLine: string
+  reason: string
+}
+
+export interface BulkDuplicateRow {
+  rowNumber: number
+  email: string
+  reason: "already_invited" | "duplicate_in_paste"
+}
+
+export interface CreateBespokeInvitesBulkResult {
+  created: CompetitionInvite[]
+  duplicates: BulkDuplicateRow[]
+  invalid: BulkInvalidRow[]
+}
+
+export interface CreateBespokeInvitesBulkInput {
+  championshipCompetitionId: string
+  championshipDivisionId: string
+  /** Raw paste body — CSV, TSV, or one-email-per-line. */
+  pasteText: string
+}
+
+/**
+ * Parse a single paste-body line into a candidate row. Emits null if the
+ * line is blank or looks like a header (literal "email" in the first
+ * column, case-insensitive). The parser auto-detects tab vs comma delimiter
+ * per line, preferring tab when present (Google Sheets paste is TSV).
+ */
+export function parseBespokePasteLine(
+  line: string,
+  rowNumber: number,
+): BulkRowInput | null {
+  const trimmed = line.trim()
+  if (trimmed === "") return null
+
+  const delimiter = trimmed.includes("\t") ? "\t" : ","
+  const fields = trimmed.split(delimiter).map((f) => f.trim())
+
+  const emailField = fields[0] ?? ""
+  if (emailField === "") return null
+  if (emailField.toLowerCase() === "email") return null // header row
+
+  return {
+    rowNumber,
+    email: emailField,
+    inviteeFirstName: fields[1] || null,
+    inviteeLastName: fields[2] || null,
+    // Field 3 is a division hint we ignore in Phase 2 (caller supplies
+    // the division). Field 4 is the bespoke reason.
+    bespokeReason: fields[4] || null,
+  }
+}
+
+/**
+ * Split the paste body into parsed rows + invalid rows. Pure function.
+ * Caps at {@link BESPOKE_BULK_MAX_ROWS}; overflow rows are silently dropped
+ * (the caller should surface the cap in the UI).
+ */
+export function parseBespokePaste(pasteText: string): {
+  rows: BulkRowInput[]
+  invalid: BulkInvalidRow[]
+} {
+  const normalizedLines = pasteText
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .slice(0, BESPOKE_BULK_MAX_ROWS + 1) // +1 so a header line doesn't eat a real row
+
+  const rows: BulkRowInput[] = []
+  const invalid: BulkInvalidRow[] = []
+
+  normalizedLines.forEach((line, i) => {
+    const rowNumber = i + 1
+    const parsed = parseBespokePasteLine(line, rowNumber)
+    if (!parsed) return
+    const normalizedEmail = normalizeInviteEmail(parsed.email)
+    if (!EMAIL_PATTERN.test(normalizedEmail)) {
+      invalid.push({
+        rowNumber,
+        rawLine: line,
+        reason: `Invalid email: ${parsed.email}`,
+      })
+      return
+    }
+    rows.push({ ...parsed, email: normalizedEmail })
+  })
+
+  return { rows: rows.slice(0, BESPOKE_BULK_MAX_ROWS), invalid }
+}
+
+export async function createBespokeInvitesBulk(
+  input: CreateBespokeInvitesBulkInput,
+): Promise<CreateBespokeInvitesBulkResult> {
+  await assertDivisionIsPaid({
+    competitionId: input.championshipCompetitionId,
+    divisionId: input.championshipDivisionId,
+  })
+
+  const { rows, invalid } = parseBespokePaste(input.pasteText)
+
+  // Dedup within the paste body, keeping the first occurrence.
+  const seen = new Map<string, BulkRowInput>()
+  const duplicates: BulkDuplicateRow[] = []
+  for (const r of rows) {
+    if (seen.has(r.email)) {
+      duplicates.push({
+        rowNumber: r.rowNumber,
+        email: r.email,
+        reason: "duplicate_in_paste",
+      })
+      continue
+    }
+    seen.set(r.email, r)
+  }
+  const uniqueRows = Array.from(seen.values())
+
+  if (uniqueRows.length === 0) {
+    return { created: [], duplicates, invalid }
+  }
+
+  const db = getDb()
+
+  // One round-trip to find emails that already have an active invite.
+  const emails = uniqueRows.map((r) => r.email)
+  const existing = await db
+    .select({ email: competitionInvitesTable.email })
+    .from(competitionInvitesTable)
+    .where(
+      and(
+        eq(
+          competitionInvitesTable.championshipCompetitionId,
+          input.championshipCompetitionId,
+        ),
+        eq(
+          competitionInvitesTable.championshipDivisionId,
+          input.championshipDivisionId,
+        ),
+        eq(
+          competitionInvitesTable.activeMarker,
+          COMPETITION_INVITE_ACTIVE_MARKER,
+        ),
+        inArray(competitionInvitesTable.email, emails),
+      ),
+    )
+
+  const existingEmails = new Set(existing.map((e) => e.email))
+  const insertable: BulkRowInput[] = []
+  for (const r of uniqueRows) {
+    if (existingEmails.has(r.email)) {
+      duplicates.push({
+        rowNumber: r.rowNumber,
+        email: r.email,
+        reason: "already_invited",
+      })
+      continue
+    }
+    insertable.push(r)
+  }
+
+  if (insertable.length === 0) {
+    return { created: [], duplicates, invalid }
+  }
+
+  const now = new Date()
+  const newRows: CompetitionInvite[] = insertable.map((r) => ({
+    id: createCompetitionInviteId(),
+    championshipCompetitionId: input.championshipCompetitionId,
+    roundId: "",
+    origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+    sourceId: null,
+    sourceCompetitionId: null,
+    sourcePlacement: null,
+    sourcePlacementLabel: null,
+    bespokeReason: r.bespokeReason ?? null,
+    championshipDivisionId: input.championshipDivisionId,
+    email: r.email,
+    userId: null,
+    inviteeFirstName: r.inviteeFirstName ?? null,
+    inviteeLastName: r.inviteeLastName ?? null,
+    claimTokenHash: null,
+    claimTokenLast4: null,
+    expiresAt: null,
+    sendAttempt: 0,
+    status: COMPETITION_INVITE_STATUS.PENDING,
+    paidAt: null,
+    declinedAt: null,
+    revokedAt: null,
+    revokedByUserId: null,
+    claimedRegistrationId: null,
+    emailDeliveryStatus: COMPETITION_INVITE_EMAIL_DELIVERY_STATUS.SKIPPED,
+    emailLastError: null,
+    activeMarker: COMPETITION_INVITE_ACTIVE_MARKER,
+    createdAt: now,
+    updatedAt: now,
+    updateCounter: 0,
+  }))
+
+  await db.insert(competitionInvitesTable).values(newRows)
+
+  return { created: newRows, duplicates, invalid }
+}

--- a/apps/wodsmith-start/src/server/competition-invites/bespoke.ts
+++ b/apps/wodsmith-start/src/server/competition-invites/bespoke.ts
@@ -38,6 +38,7 @@ import {
 } from "@/db/schemas/competition-invites"
 import { getRegistrationFee } from "@/server/commerce/fee-calculator"
 import {
+  EMAIL_PATTERN,
   FreeCompetitionNotEligibleError,
   InviteIssueValidationError,
   normalizeInviteEmail,
@@ -61,8 +62,6 @@ export interface CreateBespokeInviteInput {
   inviteeLastName?: string | null
   bespokeReason?: string | null
 }
-
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 async function assertDivisionIsPaid(params: {
   competitionId: string
@@ -89,72 +88,78 @@ export async function createBespokeInvite(
 
   const db = getDb()
 
-  const existing = await db
-    .select()
-    .from(competitionInvitesTable)
-    .where(
-      and(
-        eq(
-          competitionInvitesTable.championshipCompetitionId,
-          input.championshipCompetitionId,
+  // Wrapped in a transaction so the existence check + insert can't race
+  // a concurrent bespoke create / batch issue from raising a raw
+  // `ER_DUP_ENTRY` (the active-marker unique index would otherwise leak
+  // through). Matches the pattern in `issueInvitesForRecipients`.
+  return db.transaction(async (tx) => {
+    const existing = await tx
+      .select()
+      .from(competitionInvitesTable)
+      .where(
+        and(
+          eq(
+            competitionInvitesTable.championshipCompetitionId,
+            input.championshipCompetitionId,
+          ),
+          eq(
+            competitionInvitesTable.championshipDivisionId,
+            input.championshipDivisionId,
+          ),
+          eq(competitionInvitesTable.email, email),
+          eq(
+            competitionInvitesTable.activeMarker,
+            COMPETITION_INVITE_ACTIVE_MARKER,
+          ),
         ),
-        eq(
-          competitionInvitesTable.championshipDivisionId,
-          input.championshipDivisionId,
-        ),
-        eq(competitionInvitesTable.email, email),
-        eq(
-          competitionInvitesTable.activeMarker,
-          COMPETITION_INVITE_ACTIVE_MARKER,
-        ),
-      ),
-    )
-    .limit(1)
-    .then((rows) => rows[0] ?? null)
+      )
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
 
-  if (existing) {
-    throw new InviteIssueValidationError(
-      `${email} already has an active invite for this championship division`,
-    )
-  }
+    if (existing) {
+      throw new InviteIssueValidationError(
+        `${email} already has an active invite for this championship division`,
+      )
+    }
 
-  const id = createCompetitionInviteId()
-  const now = new Date()
-  const row: CompetitionInvite = {
-    id,
-    championshipCompetitionId: input.championshipCompetitionId,
-    roundId: "",
-    origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
-    sourceId: null,
-    sourceCompetitionId: null,
-    sourcePlacement: null,
-    sourcePlacementLabel: null,
-    bespokeReason: input.bespokeReason ?? null,
-    championshipDivisionId: input.championshipDivisionId,
-    email,
-    userId: null,
-    inviteeFirstName: input.inviteeFirstName ?? null,
-    inviteeLastName: input.inviteeLastName ?? null,
-    claimTokenHash: null,
-    claimTokenLast4: null,
-    expiresAt: null,
-    sendAttempt: 0,
-    status: COMPETITION_INVITE_STATUS.PENDING,
-    paidAt: null,
-    declinedAt: null,
-    revokedAt: null,
-    revokedByUserId: null,
-    claimedRegistrationId: null,
-    emailDeliveryStatus: COMPETITION_INVITE_EMAIL_DELIVERY_STATUS.SKIPPED,
-    emailLastError: null,
-    activeMarker: COMPETITION_INVITE_ACTIVE_MARKER,
-    createdAt: now,
-    updatedAt: now,
-    updateCounter: 0,
-  }
+    const id = createCompetitionInviteId()
+    const now = new Date()
+    const row: CompetitionInvite = {
+      id,
+      championshipCompetitionId: input.championshipCompetitionId,
+      roundId: "",
+      origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+      sourceId: null,
+      sourceCompetitionId: null,
+      sourcePlacement: null,
+      sourcePlacementLabel: null,
+      bespokeReason: input.bespokeReason ?? null,
+      championshipDivisionId: input.championshipDivisionId,
+      email,
+      userId: null,
+      inviteeFirstName: input.inviteeFirstName ?? null,
+      inviteeLastName: input.inviteeLastName ?? null,
+      claimTokenHash: null,
+      claimTokenLast4: null,
+      expiresAt: null,
+      sendAttempt: 0,
+      status: COMPETITION_INVITE_STATUS.PENDING,
+      paidAt: null,
+      declinedAt: null,
+      revokedAt: null,
+      revokedByUserId: null,
+      claimedRegistrationId: null,
+      emailDeliveryStatus: COMPETITION_INVITE_EMAIL_DELIVERY_STATUS.SKIPPED,
+      emailLastError: null,
+      activeMarker: COMPETITION_INVITE_ACTIVE_MARKER,
+      createdAt: now,
+      updatedAt: now,
+      updateCounter: 0,
+    }
 
-  await db.insert(competitionInvitesTable).values(row)
-  return row
+    await tx.insert(competitionInvitesTable).values(row)
+    return row
+  })
 }
 
 // ============================================================================
@@ -196,6 +201,42 @@ export interface CreateBespokeInvitesBulkInput {
 }
 
 /**
+ * Quote-aware CSV splitter. Handles `"Doe, Jane",jane@x.com,...` by
+ * keeping the comma inside the quoted field. Doubled quotes inside a
+ * quoted field decode to a single quote (`""` → `"`). For TSV input we
+ * skip this entirely — tabs can't appear inside a tab-delimited field.
+ */
+function splitCsvLine(line: string): string[] {
+  const out: string[] = []
+  let buf = ""
+  let inQuotes = false
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i]
+    if (inQuotes) {
+      if (c === '"') {
+        if (line[i + 1] === '"') {
+          buf += '"'
+          i++
+        } else {
+          inQuotes = false
+        }
+      } else {
+        buf += c
+      }
+    } else if (c === '"') {
+      inQuotes = true
+    } else if (c === ",") {
+      out.push(buf)
+      buf = ""
+    } else {
+      buf += c
+    }
+  }
+  out.push(buf)
+  return out
+}
+
+/**
  * Parse a single paste-body line into a candidate row. Emits null if the
  * line is blank or looks like a header (literal "email" in the first
  * column, case-insensitive). The parser auto-detects tab vs comma delimiter
@@ -208,8 +249,10 @@ export function parseBespokePasteLine(
   const trimmed = line.trim()
   if (trimmed === "") return null
 
-  const delimiter = trimmed.includes("\t") ? "\t" : ","
-  const fields = trimmed.split(delimiter).map((f) => f.trim())
+  const fields =
+    trimmed.includes("\t")
+      ? trimmed.split("\t").map((f) => f.trim())
+      : splitCsvLine(trimmed).map((f) => f.trim())
 
   const emailField = fields[0] ?? ""
   if (emailField === "") return null

--- a/apps/wodsmith-start/src/server/competition-invites/issue.ts
+++ b/apps/wodsmith-start/src/server/competition-invites/issue.ts
@@ -112,6 +112,13 @@ export function normalizeInviteEmail(email: string): string {
   return email.trim().toLowerCase()
 }
 
+/**
+ * Permissive email pattern used at write boundaries (issue + bespoke
+ * staging). Not RFC 5322 — but tight enough to reject the obvious
+ * garbage that would otherwise slip into the queue.
+ */
+export const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 export function assertRecipientOriginValid(r: IssueInviteRecipient): void {
   if (r.origin === COMPETITION_INVITE_ORIGIN.SOURCE) {
     if (!r.sourceId) {
@@ -172,7 +179,11 @@ export async function issueInvitesForRecipients(
 
   const normalized = input.recipients.map((r) => {
     assertRecipientOriginValid(r)
-    return { ...r, email: normalizeInviteEmail(r.email) }
+    const email = normalizeInviteEmail(r.email)
+    if (!EMAIL_PATTERN.test(email)) {
+      throw new InviteIssueValidationError(`Invalid email: ${r.email}`)
+    }
+    return { ...r, email }
   })
 
   const emails = Array.from(new Set(normalized.map((r) => r.email)))
@@ -213,7 +224,13 @@ export async function issueInvitesForRecipients(
         alreadyActive.push({
           email: r.email,
           existingInviteId: existingRow.id,
-          isDraft: !existingRow.claimTokenHash,
+          // A draft is a bespoke row staged without a token (`pending` +
+          // null hash). `accepted_paid` rows also null `claimTokenHash`
+          // while keeping `activeMarker = "active"` — the status guard
+          // keeps them out of the draft bucket.
+          isDraft:
+            !existingRow.claimTokenHash &&
+            existingRow.status === COMPETITION_INVITE_STATUS.PENDING,
         })
       } else {
         toInsertInputs.push(r)
@@ -306,6 +323,11 @@ export interface ReissueInviteInput {
  * remain correlated across attempts. Rejects when the target division's
  * registration fee is $0.
  *
+ * The UPDATE pins `status IN (pending, expired)` in the WHERE clause so
+ * a concurrent claim/decline/revoke between read and write can't be
+ * silently overwritten. A 0-row outcome forces a re-read to tell apart
+ * "row vanished" from "row terminal-transitioned mid-flight".
+ *
  * Returns the rotated invite + the new plaintext token.
  */
 export async function reissueInvite(
@@ -345,7 +367,7 @@ export async function reissueInvite(
   const nextSendAttempt = existing.sendAttempt + 1
   const now = new Date()
 
-  await db
+  const updateResult = await db
     .update(competitionInvitesTable)
     .set({
       claimTokenHash: artifacts.hash,
@@ -359,7 +381,29 @@ export async function reissueInvite(
       roundId: input.roundId ?? existing.roundId,
       updatedAt: now,
     })
-    .where(eq(competitionInvitesTable.id, input.inviteId))
+    .where(
+      and(
+        eq(competitionInvitesTable.id, input.inviteId),
+        inArray(competitionInvitesTable.status, [
+          COMPETITION_INVITE_STATUS.PENDING,
+          COMPETITION_INVITE_STATUS.EXPIRED,
+        ]),
+      ),
+    )
+
+  const affected = (updateResult as unknown as { affectedRows?: number })
+    .affectedRows
+  if (affected === 0) {
+    const fresh = await db
+      .select({ status: competitionInvitesTable.status })
+      .from(competitionInvitesTable)
+      .where(eq(competitionInvitesTable.id, input.inviteId))
+      .limit(1)
+      .then((rows) => rows[0] ?? null)
+    throw new InviteIssueValidationError(
+      `Invite ${input.inviteId} cannot be reissued — concurrently transitioned to ${fresh?.status ?? "unknown"}`,
+    )
+  }
 
   const rotated: CompetitionInvite = {
     ...existing,

--- a/apps/wodsmith-start/src/server/competition-invites/issue.ts
+++ b/apps/wodsmith-start/src/server/competition-invites/issue.ts
@@ -1,0 +1,379 @@
+/**
+ * Competition invite issue helpers (Phase 2).
+ *
+ * DB-side-only layer that writes `competition_invites` rows for new sends
+ * and rotates tokens on re-send. Does NOT render email, does NOT enqueue
+ * — those belong to `competition-invite-fns.issueInvitesFn` (2.13) so the
+ * email queue consumer is the only path that calls Resend.
+ *
+ * Two primary helpers:
+ * - {@link issueInvitesForRecipients} — insert new pending invite rows for
+ *   source-derived and fresh bespoke recipients. Returns the inserted rows
+ *   together with their *plaintext* claim tokens (the only place the
+ *   plaintext exists). Conflicts against an already-active invite surface
+ *   as `alreadyActive` with the existing invite id so the caller can
+ *   decide to reissue.
+ * - {@link reissueInvite} — rotate token + last4, bump `sendAttempt`,
+ *   bump `expiresAt`, restore `activeMarker = "active"`, and flip
+ *   `expired`/draft-no-token rows back to `pending`. Covers both
+ *   extend-expired-invite and activate-draft-bespoke paths.
+ *
+ * Both paths reject at the target division's registration fee of $0 —
+ * free competitions are not eligible for invites in the MVP (ADR-0011
+ * "Capacity Math" → "Free competitions").
+ */
+// @lat: [[competition-invites#Issue helpers]]
+
+import { and, eq, inArray } from "drizzle-orm"
+import { getDb } from "@/db"
+import { createCompetitionInviteId } from "@/db/schemas/common"
+import {
+  COMPETITION_INVITE_ACTIVE_MARKER,
+  COMPETITION_INVITE_EMAIL_DELIVERY_STATUS,
+  COMPETITION_INVITE_ORIGIN,
+  COMPETITION_INVITE_STATUS,
+  type CompetitionInvite,
+  type CompetitionInviteOrigin,
+  competitionInvitesTable,
+} from "@/db/schemas/competition-invites"
+import { generateInviteClaimToken } from "@/lib/competition-invites/tokens"
+import { getRegistrationFee } from "@/server/commerce/fee-calculator"
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface IssueInviteRecipient {
+  email: string
+  origin: CompetitionInviteOrigin
+  sourceId?: string | null
+  sourceCompetitionId?: string | null
+  sourcePlacement?: number | null
+  sourcePlacementLabel?: string | null
+  bespokeReason?: string | null
+  inviteeFirstName?: string | null
+  inviteeLastName?: string | null
+  userId?: string | null
+}
+
+export interface IssueInvitesInput {
+  championshipCompetitionId: string
+  championshipDivisionId: string
+  rsvpDeadlineAt: Date
+  /** Phase 2: empty-string sentinel; Phase 3 replaces with a real round id. */
+  roundId?: string
+  recipients: IssueInviteRecipient[]
+}
+
+export interface IssuedInvite {
+  invite: CompetitionInvite
+  /** Plaintext claim token. Put this only in an outgoing email. */
+  plaintextToken: string
+}
+
+export interface AlreadyActiveInvite {
+  email: string
+  existingInviteId: string
+  /** True when the existing row has no token yet (a draft bespoke invite). */
+  isDraft: boolean
+}
+
+export interface IssueInvitesResult {
+  inserted: IssuedInvite[]
+  alreadyActive: AlreadyActiveInvite[]
+}
+
+export class InviteIssueValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "InviteIssueValidationError"
+  }
+}
+
+export class FreeCompetitionNotEligibleError extends Error {
+  constructor(params: { competitionId: string; divisionId: string }) {
+    super(
+      `Invites are not supported for free divisions. Competition ${params.competitionId} division ${params.divisionId} has a $0 registration fee.`,
+    )
+    this.name = "FreeCompetitionNotEligibleError"
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Lowercase + trim. The invite is locked to this exact value and every
+ * downstream lookup (claim resolution, identity match, roster join) uses
+ * the same normalization.
+ */
+export function normalizeInviteEmail(email: string): string {
+  return email.trim().toLowerCase()
+}
+
+export function assertRecipientOriginValid(r: IssueInviteRecipient): void {
+  if (r.origin === COMPETITION_INVITE_ORIGIN.SOURCE) {
+    if (!r.sourceId) {
+      throw new InviteIssueValidationError(
+        `Source recipient ${r.email} is missing sourceId`,
+      )
+    }
+    if (!r.sourceCompetitionId) {
+      throw new InviteIssueValidationError(
+        `Source recipient ${r.email} is missing sourceCompetitionId`,
+      )
+    }
+  } else {
+    if (r.sourceId || r.sourceCompetitionId || r.sourcePlacement) {
+      throw new InviteIssueValidationError(
+        `Bespoke recipient ${r.email} must not carry source attribution`,
+      )
+    }
+  }
+}
+
+async function assertDivisionIsPaid(params: {
+  competitionId: string
+  divisionId: string
+}): Promise<void> {
+  const fee = await getRegistrationFee(params.competitionId, params.divisionId)
+  if (fee <= 0) {
+    throw new FreeCompetitionNotEligibleError(params)
+  }
+}
+
+// ============================================================================
+// Issue (new inserts)
+// ============================================================================
+
+/**
+ * Insert new pending invite rows for each recipient. Recipients whose
+ * email already has an active invite for the target (championship, division)
+ * are returned in `alreadyActive` with the existing invite's id — the caller
+ * decides whether to reissue (bespoke drafts) or report it as a skip.
+ *
+ * Transactional: either all rows are inserted or none are, so a mid-batch
+ * failure never leaves a half-sent round. Email normalization (lowercase +
+ * trim) is applied per recipient before either the conflict lookup or the
+ * insert.
+ */
+export async function issueInvitesForRecipients(
+  input: IssueInvitesInput,
+): Promise<IssueInvitesResult> {
+  if (input.recipients.length === 0) {
+    return { inserted: [], alreadyActive: [] }
+  }
+
+  await assertDivisionIsPaid({
+    competitionId: input.championshipCompetitionId,
+    divisionId: input.championshipDivisionId,
+  })
+
+  const normalized = input.recipients.map((r) => {
+    assertRecipientOriginValid(r)
+    return { ...r, email: normalizeInviteEmail(r.email) }
+  })
+
+  const emails = Array.from(new Set(normalized.map((r) => r.email)))
+  const db = getDb()
+
+  return db.transaction(async (tx) => {
+    const existing = await tx
+      .select()
+      .from(competitionInvitesTable)
+      .where(
+        and(
+          eq(
+            competitionInvitesTable.championshipCompetitionId,
+            input.championshipCompetitionId,
+          ),
+          eq(
+            competitionInvitesTable.championshipDivisionId,
+            input.championshipDivisionId,
+          ),
+          eq(
+            competitionInvitesTable.activeMarker,
+            COMPETITION_INVITE_ACTIVE_MARKER,
+          ),
+          inArray(competitionInvitesTable.email, emails),
+        ),
+      )
+
+    const existingByEmail = new Map(existing.map((e) => [e.email, e]))
+
+    const alreadyActive: AlreadyActiveInvite[] = []
+    const toInsertInputs: IssueInviteRecipient[] = []
+    const seenEmails = new Set<string>()
+    for (const r of normalized) {
+      if (seenEmails.has(r.email)) continue
+      seenEmails.add(r.email)
+      const existingRow = existingByEmail.get(r.email)
+      if (existingRow) {
+        alreadyActive.push({
+          email: r.email,
+          existingInviteId: existingRow.id,
+          isDraft: !existingRow.claimTokenHash,
+        })
+      } else {
+        toInsertInputs.push(r)
+      }
+    }
+
+    if (toInsertInputs.length === 0) {
+      return { inserted: [], alreadyActive }
+    }
+
+    const inserted: IssuedInvite[] = []
+    const rowsToInsert: CompetitionInvite[] = []
+    for (const r of toInsertInputs) {
+      const artifacts = await generateInviteClaimToken()
+      const id = createCompetitionInviteId()
+      const now = new Date()
+      const row: CompetitionInvite = {
+        id,
+        championshipCompetitionId: input.championshipCompetitionId,
+        roundId: input.roundId ?? "",
+        origin: r.origin,
+        sourceId: r.origin === COMPETITION_INVITE_ORIGIN.SOURCE
+          ? r.sourceId ?? null
+          : null,
+        sourceCompetitionId:
+          r.origin === COMPETITION_INVITE_ORIGIN.SOURCE
+            ? r.sourceCompetitionId ?? null
+            : null,
+        sourcePlacement:
+          r.origin === COMPETITION_INVITE_ORIGIN.SOURCE
+            ? r.sourcePlacement ?? null
+            : null,
+        sourcePlacementLabel: r.sourcePlacementLabel ?? null,
+        bespokeReason:
+          r.origin === COMPETITION_INVITE_ORIGIN.BESPOKE
+            ? r.bespokeReason ?? null
+            : null,
+        championshipDivisionId: input.championshipDivisionId,
+        email: r.email,
+        userId: r.userId ?? null,
+        inviteeFirstName: r.inviteeFirstName ?? null,
+        inviteeLastName: r.inviteeLastName ?? null,
+        claimTokenHash: artifacts.hash,
+        claimTokenLast4: artifacts.last4,
+        expiresAt: input.rsvpDeadlineAt,
+        sendAttempt: 0,
+        status: COMPETITION_INVITE_STATUS.PENDING,
+        paidAt: null,
+        declinedAt: null,
+        revokedAt: null,
+        revokedByUserId: null,
+        claimedRegistrationId: null,
+        emailDeliveryStatus: COMPETITION_INVITE_EMAIL_DELIVERY_STATUS.QUEUED,
+        emailLastError: null,
+        activeMarker: COMPETITION_INVITE_ACTIVE_MARKER,
+        createdAt: now,
+        updatedAt: now,
+        updateCounter: 0,
+      }
+      rowsToInsert.push(row)
+      inserted.push({ invite: row, plaintextToken: artifacts.token })
+    }
+
+    await tx.insert(competitionInvitesTable).values(rowsToInsert)
+
+    return { inserted, alreadyActive }
+  })
+}
+
+// ============================================================================
+// Reissue (rotate token on existing row)
+// ============================================================================
+
+export interface ReissueInviteInput {
+  inviteId: string
+  newExpiresAt: Date
+  /**
+   * Phase 2 optionally updates the invite's roundId (implicit round-label
+   * metadata). Phase 3 will make this a real round FK.
+   */
+  roundId?: string
+}
+
+/**
+ * Rotate the token on an existing invite. Covers two cases:
+ * 1. Activate a draft bespoke invite (no `claimTokenHash` yet).
+ * 2. Extend/re-send a `pending` (near-expiry) or `expired` invite.
+ *
+ * Preserves `invite.id` so Stripe metadata, webhooks, and audit queries
+ * remain correlated across attempts. Rejects when the target division's
+ * registration fee is $0.
+ *
+ * Returns the rotated invite + the new plaintext token.
+ */
+export async function reissueInvite(
+  input: ReissueInviteInput,
+): Promise<IssuedInvite> {
+  const db = getDb()
+
+  const existing = await db
+    .select()
+    .from(competitionInvitesTable)
+    .where(eq(competitionInvitesTable.id, input.inviteId))
+    .limit(1)
+    .then((rows) => rows[0] ?? null)
+
+  if (!existing) {
+    throw new InviteIssueValidationError(
+      `Invite ${input.inviteId} does not exist`,
+    )
+  }
+
+  if (
+    existing.status === COMPETITION_INVITE_STATUS.ACCEPTED_PAID ||
+    existing.status === COMPETITION_INVITE_STATUS.DECLINED ||
+    existing.status === COMPETITION_INVITE_STATUS.REVOKED
+  ) {
+    throw new InviteIssueValidationError(
+      `Invite ${input.inviteId} cannot be reissued from status ${existing.status}`,
+    )
+  }
+
+  await assertDivisionIsPaid({
+    competitionId: existing.championshipCompetitionId,
+    divisionId: existing.championshipDivisionId,
+  })
+
+  const artifacts = await generateInviteClaimToken()
+  const nextSendAttempt = existing.sendAttempt + 1
+  const now = new Date()
+
+  await db
+    .update(competitionInvitesTable)
+    .set({
+      claimTokenHash: artifacts.hash,
+      claimTokenLast4: artifacts.last4,
+      expiresAt: input.newExpiresAt,
+      sendAttempt: nextSendAttempt,
+      status: COMPETITION_INVITE_STATUS.PENDING,
+      activeMarker: COMPETITION_INVITE_ACTIVE_MARKER,
+      emailDeliveryStatus: COMPETITION_INVITE_EMAIL_DELIVERY_STATUS.QUEUED,
+      emailLastError: null,
+      roundId: input.roundId ?? existing.roundId,
+      updatedAt: now,
+    })
+    .where(eq(competitionInvitesTable.id, input.inviteId))
+
+  const rotated: CompetitionInvite = {
+    ...existing,
+    claimTokenHash: artifacts.hash,
+    claimTokenLast4: artifacts.last4,
+    expiresAt: input.newExpiresAt,
+    sendAttempt: nextSendAttempt,
+    status: COMPETITION_INVITE_STATUS.PENDING,
+    activeMarker: COMPETITION_INVITE_ACTIVE_MARKER,
+    emailDeliveryStatus: COMPETITION_INVITE_EMAIL_DELIVERY_STATUS.QUEUED,
+    emailLastError: null,
+    roundId: input.roundId ?? existing.roundId,
+    updatedAt: now,
+  }
+
+  return { invite: rotated, plaintextToken: artifacts.token }
+}

--- a/apps/wodsmith-start/test/lib/competition-invites/tokens.test.ts
+++ b/apps/wodsmith-start/test/lib/competition-invites/tokens.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import {
+  generateInviteClaimToken,
+  generateInviteClaimTokenPlaintext,
+  hashInviteClaimToken,
+  inviteClaimTokenLast4,
+} from "@/lib/competition-invites/tokens"
+
+describe("hashInviteClaimToken", () => {
+  it("is deterministic — same input yields same hash", async () => {
+    const a = await hashInviteClaimToken("abc123")
+    const b = await hashInviteClaimToken("abc123")
+    expect(a).toBe(b)
+  })
+
+  it("differs for different inputs", async () => {
+    const a = await hashInviteClaimToken("abc123")
+    const b = await hashInviteClaimToken("abc124")
+    expect(a).not.toBe(b)
+  })
+
+  it("returns 64 lowercase hex chars (SHA-256)", async () => {
+    const hash = await hashInviteClaimToken("hello")
+    expect(hash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  it("matches a known SHA-256 of 'hello'", async () => {
+    expect(await hashInviteClaimToken("hello")).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    )
+  })
+})
+
+describe("generateInviteClaimTokenPlaintext", () => {
+  it("emits URL-safe characters only (unpadded base64url)", () => {
+    const token = generateInviteClaimTokenPlaintext()
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(token).not.toContain("=")
+  })
+
+  it("is long enough to encode 32 random bytes", () => {
+    const token = generateInviteClaimTokenPlaintext()
+    // 32 bytes → ceil(32*8/6) = 43 unpadded base64url characters.
+    expect(token.length).toBe(43)
+  })
+
+  it("produces unique values across a 1000-generation sample", () => {
+    const seen = new Set<string>()
+    for (let i = 0; i < 1000; i++) {
+      seen.add(generateInviteClaimTokenPlaintext())
+    }
+    expect(seen.size).toBe(1000)
+  })
+})
+
+describe("inviteClaimTokenLast4", () => {
+  it("returns the last 4 characters", () => {
+    expect(inviteClaimTokenLast4("abcdefg")).toBe("defg")
+  })
+
+  it("is idempotent for short tokens", () => {
+    expect(inviteClaimTokenLast4("ab")).toBe("ab")
+  })
+})
+
+describe("generateInviteClaimToken", () => {
+  it("returns plaintext + hash + last4 derived from the same token", async () => {
+    const { token, hash, last4 } = await generateInviteClaimToken()
+    expect(last4).toBe(token.slice(-4))
+    expect(hash).toBe(await hashInviteClaimToken(token))
+  })
+})

--- a/apps/wodsmith-start/test/server/competition-invites/bespoke.test.ts
+++ b/apps/wodsmith-start/test/server/competition-invites/bespoke.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, vi } from "vitest"
+import {
+  BESPOKE_BULK_MAX_ROWS,
+  createBespokeInvite,
+  createBespokeInvitesBulk,
+  parseBespokePaste,
+  parseBespokePasteLine,
+} from "@/server/competition-invites/bespoke"
+import { FreeCompetitionNotEligibleError } from "@/server/competition-invites/issue"
+
+vi.mock("@/server/commerce/fee-calculator", () => ({
+  getRegistrationFee: vi.fn(async () => 0),
+}))
+
+describe("parseBespokePasteLine", () => {
+  it("parses a comma-separated row", () => {
+    const row = parseBespokePasteLine(
+      "jane@example.com,Jane,Doe,rx-men,Sponsored",
+      1,
+    )
+    expect(row).toEqual({
+      rowNumber: 1,
+      email: "jane@example.com",
+      inviteeFirstName: "Jane",
+      inviteeLastName: "Doe",
+      bespokeReason: "Sponsored",
+    })
+  })
+
+  it("parses a tab-separated row (Google Sheets paste)", () => {
+    const row = parseBespokePasteLine(
+      "jane@example.com\tJane\tDoe\t\tWildcard",
+      2,
+    )
+    expect(row).toEqual({
+      rowNumber: 2,
+      email: "jane@example.com",
+      inviteeFirstName: "Jane",
+      inviteeLastName: "Doe",
+      bespokeReason: "Wildcard",
+    })
+  })
+
+  it("parses an email-only line", () => {
+    const row = parseBespokePasteLine("bob@example.com", 3)
+    expect(row).toEqual({
+      rowNumber: 3,
+      email: "bob@example.com",
+      inviteeFirstName: null,
+      inviteeLastName: null,
+      bespokeReason: null,
+    })
+  })
+
+  it("skips blank lines", () => {
+    expect(parseBespokePasteLine("   ", 4)).toBeNull()
+    expect(parseBespokePasteLine("", 5)).toBeNull()
+  })
+
+  it("skips a literal header row", () => {
+    expect(parseBespokePasteLine("email,firstName,lastName", 1)).toBeNull()
+    expect(parseBespokePasteLine("EMAIL", 1)).toBeNull()
+  })
+
+  it("prefers tab when both tab and comma are present", () => {
+    const row = parseBespokePasteLine(
+      "a@x.com\tAlice,Smith\tSmith\t\t",
+      1,
+    )
+    // With tab as delimiter the first comma stays inside the firstName field.
+    expect(row?.inviteeFirstName).toBe("Alice,Smith")
+  })
+})
+
+describe("parseBespokePaste", () => {
+  it("normalizes emails (lowercase + trim)", () => {
+    const { rows } = parseBespokePaste("  Alice@Example.com  \nbob@example.com")
+    expect(rows.map((r) => r.email)).toEqual([
+      "alice@example.com",
+      "bob@example.com",
+    ])
+  })
+
+  it("reports invalid emails in the invalid bucket", () => {
+    const { rows, invalid } = parseBespokePaste(
+      "jane@example.com\nnot-an-email\nbob@example.com",
+    )
+    expect(rows).toHaveLength(2)
+    expect(invalid).toHaveLength(1)
+    expect(invalid[0]?.reason).toMatch(/Invalid email/)
+    expect(invalid[0]?.rowNumber).toBe(2)
+  })
+
+  it("handles CRLF line endings", () => {
+    const { rows } = parseBespokePaste("a@x.com\r\nb@x.com\r\n")
+    expect(rows).toHaveLength(2)
+  })
+
+  it(`caps the paste at ${BESPOKE_BULK_MAX_ROWS} rows`, () => {
+    const lines: string[] = []
+    for (let i = 0; i < BESPOKE_BULK_MAX_ROWS + 50; i++) {
+      lines.push(`row${i}@example.com`)
+    }
+    const { rows } = parseBespokePaste(lines.join("\n"))
+    expect(rows.length).toBeLessThanOrEqual(BESPOKE_BULK_MAX_ROWS)
+  })
+})
+
+describe("createBespokeInvite", () => {
+  it("rejects an invalid email format", async () => {
+    await expect(
+      createBespokeInvite({
+        championshipCompetitionId: "comp_c",
+        championshipDivisionId: "div_rxm",
+        email: "not-an-email",
+      }),
+    ).rejects.toThrow(/Invalid email/)
+  })
+
+  it("rejects free-division competitions", async () => {
+    await expect(
+      createBespokeInvite({
+        championshipCompetitionId: "comp_c",
+        championshipDivisionId: "div_rxm",
+        email: "jane@example.com",
+      }),
+    ).rejects.toBeInstanceOf(FreeCompetitionNotEligibleError)
+  })
+})
+
+describe("createBespokeInvitesBulk", () => {
+  it("rejects free-division competitions before parsing", async () => {
+    await expect(
+      createBespokeInvitesBulk({
+        championshipCompetitionId: "comp_c",
+        championshipDivisionId: "div_rxm",
+        pasteText: "jane@example.com\nbob@example.com",
+      }),
+    ).rejects.toBeInstanceOf(FreeCompetitionNotEligibleError)
+  })
+})

--- a/apps/wodsmith-start/test/server/competition-invites/bespoke.test.ts
+++ b/apps/wodsmith-start/test/server/competition-invites/bespoke.test.ts
@@ -70,6 +70,28 @@ describe("parseBespokePasteLine", () => {
     // With tab as delimiter the first comma stays inside the firstName field.
     expect(row?.inviteeFirstName).toBe("Alice,Smith")
   })
+
+  it("respects double-quoted CSV fields containing commas", () => {
+    const row = parseBespokePasteLine(
+      'jane@example.com,"Doe, Jane",Smith,,Wildcard',
+      6,
+    )
+    expect(row).toEqual({
+      rowNumber: 6,
+      email: "jane@example.com",
+      inviteeFirstName: "Doe, Jane",
+      inviteeLastName: "Smith",
+      bespokeReason: "Wildcard",
+    })
+  })
+
+  it("decodes doubled quotes inside a quoted CSV field", () => {
+    const row = parseBespokePasteLine(
+      'jane@example.com,"O""Brien",Smith,,',
+      7,
+    )
+    expect(row?.inviteeFirstName).toBe('O"Brien')
+  })
 })
 
 describe("parseBespokePaste", () => {

--- a/apps/wodsmith-start/test/server/competition-invites/issue.test.ts
+++ b/apps/wodsmith-start/test/server/competition-invites/issue.test.ts
@@ -108,4 +108,25 @@ describe("issueInvitesForRecipients", () => {
       }),
     ).rejects.toBeInstanceOf(FreeCompetitionNotEligibleError)
   })
+
+  it("rejects malformed email addresses before opening a transaction", async () => {
+    const { getRegistrationFee } = await import(
+      "@/server/commerce/fee-calculator"
+    )
+    vi.mocked(getRegistrationFee).mockResolvedValueOnce(2500)
+
+    await expect(
+      issueInvitesForRecipients({
+        championshipCompetitionId: "comp_c",
+        championshipDivisionId: "div_rxm",
+        rsvpDeadlineAt: new Date("2026-05-01T00:00:00Z"),
+        recipients: [
+          {
+            email: "not-an-email",
+            origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(InviteIssueValidationError)
+  })
 })

--- a/apps/wodsmith-start/test/server/competition-invites/issue.test.ts
+++ b/apps/wodsmith-start/test/server/competition-invites/issue.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest"
+import { COMPETITION_INVITE_ORIGIN } from "@/db/schemas/competition-invites"
+import {
+  assertRecipientOriginValid,
+  FreeCompetitionNotEligibleError,
+  InviteIssueValidationError,
+  issueInvitesForRecipients,
+  normalizeInviteEmail,
+} from "@/server/competition-invites/issue"
+
+vi.mock("@/server/commerce/fee-calculator", () => ({
+  getRegistrationFee: vi.fn(async () => 0),
+}))
+
+describe("normalizeInviteEmail", () => {
+  it("lowercases", () => {
+    expect(normalizeInviteEmail("Alice@Example.com")).toBe("alice@example.com")
+  })
+
+  it("trims whitespace", () => {
+    expect(normalizeInviteEmail("  bob@example.com  ")).toBe("bob@example.com")
+  })
+
+  it("handles combined case + whitespace", () => {
+    expect(normalizeInviteEmail("  CAROL@Example.com\t")).toBe(
+      "carol@example.com",
+    )
+  })
+})
+
+describe("assertRecipientOriginValid", () => {
+  it("accepts a complete source recipient", () => {
+    expect(() =>
+      assertRecipientOriginValid({
+        email: "a@x.com",
+        origin: COMPETITION_INVITE_ORIGIN.SOURCE,
+        sourceId: "cisrc_1",
+        sourceCompetitionId: "comp_1",
+        sourcePlacement: 1,
+      }),
+    ).not.toThrow()
+  })
+
+  it("accepts a bespoke recipient with no source attribution", () => {
+    expect(() =>
+      assertRecipientOriginValid({
+        email: "b@x.com",
+        origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+        bespokeReason: "Sponsored",
+      }),
+    ).not.toThrow()
+  })
+
+  it("rejects a source recipient missing sourceId", () => {
+    expect(() =>
+      assertRecipientOriginValid({
+        email: "a@x.com",
+        origin: COMPETITION_INVITE_ORIGIN.SOURCE,
+        sourceCompetitionId: "comp_1",
+      }),
+    ).toThrow(InviteIssueValidationError)
+  })
+
+  it("rejects a source recipient missing sourceCompetitionId", () => {
+    expect(() =>
+      assertRecipientOriginValid({
+        email: "a@x.com",
+        origin: COMPETITION_INVITE_ORIGIN.SOURCE,
+        sourceId: "cisrc_1",
+      }),
+    ).toThrow(InviteIssueValidationError)
+  })
+
+  it("rejects a bespoke recipient carrying source attribution", () => {
+    expect(() =>
+      assertRecipientOriginValid({
+        email: "b@x.com",
+        origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+        sourceId: "cisrc_1",
+      }),
+    ).toThrow(InviteIssueValidationError)
+  })
+})
+
+describe("issueInvitesForRecipients", () => {
+  it("short-circuits for an empty recipient list without touching fee logic", async () => {
+    const result = await issueInvitesForRecipients({
+      championshipCompetitionId: "comp_c",
+      championshipDivisionId: "div_rxm",
+      rsvpDeadlineAt: new Date("2026-05-01T00:00:00Z"),
+      recipients: [],
+    })
+    expect(result).toEqual({ inserted: [], alreadyActive: [] })
+  })
+
+  it("rejects when the target division has a $0 registration fee", async () => {
+    await expect(
+      issueInvitesForRecipients({
+        championshipCompetitionId: "comp_c",
+        championshipDivisionId: "div_rxm",
+        rsvpDeadlineAt: new Date("2026-05-01T00:00:00Z"),
+        recipients: [
+          {
+            email: "free@example.com",
+            origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+          },
+        ],
+      }),
+    ).rejects.toBeInstanceOf(FreeCompetitionNotEligibleError)
+  })
+})

--- a/lat.md/competition-invites.md
+++ b/lat.md/competition-invites.md
@@ -4,6 +4,8 @@ ADR-0011 ships a qualification-source → roster → invite-round system for cha
 
 Phase 1 is read-only: declarative sources, a roster table that joins source leaderboards with invite-state columns set to null, and the organizer route shell. Schema lives in [[apps/wodsmith-start/src/db/schemas/competition-invites.ts]]. ADR reference: `docs/adr/0011-competition-invites.md`.
 
+Phase 2 (in progress) lays the data + logic groundwork for email-locked single-send invites: per-athlete invite rows in `competition_invites`, SHA-256-hashed claim tokens, server-side issue + reissue helpers, and bespoke staging. Routes, Stripe workflow wiring, email queue, and the organizer UI follow in the remaining sub-arcs.
+
 ## Sources schema
 
 A qualification source attached to a championship competition. Each row references either a single competition or a series (never both); allocation and division-mapping columns describe how many invitees the source contributes.
@@ -46,8 +48,44 @@ Both the sidebar link and the route page are gated on the PostHog feature flag `
 
 Pattern mirrors the existing `competition-global-leaderboard` gate in [[apps/wodsmith-start/src/routes/compete/organizer/series/$groupId/leaderboard.tsx]] — `posthog.isFeatureEnabled()` seeds state, `posthog.onFeatureFlags()` subscribes to flag updates. The gate only compares `=== true` / `=== false` so the `undefined` pre-load state neither shows the link nor triggers a redirect, avoiding flicker.
 
+## Invites schema
+
+Each invite is a per-athlete row in [[apps/wodsmith-start/src/db/schemas/competition-invites.ts#competitionInvitesTable]] carrying the email-locked claim token, status, and origin attribution. ULID primary keys via [[apps/wodsmith-start/src/db/schemas/common.ts#createCompetitionInviteId]].
+
+The `activeMarker` column is the correctness pivot: it holds the literal `"active"` while `status IN (pending, accepted_paid)` and is NULL on every terminal state. Combined with the unique index `(championshipCompetitionId, email, championshipDivisionId, activeMarker)` this enforces "at most one active invite per (championship, division, email)" while letting declined/expired/revoked rows accumulate (MySQL treats multiple NULLs as distinct). The unique index on `claimTokenHash` exploits the same semantics — terminal transitions null the hash so historical rows coexist. `sendAttempt` (default 0) is the re-send counter that drives the Resend `Idempotency-Key` suffix; reusing `invite.id` across re-issues stays safe because the suffix rotates.
+
+Draft bespoke rows (created before any send) use a distinctive shape: `activeMarker = "active"`, `claimTokenHash = NULL`, `expiresAt = NULL`, `emailDeliveryStatus = "skipped"`. The unique-active index blocks duplicate bespoke adds for the same (championship, division, email). Secondary indexes cover the organizer table queries — `(roundId)`, `(sourceId)`, `(origin)`, `(status)`, `(email)`, plus `(championshipCompetitionId)` and `(userId)` for roster-side joins.
+
+Phase 2 uses `roundId = ""` as a sentinel pending the Phase 3 `competition_invite_rounds` table; the column is NOT NULL with a default of `""` so a Phase-3 backfill can rewrite every Phase-2 row to a synthetic "Round 1 — Backfill" without schema gymnastics.
+
+## Token helpers
+
+Claim tokens are 32-byte URL-safe random strings, hashed with SHA-256 before they touch the DB. Helpers live in [[apps/wodsmith-start/src/lib/competition-invites/tokens.ts]].
+
+[[apps/wodsmith-start/src/lib/competition-invites/tokens.ts#generateInviteClaimTokenPlaintext]] uses `crypto.getRandomValues` + base64url-no-padding (via `@oslojs/encoding`) so every character carries entropy and the result is safe in a URL path; [[apps/wodsmith-start/src/lib/competition-invites/tokens.ts#hashInviteClaimToken]] returns lowercase hex that matches the `varchar(64)` column exactly; [[apps/wodsmith-start/src/lib/competition-invites/tokens.ts#inviteClaimTokenLast4]] exposes the support-facing display suffix. The one-shot [[apps/wodsmith-start/src/lib/competition-invites/tokens.ts#generateInviteClaimToken]] returns `{ token, hash, last4 }` so all three artifacts derive from the same plaintext and the plaintext never has a chance to escape the email path. Pure functions — safe to call from server functions, workflows, queue consumers, and tests.
+
+## Issue helpers
+
+The DB-side-only layer that writes invite rows lives in [[apps/wodsmith-start/src/server/competition-invites/issue.ts]]. It never renders HTML and never enqueues — that belongs to the `issueInvitesFn` server fn in a later sub-arc.
+
+[[apps/wodsmith-start/src/server/competition-invites/issue.ts#issueInvitesForRecipients]] runs in a single transaction: it snapshots existing active invites for the recipient emails, treats matches as `alreadyActive` (annotated with `isDraft` when the row has no `claimTokenHash` yet so the caller can choose to reissue instead of skip), and inserts fresh rows for the rest. Each new row carries a freshly generated token hash, `activeMarker = "active"`, `status = "pending"`, and `sendAttempt = 0`. The return shape `{ inserted, alreadyActive }` hands the caller the *plaintext* tokens for the just-inserted rows — the only moment the plaintext exists in process memory before it's templated into an outgoing email.
+
+[[apps/wodsmith-start/src/server/competition-invites/issue.ts#reissueInvite]] rotates the token on an existing row in place, increments `sendAttempt`, bumps `expiresAt`, restores `activeMarker = "active"`, and flips `expired` rows back to `pending`. It covers both the "extend an expired invite" path and the "activate a draft bespoke invite" path (draft rows have `claimTokenHash = NULL`; reissue installs the first token). Preserving `invite.id` across rotations keeps Stripe metadata, webhook correlation, and audit queries stable. Both helpers reject via [[apps/wodsmith-start/src/server/competition-invites/issue.ts#FreeCompetitionNotEligibleError]] when the target division resolves to a $0 registration fee — free competitions are scope-trimmed out of invites in the MVP (ADR-0011 "Capacity Math → Free competitions").
+
+[[apps/wodsmith-start/src/server/competition-invites/issue.ts#normalizeInviteEmail]] (trim + lowercase) is the canonical normalizer — applied at every write, every lookup, and every identity match so the email lock compares apples to apples.
+
+## Bespoke helpers
+
+Bespoke staging lives in [[apps/wodsmith-start/src/server/competition-invites/bespoke.ts]]. A draft bespoke invite stages a row the organizer can later include in a send; it has the distinctive "active but no token" shape described in "Invites schema".
+
+[[apps/wodsmith-start/src/server/competition-invites/bespoke.ts#createBespokeInvite]] validates the email format, rejects free divisions, checks the unique-active invariant, and inserts a draft row. [[apps/wodsmith-start/src/server/competition-invites/bespoke.ts#createBespokeInvitesBulk]] accepts a paste body — CSV, TSV (Google Sheets paste), or one-email-per-line — parses rows via [[apps/wodsmith-start/src/server/competition-invites/bespoke.ts#parseBespokePaste]], normalizes emails, dedups within-batch, checks cross-batch against existing active invites, and inserts the survivors. Duplicates and invalid rows come back as `BulkDuplicateRow[]` / `BulkInvalidRow[]` — structured results, not exceptions — so the organizer UI can render row-level inline feedback. The paste is capped at `BESPOKE_BULK_MAX_ROWS` (500, per ADR-0011 OQ#8).
+
+The line parser auto-detects delimiter per line — tab wins when present so a Google Sheets column paste keeps comma-containing fields intact — and skips literal header rows whose first column is `email` (case-insensitive). A division-hint column is accepted for copy-paste compatibility but ignored in Phase 2 (the caller always passes `championshipDivisionId` explicitly).
+
 ## Seed data
 
 Running `pnpm db:seed` populates `competition_invite_sources` with a ready-to-demo scenario so the organizer `/invites` route renders non-empty. Phase 1 has no source-creation UI, so seeding is the only path to exercise the live tabs.
 
-Scenario defined by [[apps/wodsmith-start/scripts/seed/seeders/20-competition-invites.ts]]: a championship competition "2026 WODsmith Invitational" (`comp_inv_championship`) receiving invites from three sources — a Regional Qualifier (`comp_inv_qualifier`) with 5 scored Men's RX athletes + allocation 3 that triggers the roster cutoff divider, Boise Throwdown (`comp_mwfc_a`) reusing MWFC series fixtures, and the MWFC series itself to demo the Series card + sub-tabs. The seeder sits after `19-broadcasts` and its table is cleaned ahead of competitions in [[apps/wodsmith-start/scripts/seed/cleanup.ts]].
+Scenario defined by [[apps/wodsmith-start/scripts/seed/seeders/20-competition-invites.ts]]: a championship competition "2026 WODsmith Invitational" (`comp_inv_championship`) receiving invites from three sources — a Regional Qualifier (`comp_inv_qualifier`) with 5 scored Men's RX athletes + allocation 3 that triggers the roster cutoff divider, Boise Throwdown (`comp_mwfc_a`) reusing MWFC series fixtures, and the MWFC series itself to demo the Series card + sub-tabs. The seeder sits after `19-broadcasts` and its tables are cleaned ahead of competitions in [[apps/wodsmith-start/scripts/seed/cleanup.ts]] (`competition_invites` then `competition_invite_sources`).
+
+The same seeder adds six Phase-2 `competition_invites` rows, one per lifecycle state, so the invite-row shapes are inspectable in Drizzle Studio without manual editing: a pending source-derived invite for Mike, an `accepted_paid` invite for Ryan (activeMarker still "active", claim token nulled), an `expired` invite for Alex (activeMarker NULL), a `declined` invite for Sarah, a draft bespoke invite ("active but no token" shape), and a sent bespoke invite. Tokens use deterministic plaintexts (`seed-invite-mike-pending-men-rx-phase2` / `seed-invite-ryan-expired-men-rx-phase2`) that the seeder logs on run — SHA-256 of those strings reproduces the `claim_token_hash` column so a dev can recover a working claim URL without re-running the seed.


### PR DESCRIPTION
## Summary

Phase 2 sub-arc A of [ADR-0011](../blob/main/docs/adr/0011-competition-invites.md) — the data + pure-logic groundwork for email-locked single-send invites. No UI, no routes, no email yet. Follow-up PRs land those in sub-arcs B (claim + auth), C (Stripe workflow + queue + server fns), and D (organizer UI + cron + integration tests).

**What changed**

- `competition_invites` table with the four indexes that enforce the invite correctness model:
  - `UNIQUE (championshipCompetitionId, email, championshipDivisionId, activeMarker)` — "at most one active invite per (championship, division, email)" via MySQL's multiple-NULL semantics. Terminal rows null `activeMarker` so they accumulate without collision.
  - `UNIQUE claim_token_hash` — tokens are globally unique while live; NULL on terminal transitions so historical rows coexist.
  - Secondary indexes on `roundId`, `sourceId`, `origin`, `status`, `email`, `championshipCompetitionId`, `userId`.
  - `championshipCompetitionId` and `championshipDivisionId` are `varchar(64)` instead of `varchar(255)` so the unique key fits MySQL's 3072-byte limit (ULIDs are \~30 chars, 64 is plenty).
  - `roundId` is `varchar(255) NOT NULL default ""` — Phase 2 sentinel; Phase 3 replaces with a real round FK + backfill.
- `src/lib/competition-invites/tokens.ts` — 32-byte URL-safe random token (getRandomValues + base64url-no-padding), SHA-256 hash (oslojs), last4 extraction. Pure functions.
- `src/server/competition-invites/issue.ts` — `issueInvitesForRecipients` (new inserts, `{ inserted, alreadyActive }` return) + `reissueInvite` (rotate token, bump sendAttempt, cover both extend-expired and activate-draft-bespoke paths). Both reject `$0`-fee divisions (free comps are out of scope per ADR Capacity Math).
- `src/server/competition-invites/bespoke.ts` — `createBespokeInvite` (single-add) + `createBespokeInvitesBulk` (CSV/TSV/one-email-per-line paste, 500-row cap, structured duplicate/invalid reporting).
- Seed updates: `20-competition-invites.ts` now inserts 6 `competition_invites` rows (pending source, accepted\_paid source, expired source, declined source, draft bespoke, sent bespoke) so the lifecycle states are inspectable in Drizzle Studio. Deterministic tokens logged on seed run.
- `lat.md/competition-invites.md` sections for invites schema, token helpers, issue helpers, bespoke helpers, and Phase-2 seed additions.

**Stacked follow-ups (local stack — stacked PRs disabled at repo level, so posting as a sequence)**

- **B** claim resolution + `/compete/$slug/claim/$token` routes + sign-in/sign-up `?claim=` extension
- **C** registration-fn `inviteToken` param + Stripe workflow invite-status step + email queue consumer + invite server fns
- **D** organizer bespoke dialogs + roster send UX + invite-expiry cron + integration test

## Test plan

- [ ] `pnpm test -- test/lib/competition-invites test/server/competition-invites` — 50 tests
- [ ] `pnpm type-check` clean
- [ ] `DATABASE_URL='mysql://…/wodsmith-db' pnpm db:push` — table + indexes created, no drift
- [ ] `pnpm db:seed` — 6 invite rows land in `competition_invites`, one per lifecycle state; deterministic tokens printed
- [ ] Attempt to insert a duplicate active invite for a seeded (championship, email, division) → MySQL rejects with `ER_DUP_ENTRY`
- [ ] Attempt to insert the same (championship, email, division) with `active_marker = NULL` → succeeds (terminal row accumulation works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->

***

## Summary by cubic

Phase 2A of ADR-0011: adds the invites data layer and pure helpers for email‑locked single‑send invites. Now includes safety fixes in reissue logic, email validation, and CSV parsing. No UI or email routes yet.

- **New Features**
  - Schema: `competition_invites` with one‑active‑invite uniqueness via `activeMarker`, unique `claimTokenHash`, `roundId` empty‑string sentinel, shortened ULID FKs (`varchar(64)`), delivery/status fields, and `createCompetitionInviteId`.
  - Tokens: 32‑byte URL‑safe tokens, SHA‑256 hashing, last‑4 helper in `src/lib/competition-invites/tokens.ts` (uses `@oslojs/encoding`); pure and unit‑tested.
  - Issue: `issueInvitesForRecipients` (transactional inserts; returns plaintext tokens) and `reissueInvite` (rotate token, bump expiry/sendAttempt, restore active; activate draft bespoke or extend expired). Normalizes emails; rejects $0‑fee divisions.
  - Bespoke: `createBespokeInvite` and `createBespokeInvitesBulk` (CSV/TSV/one‑per‑line, header‑aware, auto delimiter, 500‑row cap) with structured invalid/duplicate reporting; draft rows are “active but no token”.
  - Seeds/Docs/Tests: six `competition_invites` rows covering lifecycle states with deterministic tokens; cleanup order updated; docs in `lat.md`; unit tests for tokens/issue/bespoke.

- **Bug Fixes**
  - Reissue race: UPDATE pinned to `status IN (pending, expired)`; re‑read on 0 affected rows to surface precise concurrent transition.
  - Draft detection: avoid classifying `accepted_paid` (hash nulled) as draft by requiring `status === pending`.
  - Bespoke create: wrap existence check + insert in a transaction to prevent `ER_DUP_ENTRY` leaks.
  - Email validation: shared `EMAIL_PATTERN` applied to issue and bespoke paths (was normalize‑only).
  - CSV parsing: quote‑aware splitter with `""` → `"` decoding; TSV stays simple split. Tests cover new edge cases.

<sup>Written for commit 90c438145b74b51d0ae5650c94cf468054bd5185. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

- **feat(invites): ADR-0011 Phase 2A — schema, tokens, issue + bespoke helpers** :point\_left: <!-- branch-stack -->
  - \#419
    - \#420
      - \#421
        - \#424
          - \#425

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**

- Added competition invite system supporting single and bulk creation
- CSV/TSV bulk import with automatic deduplication
- Invite lifecycle tracking (pending, accepted, declined, expired) and email delivery monitoring
- Token-based invite claims with cryptographic hashing
- Validation enforcing paid-only competitions
- Invite reissuance functionality with token rotation

**Tests**

- Added comprehensive test coverage for invite utilities and creation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
