### PR TITLE
Fix invite send count calculation for bespoke invites

### DIFF
--- a/apps/wodsmith-start/src/lib/competition-invites/send-count.ts
+++ b/apps/wodsmith-start/src/lib/competition-invites/send-count.ts
@@ -1,0 +1,40 @@
+/**
+ * Compute the human-readable "we've emailed this athlete N times" count
+ * for an invite row. The count drives the "Invited N×" suffix on the
+ * candidates roster pill and the bespoke section's status badge.
+ *
+ * The math depends on the invite's `origin` because the two flows arrive
+ * at the first send through different code paths:
+ *
+ * - **source**: `issueInvitesForRecipients` inserts the row with
+ *   `sendAttempt = 0` and the dispatch loop emails it directly. The first
+ *   send happens at `sendAttempt = 0`, so total sends = `sendAttempt + 1`.
+ * - **bespoke**: `createBespokeDraft(s)` inserts the row with
+ *   `sendAttempt = 0` AND no `claimToken` — it's a draft, never emailed.
+ *   When the organizer clicks Send, the row goes through `reissueInvite`
+ *   which bumps `sendAttempt` to 1 before dispatching. The first send
+ *   happens at `sendAttempt = 1`, so total sends = `sendAttempt`.
+ *
+ * Drafts (no `claimUrl`) return 0 so the StatusPill suppresses the count
+ * suffix and the row reads as "Not invited" rather than a misleading 1×.
+ *
+ * Pure function — safe for client and server.
+ */
+// @lat: [[competition-invites#Send count display]]
+
+import { COMPETITION_INVITE_ORIGIN } from "@/db/schemas/competition-invites"
+import type { CompetitionInviteOrigin } from "@/db/schemas/competition-invites"
+
+export interface InviteSendCountInput {
+  origin: CompetitionInviteOrigin
+  sendAttempt: number
+  claimUrl: string | null
+}
+
+export function computeInviteSendCount(invite: InviteSendCountInput): number {
+  if (invite.claimUrl === null) return 0
+  if (invite.origin === COMPETITION_INVITE_ORIGIN.BESPOKE) {
+    return invite.sendAttempt
+  }
+  return invite.sendAttempt + 1
+}

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/invites/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/invites/index.tsx
@@ -72,6 +72,7 @@ import {
   COMPETITION_INVITE_STATUS,
   type CompetitionInviteSource,
 } from "@/db/schemas/competition-invites"
+import { computeInviteSendCount } from "@/lib/competition-invites/send-count"
 import { usePostHog } from "@/lib/posthog"
 import type { RosterRow } from "@/server/competition-invites/roster"
 import { getCompetitionDivisionsWithCountsFn } from "@/server-fns/competition-divisions-fns"
@@ -595,17 +596,14 @@ function InvitesPage() {
     return championshipDivisionLabelById[inv.championshipDivisionId] ?? null
   }
 
