### PR TITLE
feat(refunds): organizer-initiated registration refunds (Stripe Express only)

### DIFF
--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/athletes/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/athletes/index.tsx
@@ -26,6 +26,7 @@ import {
   Mail,
   MoreHorizontal,
   Plus,
+  RotateCcw,
   Trash2,
   UserPlus,
   X,
@@ -87,7 +88,10 @@ import {
   cancelPurchaseTransferFn,
   getPendingTransfersForCompetitionFn,
 } from "@/server-fns/purchase-transfer-fns"
-import { removeRegistrationFn } from "@/server-fns/registration-fns"
+import {
+  refundRegistrationFn,
+  removeRegistrationFn,
+} from "@/server-fns/registration-fns"
 import {
   getCompetitionQuestionsFn,
   getCompetitionRegistrationAnswersFn,
@@ -187,6 +191,8 @@ export const Route = createFileRoute(
 
     return {
       registrations: registrationsResult.registrations,
+      canRefund: registrationsResult.canRefund,
+      refundedPurchaseIds: registrationsResult.refundedPurchaseIds,
       divisions: divisionsResult.divisions,
       questions: questionsResult.questions,
       answersByRegistration: answersResult.answersByRegistration,
@@ -215,6 +221,8 @@ function AthletesPage() {
   const { competition } = parentRoute.useLoaderData()
   const {
     registrations,
+    canRefund,
+    refundedPurchaseIds,
     divisions,
     questions,
     answersByRegistration,
@@ -229,6 +237,10 @@ function AthletesPage() {
     currentSortDir,
     teamId,
   } = Route.useLoaderData()
+  const refundedPurchaseIdSet = React.useMemo(
+    () => new Set(refundedPurchaseIds),
+    [refundedPurchaseIds],
+  )
   const navigate = useNavigate()
   const router = useRouter()
   const { tab } = Route.useSearch()
@@ -243,6 +255,7 @@ function AthletesPage() {
     })
   }
   const removeRegistration = useServerFn(removeRegistrationFn)
+  const refundRegistration = useServerFn(refundRegistrationFn)
   const cancelPurchaseTransfer = useServerFn(cancelPurchaseTransferFn)
   const [removingRegistration, setRemovingRegistration] = useState<{
     id: string
@@ -250,6 +263,12 @@ function AthletesPage() {
     teamName: string | null
   } | null>(null)
   const [isRemoving, setIsRemoving] = useState(false)
+  const [refundingRegistration, setRefundingRegistration] = useState<{
+    id: string
+    athleteName: string
+    teamName: string | null
+  } | null>(null)
+  const [isRefunding, setIsRefunding] = useState(false)
   const [showManualRegistration, setShowManualRegistration] = useState(false)
   const [transferTarget, setTransferTarget] = useState<{
     id: string
@@ -304,6 +323,28 @@ function AthletesPage() {
       )
     } finally {
       setIsRemoving(false)
+    }
+  }
+
+  const handleRefundRegistration = async () => {
+    if (!refundingRegistration) return
+    setIsRefunding(true)
+    try {
+      await refundRegistration({
+        data: {
+          registrationId: refundingRegistration.id,
+          competitionId: competition.id,
+        },
+      })
+      toast.success("Refund initiated. Stripe will confirm shortly.")
+      setRefundingRegistration(null)
+      router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to refund registration",
+      )
+    } finally {
+      setIsRefunding(false)
     }
   }
 
@@ -485,6 +526,7 @@ function AthletesPage() {
     registrationId: string
     registrationStatus: string // 'active' | 'removed'
     commercePurchaseId: string | null
+    paymentStatus: string | null
     athlete: {
       id: string
       firstName: string | null
@@ -587,6 +629,9 @@ function AthletesPage() {
         commercePurchaseId:
           (registration as { commercePurchaseId?: string | null })
             ?.commercePurchaseId ?? null,
+        paymentStatus:
+          (registration as { paymentStatus?: string | null })?.paymentStatus ??
+          null,
         ordinal: rowIndex,
         ordinalLabel: memberIndex === 0 ? String(rowIndex) : "",
         athlete: {
@@ -622,6 +667,7 @@ function AthletesPage() {
           registrationId: registration.id,
           registrationStatus: registration.status,
           commercePurchaseId: null,
+          paymentStatus: null,
           ordinal: rowIndex,
           ordinalLabel: "",
           athlete: {
@@ -1349,6 +1395,28 @@ function AthletesPage() {
                                         </DropdownMenuItem>
                                       )
                                     })()}
+                                    {canRefund &&
+                                      row.commercePurchaseId &&
+                                      row.paymentStatus === "PAID" &&
+                                      !refundedPurchaseIdSet.has(
+                                        row.commercePurchaseId,
+                                      ) && (
+                                        <DropdownMenuItem
+                                          onClick={() =>
+                                            setRefundingRegistration({
+                                              id: row.registrationId,
+                                              athleteName:
+                                                `${row.athlete.firstName ?? ""} ${row.athlete.lastName ?? ""}`.trim() ||
+                                                row.athlete.email ||
+                                                "Unknown",
+                                              teamName: row.teamName,
+                                            })
+                                          }
+                                        >
+                                          <RotateCcw className="h-4 w-4 mr-2" />
+                                          Refund Registration
+                                        </DropdownMenuItem>
+                                      )}
                                     <DropdownMenuItem
                                       className="text-destructive focus:text-destructive"
                                       onClick={() =>
@@ -2017,6 +2085,28 @@ function AthletesPage() {
                                             </DropdownMenuItem>
                                           )
                                         })()}
+                                        {canRefund &&
+                                          row.commercePurchaseId &&
+                                          row.paymentStatus === "PAID" &&
+                                          !refundedPurchaseIdSet.has(
+                                            row.commercePurchaseId,
+                                          ) && (
+                                            <DropdownMenuItem
+                                              onClick={() =>
+                                                setRefundingRegistration({
+                                                  id: row.registrationId,
+                                                  athleteName:
+                                                    `${row.athlete.firstName ?? ""} ${row.athlete.lastName ?? ""}`.trim() ||
+                                                    row.athlete.email ||
+                                                    "Unknown",
+                                                  teamName: row.teamName,
+                                                })
+                                              }
+                                            >
+                                              <RotateCcw className="h-4 w-4 mr-2" />
+                                              Refund Registration
+                                            </DropdownMenuItem>
+                                          )}
                                         <DropdownMenuItem
                                           className="text-destructive focus:text-destructive"
                                           onClick={() =>
@@ -2076,6 +2166,36 @@ function AthletesPage() {
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               {isRemoving ? "Removing..." : "Remove Registration"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={!!refundingRegistration}
+        onOpenChange={(open) => !open && setRefundingRegistration(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Refund Registration</AlertDialogTitle>
+            <AlertDialogDescription>
+              Refund the full registration fee for{" "}
+              <strong>{refundingRegistration?.athleteName}</strong>
+              {refundingRegistration?.teamName && (
+                <> (team: {refundingRegistration.teamName})</>
+              )}
+              ? This issues a Stripe refund and reverses the transfer to your
+              connected account. The registration itself stays in place — use
+              "Remove Registration" if you also want to release their spot.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isRefunding}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleRefundRegistration}
+              disabled={isRefunding}
+            >
+              {isRefunding ? "Refunding..." : "Refund Registration"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/apps/wodsmith-start/src/server-fns/competition-detail-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-detail-fns.ts
@@ -23,6 +23,10 @@ import {
   commercePurchaseTable,
 } from "@/db/schemas/commerce"
 import {
+  FINANCIAL_EVENT_TYPE,
+  financialEventTable,
+} from "@/db/schemas/financial-events"
+import {
   competitionRegistrationsTable,
   competitionsTable,
   REGISTRATION_STATUS,
@@ -656,7 +660,14 @@ const getOrganizerRegistrationsInputSchema = z.object({
 })
 
 /**
- * Get registrations for organizer view with full user and division details
+ * Get registrations for organizer view with full user and division details.
+ *
+ * Returns refund-capability metadata so the UI can decide whether to surface
+ * the "Refund Registration" action:
+ * - `canRefund` is true when the organizing team has a verified Stripe Express
+ *   connected account (only Express accounts use platform-mediated refunds).
+ * - `refundedPurchaseIds` lists purchases that already have a REFUND_INITIATED
+ *   or REFUND_COMPLETED financial event so the UI hides the action per row.
  */
 export const getOrganizerRegistrationsFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) =>
@@ -728,7 +739,56 @@ export const getOrganizerRegistrationsFn = createServerFn({ method: "GET" })
       ? registrations.filter((r) => r.divisionId === data.divisionFilter)
       : registrations
 
-    return { registrations: filteredRegistrations }
+    // Refund capability: organizing team Stripe Express + already-refunded set
+    const competition = await db.query.competitionsTable.findFirst({
+      where: eq(competitionsTable.id, data.competitionId),
+      columns: { organizingTeamId: true },
+    })
+
+    let canRefund = false
+    if (competition?.organizingTeamId) {
+      const team = await db.query.teamTable.findFirst({
+        where: eq(teamTable.id, competition.organizingTeamId),
+        columns: {
+          stripeConnectedAccountId: true,
+          stripeAccountStatus: true,
+          stripeAccountType: true,
+        },
+      })
+      canRefund =
+        !!team?.stripeConnectedAccountId &&
+        team.stripeAccountType === "express" &&
+        team.stripeAccountStatus === "VERIFIED"
+    }
+
+    const purchaseIds = filteredRegistrations
+      .map((r) => r.commercePurchaseId)
+      .filter((id): id is string => !!id)
+
+    let refundedPurchaseIds: string[] = []
+    if (purchaseIds.length > 0) {
+      const refundEvents = await db
+        .select({ purchaseId: financialEventTable.purchaseId })
+        .from(financialEventTable)
+        .where(
+          and(
+            inArray(financialEventTable.purchaseId, purchaseIds),
+            inArray(financialEventTable.eventType, [
+              FINANCIAL_EVENT_TYPE.REFUND_INITIATED,
+              FINANCIAL_EVENT_TYPE.REFUND_COMPLETED,
+            ]),
+          ),
+        )
+      refundedPurchaseIds = Array.from(
+        new Set(refundEvents.map((r) => r.purchaseId)),
+      )
+    }
+
+    return {
+      registrations: filteredRegistrations,
+      canRefund,
+      refundedPurchaseIds,
+    }
   })
 
 /**

--- a/apps/wodsmith-start/src/server-fns/registration-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/registration-fns.ts
@@ -36,6 +36,8 @@ import {
   createTeamId,
   createTeamMembershipId,
   createUserId,
+  FINANCIAL_EVENT_TYPE,
+  financialEventTable,
   REGISTRATION_STATUS,
   ROLES_ENUM,
   scalingGroupsTable,
@@ -81,6 +83,7 @@ import {
 } from "@/server/competition-invites/claim"
 import { assertInviteWithinAllocation } from "@/server/competition-invites/identity"
 import { normalizeInviteEmail } from "@/server/competition-invites/issue"
+import { recordRefundInitiated } from "@/server/commerce/financial-events"
 import { recordRedemption, validateCoupon } from "@/server/coupons"
 import { requireVerifiedEmail } from "@/utils/auth"
 import { createToken, getClaimTokenKey } from "@/utils/auth-utils"
@@ -2435,4 +2438,203 @@ export const refreshCompetitionTeamInviteFn = createServerFn({
     })
 
     return { success: true, newToken }
+  })
+
+// ============================================================================
+// Refund Registration (Organizer-Initiated, Stripe Express Only)
+// ============================================================================
+
+const refundRegistrationInputSchema = z.object({
+  registrationId: z.string().min(1, "Registration ID is required"),
+  competitionId: z.string().min(1, "Competition ID is required"),
+  reason: z.string().max(500).optional(),
+})
+
+/**
+ * Refund a registration's payment via Stripe.
+ *
+ * Separate from removeRegistrationFn — the registration's status is left
+ * unchanged so an organizer can refund without removing, or remove without
+ * refunding. The two actions can be used independently or together.
+ *
+ * Express-only: payouts on a Standard connected account are governed by the
+ * organizer's own Stripe dashboard, so refunds for those should originate
+ * there. We only expose this action when the organizing team's connected
+ * account is `express` and VERIFIED.
+ *
+ * Charges are destination charges (created on the platform with
+ * `transfer_data.destination`), so we issue the refund on the platform
+ * payment_intent and pass `reverse_transfer: true` to claw back the funds
+ * already routed to the connected account. The matching `charge.refunded`
+ * webhook records REFUND_COMPLETED.
+ */
+// @lat: [[registration#Registration Refund]]
+export const refundRegistrationFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => refundRegistrationInputSchema.parse(data))
+  .handler(async ({ data: input }) => {
+    const session = await requireVerifiedEmail()
+
+    const db = getDb()
+
+    updateRequestContext({ userId: session.userId })
+    addRequestContextAttribute("competitionId", input.competitionId)
+    addRequestContextAttribute("registrationId", input.registrationId)
+    getEvlog()?.set({
+      action: "refund_registration",
+      registration: {
+        id: input.registrationId,
+        competitionId: input.competitionId,
+      },
+    })
+
+    // 1. Verify competition + ownership
+    const competition = await db.query.competitionsTable.findFirst({
+      where: eq(competitionsTable.id, input.competitionId),
+      columns: { id: true, organizingTeamId: true },
+    })
+
+    if (!competition) throw new Error("Competition not found")
+
+    // 2. Authorization (admin bypass)
+    if (session.user?.role !== ROLES_ENUM.ADMIN) {
+      const team = session.teams?.find(
+        (t) => t.id === competition.organizingTeamId,
+      )
+      if (!team?.permissions.includes(TEAM_PERMISSIONS.MANAGE_COMPETITIONS)) {
+        throw new Error("Missing required permission: manage_competitions")
+      }
+    }
+
+    // 3. Registration must exist in this competition
+    const registration = await db.query.competitionRegistrationsTable.findFirst(
+      {
+        where: and(
+          eq(competitionRegistrationsTable.id, input.registrationId),
+          eq(competitionRegistrationsTable.eventId, input.competitionId),
+        ),
+      },
+    )
+
+    if (!registration) throw new Error("Registration not found")
+
+    // 4. Stripe Express requirement on the organizing team
+    const organizingTeam = await db.query.teamTable.findFirst({
+      where: eq(teamTable.id, competition.organizingTeamId),
+      columns: {
+        id: true,
+        stripeConnectedAccountId: true,
+        stripeAccountStatus: true,
+        stripeAccountType: true,
+      },
+    })
+
+    if (
+      !organizingTeam?.stripeConnectedAccountId ||
+      organizingTeam.stripeAccountType !== "express" ||
+      organizingTeam.stripeAccountStatus !== "VERIFIED"
+    ) {
+      throw new Error(
+        "Refunds require a verified Stripe Express account on the organizing team",
+      )
+    }
+
+    // 5. Purchase must be paid via Stripe
+    if (!registration.commercePurchaseId) {
+      throw new Error("Registration has no associated purchase to refund")
+    }
+
+    const purchase = await db.query.commercePurchaseTable.findFirst({
+      where: eq(commercePurchaseTable.id, registration.commercePurchaseId),
+    })
+
+    if (!purchase) {
+      throw new Error("Registration has no associated purchase to refund")
+    }
+
+    if (purchase.status !== COMMERCE_PURCHASE_STATUS.COMPLETED) {
+      throw new Error(
+        "Cannot refund: purchase is not completed",
+      )
+    }
+
+    if (!purchase.stripePaymentIntentId) {
+      throw new Error(
+        "Cannot refund: purchase has no Stripe payment intent",
+      )
+    }
+
+    // 6. Idempotency — block if a REFUND_INITIATED or REFUND_COMPLETED already exists
+    const existingRefund = await db.query.financialEventTable.findFirst({
+      where: and(
+        eq(financialEventTable.purchaseId, purchase.id),
+        inArray(financialEventTable.eventType, [
+          FINANCIAL_EVENT_TYPE.REFUND_INITIATED,
+          FINANCIAL_EVENT_TYPE.REFUND_COMPLETED,
+        ]),
+      ),
+      columns: { id: true, eventType: true },
+    })
+
+    if (existingRefund) {
+      throw new Error("Purchase has already been refunded")
+    }
+
+    logInfo({
+      message: "[Registration] Initiating refund",
+      attributes: {
+        registrationId: input.registrationId,
+        competitionId: input.competitionId,
+        purchaseId: purchase.id,
+        amountCents: purchase.totalCents,
+      },
+    })
+
+    // 7. Issue the Stripe refund. Charges are destination charges (created on
+    //    the platform with transfer_data.destination), so refund on the
+    //    platform payment_intent with reverse_transfer to claw back the
+    //    transferred amount from the connected account.
+    //
+    //    The purchase id doubles as a Stripe idempotency key — concurrent
+    //    organizer clicks for the same purchase resolve to a single refund.
+    const refund = await getStripe().refunds.create(
+      {
+        payment_intent: purchase.stripePaymentIntentId,
+        reverse_transfer: true,
+        reason: "requested_by_customer",
+        metadata: {
+          purchaseId: purchase.id,
+          registrationId: input.registrationId,
+          competitionId: input.competitionId,
+          organizerUserId: session.userId,
+        },
+      },
+      { idempotencyKey: `refund:${purchase.id}` },
+    )
+
+    // 8. Record the REFUND_INITIATED financial event. The webhook will record
+    //    REFUND_COMPLETED when Stripe confirms the refund settled.
+    await recordRefundInitiated({
+      purchaseId: purchase.id,
+      teamId: competition.organizingTeamId,
+      amountCents: purchase.totalCents,
+      stripePaymentIntentId: purchase.stripePaymentIntentId,
+      stripeRefundId: refund.id,
+      reason: input.reason ?? "Refund initiated by organizer",
+      actorId: session.userId,
+    })
+
+    logInfo({
+      message: "[Registration] Refund initiated successfully",
+      attributes: {
+        registrationId: input.registrationId,
+        purchaseId: purchase.id,
+        refundId: refund.id,
+      },
+    })
+
+    return {
+      success: true,
+      refundId: refund.id,
+      amountCents: purchase.totalCents,
+    }
   })

--- a/apps/wodsmith-start/src/server-fns/registration-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/registration-fns.ts
@@ -2449,6 +2449,15 @@ const refundRegistrationInputSchema = z.object({
   competitionId: z.string().min(1, "Competition ID is required"),
   reason: z.string().max(500).optional(),
   amountCents: z.number().int().positive().optional(),
+  /**
+   * Stable, client-generated identifier for this refund operation. Replays
+   * (e.g., a network timeout retry of the same click) MUST send the same
+   * token so the Stripe idempotency key matches and the refund collapses to
+   * a single charge. Required if the caller may issue multiple distinct
+   * partial refunds for the same purchase; optional for the full-refund
+   * path where remaining-balance check provides natural retry safety.
+   */
+  idempotencyToken: z.string().min(1).max(128).optional(),
 })
 
 /**
@@ -2639,10 +2648,18 @@ export const refundRegistrationFn = createServerFn({ method: "POST" })
       //   - refund_application_fee: false → the platform fee stays as
       //     revenue. Both flags are explicit (not relying on defaults).
       //
-      // The purchase id is the Stripe idempotency key by convention, but
-      // partial-refund retries need distinct keys, so we mix in the
-      // requested amount and the count of prior refunds.
-      const stripeIdempotencyKey = `refund:${purchase.id}:${priorRefunds.length}:${requestedAmountCents}`
+      // The Stripe idempotency key MUST be stable across client retries —
+      // if it varies between attempts of the same logical operation, Stripe
+      // issues a duplicate refund. When the caller supplies an
+      // `idempotencyToken` (a UUID generated on click and replayed on
+      // retry), we use it directly. Otherwise we fall back to
+      // `${purchaseId}:${amount}` which is retry-safe for the full-refund
+      // path (the remaining-balance check rejects retries before we get
+      // here) but cannot distinguish two intentional partial refunds of the
+      // same amount — partial-refund callers should supply a token.
+      const stripeIdempotencyKey = input.idempotencyToken
+        ? `refund:${input.idempotencyToken}`
+        : `refund:${purchase.id}:${requestedAmountCents}`
 
       const refund = await getStripe().refunds.create(
         {
@@ -2661,7 +2678,9 @@ export const refundRegistrationFn = createServerFn({ method: "POST" })
         { idempotencyKey: stripeIdempotencyKey },
       )
 
-      // Record the REFUND_INITIATED financial event. The webhook will write
+      // Record the REFUND_INITIATED financial event through the same tx so
+      // the INSERT participates in the surrounding transaction (rolls back
+      // with the lock if anything throws). The webhook will write
       // REFUND_COMPLETED when Stripe confirms the refund settled.
       await recordRefundInitiated({
         purchaseId: purchase.id,
@@ -2671,6 +2690,7 @@ export const refundRegistrationFn = createServerFn({ method: "POST" })
         stripeRefundId: refund.id,
         reason: input.reason ?? "Refund initiated by organizer",
         actorId: session.userId,
+        db: tx,
       })
 
       return { refundId: refund.id, refundAmountCents: requestedAmountCents }

--- a/apps/wodsmith-start/src/server-fns/registration-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/registration-fns.ts
@@ -2590,9 +2590,16 @@ export const refundRegistrationFn = createServerFn({ method: "POST" })
     })
 
     // 7. Issue the Stripe refund. Charges are destination charges (created on
-    //    the platform with transfer_data.destination), so refund on the
-    //    platform payment_intent with reverse_transfer to claw back the
-    //    transferred amount from the connected account.
+    //    the platform with transfer_data.destination + application_fee_amount),
+    //    so we refund on the platform payment_intent and tell Stripe how to
+    //    fund it:
+    //      - reverse_transfer: true → reverse the transfer to the connected
+    //        account so the refund is funded by the organizer's Stripe
+    //        balance, not ours.
+    //      - refund_application_fee: false → the platform fee we collected
+    //        via application_fee_amount is NOT returned; it stays as platform
+    //        revenue. Both flags are set explicitly (not relying on defaults)
+    //        because they control who bears the cost of the refund.
     //
     //    The purchase id doubles as a Stripe idempotency key — concurrent
     //    organizer clicks for the same purchase resolve to a single refund.
@@ -2600,6 +2607,7 @@ export const refundRegistrationFn = createServerFn({ method: "POST" })
       {
         payment_intent: purchase.stripePaymentIntentId,
         reverse_transfer: true,
+        refund_application_fee: false,
         reason: "requested_by_customer",
         metadata: {
           purchaseId: purchase.id,

--- a/apps/wodsmith-start/src/server-fns/registration-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/registration-fns.ts
@@ -2448,6 +2448,7 @@ const refundRegistrationInputSchema = z.object({
   registrationId: z.string().min(1, "Registration ID is required"),
   competitionId: z.string().min(1, "Competition ID is required"),
   reason: z.string().max(500).optional(),
+  amountCents: z.number().int().positive().optional(),
 })
 
 /**
@@ -2562,73 +2563,117 @@ export const refundRegistrationFn = createServerFn({ method: "POST" })
         "Cannot refund: purchase has no Stripe payment intent",
       )
     }
+    const stripePaymentIntentId = purchase.stripePaymentIntentId
 
-    // 6. Idempotency — block if a REFUND_INITIATED or REFUND_COMPLETED already exists
-    const existingRefund = await db.query.financialEventTable.findFirst({
-      where: and(
-        eq(financialEventTable.purchaseId, purchase.id),
-        inArray(financialEventTable.eventType, [
-          FINANCIAL_EVENT_TYPE.REFUND_INITIATED,
-          FINANCIAL_EVENT_TYPE.REFUND_COMPLETED,
-        ]),
-      ),
-      columns: { id: true, eventType: true },
-    })
-
-    if (existingRefund) {
-      throw new Error("Purchase has already been refunded")
-    }
-
-    logInfo({
-      message: "[Registration] Initiating refund",
-      attributes: {
-        registrationId: input.registrationId,
-        competitionId: input.competitionId,
-        purchaseId: purchase.id,
-        amountCents: purchase.totalCents,
-      },
-    })
-
-    // 7. Issue the Stripe refund. Charges are destination charges (created on
-    //    the platform with transfer_data.destination + application_fee_amount),
-    //    so we refund on the platform payment_intent and tell Stripe how to
-    //    fund it:
-    //      - reverse_transfer: true → reverse the transfer to the connected
-    //        account so the refund is funded by the organizer's Stripe
-    //        balance, not ours.
-    //      - refund_application_fee: false → the platform fee we collected
-    //        via application_fee_amount is NOT returned; it stays as platform
-    //        revenue. Both flags are set explicitly (not relying on defaults)
-    //        because they control who bears the cost of the refund.
+    // 6. Lock the purchase row, compute remaining balance, issue refund, and
+    //    record the financial event — all inside one transaction. The
+    //    SELECT ... FOR UPDATE on commerce_purchase serializes concurrent
+    //    organizer-initiated refunds for the same purchase: the second
+    //    request waits until the first commits (or rolls back), then sees
+    //    the freshly-recorded REFUND_INITIATED row and updates its remaining
+    //    balance accordingly. PlanetScale (Vitess) supports FOR UPDATE in
+    //    single-shard transactions and queues hot-row contenders.
     //
-    //    The purchase id doubles as a Stripe idempotency key — concurrent
-    //    organizer clicks for the same purchase resolve to a single refund.
-    const refund = await getStripe().refunds.create(
-      {
-        payment_intent: purchase.stripePaymentIntentId,
-        reverse_transfer: true,
-        refund_application_fee: false,
-        reason: "requested_by_customer",
-        metadata: {
-          purchaseId: purchase.id,
+    //    Trade-off: the lock is held across the Stripe network call. Refunds
+    //    are organizer-driven and low-frequency, and Stripe latency is
+    //    bounded; the alternative (releasing the lock before Stripe) would
+    //    leave a race window we'd need a second guard for.
+    const { refundId, refundAmountCents } = await db.transaction(async (tx) => {
+      // Acquire a row-level lock on the purchase. We only need the lock —
+      // the row data was already fetched above for status/paymentIntent
+      // validation.
+      await tx
+        .select({ id: commercePurchaseTable.id })
+        .from(commercePurchaseTable)
+        .where(eq(commercePurchaseTable.id, purchase.id))
+        .for("update")
+        .limit(1)
+
+      // Compute remaining refundable balance from prior REFUND_INITIATED
+      // events. Each row's amountCents is stored as a negative number
+      // (money out), so absolute values sum to the total already refunded.
+      const priorRefunds = await tx.query.financialEventTable.findMany({
+        where: and(
+          eq(financialEventTable.purchaseId, purchase.id),
+          eq(
+            financialEventTable.eventType,
+            FINANCIAL_EVENT_TYPE.REFUND_INITIATED,
+          ),
+        ),
+        columns: { amountCents: true },
+      })
+
+      const refundedCents = priorRefunds.reduce(
+        (sum, r) => sum + Math.abs(r.amountCents),
+        0,
+      )
+      const remainingCents = purchase.totalCents - refundedCents
+      const requestedAmountCents = input.amountCents ?? remainingCents
+
+      if (remainingCents <= 0) {
+        throw new Error("Purchase has already been fully refunded")
+      }
+
+      if (requestedAmountCents > remainingCents) {
+        throw new Error(
+          `Refund amount (${requestedAmountCents}) exceeds remaining balance (${remainingCents})`,
+        )
+      }
+
+      logInfo({
+        message: "[Registration] Initiating refund",
+        attributes: {
           registrationId: input.registrationId,
           competitionId: input.competitionId,
-          organizerUserId: session.userId,
+          purchaseId: purchase.id,
+          amountCents: requestedAmountCents,
+          remainingCents,
         },
-      },
-      { idempotencyKey: `refund:${purchase.id}` },
-    )
+      })
 
-    // 8. Record the REFUND_INITIATED financial event. The webhook will record
-    //    REFUND_COMPLETED when Stripe confirms the refund settled.
-    await recordRefundInitiated({
-      purchaseId: purchase.id,
-      teamId: competition.organizingTeamId,
-      amountCents: purchase.totalCents,
-      stripePaymentIntentId: purchase.stripePaymentIntentId,
-      stripeRefundId: refund.id,
-      reason: input.reason ?? "Refund initiated by organizer",
-      actorId: session.userId,
+      // Issue the Stripe refund. Destination charges (created with
+      // transfer_data.destination + application_fee_amount) require
+      // refunding on the platform payment_intent with:
+      //   - reverse_transfer: true → reverse the transfer so the refund is
+      //     funded by the organizer's balance, not ours.
+      //   - refund_application_fee: false → the platform fee stays as
+      //     revenue. Both flags are explicit (not relying on defaults).
+      //
+      // The purchase id is the Stripe idempotency key by convention, but
+      // partial-refund retries need distinct keys, so we mix in the
+      // requested amount and the count of prior refunds.
+      const stripeIdempotencyKey = `refund:${purchase.id}:${priorRefunds.length}:${requestedAmountCents}`
+
+      const refund = await getStripe().refunds.create(
+        {
+          payment_intent: stripePaymentIntentId,
+          amount: requestedAmountCents,
+          reverse_transfer: true,
+          refund_application_fee: false,
+          reason: "requested_by_customer",
+          metadata: {
+            purchaseId: purchase.id,
+            registrationId: input.registrationId,
+            competitionId: input.competitionId,
+            organizerUserId: session.userId,
+          },
+        },
+        { idempotencyKey: stripeIdempotencyKey },
+      )
+
+      // Record the REFUND_INITIATED financial event. The webhook will write
+      // REFUND_COMPLETED when Stripe confirms the refund settled.
+      await recordRefundInitiated({
+        purchaseId: purchase.id,
+        teamId: competition.organizingTeamId,
+        amountCents: requestedAmountCents,
+        stripePaymentIntentId,
+        stripeRefundId: refund.id,
+        reason: input.reason ?? "Refund initiated by organizer",
+        actorId: session.userId,
+      })
+
+      return { refundId: refund.id, refundAmountCents: requestedAmountCents }
     })
 
     logInfo({
@@ -2636,13 +2681,13 @@ export const refundRegistrationFn = createServerFn({ method: "POST" })
       attributes: {
         registrationId: input.registrationId,
         purchaseId: purchase.id,
-        refundId: refund.id,
+        refundId,
       },
     })
 
     return {
       success: true,
-      refundId: refund.id,
-      amountCents: purchase.totalCents,
+      refundId,
+      amountCents: refundAmountCents,
     }
   })

--- a/apps/wodsmith-start/src/server/commerce/financial-events.ts
+++ b/apps/wodsmith-start/src/server/commerce/financial-events.ts
@@ -15,6 +15,14 @@ import {
 import { createFinancialEventId } from "@/db/schemas/financial-events"
 import { logInfo } from "@/lib/logging/posthog-otel-logger"
 
+/**
+ * Drizzle's `db` and the `tx` argument passed to `db.transaction(async (tx) =>
+ * ...)` both expose `.insert()`, but their TS types differ. Callers may pass
+ * either: when present, the INSERT participates in the caller's transaction;
+ * when absent, the helper opens a fresh connection via `getDb()`.
+ */
+type DbOrTx = ReturnType<typeof getDb> | { insert: ReturnType<typeof getDb>["insert"] }
+
 interface RecordFinancialEventParams {
 	purchaseId: string
 	teamId: string
@@ -28,6 +36,7 @@ interface RecordFinancialEventParams {
 	metadata?: Record<string, unknown>
 	actorId?: string
 	stripeEventTimestamp?: Date
+	db?: DbOrTx
 }
 
 /**
@@ -35,10 +44,10 @@ interface RecordFinancialEventParams {
  */
 export const recordFinancialEvent = createServerOnlyFn(
 	async (params: RecordFinancialEventParams): Promise<string> => {
-		const db = getDb()
+		const conn = params.db ?? getDb()
 		const id = createFinancialEventId()
 
-		await db.insert(financialEventTable).values({
+		await conn.insert(financialEventTable).values({
 			id,
 			purchaseId: params.purchaseId,
 			teamId: params.teamId,
@@ -112,6 +121,7 @@ export const recordRefundInitiated = createServerOnlyFn(
 		stripeRefundId?: string
 		reason: string
 		actorId?: string
+		db?: DbOrTx
 	}): Promise<void> => {
 		await recordFinancialEvent({
 			purchaseId: params.purchaseId,
@@ -122,6 +132,7 @@ export const recordRefundInitiated = createServerOnlyFn(
 			stripeRefundId: params.stripeRefundId,
 			reason: params.reason,
 			actorId: params.actorId,
+			db: params.db,
 		})
 	},
 )

--- a/apps/wodsmith-start/src/server/commerce/financial-events.ts
+++ b/apps/wodsmith-start/src/server/commerce/financial-events.ts
@@ -98,6 +98,35 @@ export const recordPaymentCompleted = createServerOnlyFn(
 )
 
 /**
+ * Record a REFUND_INITIATED event (negative amount).
+ *
+ * Logged when an organizer kicks off a refund through Stripe. Stripe's
+ * `charge.refunded` webhook later writes the matching REFUND_COMPLETED row.
+ */
+export const recordRefundInitiated = createServerOnlyFn(
+	async (params: {
+		purchaseId: string
+		teamId: string
+		amountCents: number
+		stripePaymentIntentId?: string
+		stripeRefundId?: string
+		reason: string
+		actorId?: string
+	}): Promise<void> => {
+		await recordFinancialEvent({
+			purchaseId: params.purchaseId,
+			teamId: params.teamId,
+			eventType: FINANCIAL_EVENT_TYPE.REFUND_INITIATED,
+			amountCents: -Math.abs(params.amountCents), // always negative
+			stripePaymentIntentId: params.stripePaymentIntentId,
+			stripeRefundId: params.stripeRefundId,
+			reason: params.reason,
+			actorId: params.actorId,
+		})
+	},
+)
+
+/**
  * Record a REFUND_COMPLETED event (negative amount).
  */
 export const recordRefundCompleted = createServerOnlyFn(

--- a/apps/wodsmith-start/test/routes/api/webhooks/stripe.test.ts
+++ b/apps/wodsmith-start/test/routes/api/webhooks/stripe.test.ts
@@ -50,6 +50,15 @@ vi.mock('@/server/notifications', () => ({
   notifyPaymentExpired: vi.fn(),
 }))
 
+// Mock financial events recorders
+const mockRecordRefundCompleted = vi.fn()
+const mockRecordDisputeEvent = vi.fn()
+vi.mock('@/server/commerce/financial-events', () => ({
+  recordRefundCompleted: (...args: unknown[]) =>
+    mockRecordRefundCompleted(...args),
+  recordDisputeEvent: (...args: unknown[]) => mockRecordDisputeEvent(...args),
+}))
+
 // Mock TanStack for route creation
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (config: unknown) => config,
@@ -110,6 +119,8 @@ beforeEach(() => {
   mockDb.reset()
   mockDb.registerTable('commercePurchaseTable')
   mockDb.registerTable('teamTable')
+  mockDb.registerTable('competitionsTable')
+  mockDb.registerTable('financialEventTable')
 })
 
 describe('Stripe Webhook Handler', () => {
@@ -428,6 +439,145 @@ describe('Stripe Webhook Handler', () => {
       const response = await callWebhook(JSON.stringify(event))
       expect(response.status).toBe(200)
       expect(mockDb.update).toHaveBeenCalled()
+    })
+  })
+
+  describe('charge.refunded', () => {
+    function setupRefundLookups({
+      purchase,
+      competition,
+      existingRefundEvent = null,
+    }: {
+      purchase: Record<string, unknown> | null
+      competition?: Record<string, unknown> | null
+      existingRefundEvent?: Record<string, unknown> | null
+    }) {
+      mockDb.query.commercePurchaseTable = {
+        findFirst: vi.fn().mockResolvedValue(purchase),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+      mockDb.query.competitionsTable = {
+        findFirst: vi.fn().mockResolvedValue(competition ?? null),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+      mockDb.query.financialEventTable = {
+        findFirst: vi.fn().mockResolvedValue(existingRefundEvent),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+    }
+
+    it('records REFUND_COMPLETED for each succeeded refund on the charge', async () => {
+      const charge = {
+        id: 'ch_test_1',
+        payment_intent: 'pi_test_refund_1',
+        refunds: {
+          data: [
+            {id: 're_test_1', amount: 7500, status: 'succeeded', reason: null},
+          ],
+        },
+      }
+      const event = buildStripeEvent('charge.refunded', charge, 'evt_refund_1')
+      mockConstructEventAsync.mockResolvedValue(event)
+
+      setupRefundLookups({
+        purchase: {
+          id: 'purchase-1',
+          competitionId: 'comp-1',
+          stripePaymentIntentId: 'pi_test_refund_1',
+        },
+        competition: {organizingTeamId: 'team-1'},
+      })
+
+      const response = await callWebhook(JSON.stringify(event))
+      expect(response.status).toBe(200)
+
+      expect(mockRecordRefundCompleted).toHaveBeenCalledTimes(1)
+      const call = mockRecordRefundCompleted.mock.calls[0]?.[0]
+      expect(call).toMatchObject({
+        purchaseId: 'purchase-1',
+        teamId: 'team-1',
+        amountCents: 7500,
+        stripePaymentIntentId: 'pi_test_refund_1',
+        stripeRefundId: 're_test_1',
+      })
+    })
+
+    it('skips refunds whose status is not "succeeded"', async () => {
+      const charge = {
+        id: 'ch_test_2',
+        payment_intent: 'pi_test_refund_2',
+        refunds: {
+          data: [
+            {id: 're_pending', amount: 5000, status: 'pending', reason: null},
+            {id: 're_failed', amount: 5000, status: 'failed', reason: null},
+          ],
+        },
+      }
+      const event = buildStripeEvent('charge.refunded', charge)
+      mockConstructEventAsync.mockResolvedValue(event)
+
+      setupRefundLookups({
+        purchase: {
+          id: 'purchase-2',
+          competitionId: 'comp-2',
+          stripePaymentIntentId: 'pi_test_refund_2',
+        },
+        competition: {organizingTeamId: 'team-2'},
+      })
+
+      const response = await callWebhook(JSON.stringify(event))
+      expect(response.status).toBe(200)
+      expect(mockRecordRefundCompleted).not.toHaveBeenCalled()
+    })
+
+    it('is idempotent: skips refunds already recorded as REFUND_COMPLETED', async () => {
+      const charge = {
+        id: 'ch_test_3',
+        payment_intent: 'pi_test_refund_3',
+        refunds: {
+          data: [
+            {id: 're_dupe', amount: 7500, status: 'succeeded', reason: null},
+          ],
+        },
+      }
+      const event = buildStripeEvent('charge.refunded', charge)
+      mockConstructEventAsync.mockResolvedValue(event)
+
+      setupRefundLookups({
+        purchase: {
+          id: 'purchase-3',
+          competitionId: 'comp-3',
+          stripePaymentIntentId: 'pi_test_refund_3',
+        },
+        competition: {organizingTeamId: 'team-3'},
+        existingRefundEvent: {
+          id: 'fevt_existing',
+          stripeRefundId: 're_dupe',
+          eventType: 'REFUND_COMPLETED',
+        },
+      })
+
+      const response = await callWebhook(JSON.stringify(event))
+      expect(response.status).toBe(200)
+      expect(mockRecordRefundCompleted).not.toHaveBeenCalled()
+    })
+
+    it('returns 200 and does nothing when payment_intent cannot be resolved', async () => {
+      const charge = {
+        id: 'ch_test_4',
+        payment_intent: null,
+        refunds: {
+          data: [
+            {id: 're_orphan', amount: 1000, status: 'succeeded', reason: null},
+          ],
+        },
+      }
+      const event = buildStripeEvent('charge.refunded', charge)
+      mockConstructEventAsync.mockResolvedValue(event)
+
+      const response = await callWebhook(JSON.stringify(event))
+      expect(response.status).toBe(200)
+      expect(mockRecordRefundCompleted).not.toHaveBeenCalled()
     })
   })
 

--- a/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
@@ -202,6 +202,7 @@ const refundRegistration = refundRegistrationFn as unknown as (args: {
     competitionId: string
     reason?: string
     amountCents?: number
+    idempotencyToken?: string
   }
 }) => Promise<{success: boolean; refundId: string; amountCents: number}>
 
@@ -2629,6 +2630,92 @@ describe('registration-fns', () => {
         })
 
         expect(chainMock.for).toHaveBeenCalledWith('update')
+      })
+
+      it('uses the client-supplied idempotencyToken in the Stripe idempotency key', async () => {
+        // Without a stable client-supplied token, a partial-refund retry
+        // (client times out before seeing the response) would generate a
+        // different key on the second attempt and produce a DUPLICATE Stripe
+        // refund. The token is the contract that ties retries to a single
+        // logical operation — same token in, same idempotency key out.
+        setupRefundMocks()
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+            amountCents: 3000,
+            idempotencyToken: 'client-uuid-aaa-111',
+          },
+        })
+
+        expect(mockStripeRefundsCreate).toHaveBeenCalledTimes(1)
+        const opts = mockStripeRefundsCreate.mock.calls[0]?.[1]
+        expect(opts).toMatchObject({
+          idempotencyKey: 'refund:client-uuid-aaa-111',
+        })
+      })
+
+      it('produces the same Stripe idempotency key for two calls sharing the same token', async () => {
+        // Stable derivation — the test exercises the idempotency contract
+        // directly: replays of the same logical operation must collapse.
+        setupRefundMocks()
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+            amountCents: 3000,
+            idempotencyToken: 'client-uuid-stable',
+          },
+        })
+        const firstKey =
+          mockStripeRefundsCreate.mock.calls[0]?.[1]?.idempotencyKey
+
+        // Simulate the retry: prior REFUND_INITIATED row already exists
+        // (the first attempt persisted before the response was lost).
+        mockStripeRefundsCreate.mockReset()
+        mockStripeRefundsCreate.mockResolvedValue({
+          id: stripeRefundId,
+          amount: 3000,
+          status: 'succeeded',
+        })
+        mockDb.query.financialEventTable.findMany = vi.fn().mockResolvedValue([
+          {amountCents: -3000},
+        ])
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+            amountCents: 3000,
+            idempotencyToken: 'client-uuid-stable',
+          },
+        })
+        const secondKey =
+          mockStripeRefundsCreate.mock.calls[0]?.[1]?.idempotencyKey
+
+        expect(secondKey).toBe(firstKey)
+      })
+
+      it('records the financial event through the same tx (not a fresh getDb connection)', async () => {
+        // Without this, the REFUND_INITIATED INSERT escapes the transaction
+        // and survives a rollback — breaking the atomicity claim. We verify by
+        // asserting recordRefundInitiated receives the tx passed in by
+        // db.transaction(), which equals the chain mock that FakeDrizzleDb
+        // hands the callback.
+        setupRefundMocks()
+        const chainMock = mockDb.getChainMock()
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+          },
+        })
+
+        expect(mockRecordRefundInitiated).toHaveBeenCalledTimes(1)
+        const recordedParams = mockRecordRefundInitiated.mock.calls[0]?.[0]
+        expect(recordedParams.db).toBe(chainMock)
       })
     })
   })

