### PR TITLE
Add division allocation summary card to invites page

### DIFF
--- a/apps/wodsmith-start/src/components/organizer/invites/division-allocation-summary.tsx
+++ b/apps/wodsmith-start/src/components/organizer/invites/division-allocation-summary.tsx
@@ -1,0 +1,265 @@
+"use client"
+
+/**
+ * Division Allocation Summary — top-of-page card on the organizer invites
+ * route. Renders one collapsible row per championship division with the
+ * total spots allocated across every qualification source. Expanding a
+ * row shows the per-source breakdown so the organizer can see exactly
+ * which sources contribute spots to that division.
+ *
+ * Reads the same `allocationsBySourceByDivision` map the loader feeds to
+ * the Sources / Sent tabs — single source of truth for resolved spots
+ * per (source, championship-division). Each source's quota is enforced
+ * independently at claim time + Stripe re-check (see
+ * [[apps/wodsmith-start/src/server/competition-invites/claim.ts#getAcceptedPaidCountForBucket]]),
+ * so this view's per-source breakdown matches the runtime enforcement
+ * scoping the organizer cares about.
+ */
+// @lat: [[competition-invites#Division allocation summary]]
+
+import { ChevronRight, Layers, Trophy } from "lucide-react"
+import { useState } from "react"
+import { Badge } from "@/components/ui/badge"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import {
+  COMPETITION_INVITE_SOURCE_KIND,
+  type CompetitionInviteSource,
+} from "@/db/schemas/competition-invites"
+import { cn } from "@/utils/cn"
+
+interface DivisionAllocationSummaryProps {
+  divisions: ReadonlyArray<{ id: string; label: string }>
+  sources: ReadonlyArray<CompetitionInviteSource>
+  /** Resolved per-(source, championship-division) allocation map from
+   *  `listInviteSourceAllocationsFn`. Drives both the per-division total
+   *  and the per-source breakdown. */
+  allocationsBySourceByDivision: Record<string, Record<string, number>>
+  competitionNamesById?: Record<string, string>
+  seriesNamesById?: Record<string, string>
+}
+
+function sourceLabel(
+  source: CompetitionInviteSource,
+  competitionNamesById: Record<string, string> | undefined,
+  seriesNamesById: Record<string, string> | undefined,
+): string {
+  if (source.kind === COMPETITION_INVITE_SOURCE_KIND.SERIES) {
+    return source.sourceGroupId
+      ? (seriesNamesById?.[source.sourceGroupId] ?? "Unknown series")
+      : "Unknown series"
+  }
+  return source.sourceCompetitionId
+    ? (competitionNamesById?.[source.sourceCompetitionId] ??
+        "Unknown competition")
+    : "Unknown competition"
+}
+
+export function DivisionAllocationSummary({
+  divisions,
+  sources,
+  allocationsBySourceByDivision,
+  competitionNamesById,
+  seriesNamesById,
+}: DivisionAllocationSummaryProps) {
+  const [openIds, setOpenIds] = useState<Set<string>>(() => new Set())
+
+  const setOpen = (divisionId: string, next: boolean) => {
+    setOpenIds((prev) => {
+      const out = new Set(prev)
+      if (next) out.add(divisionId)
+      else out.delete(divisionId)
+      return out
+    })
+  }
+
+  if (divisions.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Allocation by division</CardTitle>
+          <CardDescription>
+            This championship has no divisions yet — add divisions to see spot
+            allocations.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  // Per-division breakdown: list of {source, spots} pairs where spots > 0.
+  // Computed inline rather than memoized — divisions count is bounded
+  // and the parent re-renders on filter / nav events anyway.
+  const divisionBreakdowns = divisions.map((division) => {
+    const breakdown = sources
+      .map((source) => ({
+        source,
+        spots: allocationsBySourceByDivision[source.id]?.[division.id] ?? 0,
+      }))
+      .filter((entry) => entry.spots > 0)
+    const total = breakdown.reduce((acc, entry) => acc + entry.spots, 0)
+    return { division, breakdown, total }
+  })
+
+  const championshipTotal = divisionBreakdowns.reduce(
+    (acc, d) => acc + d.total,
+    0,
+  )
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Allocation by division</CardTitle>
+        <CardDescription>
+          How qualifying spots are distributed across championship divisions.
+          Each source's quota is enforced independently — accepted invites from
+          one source never consume another source's spots. Click a division to
+          see the per-source breakdown.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex items-baseline justify-between rounded-md bg-muted/30 px-3 py-2 text-sm">
+          <span className="text-muted-foreground">
+            Total qualifying spots across {divisions.length} division
+            {divisions.length === 1 ? "" : "s"}
+          </span>
+          <span className="font-semibold tabular-nums">
+            {championshipTotal}
+          </span>
+        </div>
+        <div className="space-y-1">
+          {divisionBreakdowns.map(({ division, breakdown, total }) => {
+            const isOpen = openIds.has(division.id)
+            const hasBreakdown = breakdown.length > 0
+            return (
+              <Collapsible
+                key={division.id}
+                open={isOpen}
+                onOpenChange={(next) => setOpen(division.id, next)}
+              >
+                <CollapsibleTrigger
+                  disabled={!hasBreakdown}
+                  className={cn(
+                    "flex w-full items-center justify-between gap-3 rounded-md border bg-card px-4 py-3 text-left transition-colors",
+                    hasBreakdown
+                      ? "hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      : "cursor-default opacity-80",
+                  )}
+                  aria-label={`${division.label}: ${total} spots${
+                    hasBreakdown ? ", expand to see sources" : ""
+                  }`}
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <ChevronRight
+                      className={cn(
+                        "h-4 w-4 shrink-0 text-muted-foreground transition-transform",
+                        isOpen && "rotate-90",
+                        !hasBreakdown && "opacity-0",
+                      )}
+                      aria-hidden="true"
+                    />
+                    <span className="truncate font-medium">
+                      {division.label}
+                    </span>
+                  </div>
+                  <div className="flex shrink-0 items-baseline gap-2 text-sm">
+                    <span className="text-2xl font-semibold tabular-nums leading-none">
+                      {total}
+                    </span>
+                    <span className="text-muted-foreground">
+                      {total === 1 ? "spot" : "spots"}
+                      {hasBreakdown ? (
+                        <>
+                          {" · "}
+                          {breakdown.length}{" "}
+                          {breakdown.length === 1 ? "source" : "sources"}
+                        </>
+                      ) : null}
+                    </span>
+                  </div>
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="rounded-b-md border border-t-0 bg-muted/20 px-4 pb-3 pt-1">
+                    {hasBreakdown ? (
+                      <Table>
+                        <TableHeader>
+                          <TableRow className="hover:bg-transparent">
+                            <TableHead className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                              Source
+                            </TableHead>
+                            <TableHead className="w-32 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                              Spots
+                            </TableHead>
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {breakdown.map(({ source, spots }) => {
+                            const isSeries =
+                              source.kind ===
+                              COMPETITION_INVITE_SOURCE_KIND.SERIES
+                            const Icon = isSeries ? Layers : Trophy
+                            const label = sourceLabel(
+                              source,
+                              competitionNamesById,
+                              seriesNamesById,
+                            )
+                            return (
+                              <TableRow key={source.id}>
+                                <TableCell>
+                                  <div className="flex items-center gap-3">
+                                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted">
+                                      <Icon
+                                        className="h-3.5 w-3.5"
+                                        aria-hidden="true"
+                                      />
+                                    </div>
+                                    <span className="min-w-0 truncate font-medium">
+                                      {label}
+                                    </span>
+                                    <Badge
+                                      variant={
+                                        isSeries ? "default" : "secondary"
+                                      }
+                                      className="font-normal"
+                                    >
+                                      {isSeries ? "Series" : "Competition"}
+                                    </Badge>
+                                  </div>
+                                </TableCell>
+                                <TableCell className="text-right tabular-nums font-semibold">
+                                  {spots}
+                                </TableCell>
+                              </TableRow>
+                            )
+                          })}
+                        </TableBody>
+                      </Table>
+                    ) : null}
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/invites/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/invites/index.tsx
@@ -38,6 +38,7 @@ import {
   rosterRowKey,
 } from "@/components/organizer/invites/championship-roster-table"
 import { DeleteInviteSourceDialog } from "@/components/organizer/invites/delete-invite-source-dialog"
+import { DivisionAllocationSummary } from "@/components/organizer/invites/division-allocation-summary"
 import { EditInviteSourceDialog } from "@/components/organizer/invites/edit-invite-source-dialog"
 import { InviteSourcesList } from "@/components/organizer/invites/invite-sources-list"
 import {
@@ -660,6 +661,14 @@ function InvitesPage() {
         </div>
       </div>
 
+      <DivisionAllocationSummary
+        divisions={championshipDivisions}
+        sources={sources}
+        allocationsBySourceByDivision={allocationsBySourceByDivision}
+        competitionNamesById={competitionNamesById}
+        seriesNamesById={seriesNamesById}
+      />
+
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList>
           <TabsTrigger value="candidates">Candidates</TabsTrigger>
@@ -1021,7 +1030,6 @@ function InvitesPage() {
             allocationsBySourceByDivision={allocationsBySourceByDivision}
           />
         </TabsContent>
-
       </Tabs>
 
       {championshipDivisions[0] ? (

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/invites/sources/$sourceId.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/invites/sources/$sourceId.tsx
@@ -137,6 +137,7 @@ export const Route = createFileRoute(
 
     return {
       source: sourceResult.source,
+      seriesCompCount: sourceResult.seriesCompCount,
       championshipDivisions,
       allocationsBySourceByDivision:
         allocationsResult.allocationsBySourceByDivision,
@@ -156,8 +157,8 @@ interface OverrideState {
 function InviteSourceDetailsPage() {
   const {
     source,
+    seriesCompCount,
     championshipDivisions,
-    allocationsBySourceByDivision,
     rawAllocationsForSource,
     competitionOptions,
     seriesOptions,
@@ -175,23 +176,16 @@ function InviteSourceDetailsPage() {
 
   // Source default applied per-division when no override row exists.
   // Mirrors `sourceDefaultPerDivision` in the server-side allocations
-  // helper — kept simple here because the details page only needs the
-  // displayable number, not the full resolution algorithm.
-  const sourceDefaultPerDivision = useMemo(() => {
-    if (source.kind === "series") {
-      // Series default is `directSpotsPerComp * compCount + globalSpots`
-      // applied per-division. We only have the resolved per-division
-      // total in `allocationsBySourceByDivision[source.id]` — pick any
-      // entry where there's no override to derive the default. If we
-      // can't (every entry has an override), fall back to the raw
-      // globalSpots so the toggle copy still has a number to show.
-      const map = allocationsBySourceByDivision[source.id] ?? {}
-      const firstDefault = Object.values(map)[0]
-      if (typeof firstDefault === "number") return firstDefault
-      return source.globalSpots ?? 0
-    }
-    return source.globalSpots ?? 0
-  }, [source, allocationsBySourceByDivision])
+  // helper. Derived directly from the source row + seriesCompCount so the
+  // formula breakdown shown to the organizer always matches what the
+  // resolver computes — no inference from the resolved allocation map.
+  const directSpotsPerComp = source.directSpotsPerComp ?? 0
+  const globalSpots = source.globalSpots ?? 0
+  const compCount = seriesCompCount ?? 0
+  const sourceDefaultPerDivision =
+    source.kind === "series"
+      ? directSpotsPerComp * compCount + globalSpots
+      : globalSpots
 
   // Seed the per-division override map from the raw allocation rows.
   // Presence of a row in `rawAllocationsForSource` means "override is
@@ -245,8 +239,7 @@ function InviteSourceDetailsPage() {
           kind: values.kind,
           sourceCompetitionId:
             values.kind === "competition" ? values.sourceCompetitionId : null,
-          sourceGroupId:
-            values.kind === "series" ? values.sourceGroupId : null,
+          sourceGroupId: values.kind === "series" ? values.sourceGroupId : null,
           directSpotsPerComp:
             values.kind === "series"
               ? (values.directSpotsPerComp ?? null)
@@ -287,7 +280,11 @@ function InviteSourceDetailsPage() {
           return
         }
         const parsed = Number(trimmed)
-        if (!Number.isFinite(parsed) || parsed < 0 || !Number.isInteger(parsed)) {
+        if (
+          !Number.isFinite(parsed) ||
+          parsed < 0 ||
+          !Number.isInteger(parsed)
+        ) {
           setAllocationError("Spots must be 0 or greater.")
           return
         }
@@ -394,11 +391,44 @@ function InviteSourceDetailsPage() {
       <Card>
         <CardHeader>
           <CardTitle>Per-division allocation</CardTitle>
-          <CardDescription>
-            Override how many spots this source contributes per championship
-            division. Default is{" "}
-            <span className="font-semibold">{sourceDefaultPerDivision}</span>{" "}
-            per division. Toggle a row off to set an explicit value.
+          <CardDescription className="space-y-1">
+            <div>
+              Override how many spots this source contributes per championship
+              division. Toggle a row off to set an explicit value.
+            </div>
+            <div className="rounded-md border bg-muted/40 px-3 py-2 text-foreground">
+              <span className="text-muted-foreground">
+                Default per division:
+              </span>{" "}
+              <span className="font-semibold tabular-nums">
+                {sourceDefaultPerDivision}
+              </span>{" "}
+              {source.kind === "series" ? (
+                <span className="text-muted-foreground">
+                  ={" "}
+                  <span className="tabular-nums text-foreground">
+                    {directSpotsPerComp}
+                  </span>{" "}
+                  direct ×{" "}
+                  <span className="tabular-nums text-foreground">
+                    {compCount}
+                  </span>{" "}
+                  {compCount === 1 ? "comp" : "comps"} +{" "}
+                  <span className="tabular-nums text-foreground">
+                    {globalSpots}
+                  </span>{" "}
+                  global
+                </span>
+              ) : (
+                <span className="text-muted-foreground">
+                  = top{" "}
+                  <span className="tabular-nums text-foreground">
+                    {globalSpots}
+                  </span>{" "}
+                  qualifies, applied to every division
+                </span>
+              )}
+            </div>
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -499,9 +529,7 @@ function InviteSourceDetailsPage() {
             <Button
               type="button"
               onClick={onSaveAllocations}
-              disabled={
-                savingAllocations || championshipDivisions.length === 0
-              }
+              disabled={savingAllocations || championshipDivisions.length === 0}
             >
               {savingAllocations ? "Saving..." : "Save changes"}
             </Button>
@@ -511,4 +539,3 @@ function InviteSourceDetailsPage() {
     </div>
   )
 }
-

--- a/apps/wodsmith-start/src/server-fns/competition-invite-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-invite-fns.ts
@@ -614,7 +614,20 @@ export const getInviteSourceByIdFn = createServerFn({ method: "GET" })
           TEAM_PERMISSIONS.MANAGE_COMPETITIONS,
         )
 
-        return { source }
+        // For series sources, count the comps in the group so the details
+        // page can render the default-spots formula (`directSpotsPerComp ×
+        // seriesCompCount + globalSpots`). `null` for single-comp sources.
+        let seriesCompCount: number | null = null
+        if (source.sourceGroupId) {
+          const db = getDb()
+          const rows = await db
+            .select({ count: sql<number>`count(*)` })
+            .from(competitionsTable)
+            .where(eq(competitionsTable.groupId, source.sourceGroupId))
+          seriesCompCount = Number(rows[0]?.count ?? 0)
+        }
+
+        return { source, seriesCompCount }
       },
     )
   })

--- a/apps/wodsmith-start/test/components/division-allocation-summary.test.tsx
+++ b/apps/wodsmith-start/test/components/division-allocation-summary.test.tsx
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+import { DivisionAllocationSummary } from "@/components/organizer/invites/division-allocation-summary"
+import type { CompetitionInviteSource } from "@/db/schemas/competition-invites"
+
+function source(
+  overrides: Partial<CompetitionInviteSource> & { id: string },
+): CompetitionInviteSource {
+  return {
+    championshipCompetitionId: "champ_1",
+    kind: "competition",
+    sourceCompetitionId: null,
+    sourceGroupId: null,
+    directSpotsPerComp: null,
+    globalSpots: null,
+    divisionMappings: null,
+    sortOrder: 0,
+    notes: null,
+    createdAt: new Date("2026-04-01T00:00:00Z"),
+    updatedAt: new Date("2026-04-01T00:00:00Z"),
+    updateCounter: 0,
+    ...overrides,
+  }
+}
+
+const divisions = [
+  { id: "div_rxm", label: "Men's RX" },
+  { id: "div_rxw", label: "Women's RX" },
+] as const
+
+describe("DivisionAllocationSummary", () => {
+  it("renders the championship total across all divisions", () => {
+    const sources = [
+      source({
+        id: "src_series",
+        kind: "series",
+        sourceGroupId: "grp_throwdown",
+      }),
+      source({
+        id: "src_comp",
+        kind: "competition",
+        sourceCompetitionId: "comp_global",
+      }),
+    ]
+    render(
+      <DivisionAllocationSummary
+        divisions={divisions}
+        sources={sources}
+        allocationsBySourceByDivision={{
+          src_series: { div_rxm: 5, div_rxw: 5 },
+          src_comp: { div_rxm: 3, div_rxw: 3 },
+        }}
+        seriesNamesById={{ grp_throwdown: "2025 Throwdown Series" }}
+        competitionNamesById={{ comp_global: "Global Leaderboard" }}
+      />,
+    )
+    // 5 + 5 + 3 + 3 = 16
+    expect(screen.getByText("16")).toBeInTheDocument()
+  })
+
+  it("isolates each source's per-division spots in the breakdown", () => {
+    const sources = [
+      source({
+        id: "src_series",
+        kind: "series",
+        sourceGroupId: "grp_throwdown",
+      }),
+      source({
+        id: "src_comp",
+        kind: "competition",
+        sourceCompetitionId: "comp_global",
+      }),
+    ]
+    render(
+      <DivisionAllocationSummary
+        divisions={divisions}
+        sources={sources}
+        allocationsBySourceByDivision={{
+          // Series gives Men's RX 5 spots; Competition source gives 7 (override).
+          src_series: { div_rxm: 5, div_rxw: 5 },
+          src_comp: { div_rxm: 7, div_rxw: 4 },
+        }}
+        seriesNamesById={{ grp_throwdown: "2025 Throwdown Series" }}
+        competitionNamesById={{ comp_global: "Global Leaderboard" }}
+      />,
+    )
+
+    // Click the Men's RX trigger to expand its breakdown.
+    const trigger = screen.getByRole("button", {
+      name: /Men's RX:\s*12 spots/i,
+    })
+    fireEvent.click(trigger)
+
+    // Both sources appear with their independent spot counts (5 and 7).
+    expect(screen.getByText("2025 Throwdown Series")).toBeInTheDocument()
+    expect(screen.getByText("Global Leaderboard")).toBeInTheDocument()
+  })
+
+  it("hides sources that contribute zero spots from the breakdown", () => {
+    const sources = [
+      source({
+        id: "src_series",
+        kind: "series",
+        sourceGroupId: "grp_throwdown",
+      }),
+      source({
+        id: "src_zero",
+        kind: "competition",
+        sourceCompetitionId: "comp_zero",
+      }),
+    ]
+    render(
+      <DivisionAllocationSummary
+        divisions={[{ id: "div_rxm", label: "Men's RX" }]}
+        sources={sources}
+        allocationsBySourceByDivision={{
+          src_series: { div_rxm: 5 },
+          src_zero: { div_rxm: 0 },
+        }}
+        seriesNamesById={{ grp_throwdown: "2025 Throwdown Series" }}
+        competitionNamesById={{ comp_zero: "Excluded Comp" }}
+      />,
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Men's RX:\s*5 spots/i }),
+    )
+    expect(screen.getByText("2025 Throwdown Series")).toBeInTheDocument()
+    expect(screen.queryByText("Excluded Comp")).not.toBeInTheDocument()
+  })
+
+  it("disables the toggle when a division has no contributing sources", () => {
+    render(
+      <DivisionAllocationSummary
+        divisions={[{ id: "div_team", label: "Team RX" }]}
+        sources={[
+          source({
+            id: "src_series",
+            kind: "series",
+            sourceGroupId: "grp_throwdown",
+          }),
+        ]}
+        allocationsBySourceByDivision={{ src_series: {} }}
+        seriesNamesById={{ grp_throwdown: "2025 Throwdown Series" }}
+      />,
+    )
+
+    const trigger = screen.getByRole("button", {
+      name: /Team RX: 0 spots/i,
+    })
+    expect(trigger).toBeDisabled()
+  })
+
+  it("renders the empty-state copy when no divisions are provided", () => {
+    render(
+      <DivisionAllocationSummary
+        divisions={[]}
+        sources={[]}
+        allocationsBySourceByDivision={{}}
+      />,
+    )
+    expect(
+      screen.getByText(/no divisions yet/i),
+    ).toBeInTheDocument()
+  })
+
+  it("shows the per-division resolved total in the trigger row", () => {
+    render(
+      <DivisionAllocationSummary
+        divisions={[{ id: "div_rxm", label: "Men's RX" }]}
+        sources={[
+          source({
+            id: "src_series",
+            kind: "series",
+            sourceGroupId: "grp_throwdown",
+          }),
+        ]}
+        allocationsBySourceByDivision={{ src_series: { div_rxm: 5 } }}
+        seriesNamesById={{ grp_throwdown: "2025 Throwdown Series" }}
+      />,
+    )
+    const trigger = screen.getByRole("button", {
+      name: /Men's RX:\s*5 spots/i,
+    })
+    expect(within(trigger).getByText("5")).toBeInTheDocument()
+  })
+})

--- a/lat.md/competition-invites.md
+++ b/lat.md/competition-invites.md
@@ -54,6 +54,8 @@ Two write surfaces. Source meta (kind, source comp/series, default spots, notes)
 
 Loader gates on `MANAGE_COMPETITIONS` via [[apps/wodsmith-start/src/server-fns/competition-invite-fns.ts#getInviteSourceByIdFn]] — a new single-source read that resolves the championship organizing team from the source row — and runs `Promise.all` for the source row, championship divisions, the championship-wide allocation map, and the source pickers. Discard restores the loader's seed values; Save invalidates the route on success.
 
+The per-division allocation card surfaces the **default-spots formula** inline so the resolved number is never a black box: for series sources it renders `defaultPerDivision = directSpotsPerComp × seriesCompCount + globalSpots` (e.g. `5 = 2 direct × 2 comps + 1 global`), and for single-comp sources it renders `defaultPerDivision = top globalSpots qualifies, applied to every division`. The series comp count is loaded server-side by `getInviteSourceByIdFn` (one extra count query when `source.sourceGroupId` is set) and threaded through the loader so the formula always matches the resolver's math — no client-side inference from the resolved allocation map.
+
 ## Roster computation
 
 `getChampionshipRoster({ championshipId, divisionId })` in [[apps/wodsmith-start/src/server/competition-invites/roster.ts]] returns an ordered `RosterRow[]` for a championship + division. Invite-state columns are `null` in Phase 1.
@@ -73,6 +75,14 @@ The organizer route is [[apps/wodsmith-start/src/routes/compete/organizer/$compe
 The loader loads sources, divisions, the first division's roster, the active-invites projection, and the audit-view all-invites projection in parallel via `Promise.all` and passes them to child components. The sidebar ([[apps/wodsmith-start/src/components/competition-sidebar.tsx]]) gains an "Invites" entry under the Athletes section. Series sources within the Sources tab render per-comp tabs plus a series-global tab via [[apps/wodsmith-start/src/components/organizer/invites/series-source-sub-tabs.tsx]] — Phase 1 is read-only, so the component receives data from the loader rather than fetching its own, and invite pills are deliberately omitted until Phase 2.
 
 The original "Roster" tab was renamed to **Candidates** because the surface is a candidate-picking view (athletes pulled from sources plus bespoke drafts), not a registered roster. Internal helpers (`getChampionshipRoster`, `RosterRow`, `championship-roster-table.tsx`) keep their names — they describe the server-side join across source-competition leaderboards, which is still correct.
+
+## Division allocation summary
+
+Top-of-page card on the organizer invites route — [[apps/wodsmith-start/src/components/organizer/invites/division-allocation-summary.tsx#DivisionAllocationSummary]] — answering "how many spots are allocated per division, and where do they come from?" with a click-to-expand per-source breakdown.
+
+Renders one collapsible row per championship division; expanding shows one row per source contributing > 0 spots, scoped to that division. Reads `allocationsBySourceByDivision` from [[apps/wodsmith-start/src/server-fns/competition-invite-fns.ts#listInviteSourceAllocationsFn]] — the same resolved map the Sources / Sent tabs consume, so no parallel math. The card is mounted above the tabs in [[apps/wodsmith-start/src/routes/compete/organizer/$competitionId/invites/index.tsx]] so it's visible regardless of which tab is active. Divisions with zero contributing sources still render but the trigger button is disabled (no breakdown to expand) — the empty row is intentional so the organizer can see the unallocated division at a glance and decide whether that's expected.
+
+Per-source rows scope match runtime enforcement: each source's quota is enforced independently in [[apps/wodsmith-start/src/server/competition-invites/claim.ts#getAcceptedPaidCountForBucket]] (claim-time guardrail) and the Stripe re-check in [[apps/wodsmith-start/src/workflows/stripe-checkout-workflow.ts]], so an organizer who reads "Series: 5, Competition: 3" in the breakdown can trust that one source's accepted invites never consume the other's spots.
 
 ## Sent invites tab
 


### PR DESCRIPTION
## Summary
Adds a new `DivisionAllocationSummary` component to the organizer invites page that displays how qualifying spots are distributed across championship divisions. The component shows per-division totals and allows expanding each division to see the per-source breakdown, giving organizers visibility into which sources contribute spots to each division.

## Key Changes

- **New component**: `DivisionAllocationSummary` renders a collapsible card showing:
  - Total qualifying spots across all divisions
  - Per-division spot counts with source breakdown on expand
  - Per-source spot allocation for each division in a table
  - Filters out sources that contribute zero spots to a division
  - Disables expansion for divisions with no contributing sources

- **Enhanced source details page**: 
  - Now displays the default-spots formula inline for series sources: `directSpotsPerComp × seriesCompCount + globalSpots`
  - Shows the formula breakdown (e.g., "5 = 2 direct × 2 comps + 1 global") so organizers understand how defaults are calculated
  - Improved visual presentation of the per-division allocation card description

- **Server function enhancement**: `getInviteSourceByIdFn` now returns `seriesCompCount` for series sources, enabling the details page to render the formula without inferring from the resolved allocation map

- **Integration**: Added `DivisionAllocationSummary` to the main invites page, passing divisions, sources, and the allocation map

- **Comprehensive test coverage**: Added 188 lines of tests covering:
  - Championship total calculation
  - Per-source spot isolation in breakdowns
  - Filtering of zero-spot sources
  - Disabled state for divisions with no sources
  - Empty state rendering
  - Per-division totals display

## Implementation Details

The component reads the same `allocationsBySourceByDivision` map used by the Sources/Sent tabs, ensuring a single source of truth for resolved spots per (source, championship-division) pair. Each source's quota is enforced independently at claim time, so the per-source breakdown matches the runtime enforcement scoping organizers care about.

The formula display on the source details page is derived directly from the source row and `seriesCompCount` rather than inferred from the resolved allocation map, ensuring the displayed formula always matches what the resolver computes.

https://claude.ai/code/session_01AdwTtm2zcKjKBaE9ToAPhU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a collapsible Division Allocation Summary card to the invites page so organizers can see per-division totals and which sources contribute spots. Also shows the default-spots formula on the source details page to make the math clear and accurate.

- **New Features**
  - New `DivisionAllocationSummary` card with per-division totals; expand to see per-source counts. Hides zero-spot sources and disables expansion when none.
  - Mounted above the invites tabs so it’s always visible.
  - Source details page now displays the default formula for series: directSpotsPerComp × seriesCompCount + globalSpots, with a numeric breakdown. Derived from the source row and server-provided `seriesCompCount`.
  - Server: `getInviteSourceByIdFn` returns `seriesCompCount` for series sources to power the formula display.
  - Tests cover championship totals, per-source isolation, zero-source filtering, disabled/empty states, and per-division totals.

<sup>Written for commit 4d285b36a62fc74480db7d0a3cd7321f46ec7d62. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/432?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Division Allocation Summary card displaying qualifying spot allocations per championship division with collapsible per-source breakdowns on the invites page.

* **Tests**
  * Added test suite for Division Allocation Summary component covering rendering, expansion behavior, and zero-allocation filtering.

* **Documentation**
  * Updated documentation covering allocation formula logic and the new Division Allocation Summary feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->