-  // The invite row's `sendAttempt` is 0 on first dispatch and increments
-  // by one each refresh, so the human-readable "we've sent N emails"
-  // count is `sendAttempt + 1`. Drafts (claimUrl null) have never been
-  // dispatched — return 0 so the StatusPill suppresses the count
-  // suffix and the row reads as "Not invited" / "Invited" without a
-  // misleading 1×.
+  // Origin matters: source-origin rows hit `sendAttempt=0` on the first
+  // dispatch, but bespoke drafts get bumped to `sendAttempt=1` by the
+  // activation `reissueInvite` before their first send. See
+  // `computeInviteSendCount` for the full rationale.
   const getInviteSendCountForRow = (r: RosterRow): number | null => {
     const inv = lookupInviteForRow(r)
     if (!inv) return null
-    if (inv.claimUrl === null) return 0
-    return (inv.sendAttempt ?? 0) + 1
+    return computeInviteSendCount(inv)
   }
 
   const copyInviteLink = async (url: string) => {
@@ -1171,7 +1169,7 @@ function InvitesPage() {
                       // telling the organizer anything new. Mirrors
                       // the StatusPill logic in
                       // championship-roster-table.tsx.
-                      const sendCount = isDraft ? 0 : inv.sendAttempt + 1
+                      const sendCount = computeInviteSendCount(inv)
                       const sendCountSuffix =
                         sendCount >= 2 ? ` ${sendCount}×` : ""
                       const statusLabel =

--- a/apps/wodsmith-start/test/lib/competition-invites/send-count.test.ts
+++ b/apps/wodsmith-start/test/lib/competition-invites/send-count.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+import { computeInviteSendCount } from "@/lib/competition-invites/send-count"
+import { COMPETITION_INVITE_ORIGIN } from "@/db/schemas/competition-invites"
+
+describe("computeInviteSendCount", () => {
+  describe("drafts (no claimUrl)", () => {
+    it("returns 0 for a bespoke draft so the StatusPill suppresses the suffix", () => {
+      // Drafts have never been dispatched. Returning 0 lets the "Invited"
+      // pill render without a misleading "1×".
+      expect(
+        computeInviteSendCount({
+          origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+          sendAttempt: 0,
+          claimUrl: null,
+        }),
+      ).toBe(0)
+    })
+  })
+
+  describe("source-origin invites", () => {
+    it("counts the initial dispatch when sendAttempt is 0", () => {
+      // Source invites are inserted with sendAttempt=0 and dispatched
+      // directly — the first email goes out at sendAttempt=0.
+      expect(
+        computeInviteSendCount({
+          origin: COMPETITION_INVITE_ORIGIN.SOURCE,
+          sendAttempt: 0,
+          claimUrl: "https://example.com/compete/c/claim/tok",
+        }),
+      ).toBe(1)
+    })
+
+    it("returns sendAttempt+1 once the row has been re-issued", () => {
+      // Each reissueInvite/redeliverInvite bumps sendAttempt by 1.
+      expect(
+        computeInviteSendCount({
+          origin: COMPETITION_INVITE_ORIGIN.SOURCE,
+          sendAttempt: 2,
+          claimUrl: "https://example.com/compete/c/claim/tok",
+        }),
+      ).toBe(3)
+    })
+  })
+
+  describe("bespoke invites that have been sent", () => {
+    it("returns sendAttempt (not +1) for a single-send bespoke invite", () => {
+      // Bespoke invites are inserted as drafts (sendAttempt=0, no token).
+      // Activation runs through reissueInvite which bumps sendAttempt to 1
+      // and dispatches the FIRST email — so sendAttempt=1 means one send,
+      // not two. This is the regression: the old code rendered "Invited 2×"
+      // for single-send bespoke rows.
+      expect(
+        computeInviteSendCount({
+          origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+          sendAttempt: 1,
+          claimUrl: "https://example.com/compete/c/claim/tok",
+        }),
+      ).toBe(1)
+    })
+
+    it("returns sendAttempt for a re-sent bespoke invite", () => {
+      // After the activation send (sendAttempt=1), a single resend bumps
+      // to sendAttempt=2, which means the athlete has been emailed twice.
+      expect(
+        computeInviteSendCount({
+          origin: COMPETITION_INVITE_ORIGIN.BESPOKE,
+          sendAttempt: 2,
+          claimUrl: "https://example.com/compete/c/claim/tok",
+        }),
+      ).toBe(2)
+    })
+  })
+})

--- a/lat.md/competition-invites.md
+++ b/lat.md/competition-invites.md
@@ -134,6 +134,14 @@ Plaintext storage matches [[apps/wodsmith-start/src/db/schemas/teams.ts#teamInvi
 
 Threat model: the token already lives forever in the recipient's email inbox and the email provider's outbound logs, so a DB hash was never the only or even primary copy of the secret. The actual auth gate is `identityMatch` — even with a stolen token, the visitor must be signed in as the invited email address (verification-gated sign-up if no account exists) to claim. The token is an unguessable identifier scoped to a recipient, not a bearer password. Defense-in-depth: terminal transitions (`accepted_paid`, `declined`, `revoked`, `expired`) null `claimToken` so a leaked active row cannot replay after payment, and the organizer can copy the live claim URL straight from the invite list UI to resend or hand-deliver — the user-visible feature that motivated the change.
 
+## Send count display
+
+The "Invited N×" suffix on the candidates roster pill and bespoke status badge counts how many emails have gone out. Centralized in [[apps/wodsmith-start/src/lib/competition-invites/send-count.ts#computeInviteSendCount]] because the math depends on `origin` — the two flows arrive at the first send differently.
+
+Source-origin invites are inserted by [[apps/wodsmith-start/src/server/competition-invites/issue.ts#issueInvitesForRecipients]] with `sendAttempt = 0` and dispatched directly — the first email goes out at `sendAttempt = 0`, so total sends = `sendAttempt + 1`. Bespoke invites are inserted by [[apps/wodsmith-start/src/server/competition-invites/bespoke.ts]] as drafts (`sendAttempt = 0`, `claimToken = NULL`, `emailDeliveryStatus = SKIPPED`); the activation `reissueInvite` call bumps `sendAttempt` to 1 *before* the first email goes out, so for bespoke total sends = `sendAttempt`. The pre-fix formula was `sendAttempt + 1` for both origins, which over-counted bespoke rows by 1 — a single-send bespoke invite rendered as "Invited 2×".
+
+Drafts (`claimUrl === null`) return 0 so the StatusPill suppresses the suffix and the row reads as "Not invited" rather than a misleading 1×. Both call sites — `getInviteSendCountForRow` and the inline bespoke-row computation in [[apps/wodsmith-start/src/routes/compete/organizer/$competitionId/invites/index.tsx]] — go through the helper so the candidates tab and the bespoke section stay in lock-step.
+
 ## Issue helpers
 
 The DB-side-only layer that writes invite rows lives in [[apps/wodsmith-start/src/server/competition-invites/issue.ts]]. It never renders HTML and never enqueues — that belongs to the `issueInvitesFn` server fn in a later sub-arc.


### PR DESCRIPTION
## Summary

Fixes an off-by-one error in the "Invited N×" send count display for bespoke competition invites. Single-send bespoke invites were incorrectly showing "Invited 2×" instead of "Invited 1×".

## Root Cause

The send count formula was `sendAttempt + 1` for all invite origins, but the two flows arrive at their first send differently:

- **Source-origin invites**: Inserted with `sendAttempt = 0` and dispatched immediately, so the first email goes out at `sendAttempt = 0` → total sends = `sendAttempt + 1`
- **Bespoke invites**: Inserted as drafts with `sendAttempt = 0` and `claimToken = NULL`. When activated, `reissueInvite` bumps `sendAttempt` to 1 *before* dispatching the first email → total sends = `sendAttempt`

The old code applied the source formula to both, over-counting bespoke rows by 1.

## Changes

- **New module** `src/lib/competition-invites/send-count.ts`: Centralized `computeInviteSendCount()` helper that applies the correct formula based on invite origin. Drafts (no `claimUrl`) return 0 to suppress the count suffix.
- **Updated** `src/routes/compete/organizer/$competitionId/invites/index.tsx`: Replaced inline send count calculations with calls to the helper in both the roster row lookup and the bespoke section status badge.
- **Added** comprehensive test suite in `test/lib/competition-invites/send-count.test.ts` covering all three cases: drafts, source-origin invites, and bespoke invites at various send stages.
- **Updated** `lat.md/competition-invites.md` with detailed documentation of the send count logic and both call sites.

## Implementation Details

The helper is a pure function safe for both client and server use. Both call sites now go through it to keep the candidates tab and bespoke section in lock-step.

https://claude.ai/code/session_01W8nKrP6w1uRx6R3j4MhxLo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the off-by-one “Invited N×” display for bespoke invites. Single-send bespoke invites now show “Invited 1×”, and drafts suppress the count.

- **Bug Fixes**
  - Centralized `computeInviteSendCount()` to compute counts by origin: source = `sendAttempt + 1`, bespoke = `sendAttempt`; drafts (`claimUrl === null`) return 0.
  - Replaced inline math in `invites/index.tsx` with the helper for both roster and bespoke badges.
  - Added tests for drafts, source-origin, and bespoke scenarios; updated docs.

<sup>Written for commit e05d82d60a967262b03999bda784bc6ef8ccb498. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Centralized invitation send count logic to ensure consistent "Invited N×" displays across the competition organizer interface for all invitation types

* **Improvements**
  * Enhanced accuracy in tracking invitation sends for different invitation origins

* **Documentation**
  * Added documentation for invitation send count display calculations and behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->