--- a/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
@@ -197,7 +197,12 @@ const transferRegistrationDivision = transferRegistrationDivisionFn as unknown a
 }) => Promise<{success: boolean; removedHeatAssignments: number}>
 
 const refundRegistration = refundRegistrationFn as unknown as (args: {
-  data: {registrationId: string; competitionId: string; reason?: string}
+  data: {
+    registrationId: string
+    competitionId: string
+    reason?: string
+    amountCents?: number
+  }
 }) => Promise<{success: boolean; refundId: string; amountCents: number}>
 
 // Helper to set mock session
@@ -2354,15 +2359,91 @@ describe('registration-fns', () => {
       })
     })
 
-    describe('idempotency', () => {
-      it('throws when a REFUND event already exists for this purchase', async () => {
-        setupRefundMocks({
-          existingRefundEvent: {
-            id: 'fevt_existing',
-            purchaseId: refundPurchaseId,
-            eventType: 'REFUND_INITIATED',
+    describe('partial refund', () => {
+      it('passes the requested amountCents to Stripe (not the full purchase total)', async () => {
+        // Purchase total: $75.00 — organizer requests a partial $30.00 refund.
+        setupRefundMocks()
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+            amountCents: 3000,
           },
         })
+
+        expect(mockStripeRefundsCreate).toHaveBeenCalledTimes(1)
+        const call = mockStripeRefundsCreate.mock.calls[0]?.[0]
+        expect(call).toMatchObject({
+          payment_intent: stripePaymentIntent,
+          amount: 3000,
+          reverse_transfer: true,
+          refund_application_fee: false,
+        })
+      })
+
+      it('allows a follow-up refund up to the remaining balance', async () => {
+        // $75 purchase, $30 already refunded → $45 remaining.
+        setupRefundMocks()
+        mockDb.query.financialEventTable.findMany = vi.fn().mockResolvedValue([
+          {
+            id: 'fevt_prior',
+            purchaseId: refundPurchaseId,
+            eventType: 'REFUND_INITIATED',
+            amountCents: -3000,
+          },
+        ])
+
+        const result = await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+            amountCents: 4500,
+          },
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.amountCents).toBe(4500)
+        expect(mockStripeRefundsCreate).toHaveBeenCalledTimes(1)
+        expect(mockStripeRefundsCreate.mock.calls[0]?.[0]).toMatchObject({
+          amount: 4500,
+        })
+      })
+
+      it('rejects a refund that would exceed the remaining balance', async () => {
+        // $75 purchase, $30 already refunded → $45 remaining.
+        // Asking for $50 must be rejected; Stripe is never called.
+        setupRefundMocks()
+        mockDb.query.financialEventTable.findMany = vi.fn().mockResolvedValue([
+          {
+            id: 'fevt_prior',
+            purchaseId: refundPurchaseId,
+            eventType: 'REFUND_INITIATED',
+            amountCents: -3000,
+          },
+        ])
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+              amountCents: 5000,
+            },
+          }),
+        ).rejects.toThrow(/exceed|remaining|balance/i)
+
+        expect(mockStripeRefundsCreate).not.toHaveBeenCalled()
+        expect(mockRecordRefundInitiated).not.toHaveBeenCalled()
+      })
+
+      it('rejects when the purchase has already been fully refunded', async () => {
+        // $75 purchase, $75 already refunded across two prior partials → $0 remaining.
+        setupRefundMocks()
+        mockDb.query.financialEventTable.findMany = vi.fn().mockResolvedValue([
+          {amountCents: -3000},
+          {amountCents: -4500},
+        ])
 
         await expect(
           refundRegistration({
@@ -2371,9 +2452,34 @@ describe('registration-fns', () => {
               competitionId: testCompetitionId,
             },
           }),
-        ).rejects.toThrow(/already.*refund/i)
+        ).rejects.toThrow(/fully refunded|already.*refund/i)
 
         expect(mockStripeRefundsCreate).not.toHaveBeenCalled()
+        expect(mockRecordRefundInitiated).not.toHaveBeenCalled()
+      })
+
+      it('defaults amountCents to remaining balance when not provided', async () => {
+        // $75 purchase, $30 already refunded → $45 remaining.
+        // Caller omits amountCents, so the function should refund $45.
+        setupRefundMocks()
+        mockDb.query.financialEventTable.findMany = vi.fn().mockResolvedValue([
+          {amountCents: -3000},
+        ])
+
+        const result = await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+          },
+        })
+
+        expect(result.amountCents).toBe(4500)
+        expect(mockStripeRefundsCreate.mock.calls[0]?.[0]).toMatchObject({
+          amount: 4500,
+        })
+        expect(mockRecordRefundInitiated.mock.calls[0]?.[0]).toMatchObject({
+          amountCents: 4500,
+        })
       })
     })
 
@@ -2482,6 +2588,47 @@ describe('registration-fns', () => {
         ).rejects.toThrow(/Stripe|refund/i)
 
         expect(mockRecordRefundInitiated).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('concurrency safety', () => {
+      // The TOCTOU race between balance-check and event-write is closed by
+      // running the entire balance-check + Stripe-call + event-write inside
+      // a single db.transaction() and acquiring a row-level lock on the
+      // purchase row (SELECT ... FOR UPDATE). PlanetScale (Vitess) supports
+      // FOR UPDATE in single-shard transactions and queues concurrent
+      // requests via "hot row protection". The lock can't be exercised in a
+      // unit test (the mock has no real concurrency), so this asserts the
+      // structural property: the work is wrapped in a transaction.
+      it('wraps the refund flow in db.transaction()', async () => {
+        setupRefundMocks()
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+          },
+        })
+
+        expect(mockDb.transaction).toHaveBeenCalledTimes(1)
+        // Stripe refund must happen inside the transaction (so a thrown
+        // error rolls back the lock cleanly without recording a phantom
+        // financial event).
+        expect(mockStripeRefundsCreate).toHaveBeenCalledTimes(1)
+      })
+
+      it('acquires a SELECT ... FOR UPDATE lock on the purchase row inside the transaction', async () => {
+        setupRefundMocks()
+        const chainMock = mockDb.getChainMock()
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+          },
+        })
+
+        expect(chainMock.for).toHaveBeenCalledWith('update')
       })
     })
   })

