### PR TITLE
Migrate cohost invite flow from query params to route params

### DIFF
--- a/apps/wodsmith-start/src/routes/compete/cohost-invite.tsx
+++ b/apps/wodsmith-start/src/routes/compete/cohost-invite.tsx
@@ -1,5 +1,16 @@
-import { Outlet, createFileRoute } from "@tanstack/react-router"
+import { Outlet, createFileRoute, redirect } from "@tanstack/react-router"
 
 export const Route = createFileRoute("/compete/cohost-invite")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    token: typeof search.token === "string" ? search.token : undefined,
+  }),
+  beforeLoad: ({ search }) => {
+    if (search.token) {
+      throw redirect({
+        to: "/compete/cohost-invite/$token",
+        params: { token: search.token },
+      })
+    }
+  },
   component: () => <Outlet />,
 })

--- a/apps/wodsmith-start/src/utils/email.tsx
+++ b/apps/wodsmith-start/src/utils/email.tsx
@@ -340,7 +340,7 @@ export async function sendVolunteerDirectInviteEmail({
 /**
  * Sends a cohost invitation email.
  * Used when an organizer invites a co-host to help manage a competition.
- * Routes to /compete/cohost-invite?token=... for the acceptance flow.
+ * Routes to /compete/cohost-invite/:token for the acceptance flow.
  */
 export async function sendCohostInviteEmail({
   email,
@@ -354,7 +354,7 @@ export async function sendCohostInviteEmail({
   inviterName: string
 }): Promise<void> {
   const siteUrl = getSiteUrl()
-  const inviteUrl = `${siteUrl}/compete/cohost-invite?token=${encodeURIComponent(invitationToken)}`
+  const inviteUrl = `${siteUrl}/compete/cohost-invite/${encodeURIComponent(invitationToken)}`
 
   // In dev mode, console.warn shows the URL for easy testing
   if (!shouldSendEmail()) {


### PR DESCRIPTION
## Summary
Refactored the cohost invitation flow to use route parameters instead of query parameters, improving URL structure and routing clarity.

## Key Changes
- Updated `/compete/cohost-invite` route to validate and redirect query parameter tokens to the new route parameter structure
  - Added `validateSearch` to extract the `token` query parameter
  - Added `beforeLoad` hook to redirect from `?token=...` to `/:token` format
- Modified `sendCohostInviteEmail` to generate invitation URLs using the new route parameter format (`/compete/cohost-invite/:token` instead of `/compete/cohost-invite?token=...`)
- Updated documentation comment to reflect the new URL structure

## Implementation Details
The migration uses a redirect strategy to maintain backward compatibility - any existing links or emails with query parameters will automatically redirect to the new route parameter format. This ensures a smooth transition while establishing the cleaner URL structure going forward.

https://claude.ai/code/session_01Wh5NDaFc5B1tV8vo2qdjng

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the cohost invite flow to use route params (`/compete/cohost-invite/:token`) and fixed emailed links that were 404ing. Old `?token=...` links now auto-redirect to the new path.

- **Bug Fixes**
  - Generate invite URLs with the `/:token` path in emails instead of `?token=...`.
  - Add `validateSearch` and a `beforeLoad` redirect in `@tanstack/react-router` to support old links.

<sup>Written for commit cc07c5894c7a9d89c2af117ca3e2cd8d8fd0f858. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/431?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cohost invitation URL structure and routing to use path-based parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->