### PR TITLE
feat(competition): add volunteer sign-up button to registration sidebar

### DIFF
--- a/apps/wodsmith-start/src/components/registration-sidebar.tsx
+++ b/apps/wodsmith-start/src/components/registration-sidebar.tsx
@@ -4,6 +4,7 @@ import {
   Calendar,
   CheckCircle2,
   Clock,
+  HandHeart,
   MapPin,
   Plus,
   Users,
@@ -272,6 +273,23 @@ export function RegistrationSidebar({
                 Registration closes {formatDeadlineDate(regClosesAt)}
               </p>
             )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Volunteer Sign-Up Card — secondary action for non-volunteers */}
+      {!isVolunteer && (
+        <Card className="border-white/10 bg-white/5 backdrop-blur-md">
+          <CardContent className="p-4">
+            <Button asChild variant="outline" size="sm" className="w-full">
+              <Link
+                to="/compete/$slug/volunteer"
+                params={{ slug: competition.slug }}
+              >
+                <HandHeart className="mr-2 h-4 w-4" />
+                Sign Up to Volunteer
+              </Link>
+            </Button>
           </CardContent>
         </Card>
       )}


### PR DESCRIPTION
Secondary action placed below the Register Now block on the public
competition page, hidden for users already on the volunteer roster.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a "Sign Up to Volunteer" button to the registration sidebar on public competition pages. It appears below Register Now, links to `/compete/$slug/volunteer`, and is hidden for users already on the volunteer roster.

<sup>Written for commit b2f81c3d100dbb4f5499803c3a91ba24857b664c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a volunteer sign-up option to the registration sidebar for users not yet registered as volunteers, with a direct link to competition-specific volunteer registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->