--- a/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
@@ -45,6 +45,7 @@ vi.mock('@/lib/env', () => ({
 
 // Mock Stripe
 const mockStripeCheckoutCreate = vi.fn()
+const mockStripeRefundsCreate = vi.fn()
 vi.mock('@/lib/stripe', () => ({
   getStripe: vi.fn(() => ({
     checkout: {
@@ -52,7 +53,23 @@ vi.mock('@/lib/stripe', () => ({
         create: (...args: unknown[]) => mockStripeCheckoutCreate(...args),
       },
     },
+    refunds: {
+      create: (...args: unknown[]) => mockStripeRefundsCreate(...args),
+    },
   })),
+}))
+
+// Mock financial events module so refund tests can observe and assert on writes
+const mockRecordRefundInitiated = vi.fn()
+const mockRecordFinancialEvent = vi.fn()
+vi.mock('@/server/commerce/financial-events', () => ({
+  recordRefundInitiated: (...args: unknown[]) =>
+    mockRecordRefundInitiated(...args),
+  recordRefundCompleted: vi.fn(),
+  recordFinancialEvent: (...args: unknown[]) =>
+    mockRecordFinancialEvent(...args),
+  recordPaymentCompleted: vi.fn(),
+  recordDisputeEvent: vi.fn(),
 }))
 
 // Mock division capacity
@@ -138,6 +155,7 @@ import {
   initiateRegistrationPaymentFn,
   cancelPendingPurchaseFn,
   removeRegistrationFn,
+  refundRegistrationFn,
   transferRegistrationDivisionFn,
 } from '@/server-fns/registration-fns'
 
@@ -177,6 +195,10 @@ const removeRegistration = removeRegistrationFn as unknown as (args: {
 const transferRegistrationDivision = transferRegistrationDivisionFn as unknown as (args: {
   data: {registrationId: string; competitionId: string; targetDivisionId: string}
 }) => Promise<{success: boolean; removedHeatAssignments: number}>
+
+const refundRegistration = refundRegistrationFn as unknown as (args: {
+  data: {registrationId: string; competitionId: string; reason?: string}
+}) => Promise<{success: boolean; refundId: string; amountCents: number}>
 
 // Helper to set mock session
 const setMockSession = (session: unknown) => {
@@ -2009,6 +2031,427 @@ describe('registration-fns', () => {
         })
 
         expect(result.success).toBe(true)
+      })
+    })
+  })
+
+  // ============================================================================
+  // Refund Registration (Organizer-Initiated, Stripe Express Only) Tests
+  // ============================================================================
+
+  describe('refundRegistrationFn', () => {
+    const organizingTeamId = 'org-team-1'
+    const refundPurchaseId = 'purchase-refund-1'
+    const stripePaymentIntent = 'pi_refundtest123'
+    const stripeRefundId = 're_test_abc123'
+    const stripeConnectedAccountId = 'acct_express_1'
+
+    const mockOrganizerSession = {
+      userId: 'organizer-user-1',
+      user: {id: 'organizer-user-1', email: 'organizer@example.com', role: 'user'},
+      teams: [
+        {
+          id: organizingTeamId,
+          permissions: ['manage_competitions'],
+        },
+      ],
+    }
+
+    const mockAdminSession = {
+      userId: 'admin-user-1',
+      user: {id: 'admin-user-1', email: 'admin@example.com', role: 'admin'},
+      teams: [],
+    }
+
+    const mockCompetition = {
+      id: testCompetitionId,
+      organizingTeamId,
+    }
+
+    const mockRefundableRegistration = {
+      id: testRegistrationId,
+      userId: registeredUserId,
+      eventId: testCompetitionId,
+      divisionId: testDivisionId,
+      status: 'active',
+      athleteTeamId: null,
+      teamMemberId: 'member-123',
+      paymentStatus: 'PAID',
+      commercePurchaseId: refundPurchaseId,
+    }
+
+    const mockExpressTeam = {
+      id: organizingTeamId,
+      stripeConnectedAccountId,
+      stripeAccountStatus: 'VERIFIED',
+      stripeAccountType: 'express',
+    }
+
+    const mockStandardTeam = {
+      id: organizingTeamId,
+      stripeConnectedAccountId,
+      stripeAccountStatus: 'VERIFIED',
+      stripeAccountType: 'standard',
+    }
+
+    const mockUnverifiedExpressTeam = {
+      id: organizingTeamId,
+      stripeConnectedAccountId,
+      stripeAccountStatus: 'PENDING',
+      stripeAccountType: 'express',
+    }
+
+    const mockCompletedPurchase = {
+      id: refundPurchaseId,
+      userId: registeredUserId,
+      status: 'COMPLETED',
+      totalCents: 7500,
+      stripePaymentIntentId: stripePaymentIntent,
+    }
+
+    function setupRefundMocks(overrides?: {
+      registration?: Record<string, unknown> | null
+      team?: Record<string, unknown> | null
+      purchase?: Record<string, unknown> | null
+      existingRefundEvent?: Record<string, unknown> | null
+    }) {
+      mockDb.registerTable('competitionsTable')
+      mockDb.registerTable('competitionRegistrationsTable')
+      mockDb.registerTable('teamTable')
+      mockDb.registerTable('commercePurchaseTable')
+      mockDb.registerTable('financialEventTable')
+
+      const registration = overrides?.registration === undefined
+        ? mockRefundableRegistration
+        : overrides.registration
+      const team = overrides?.team === undefined ? mockExpressTeam : overrides.team
+      const purchase = overrides?.purchase === undefined
+        ? mockCompletedPurchase
+        : overrides.purchase
+      const existingRefundEvent = overrides?.existingRefundEvent ?? null
+
+      mockDb.query.competitionsTable = {
+        findFirst: vi.fn().mockResolvedValue(mockCompetition),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+      mockDb.query.competitionRegistrationsTable = {
+        findFirst: vi.fn().mockResolvedValue(registration),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+      mockDb.query.teamTable = {
+        findFirst: vi.fn().mockResolvedValue(team),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+      mockDb.query.commercePurchaseTable = {
+        findFirst: vi.fn().mockResolvedValue(purchase),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+      mockDb.query.financialEventTable = {
+        findFirst: vi.fn().mockResolvedValue(existingRefundEvent),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+
+      mockStripeRefundsCreate.mockResolvedValue({
+        id: stripeRefundId,
+        amount: purchase?.totalCents ?? 0,
+        status: 'succeeded',
+        payment_intent: stripePaymentIntent,
+      })
+    }
+
+    beforeEach(() => {
+      mockStripeRefundsCreate.mockReset()
+      mockRecordRefundInitiated.mockReset()
+      setMockSession(mockOrganizerSession)
+    })
+
+    describe('authentication', () => {
+      it('rejects unauthenticated users', async () => {
+        vi.mocked(requireVerifiedEmail).mockRejectedValue(new Error('Unauthorized'))
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow('Unauthorized')
+      })
+    })
+
+    describe('authorization', () => {
+      it('rejects users without manage_competitions permission', async () => {
+        setupRefundMocks()
+        setMockSession({
+          userId: 'random-user',
+          user: {id: 'random-user', email: 'random@example.com', role: 'user'},
+          teams: [{id: organizingTeamId, permissions: ['access_dashboard']}],
+        })
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow('Missing required permission: manage_competitions')
+      })
+
+      it('allows site admins to bypass team check', async () => {
+        setupRefundMocks()
+        setMockSession(mockAdminSession)
+
+        const result = await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+          },
+        })
+
+        expect(result.success).toBe(true)
+      })
+    })
+
+    describe('Stripe Express requirement', () => {
+      it('rejects when team has no Stripe Connect account', async () => {
+        setupRefundMocks({
+          team: {
+            id: organizingTeamId,
+            stripeConnectedAccountId: null,
+            stripeAccountStatus: null,
+            stripeAccountType: null,
+          },
+        })
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow(/Stripe Express/)
+      })
+
+      it('rejects when team uses a Standard (non-Express) account', async () => {
+        setupRefundMocks({team: mockStandardTeam})
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow(/Stripe Express/)
+      })
+
+      it('rejects when Express account is not VERIFIED', async () => {
+        setupRefundMocks({team: mockUnverifiedExpressTeam})
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow(/Stripe Express/)
+      })
+
+      it('does not call Stripe when Express check fails', async () => {
+        setupRefundMocks({team: mockStandardTeam})
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow()
+
+        expect(mockStripeRefundsCreate).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('validation', () => {
+      it('throws when competition not found', async () => {
+        setupRefundMocks()
+        mockDb.query.competitionsTable = {
+          findFirst: vi.fn().mockResolvedValue(null),
+          findMany: vi.fn().mockResolvedValue([]),
+        }
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: 'nonexistent',
+            },
+          }),
+        ).rejects.toThrow('Competition not found')
+      })
+
+      it('throws when registration not found', async () => {
+        setupRefundMocks({registration: null})
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: 'nonexistent',
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow('Registration not found')
+      })
+
+      it('throws when registration has no associated purchase', async () => {
+        setupRefundMocks({
+          registration: {...mockRefundableRegistration, commercePurchaseId: null},
+        })
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow(/no.*purchase|not.*paid/i)
+      })
+
+      it('throws when purchase is not COMPLETED', async () => {
+        setupRefundMocks({
+          purchase: {...mockCompletedPurchase, status: 'PENDING'},
+        })
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow(/not.*completed|cannot.*refund/i)
+      })
+
+      it('throws when purchase has no Stripe payment intent', async () => {
+        setupRefundMocks({
+          purchase: {...mockCompletedPurchase, stripePaymentIntentId: null},
+        })
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow(/payment intent|cannot.*refund/i)
+      })
+    })
+
+    describe('idempotency', () => {
+      it('throws when a REFUND event already exists for this purchase', async () => {
+        setupRefundMocks({
+          existingRefundEvent: {
+            id: 'fevt_existing',
+            purchaseId: refundPurchaseId,
+            eventType: 'REFUND_INITIATED',
+          },
+        })
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow(/already.*refund/i)
+
+        expect(mockStripeRefundsCreate).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('happy path', () => {
+      it('creates a Stripe refund with reverse_transfer for destination charges', async () => {
+        setupRefundMocks()
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+          },
+        })
+
+        expect(mockStripeRefundsCreate).toHaveBeenCalledTimes(1)
+        const call = mockStripeRefundsCreate.mock.calls[0]?.[0]
+        expect(call).toMatchObject({
+          payment_intent: stripePaymentIntent,
+          reverse_transfer: true,
+        })
+      })
+
+      it('records a REFUND_INITIATED financial event', async () => {
+        setupRefundMocks()
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+            reason: 'Athlete unable to compete',
+          },
+        })
+
+        expect(mockRecordRefundInitiated).toHaveBeenCalledTimes(1)
+        const call = mockRecordRefundInitiated.mock.calls[0]?.[0]
+        expect(call).toMatchObject({
+          purchaseId: refundPurchaseId,
+          teamId: organizingTeamId,
+          amountCents: 7500,
+          stripePaymentIntentId: stripePaymentIntent,
+          stripeRefundId,
+          actorId: 'organizer-user-1',
+        })
+      })
+
+      it('returns the Stripe refund id and amount', async () => {
+        setupRefundMocks()
+
+        const result = await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+          },
+        })
+
+        expect(result.success).toBe(true)
+        expect(result.refundId).toBe(stripeRefundId)
+        expect(result.amountCents).toBe(7500)
+      })
+    })
+
+    describe('Stripe failure handling', () => {
+      it('does not record a financial event if Stripe rejects the refund', async () => {
+        setupRefundMocks()
+        mockStripeRefundsCreate.mockRejectedValueOnce(
+          new Error('Stripe error: insufficient funds'),
+        )
+
+        await expect(
+          refundRegistration({
+            data: {
+              registrationId: testRegistrationId,
+              competitionId: testCompetitionId,
+            },
+          }),
+        ).rejects.toThrow(/Stripe|refund/i)
+
+        expect(mockRecordRefundInitiated).not.toHaveBeenCalled()
       })
     })
   })

