### PR TITLE
fix(cohost): allow leaderboardPreview to fetch divisions

### DIFF
--- a/apps/wodsmith-start/src/server-fns/cohost/cohost-division-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/cohost/cohost-division-fns.ts
@@ -435,7 +435,11 @@ async function getRegistrationCountForDivision({
 export const cohostGetDivisionsWithCountsFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => cohostDivisionsInputSchema.parse(data))
   .handler(async ({ data }) => {
-    await requireCohostPermission(data.competitionTeamId, "divisions")
+    await requireCohostPermission(data.competitionTeamId, [
+      "divisions",
+      "leaderboardPreview",
+      "results",
+    ])
     await requireCohostCompetitionOwnership(data.competitionTeamId, data.competitionId)
     const db = getDb()
 

--- a/apps/wodsmith-start/src/utils/cohost-auth.ts
+++ b/apps/wodsmith-start/src/utils/cohost-auth.ts
@@ -21,7 +21,9 @@ import { and, eq } from "drizzle-orm"
  */
 export async function requireCohostPermission(
   competitionTeamId: string,
-  permissionKey?: keyof CohostMembershipMetadata,
+  permissionKey?:
+    | keyof CohostMembershipMetadata
+    | Array<keyof CohostMembershipMetadata>,
 ): Promise<CohostMembershipMetadata> {
   const session = await getSessionFromCookie()
   if (!session) {
@@ -54,10 +56,14 @@ export async function requireCohostPermission(
     throw new Error("FORBIDDEN: Not a cohost for this competition")
   }
 
-  if (permissionKey && !permissions[permissionKey]) {
-    throw new Error(
-      "FORBIDDEN: This action is not enabled for your cohost role",
-    )
+  if (permissionKey) {
+    const keys = Array.isArray(permissionKey) ? permissionKey : [permissionKey]
+    const hasAny = keys.some((k) => permissions[k])
+    if (!hasAny) {
+      throw new Error(
+        "FORBIDDEN: This action is not enabled for your cohost role",
+      )
+    }
   }
 
   return permissions


### PR DESCRIPTION
## Summary

- Cohosts with only `leaderboardPreview` hit FORBIDDEN on `/compete/cohost/$competitionId/leaderboard-preview` because the loader called `cohostGetDivisionsWithCountsFn`, which required `divisions`.
- Widen `requireCohostPermission` to accept a single key or an array (any-of semantics).
- `cohostGetDivisionsWithCountsFn` now accepts `divisions`, `leaderboardPreview`, or `results`.

## Test plan

- [ ] Invite a cohost with only `leaderboardPreview` enabled
- [ ] Navigate to `/compete/cohost/<id>/leaderboard-preview` — divisions load, no FORBIDDEN
- [ ] Cohost with `divisions` permission still sees divisions elsewhere as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FORBIDDEN errors on the cohost leaderboard preview by allowing cohosts with only `leaderboardPreview` to load divisions.

- **Bug Fixes**
  - `requireCohostPermission` now accepts a single key or an array (any-of).
  - `cohostGetDivisionsWithCountsFn` authorizes with `divisions`, `leaderboardPreview`, or `results`.

<sup>Written for commit b46db68085e1d190f3009ef0042f9698ad603098. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

- \#359 <!-- branch-stack -->
  - **fix(cohost): allow leaderboardPreview to fetch divisions** :point\_left:
