### PR TITLE
fix(invites): show all candidates + hold allocation during Stripe checkout

### DIFF
--- a/apps/wodsmith-start/src/server-fns/competition-invite-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-invite-fns.ts
@@ -64,7 +64,7 @@ import {
 } from "@/server/competition-invites/bespoke"
 import {
   assertInviteClaimable,
-  getAcceptedPaidCountForBucket,
+  getOccupiedCountForBucket,
   type InviteClaimableError,
   InviteNotClaimableError,
   resolveAllocationForInvite,
@@ -792,19 +792,23 @@ export const getInviteByTokenFn = createServerFn({ method: "GET" })
         // ADR-0012 Phase 5: per-(source, division) allocation guardrail.
         // Best-effort UX gate — the authoritative re-check lives in the
         // Stripe workflow at payment confirmation. Bespoke invites
-        // (sourceId IS NULL) bypass.
+        // (sourceId IS NULL) bypass. The occupied count includes both
+        // accepted_paid invites AND in-flight Stripe checkouts (held for
+        // PENDING_PURCHASE_MAX_AGE_MINUTES) so two athletes can't both pass
+        // the gate while one is mid-payment.
         if (invite.sourceId) {
-          const [allocation, acceptedCount] = await Promise.all([
+          const [allocation, occupiedCount] = await Promise.all([
             resolveAllocationForInvite({ invite }),
-            getAcceptedPaidCountForBucket({
+            getOccupiedCountForBucket({
               sourceId: invite.sourceId,
+              championshipCompetitionId: invite.championshipCompetitionId,
               championshipDivisionId: invite.championshipDivisionId,
             }),
           ])
           const allocationCheck = assertInviteWithinAllocation({
             invite: { sourceId: invite.sourceId },
             allocation: allocation ?? 0,
-            acceptedCount,
+            acceptedCount: occupiedCount,
           })
           if (!allocationCheck.ok) {
             logInfo({
@@ -814,7 +818,7 @@ export const getInviteByTokenFn = createServerFn({ method: "GET" })
                 sourceId: invite.sourceId,
                 championshipDivisionId: invite.championshipDivisionId,
                 allocation: allocation ?? 0,
-                acceptedCount,
+                occupiedCount,
               },
             })
             return {

--- a/apps/wodsmith-start/src/server/competition-invites/claim.ts
+++ b/apps/wodsmith-start/src/server/competition-invites/claim.ts
@@ -25,8 +25,12 @@
  */
 // @lat: [[competition-invites#Claim resolution]]
 
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, gt, sql } from "drizzle-orm"
 import { getDb } from "@/db"
+import {
+  COMMERCE_PURCHASE_STATUS,
+  commercePurchaseTable,
+} from "@/db/schemas/commerce"
 import {
   COMPETITION_INVITE_ACTIVE_MARKER,
   COMPETITION_INVITE_STATUS,
@@ -34,6 +38,7 @@ import {
   competitionInvitesTable,
 } from "@/db/schemas/competition-invites"
 import { competitionsTable } from "@/db/schemas/competitions"
+import { PENDING_PURCHASE_MAX_AGE_MINUTES } from "@/server-fns/competition-divisions-fns"
 import {
   listAllocationsForChampionship,
   resolveSourceAllocations,
@@ -153,6 +158,83 @@ export async function getAcceptedPaidCountForBucket(args: {
       ),
     )
   return Number(rows[0]?.count ?? 0)
+}
+
+/**
+ * Count occupied slots in a `(sourceId, championshipDivisionId)` bucket.
+ * Mirrors the regular division-capacity pattern: a slot is occupied when
+ * an invite has been claimed (`accepted_paid`) OR an athlete is mid-Stripe-
+ * checkout for an invite-driven registration.
+ *
+ * "Mid-checkout" = a `commerce_purchases` row in `pending` with
+ * `metadata.inviteId` pointing at an invite in this bucket and
+ * `created_at > now - PENDING_PURCHASE_MAX_AGE_MINUTES`. The TTL matches
+ * the Stripe checkout session expiry — abandoned sessions free their hold
+ * implicitly without a sweep job. Pass `excludePurchaseId` to skip the
+ * webhook's own purchase row during the authoritative race-close.
+ *
+ * Existing accepted-paid count + soft-hold count = the number to compare
+ * against the bucket's allocation. Two athletes claiming the last spot
+ * concurrently both see the hold in the count, so the second one bounces
+ * at claim load instead of paying-then-refunding.
+ */
+// @lat: [[competition-invites#Claim resolution]]
+export async function getOccupiedCountForBucket(args: {
+  sourceId: string
+  championshipCompetitionId: string
+  championshipDivisionId: string
+  excludePurchaseId?: string
+}): Promise<number> {
+  const db = getDb()
+  const cutoff = new Date(
+    Date.now() - PENDING_PURCHASE_MAX_AGE_MINUTES * 60 * 1000,
+  )
+
+  const [accepted, pending] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(competitionInvitesTable)
+      .where(
+        and(
+          eq(competitionInvitesTable.sourceId, args.sourceId),
+          eq(
+            competitionInvitesTable.championshipDivisionId,
+            args.championshipDivisionId,
+          ),
+          eq(
+            competitionInvitesTable.status,
+            COMPETITION_INVITE_STATUS.ACCEPTED_PAID,
+          ),
+        ),
+      ),
+    db
+      .select({ count: sql<number>`count(*)` })
+      .from(commercePurchaseTable)
+      .innerJoin(
+        competitionInvitesTable,
+        sql`${competitionInvitesTable.id} = JSON_UNQUOTE(JSON_EXTRACT(${commercePurchaseTable.metadata}, '$.inviteId'))`,
+      )
+      .where(
+        and(
+          eq(
+            commercePurchaseTable.competitionId,
+            args.championshipCompetitionId,
+          ),
+          eq(
+            commercePurchaseTable.divisionId,
+            args.championshipDivisionId,
+          ),
+          eq(commercePurchaseTable.status, COMMERCE_PURCHASE_STATUS.PENDING),
+          gt(commercePurchaseTable.createdAt, cutoff),
+          eq(competitionInvitesTable.sourceId, args.sourceId),
+          args.excludePurchaseId
+            ? sql`${commercePurchaseTable.id} != ${args.excludePurchaseId}`
+            : sql`1 = 1`,
+        ),
+      ),
+  ])
+
+  return Number(accepted[0]?.count ?? 0) + Number(pending[0]?.count ?? 0)
 }
 
 /**

--- a/apps/wodsmith-start/src/server/competition-invites/roster.ts
+++ b/apps/wodsmith-start/src/server/competition-invites/roster.ts
@@ -33,11 +33,7 @@ import {
 import { competitionsTable } from "@/db/schemas/competitions"
 import { scalingLevelsTable } from "@/db/schemas/scaling"
 import { parseCompetitionSettings } from "@/server-fns/competition-divisions-fns"
-import {
-  listAllocationsForChampionship,
-  resolveSourceAllocations,
-  type ResolvedSourceAllocations,
-} from "./allocations"
+import type { ResolvedSourceAllocations } from "./allocations"
 import { getCandidatesForSourceComp } from "./candidates"
 import { type DivisionMapping, listSourcesForChampionship } from "./sources"
 
@@ -340,41 +336,6 @@ async function resolveDivisionRefs(
 }
 
 /**
- * Resolve the championship's own divisions (scaling levels of its
- * scaling group). These are the keys used by `resolveSourceAllocations`
- * — the cutoff math compares each leaderboard's source-side division
- * against this championship-side list to decide which allocation row
- * applies.
- */
-async function resolveChampionshipDivisions(
-  championshipId: string,
-): Promise<ChampionshipDivisionInfo[]> {
-  const db = getDb()
-  const [championship] = await db
-    .select({ settings: competitionsTable.settings })
-    .from(competitionsTable)
-    .where(inArray(competitionsTable.id, [championshipId]))
-    .limit(1)
-  if (!championship) return []
-  const settings = parseCompetitionSettings(championship.settings)
-  const sgid = settings?.divisions?.scalingGroupId
-  if (!sgid) return []
-
-  const levels = await db
-    .select({
-      id: scalingLevelsTable.id,
-      label: scalingLevelsTable.label,
-      position: scalingLevelsTable.position,
-    })
-    .from(scalingLevelsTable)
-    .where(inArray(scalingLevelsTable.scalingGroupId, [sgid]))
-
-  return levels
-    .sort((a, b) => a.position - b.position)
-    .map((l) => ({ id: l.id, label: l.label }))
-}
-
-/**
  * Compute the cutoff (max number of qualifying placements) for a
  * leaderboard fetched for `(source, sourceCompetitionId, sourceDivisionId)`.
  *
@@ -443,41 +404,11 @@ function computeCutoffForLeaderboard(args: {
 export async function getChampionshipRoster(
   input: GetChampionshipRosterInput,
 ): Promise<{ rows: RosterRow[] }> {
-  const { sources, refs: comps, seriesCompCountBySourceId } =
-    await resolveSourceCompetitions(input.championshipId)
+  const { refs: comps } = await resolveSourceCompetitions(input.championshipId)
   if (comps.length === 0) return { rows: [] }
 
   const divisionRefs = await resolveDivisionRefs(comps)
   if (divisionRefs.length === 0) return { rows: [] }
-
-  // ADR-0012: load championship divisions + allocation rows once at the
-  // top, then resolve per-source allocation maps that feed the cutoff
-  // helper. Both reads are bounded by championship size (small).
-  const [championshipDivisions, allocations] = await Promise.all([
-    resolveChampionshipDivisions(input.championshipId),
-    listAllocationsForChampionship({
-      championshipCompetitionId: input.championshipId,
-    }),
-  ])
-
-  const sourceById = new Map(sources.map((s) => [s.id, s]))
-  const resolvedBySourceId = new Map<string, ResolvedSourceAllocations>()
-  const divisionMappingsBySourceId = new Map<string, DivisionMapping[]>()
-  for (const source of sources) {
-    divisionMappingsBySourceId.set(
-      source.id,
-      parseDivisionMappings(source.divisionMappings),
-    )
-    resolvedBySourceId.set(
-      source.id,
-      resolveSourceAllocations({
-        source,
-        championshipDivisions,
-        allocations: allocations.filter((a) => a.sourceId === source.id),
-        seriesCompCount: seriesCompCountBySourceId.get(source.id),
-      }),
-    )
-  }
 
   // Fan out per (sourceComp × division) candidate fetches in parallel.
   // `getCandidatesForSourceComp` is purpose-built for this surface: it
@@ -485,6 +416,13 @@ export async function getChampionshipRoster(
   // publication gating. The roster used to call `getCompetitionLeaderboard`
   // here, which silently dropped divisions whose athletes hadn't been
   // heat-assigned — see docs/bugs/0001-invite-candidates-missing-divisions.md.
+  //
+  // Cutoff is allocation budget metadata, not a candidate filter. The
+  // organizer needs every eligible athlete on the page so they can pick
+  // whom to invite — `entries.slice(0, cutoff)` previously dropped
+  // eligible candidates whenever the source had more registrants than
+  // the championship-division allocation. The denominator math lives in
+  // `divisionAllocationTotals` outside this fan-out.
   const candidates = await Promise.all(
     divisionRefs.map((ref) =>
       getCandidatesForSourceComp({
@@ -496,26 +434,7 @@ export async function getChampionshipRoster(
 
   const rows: RosterRow[] = []
   for (const { ref, entries } of candidates) {
-    const source = sourceById.get(ref.sourceId)
-    const resolved = resolvedBySourceId.get(ref.sourceId)
-    const divisionMappings =
-      divisionMappingsBySourceId.get(ref.sourceId) ?? []
-
-    let cutoff: number | null = null
-    if (source && resolved && championshipDivisions.length > 0) {
-      cutoff = computeCutoffForLeaderboard({
-        source,
-        sourceDivisionId: ref.divisionId,
-        sourceDivisionLabel: ref.divisionLabel,
-        championshipDivisions,
-        resolved,
-        divisionMappings,
-      })
-    }
-    const truncated =
-      cutoff !== null && cutoff >= 0 ? entries.slice(0, cutoff) : entries
-
-    truncated.forEach((e, idx) => {
+    entries.forEach((e, idx) => {
       rows.push({
         sourcePlacement: idx + 1,
         sourceId: ref.sourceId,

--- a/apps/wodsmith-start/src/workflows/stripe-checkout-workflow.ts
+++ b/apps/wodsmith-start/src/workflows/stripe-checkout-workflow.ts
@@ -56,7 +56,7 @@ import { PENDING_PURCHASE_MAX_AGE_MINUTES } from "@/server-fns/competition-divis
 import { calculateDivisionCapacity } from "@/utils/division-capacity"
 import { calculateCompetitionCapacity } from "@/utils/competition-capacity"
 import {
-  getAcceptedPaidCountForBucket,
+  getOccupiedCountForBucket,
   resolveAllocationForInvite,
 } from "@/server/competition-invites/claim"
 import { assertInviteWithinAllocation } from "@/server/competition-invites/identity"
@@ -486,17 +486,24 @@ async function createRegistration(
       where: eq(competitionInvitesTable.id, registrationData.inviteId),
     })
     if (inviteRow?.sourceId) {
-      const [allocation, acceptedCount] = await Promise.all([
+      // Authoritative re-check: count accepted_paid + in-flight pending
+      // purchases in the bucket, excluding our own purchase row (which is
+      // still PENDING at this point in the workflow). This closes the
+      // millisecond race where two purchases initiate concurrently — only
+      // the first webhook to reach this check sees occupiedCount = 0.
+      const [allocation, occupiedCount] = await Promise.all([
         resolveAllocationForInvite({ invite: inviteRow }),
-        getAcceptedPaidCountForBucket({
+        getOccupiedCountForBucket({
           sourceId: inviteRow.sourceId,
+          championshipCompetitionId: inviteRow.championshipCompetitionId,
           championshipDivisionId: inviteRow.championshipDivisionId,
+          excludePurchaseId: purchaseId,
         }),
       ])
       const allocationCheck = assertInviteWithinAllocation({
         invite: { sourceId: inviteRow.sourceId },
         allocation: allocation ?? 0,
-        acceptedCount,
+        acceptedCount: occupiedCount,
       })
       if (!allocationCheck.ok) {
         logError({
@@ -510,7 +517,7 @@ async function createRegistration(
             inviteId: registrationData.inviteId,
             sourceId: inviteRow.sourceId,
             allocation,
-            acceptedCount,
+            occupiedCount,
           },
         })
 

--- a/apps/wodsmith-start/test/server-fns/competition-invite-fns.athlete.test.ts
+++ b/apps/wodsmith-start/test/server-fns/competition-invite-fns.athlete.test.ts
@@ -84,7 +84,7 @@ vi.mock("@/server/competition-invites/claim", () => ({
   resolveInviteByToken: vi.fn(),
   assertInviteClaimable: vi.fn(),
   resolveAllocationForInvite: vi.fn(),
-  getAcceptedPaidCountForBucket: vi.fn(),
+  getOccupiedCountForBucket: vi.fn(),
   InviteNotClaimableError: class InviteNotClaimableError extends Error {
     readonly reason: string
     constructor(reason: string, message?: string) {
@@ -372,7 +372,7 @@ describe("getInviteByTokenFn", () => {
     vi.mocked(claim.resolveInviteByToken).mockResolvedValueOnce(invite)
     vi.mocked(claim.assertInviteClaimable).mockImplementationOnce(() => {})
     vi.mocked(claim.resolveAllocationForInvite).mockResolvedValueOnce(2)
-    vi.mocked(claim.getAcceptedPaidCountForBucket).mockResolvedValueOnce(2)
+    vi.mocked(claim.getOccupiedCountForBucket).mockResolvedValueOnce(2)
     vi.mocked(identity.assertInviteWithinAllocation).mockReturnValueOnce({
       ok: false,
       reason: "over_allocated",

--- a/apps/wodsmith-start/test/server/competition-invites/bucket-occupancy.test.ts
+++ b/apps/wodsmith-start/test/server/competition-invites/bucket-occupancy.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+// Two-row select-result queue. The bucket count helper fires two reads
+// in parallel (accepted-paid invites + pending invite-driven purchases);
+// the queue maps 1:1 to those reads in dispatch order.
+const selectQueue: unknown[][] = []
+
+function makeChain(): unknown {
+	const chain: Record<string, unknown> = {}
+	const noop = () => chain
+	for (const m of ["from", "where", "innerJoin"]) {
+		chain[m] = vi.fn(noop)
+	}
+	chain.then = (resolve: (value: unknown) => void) => {
+		const next = selectQueue.shift() ?? []
+		resolve(next)
+		return Promise.resolve(next)
+	}
+	return chain
+}
+
+const fakeDb = {
+	select: vi.fn(() => makeChain()),
+}
+
+vi.mock("@/db", () => ({
+	getDb: vi.fn(() => fakeDb),
+}))
+
+vi.mock("cloudflare:workers", () => ({
+	env: { APP_URL: "https://test.wodsmith.com" },
+}))
+
+import { getOccupiedCountForBucket } from "@/server/competition-invites/claim"
+
+beforeEach(() => {
+	selectQueue.length = 0
+	fakeDb.select.mockClear()
+})
+
+// @lat: [[competition-invites#Claim resolution]]
+describe("getOccupiedCountForBucket", () => {
+	// Mirrors the regular division-capacity pattern: a slot in the
+	// (sourceId, championshipDivisionId) bucket is occupied when an
+	// invite is accepted_paid OR an athlete is mid-Stripe-checkout for
+	// an invite-driven purchase. Two athletes claiming the last spot
+	// must both see the in-flight hold so the second one bounces at
+	// claim load instead of paying-then-refunding.
+	it("sums accepted_paid invites and in-flight pending purchases in the bucket", async () => {
+		// Read 1: accepted_paid invites count.
+		selectQueue.push([{ count: 3 }])
+		// Read 2: pending invite-driven purchases count (held spots).
+		selectQueue.push([{ count: 2 }])
+
+		const total = await getOccupiedCountForBucket({
+			sourceId: "cisrc_1",
+			championshipCompetitionId: "comp_champ",
+			championshipDivisionId: "div_rxm",
+		})
+
+		expect(total).toBe(5)
+		expect(fakeDb.select).toHaveBeenCalledTimes(2)
+	})
+
+	it("coerces string COUNT(*) values from the PlanetScale driver to numbers", async () => {
+		// PlanetScale returns COUNT(*) as a string in some shapes. The
+		// previous helper already used Number() — pin that the new helper
+		// keeps doing so for both component reads.
+		selectQueue.push([{ count: "4" }])
+		selectQueue.push([{ count: "1" }])
+
+		const total = await getOccupiedCountForBucket({
+			sourceId: "cisrc_1",
+			championshipCompetitionId: "comp_champ",
+			championshipDivisionId: "div_rxm",
+		})
+
+		expect(total).toBe(5)
+	})
+
+	it("returns 0 when neither accepted nor pending rows exist for the bucket", async () => {
+		selectQueue.push([{ count: 0 }])
+		selectQueue.push([{ count: 0 }])
+
+		const total = await getOccupiedCountForBucket({
+			sourceId: "cisrc_empty",
+			championshipCompetitionId: "comp_champ",
+			championshipDivisionId: "div_rxm",
+		})
+
+		expect(total).toBe(0)
+	})
+
+	// The exclude trick is what makes the webhook re-check work: the
+	// current purchase is still PENDING when the workflow probes the
+	// bucket, so the count must subtract it. Same `id != $purchaseId`
+	// pattern the regular division-capacity webhook uses.
+	it("accepts excludePurchaseId so the webhook can omit its own purchase row", async () => {
+		selectQueue.push([{ count: 1 }])
+		selectQueue.push([{ count: 0 }])
+
+		const total = await getOccupiedCountForBucket({
+			sourceId: "cisrc_1",
+			championshipCompetitionId: "comp_champ",
+			championshipDivisionId: "div_rxm",
+			excludePurchaseId: "cmp_self",
+		})
+
+		expect(total).toBe(1)
+	})
+})

--- a/apps/wodsmith-start/test/server/competition-invites/roster-candidates-wiring.test.ts
+++ b/apps/wodsmith-start/test/server/competition-invites/roster-candidates-wiring.test.ts
@@ -217,3 +217,80 @@ describe("getChampionshipRoster — wires through getCandidatesForSourceComp", (
 		expect(byUser.usr_b).toBe("athlete-b@example.com")
 	})
 })
+
+// @lat: [[competition-invites#Roster computation]]
+describe("getChampionshipRoster — does not truncate candidates by allocation cutoff", () => {
+	// Repro for the production case where Ian's registration on
+	// `comp_inv_qualifier` (creg_01KQGX21AH1XSXD4S7X1WQFBT4, Men's RX,
+	// active) silently disappeared from the championship Candidates page.
+	// The qualifier source had a per-division allocation override of 5
+	// spots for the championship's Men's RX, but 6 athletes were actively
+	// registered in the matching source division. `entries.slice(0, 5)`
+	// dropped the 6th athlete (Ian) without surfacing him anywhere.
+	//
+	// The cutoff is allocation budget metadata, not a candidate filter —
+	// the organizer needs every eligible athlete on the page so they can
+	// choose whom to invite. This test pins that contract.
+	it("returns every active candidate even when allocation spots < candidate count", async () => {
+		listSourcesForChampionship.mockResolvedValueOnce([
+			sourceFixture({ globalSpots: 2 }),
+		])
+
+		listAllocationsForChampionship.mockResolvedValueOnce([])
+		// Override gives Men's RX exactly 5 spots from this source — fewer
+		// than the 6 registrations below.
+		resolveSourceAllocations.mockReturnValue({
+			total: 5,
+			byDivision: { div_champ_rx: 5 },
+		})
+
+		// resolveSourceCompetitions → directComps lookup.
+		selectQueue.push([
+			{ id: "comp_qual", name: "Qualifier Open", groupId: null },
+		])
+		// resolveDivisionRefs → competition settings rows.
+		selectQueue.push([{ id: "comp_qual", settings: "{}" }])
+		// resolveDivisionRefs → scaling levels for the source comp.
+		selectQueue.push([
+			{
+				id: "div_qual_rx",
+				label: "Rx",
+				scalingGroupId: "sg_qual",
+				position: 0,
+			},
+		])
+		// resolveChampionshipDivisions → championship settings row.
+		selectQueue.push([{ settings: "{}" }])
+		// resolveChampionshipDivisions → championship scaling levels.
+		// Label "Rx" matches source → cutoff resolves via div_champ_rx.
+		selectQueue.push([{ id: "div_champ_rx", label: "Rx", position: 0 }])
+
+		// 6 active candidates in the source division — one more than the
+		// allocation cutoff (5).
+		const candidateEntries = Array.from({ length: 6 }, (_, i) => ({
+			registrationId: `reg_${i + 1}`,
+			userId: `usr_${i + 1}`,
+			athleteName: `Athlete ${i + 1}`,
+			athleteEmail: `athlete-${i + 1}@example.com`,
+			divisionId: "div_qual_rx",
+			divisionLabel: "Rx",
+			registeredAt: new Date(`2026-04-${10 + i}T12:00:00Z`),
+		}))
+		getCandidatesForSourceComp.mockResolvedValueOnce({
+			entries: candidateEntries,
+		})
+
+		const result = await getChampionshipRoster({
+			championshipId: "comp_champ",
+		})
+
+		// All 6 candidates surface — the 6th (latest registrant) is the
+		// one that previously disappeared via `entries.slice(0, cutoff)`.
+		expect(result.rows).toHaveLength(6)
+		const userIds = result.rows.map((r) => r.userId)
+		expect(userIds).toContain("usr_6")
+		expect(new Set(userIds)).toEqual(
+			new Set(candidateEntries.map((c) => c.userId)),
+		)
+	})
+})


### PR DESCRIPTION
## Summary

Two related fixes to the championship-invite allocation flow:

1. **Candidates page no longer hides eligible athletes.** `getChampionshipRoster` was slicing the per-`(source × division)` candidate list by the allocation cutoff (`entries.slice(0, cutoff)`), silently dropping registrants whenever a source had more active registrations than the championship's allocated spots. The cutoff is allocation-budget metadata that feeds the Sent-tab denominator — it is not a candidate filter. Repro on PlanetScale `wodsmith-db@demo`: `comp_inv_qualifier` had 6 active Men's RX registrants but the override allocated 5 spots; the 6th (`ian+invite2@wodsmith.com`) never appeared on the championship Candidates page.

2. **Allocation guardrail now holds the slot during in-flight Stripe checkout.** Previously `getAcceptedPaidCountForBucket` counted only `accepted_paid` invites toward the per-`(source, championshipDivision)` cap. Two athletes claiming the last spot concurrently both passed the soft gate; the second only discovered the conflict at webhook time and was charged-then-refunded. The new `getOccupiedCountForBucket` mirrors the regular division-capacity pattern: a slot is also occupied while an athlete has a `pending` invite-driven `commerce_purchases` row inside the 35-min Stripe-session TTL. Joins purchases to invites via `metadata.inviteId` so only invite-driven holds count. Webhook re-check passes `purchaseId` as `excludePurchaseId` to avoid self-counting — same trick the existing division/competition caps use. Abandoned Stripe sessions free their hold once the TTL filter cuts them off, no sweep job.

## Test plan

- [x] `pnpm test` — 110/110 passing in the touched suites; new tests:
  - `test/server/competition-invites/roster-candidates-wiring.test.ts` — pins that 6 candidates with cutoff 5 all surface on the roster.
  - `test/server/competition-invites/bucket-occupancy.test.ts` — covers sum, PlanetScale string-coercion, empty bucket, and `excludePurchaseId`.
- [x] `pnpm type-check` — clean
- [x] `lat check` — clean
- [ ] Manual: send an invite to athlete A, start checkout, leave it open. Athlete B's claim page shows `over_allocated` while A's session is live; once A's Stripe session expires (~30 min) or A pays, B's page reflects the new state.
- [ ] Manual: confirm the candidates page now lists every active registrant in each source-division pair (no silent drops past the cutoff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capacity management to account for pending payments during checkout, preventing overbooking scenarios.
  * Enhanced roster generation to include all qualified candidates without artificial allocation-based limits.

* **Tests**
  * Added test coverage for occupied capacity calculation and roster candidate selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->