--- a/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
@@ -2396,6 +2396,36 @@ describe('registration-fns', () => {
         })
       })
 
+      it('pulls funds from the connect account and keeps the platform application fee', async () => {
+        // Stripe Connect destination charges:
+        //  - reverse_transfer: true → reverses the transfer, debiting the
+        //    connect account so the refund is funded by the organizer's
+        //    balance, not the platform's.
+        //  - refund_application_fee: false → the platform fee we collected
+        //    via application_fee_amount is NOT refunded; it stays as
+        //    platform revenue.
+        // Both flags must be explicit (not relying on defaults) since this
+        // controls who bears the cost of the refund.
+        setupRefundMocks()
+
+        await refundRegistration({
+          data: {
+            registrationId: testRegistrationId,
+            competitionId: testCompetitionId,
+          },
+        })
+
+        const call = mockStripeRefundsCreate.mock.calls[0]?.[0]
+        expect(call).toMatchObject({
+          reverse_transfer: true,
+          refund_application_fee: false,
+        })
+        // Belt-and-suspenders: also assert the value isn't undefined so we
+        // notice if a future refactor accidentally drops the explicit flag
+        // and falls back to Stripe's default.
+        expect(call?.refund_application_fee).toBe(false)
+      })
+
       it('records a REFUND_INITIATED financial event', async () => {
         setupRefundMocks()
 

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -94,6 +94,16 @@ Organizers can soft-delete registrations via `removeRegistrationFn`, setting sta
 
 Cascading cleanup: deactivates team memberships (captain in event team + all members in athlete team), cancels pending invitations, deletes heat assignments, and deletes scores for the registered user(s) across all competition events. Requires `MANAGE_COMPETITIONS` permission.
 
+## Registration Refund
+
+Organizers can refund a paid registration via [[apps/wodsmith-start/src/server-fns/registration-fns.ts#refundRegistrationFn]]. This is a separate action from removal — refunds and removals can be done independently or together.
+
+Express-only: surface this action only when the organizing team's connected account is `express` and `VERIFIED`. Standard accounts manage refunds in their own Stripe dashboard, so we do not initiate them through the platform.
+
+Charges use destination charges (`transfer_data.destination`), so we refund on the platform `payment_intent` with `reverse_transfer: true` to claw back the transfer to the connected account. The refund is bounded by purchase id as a Stripe idempotency key. A `REFUND_INITIATED` financial event is recorded immediately; the existing `charge.refunded` webhook records `REFUND_COMPLETED` once Stripe confirms.
+
+Idempotency on the app side: the action is blocked if any `REFUND_INITIATED` or `REFUND_COMPLETED` row already exists for the purchase. The athletes loader returns `canRefund` (team capability) and `refundedPurchaseIds` (already-refunded set) so the dropdown only shows the action for eligible rows.
+
 ## Division Transfer
 
 Organizers can move a registration between divisions via `transferRegistrationDivisionFn`.

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -105,7 +105,7 @@ Charges use destination charges (`transfer_data.destination` + `application_fee_
 - `reverse_transfer: true` — funds are pulled from the organizer's connected account, not the platform balance.
 - `refund_application_fee: false` — the platform fee we collected stays as platform revenue and is NOT returned to the organizer or the customer.
 
-Both flags are set explicitly (not via Stripe defaults) since this controls who bears the refund cost. The Stripe idempotency key mixes the purchase id, the count of prior refunds, and the requested amount so partial-refund retries don't collide while accidental double-clicks for the same partial still dedupe. A `REFUND_INITIATED` financial event is recorded immediately; the existing `charge.refunded` webhook records `REFUND_COMPLETED` once Stripe confirms.
+Both flags are set explicitly (not via Stripe defaults) since this controls who bears the refund cost. A `REFUND_INITIATED` financial event is recorded immediately; the existing `charge.refunded` webhook records `REFUND_COMPLETED` once Stripe confirms.
 
 ### Partial refunds and concurrency
 
@@ -113,7 +113,13 @@ Refunds accept an optional `amountCents` and reject any request that would excee
 
 When `amountCents` is omitted, the request defaults to a full refund of the remaining balance. The handler computes `remainingCents = purchase.totalCents − Σ|prior REFUND_INITIATED amountCents|` and requires `requestedAmountCents ≤ remainingCents`. Once `remainingCents` reaches zero the action is rejected as already-fully-refunded.
 
-The balance check, the Stripe call, and the financial-event write all run inside a single `db.transaction()` that opens with `SELECT ... FOR UPDATE` on the `commerce_purchases` row. PlanetScale (Vitess) supports `FOR UPDATE` in single-shard transactions and queues hot-row contenders, so concurrent organizer refund requests for the same purchase serialize: the second attempt waits for the first commit (or rollback), then sees the freshly-recorded `REFUND_INITIATED` row and recomputes its remaining balance accordingly. Trade-off: the lock is held across the Stripe network call. Refunds are organizer-driven and low-frequency, so the lock duration is acceptable; releasing the lock before the Stripe call would reopen the TOCTOU race.
+The balance check, the Stripe call, and the financial-event write all run inside a single `db.transaction()` that opens with `SELECT ... FOR UPDATE` on the `commerce_purchases` row. The `tx` is threaded into [[apps/wodsmith-start/src/server/commerce/financial-events.ts#recordRefundInitiated]] via its `db` parameter so the `REFUND_INITIATED` INSERT participates in the same transaction (without it, the helper's internal `getDb()` would commit on a separate connection and survive a rollback). PlanetScale (Vitess) supports `FOR UPDATE` in single-shard transactions and queues hot-row contenders, so concurrent organizer refund requests for the same purchase serialize: the second attempt waits for the first commit (or rollback), then sees the freshly-recorded `REFUND_INITIATED` row and recomputes its remaining balance accordingly. Trade-off: the lock is held across the Stripe network call. Refunds are organizer-driven and low-frequency, so the lock duration is acceptable; releasing the lock before the Stripe call would reopen the TOCTOU race.
+
+### Stripe idempotency key
+
+The Stripe idempotency key MUST stay stable across client retries; otherwise Stripe processes a duplicate refund.
+
+Callers can pass an `idempotencyToken` (UUID generated on click, replayed on timeout retry) — the key becomes `refund:${token}`. When omitted, the key is `refund:${purchaseId}:${requestedAmountCents}`, which is retry-safe for the full-refund path because the remaining-balance check rejects the retry before reaching Stripe but cannot distinguish two intentional partial refunds of the same amount. Partial-refund callers should always supply a token.
 
 The athletes loader returns `canRefund` (team capability) and `refundedPurchaseIds` (purchases with any prior refund) so the dropdown surface stays accurate. Once partial refunds are exposed in the UI, the loader should expose remaining balance instead of a binary refunded set.
 

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -105,9 +105,17 @@ Charges use destination charges (`transfer_data.destination` + `application_fee_
 - `reverse_transfer: true` — funds are pulled from the organizer's connected account, not the platform balance.
 - `refund_application_fee: false` — the platform fee we collected stays as platform revenue and is NOT returned to the organizer or the customer.
 
-Both flags are set explicitly (not via Stripe defaults) since this controls who bears the refund cost. The purchase id doubles as a Stripe idempotency key. A `REFUND_INITIATED` financial event is recorded immediately; the existing `charge.refunded` webhook records `REFUND_COMPLETED` once Stripe confirms.
+Both flags are set explicitly (not via Stripe defaults) since this controls who bears the refund cost. The Stripe idempotency key mixes the purchase id, the count of prior refunds, and the requested amount so partial-refund retries don't collide while accidental double-clicks for the same partial still dedupe. A `REFUND_INITIATED` financial event is recorded immediately; the existing `charge.refunded` webhook records `REFUND_COMPLETED` once Stripe confirms.
 
-Idempotency on the app side: the action is blocked if any `REFUND_INITIATED` or `REFUND_COMPLETED` row already exists for the purchase. The athletes loader returns `canRefund` (team capability) and `refundedPurchaseIds` (already-refunded set) so the dropdown only shows the action for eligible rows.
+### Partial refunds and concurrency
+
+Refunds accept an optional `amountCents` and reject any request that would exceed the remaining balance, computed from prior `REFUND_INITIATED` events.
+
+When `amountCents` is omitted, the request defaults to a full refund of the remaining balance. The handler computes `remainingCents = purchase.totalCents − Σ|prior REFUND_INITIATED amountCents|` and requires `requestedAmountCents ≤ remainingCents`. Once `remainingCents` reaches zero the action is rejected as already-fully-refunded.
+
+The balance check, the Stripe call, and the financial-event write all run inside a single `db.transaction()` that opens with `SELECT ... FOR UPDATE` on the `commerce_purchases` row. PlanetScale (Vitess) supports `FOR UPDATE` in single-shard transactions and queues hot-row contenders, so concurrent organizer refund requests for the same purchase serialize: the second attempt waits for the first commit (or rollback), then sees the freshly-recorded `REFUND_INITIATED` row and recomputes its remaining balance accordingly. Trade-off: the lock is held across the Stripe network call. Refunds are organizer-driven and low-frequency, so the lock duration is acceptable; releasing the lock before the Stripe call would reopen the TOCTOU race.
+
+The athletes loader returns `canRefund` (team capability) and `refundedPurchaseIds` (purchases with any prior refund) so the dropdown surface stays accurate. Once partial refunds are exposed in the UI, the loader should expose remaining balance instead of a binary refunded set.
 
 ## Division Transfer
 

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -100,7 +100,12 @@ Organizers can refund a paid registration via [[apps/wodsmith-start/src/server-f
 
 Express-only: surface this action only when the organizing team's connected account is `express` and `VERIFIED`. Standard accounts manage refunds in their own Stripe dashboard, so we do not initiate them through the platform.
 
-Charges use destination charges (`transfer_data.destination`), so we refund on the platform `payment_intent` with `reverse_transfer: true` to claw back the transfer to the connected account. The refund is bounded by purchase id as a Stripe idempotency key. A `REFUND_INITIATED` financial event is recorded immediately; the existing `charge.refunded` webhook records `REFUND_COMPLETED` once Stripe confirms.
+Charges use destination charges (`transfer_data.destination` + `application_fee_amount`), so we refund on the platform `payment_intent` with two explicit flags that decide who pays for the refund:
+
+- `reverse_transfer: true` — funds are pulled from the organizer's connected account, not the platform balance.
+- `refund_application_fee: false` — the platform fee we collected stays as platform revenue and is NOT returned to the organizer or the customer.
+
+Both flags are set explicitly (not via Stripe defaults) since this controls who bears the refund cost. The purchase id doubles as a Stripe idempotency key. A `REFUND_INITIATED` financial event is recorded immediately; the existing `charge.refunded` webhook records `REFUND_COMPLETED` once Stripe confirms.
 
 Idempotency on the app side: the action is blocked if any `REFUND_INITIATED` or `REFUND_COMPLETED` row already exists for the purchase. The athletes loader returns `canRefund` (team capability) and `refundedPurchaseIds` (already-refunded set) so the dropdown only shows the action for eligible rows.
 

--- a/packages/test-utils/src/fakes/fake-drizzle-db.ts
+++ b/packages/test-utils/src/fakes/fake-drizzle-db.ts
@@ -51,6 +51,8 @@ interface ChainableMock {
 	offset: Mock<(count: number) => ChainableMock>
 	orderBy: Mock<(column: unknown) => ChainableMock>
 	groupBy: Mock<(column: unknown) => ChainableMock>
+	// MySQL-specific: SELECT ... FOR UPDATE / LOCK IN SHARE MODE
+	for: Mock<(strength: "update" | "share", config?: unknown) => ChainableMock>
 
 	// Insert chain
 	insert: Mock<(table: unknown) => ChainableMock>
@@ -210,6 +212,7 @@ export class FakeDrizzleDb {
 			offset: this.createMockFn(() => mock),
 			orderBy: this.createMockFn(() => mock),
 			groupBy: this.createMockFn(() => mock),
+			for: this.createMockFn(() => mock),
 
 			// Insert chain
 			insert: this.createMockFn(() => mock),
@@ -236,6 +239,17 @@ export class FakeDrizzleDb {
 			all: this.createMockFn(() => Promise.resolve(self.mockReturnValue)),
 			run: this.createMockFn(() => Promise.resolve({ changes: self.mockChanges })),
 		} as ChainableMock
+
+		// When the chain mock is handed back as `tx` from a transaction
+		// callback, callers expect tx.query.tableName.findFirst/findMany to
+		// work the same as db.query.* (Drizzle's tx inherits the query API).
+		// Lazily proxy reads of `query` to the parent db's query API so that
+		// per-test reconfiguration of mockDb.query.X.findMany also takes
+		// effect inside transactions.
+		Object.defineProperty(mock, "query", {
+			get: () => self.query,
+			configurable: true,
+		})
 
 		return mock
 	}


### PR DESCRIPTION
## Summary
- Adds `refundRegistrationFn` so organizers can refund a paid registration as a **separate action** from removal — refund and remove can be used independently or together. The registration's status is intentionally untouched.
- **Express-only**: the action is gated on the organizing team's connected account being `express` + `VERIFIED`. Standard accounts manage refunds in their own Stripe dashboard.
- Charges use destination charges (`transfer_data.destination`), so the refund hits the platform `payment_intent` with `reverse_transfer: true` and a Stripe idempotency key (`refund:<purchaseId>`). The existing `charge.refunded` webhook records `REFUND_COMPLETED` on settlement.

## What changed
- **Server fn** (`src/server-fns/registration-fns.ts`): new `refundRegistrationFn` validating auth (`MANAGE_COMPETITIONS` + admin bypass), Express requirement, paid `commercePurchase` with `stripePaymentIntentId`, and app-side idempotency against the `financial_events` log; records `REFUND_INITIATED` on success.
- **Helper** (`src/server/commerce/financial-events.ts`): adds `recordRefundInitiated` (negative amount, with `actorId`).
- **Webhook** (`src/routes/api/webhooks/stripe.ts`): no logic changes — `charge.refunded` already records `REFUND_COMPLETED` idempotently. Adds 4 regression tests covering succeeded refund, non-succeeded skip, dedupe by `stripeRefundId`, and orphaned `payment_intent`.
- **Loader** (`src/server-fns/competition-detail-fns.ts`): `getOrganizerRegistrationsFn` now returns `canRefund` (team capability) and `refundedPurchaseIds` (already-refunded set).
- **UI** (`routes/compete/organizer/$competitionId/athletes/index.tsx`): new "Refund Registration" dropdown item + confirmation dialog. Visible only when `canRefund && row.commercePurchaseId && row.paymentStatus === \"PAID\" && !refunded`.
- **Docs**: new `## Registration Refund` section in `lat.md/registration.md`.

## Tests
- 17 new tests for `refundRegistrationFn` (auth, authz, Express, validation, idempotency, happy path, Stripe failure rollback)
- 4 new webhook tests for `charge.refunded`
- 110/110 tests pass in the touched suites; \`pnpm type-check\` clean
- Pre-existing flakiness in `competition-invite-fns.*` suites is unrelated (verified failing on `origin/main` without these changes)

## Test plan
- [ ] Verify refund option only appears for organizers whose team has a verified Stripe Express account
- [ ] Verify refund option is hidden on rows that aren't `paymentStatus === \"PAID\"` or have a `commercePurchaseId === null`
- [ ] Verify the option is hidden after a refund is recorded (until next reload, then permanently)
- [ ] Issue a refund end-to-end against a Stripe test charge — confirm:
  - [ ] Stripe creates the refund with `reverse_transfer: true`
  - [ ] `REFUND_INITIATED` event lands in `financial_events`
  - [ ] `charge.refunded` webhook fires and writes `REFUND_COMPLETED`
- [ ] Confirm a second click on the same purchase fails with "already been refunded"
- [ ] Confirm refunding does NOT change registration status (still `active`)
- [ ] Confirm Standard-account organizers don't see the option

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds organizer-initiated refunds for paid registrations, limited to teams with verified Stripe Express accounts. Supports partial refunds with a row-locked balance check, reverses transfers, keeps the platform fee, and records events transactionally with a client `idempotencyToken`.

- **New Features**
  - Server: `refundRegistrationFn` (auth + Express-only) accepts optional `amountCents`, `reason`, and `idempotencyToken`; computes remaining from prior `REFUND_INITIATED`; runs in `db.transaction()` with `SELECT ... FOR UPDATE`; calls `stripe.refunds.create` with `reverse_transfer: true` and `refund_application_fee: false`; uses idempotency key `refund:<token>` or `refund:<purchaseId>:<amount>`; records `REFUND_INITIATED` inside the same transaction; webhook records `REFUND_COMPLETED`.
  - Loader/UI: `getOrganizerRegistrationsFn` returns `canRefund` and `refundedPurchaseIds`; shows “Refund Registration” with confirmation only when eligible; registration status is unchanged.
  - Tests/Docs: adds tests for partial refunds, transactional `REFUND_INITIATED`, webhook idempotency, and Stripe flags; docs cover partials, concurrency (`FOR UPDATE`), and idempotency keys.

<sup>Written for commit c3b06212d9df5744abe4ea8a4ded0d5bfc0f2305. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organizers can refund athlete registrations (including partial refunds) when eligible; UI shows refund eligibility and refunded status.
  * Added a unified "Refund Registration" action and confirmation dialog with success/error feedback and automatic refresh.

* **Tests**
  * Added comprehensive tests for refund flows and related webhook processing.

* **Documentation**
  * Added registration refund docs covering eligibility, partial refunds, and expected UI behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/450)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->