### PR TITLE
feat(refunds): refund status badge + per-division refunds on Revenue page

### DIFF
--- a/apps/wodsmith-start/src/routes/compete/cohost/$competitionId/revenue.tsx
+++ b/apps/wodsmith-start/src/routes/compete/cohost/$competitionId/revenue.tsx
@@ -7,15 +7,13 @@
  */
 
 import { createFileRoute, redirect } from "@tanstack/react-router"
+import { RevenueStatsDisplay } from "@/routes/compete/organizer/$competitionId/-components/revenue-stats-display"
 import {
   getCompetitionRevenueStatsFn,
   getOrganizerStripeStatusFn,
 } from "@/server-fns/commerce-fns"
-import { RevenueStatsDisplay } from "@/routes/compete/organizer/$competitionId/-components/revenue-stats-display"
 
-export const Route = createFileRoute(
-  "/compete/cohost/$competitionId/revenue",
-)({
+export const Route = createFileRoute("/compete/cohost/$competitionId/revenue")({
   staleTime: 10_000,
   loader: async ({ params, parentMatchPromise }) => {
     const parentMatch = await parentMatchPromise
@@ -31,8 +29,19 @@ export const Route = createFileRoute(
 
     // Parallel fetch: revenue stats and stripe status
     const [revenueResult, stripeResult] = await Promise.all([
-      getCompetitionRevenueStatsFn({ data: { competitionId: competition.id } })
-        .catch(() => ({ stats: { totalGrossCents: 0, totalPlatformFeeCents: 0, totalStripeFeeCents: 0, totalOrganizerNetCents: 0, purchaseCount: 0, byDivision: [] } })),
+      getCompetitionRevenueStatsFn({
+        data: { competitionId: competition.id },
+      }).catch(() => ({
+        stats: {
+          totalGrossCents: 0,
+          totalPlatformFeeCents: 0,
+          totalStripeFeeCents: 0,
+          totalOrganizerNetCents: 0,
+          totalRefundedCents: 0,
+          purchaseCount: 0,
+          byDivision: [],
+        },
+      })),
       getOrganizerStripeStatusFn({
         data: { organizingTeamId: competition.organizingTeamId },
       }).catch(() => ({ stripeStatus: null })),

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/refund-status-badge.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/refund-status-badge.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { RotateCcw } from "lucide-react"
+import { Badge } from "@/components/ui/badge"
+
+interface RefundStatusBadgeProps {
+  refundedCents: number
+  totalCents: number
+  className?: string
+}
+
+function formatCents(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}
+
+/**
+ * Badge surfacing the refund state of a registration row.
+ *
+ * - No refund recorded → renders nothing (caller doesn't have to gate)
+ * - Full refund (refundedCents >= totalCents) → solid red "Refunded"
+ * - Partial refund → orange "Partially refunded ($X.XX)" so organizers see
+ *   the refunded amount without drilling into the purchase
+ */
+export function RefundStatusBadge({
+  refundedCents,
+  totalCents,
+  className,
+}: RefundStatusBadgeProps) {
+  if (refundedCents <= 0) return null
+
+  const isFull = refundedCents >= totalCents
+
+  if (isFull) {
+    return (
+      <Badge variant="destructive" className={`text-xs ${className ?? ""}`}>
+        <RotateCcw className="h-3 w-3 mr-1" />
+        Refunded
+      </Badge>
+    )
+  }
+
+  return (
+    <Badge
+      variant="outline"
+      className={`text-xs bg-orange-50 text-orange-700 border-orange-300 ${className ?? ""}`}
+    >
+      <RotateCcw className="h-3 w-3 mr-1" />
+      Partially refunded ({formatCents(refundedCents)})
+    </Badge>
+  )
+}

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/revenue-stats-display.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/revenue-stats-display.tsx
@@ -47,6 +47,13 @@ export function RevenueStatsDisplay({
 }: RevenueStatsDisplayProps) {
   const location = useLocation()
   const hasRevenue = stats.purchaseCount > 0
+  const hasRefunds = stats.totalRefundedCents > 0
+  // Net Revenue shown to organizers is post-refund: refunds use
+  // reverse_transfer (organizer's account funds the refund) so they reduce
+  // what the organizer keeps. Platform/Stripe fees stay (refund_application_fee
+  // is false), so the net subtracts only the refunded principal.
+  const netAfterRefundsCents =
+    stats.totalOrganizerNetCents - stats.totalRefundedCents
 
   // Build payouts URL with returnTo so user comes back here after setup
   const payoutsUrl = stripeStatus
@@ -68,7 +75,8 @@ export function RevenueStatsDisplay({
               "The organizer has not yet connected a Stripe account for payouts."
             ) : (
               <>
-                Connect your Stripe account to receive payouts for registrations.{" "}
+                Connect your Stripe account to receive payouts for
+                registrations.{" "}
                 <Link to={payoutsUrl as "/"} className="font-medium underline">
                   Set up payouts &rarr;
                 </Link>
@@ -104,9 +112,11 @@ export function RevenueStatsDisplay({
           </CardHeader>
           <CardContent>
             <div className="text-2xl font-bold text-green-600">
-              {formatCents(stats.totalOrganizerNetCents)}
+              {formatCents(netAfterRefundsCents)}
             </div>
-            <p className="text-xs text-muted-foreground">After all fees</p>
+            <p className="text-xs text-muted-foreground">
+              {hasRefunds ? "After all fees and refunds" : "After all fees"}
+            </p>
           </CardContent>
         </Card>
 
@@ -168,10 +178,18 @@ export function RevenueStatsDisplay({
                   - {formatCents(stats.totalPlatformFeeCents)}
                 </span>
               </div>
+              {hasRefunds && (
+                <div className="flex items-center justify-between text-muted-foreground">
+                  <span className="text-sm">Refunds</span>
+                  <span className="text-sm">
+                    - {formatCents(stats.totalRefundedCents)}
+                  </span>
+                </div>
+              )}
               <div className="border-t pt-4 flex items-center justify-between">
                 <span className="font-medium">Your Net Revenue</span>
                 <span className="font-bold text-green-600">
-                  {formatCents(stats.totalOrganizerNetCents)}
+                  {formatCents(netAfterRefundsCents)}
                 </span>
               </div>
             </div>
@@ -204,6 +222,11 @@ export function RevenueStatsDisplay({
                   <TableHead className="text-right text-red-400">
                     Stripe Fee
                   </TableHead>
+                  {hasRefunds && (
+                    <TableHead className="text-right text-red-400">
+                      Refunds
+                    </TableHead>
+                  )}
                   <TableHead className="text-right">Net</TableHead>
                 </TableRow>
               </TableHeader>
@@ -228,8 +251,17 @@ export function RevenueStatsDisplay({
                     <TableCell className="text-right text-red-400">
                       -{formatCents(division.stripeFeeCents)}
                     </TableCell>
+                    {hasRefunds && (
+                      <TableCell className="text-right text-red-400">
+                        {division.refundedCents > 0
+                          ? `-${formatCents(division.refundedCents)}`
+                          : "—"}
+                      </TableCell>
+                    )}
                     <TableCell className="text-right text-green-600">
-                      {formatCents(division.organizerNetCents)}
+                      {formatCents(
+                        division.organizerNetCents - division.refundedCents,
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/athletes/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/athletes/index.tsx
@@ -101,6 +101,7 @@ import {
   getCompetitionWaiversFn,
 } from "@/server-fns/waiver-fns"
 import { ManualRegistrationDialog } from "../-components/manual-registration-dialog"
+import { RefundStatusBadge } from "../-components/refund-status-badge"
 import { TransferDivisionDialog } from "../-components/transfer-division-dialog"
 import { TransferRegistrationDialog } from "../-components/transfer-registration-dialog"
 
@@ -192,7 +193,7 @@ export const Route = createFileRoute(
     return {
       registrations: registrationsResult.registrations,
       canRefund: registrationsResult.canRefund,
-      refundedPurchaseIds: registrationsResult.refundedPurchaseIds,
+      refundsByPurchaseId: registrationsResult.refundsByPurchaseId,
       divisions: divisionsResult.divisions,
       questions: questionsResult.questions,
       answersByRegistration: answersResult.answersByRegistration,
@@ -222,7 +223,7 @@ function AthletesPage() {
   const {
     registrations,
     canRefund,
-    refundedPurchaseIds,
+    refundsByPurchaseId,
     divisions,
     questions,
     answersByRegistration,
@@ -237,9 +238,22 @@ function AthletesPage() {
     currentSortDir,
     teamId,
   } = Route.useLoaderData()
-  const refundedPurchaseIdSet = React.useMemo(
-    () => new Set(refundedPurchaseIds),
-    [refundedPurchaseIds],
+  /**
+   * Resolve refund status for a given purchaseId. Returns:
+   *   - null  → no refund recorded
+   *   - "full"    → refundedCents >= totalCents (e.g. organizer refunded the full ticket)
+   *   - "partial" → 0 < refundedCents < totalCents
+   * The dropdown action hides on any refund, but the badge surfaces the
+   * distinction so an organizer can tell at a glance whether more remains.
+   */
+  const getRefundStatus = React.useCallback(
+    (purchaseId: string | null): "full" | "partial" | null => {
+      if (!purchaseId) return null
+      const refund = refundsByPurchaseId[purchaseId]
+      if (!refund || refund.refundedCents <= 0) return null
+      return refund.refundedCents >= refund.totalCents ? "full" : "partial"
+    },
+    [refundsByPurchaseId],
   )
   const navigate = useNavigate()
   const router = useRouter()
@@ -1398,7 +1412,7 @@ function AthletesPage() {
                                     {canRefund &&
                                       row.commercePurchaseId &&
                                       row.paymentStatus === "PAID" &&
-                                      !refundedPurchaseIdSet.has(
+                                      !getRefundStatus(
                                         row.commercePurchaseId,
                                       ) && (
                                         <DropdownMenuItem
@@ -1504,6 +1518,21 @@ function AthletesPage() {
                                   {row.division.label}
                                 </Badge>
                               )}
+                              {row.commercePurchaseId &&
+                                refundsByPurchaseId[row.commercePurchaseId] && (
+                                  <RefundStatusBadge
+                                    refundedCents={
+                                      refundsByPurchaseId[
+                                        row.commercePurchaseId
+                                      ]?.refundedCents ?? 0
+                                    }
+                                    totalCents={
+                                      refundsByPurchaseId[
+                                        row.commercePurchaseId
+                                      ]?.totalCents ?? 0
+                                    }
+                                  />
+                                )}
                             </div>
                             <div className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
                               {row.teamName && (
@@ -1810,6 +1839,25 @@ function AthletesPage() {
                                       </button>
                                     </div>
                                   ) : null}
+                                  {row.commercePurchaseId &&
+                                    refundsByPurchaseId[
+                                      row.commercePurchaseId
+                                    ] && (
+                                      <div className="mt-1">
+                                        <RefundStatusBadge
+                                          refundedCents={
+                                            refundsByPurchaseId[
+                                              row.commercePurchaseId
+                                            ]?.refundedCents ?? 0
+                                          }
+                                          totalCents={
+                                            refundsByPurchaseId[
+                                              row.commercePurchaseId
+                                            ]?.totalCents ?? 0
+                                          }
+                                        />
+                                      </div>
+                                    )}
                                 </TableCell>
                                 <TableCell>
                                   <div className="flex items-center gap-3">
@@ -2088,7 +2136,7 @@ function AthletesPage() {
                                         {canRefund &&
                                           row.commercePurchaseId &&
                                           row.paymentStatus === "PAID" &&
-                                          !refundedPurchaseIdSet.has(
+                                          !getRefundStatus(
                                             row.commercePurchaseId,
                                           ) && (
                                             <DropdownMenuItem

--- a/apps/wodsmith-start/src/server-fns/competition-detail-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-detail-fns.ts
@@ -660,14 +660,48 @@ const getOrganizerRegistrationsInputSchema = z.object({
 })
 
 /**
+ * Roll up refund events into a per-purchase map keyed by purchaseId. Negative
+ * `amountCents` values (sign convention from financial_events) are normalized
+ * to positive cents so the UI can compare refundedCents to totalCents
+ * directly. Refund events for purchaseIds not present in the totals map are
+ * dropped — they cannot be paired with a purchase total and would render an
+ * incomplete badge.
+ *
+ * Pure for testability; used by getOrganizerRegistrationsFn below.
+ */
+export function computeRefundsByPurchase(
+  refundEvents: Array<{ purchaseId: string; amountCents: number }>,
+  purchaseTotals: Map<string, number>,
+): Record<string, { refundedCents: number; totalCents: number }> {
+  const result: Record<
+    string,
+    { refundedCents: number; totalCents: number }
+  > = {}
+  for (const event of refundEvents) {
+    const totalCents = purchaseTotals.get(event.purchaseId)
+    if (totalCents === undefined) continue
+    const cents = Math.abs(event.amountCents)
+    const existing = result[event.purchaseId]
+    if (existing) {
+      existing.refundedCents += cents
+    } else {
+      result[event.purchaseId] = { refundedCents: cents, totalCents }
+    }
+  }
+  return result
+}
+
+/**
  * Get registrations for organizer view with full user and division details.
  *
- * Returns refund-capability metadata so the UI can decide whether to surface
- * the "Refund Registration" action:
+ * Returns refund metadata so the UI can decide whether to surface the "Refund
+ * Registration" action and render the appropriate refund-status badge:
  * - `canRefund` is true when the organizing team has a verified Stripe Express
  *   connected account (only Express accounts use platform-mediated refunds).
- * - `refundedPurchaseIds` lists purchases that already have a REFUND_INITIATED
- *   or REFUND_COMPLETED financial event so the UI hides the action per row.
+ * - `refundsByPurchaseId` maps each refunded purchase to {refundedCents,
+ *   totalCents} so the UI shows "Refunded" for full refunds and "Partially
+ *   refunded" for partials, and so the dropdown action can be hidden once a
+ *   purchase has any refund recorded.
  */
 export const getOrganizerRegistrationsFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) =>
@@ -765,29 +799,52 @@ export const getOrganizerRegistrationsFn = createServerFn({ method: "GET" })
       .map((r) => r.commercePurchaseId)
       .filter((id): id is string => !!id)
 
-    let refundedPurchaseIds: string[] = []
+    let refundsByPurchaseId: Record<
+      string,
+      { refundedCents: number; totalCents: number }
+    > = {}
     if (purchaseIds.length > 0) {
-      const refundEvents = await db
-        .select({ purchaseId: financialEventTable.purchaseId })
-        .from(financialEventTable)
-        .where(
-          and(
-            inArray(financialEventTable.purchaseId, purchaseIds),
-            inArray(financialEventTable.eventType, [
-              FINANCIAL_EVENT_TYPE.REFUND_INITIATED,
-              FINANCIAL_EVENT_TYPE.REFUND_COMPLETED,
-            ]),
+      // Pull the totals (so the UI can detect full vs partial refunds) and
+      // refund events (REFUND_INITIATED only — counting INITIATED + COMPLETED
+      // would double-count once Stripe's webhook lands).
+      const [purchaseRows, refundEvents] = await Promise.all([
+        db
+          .select({
+            id: commercePurchaseTable.id,
+            totalCents: commercePurchaseTable.totalCents,
+          })
+          .from(commercePurchaseTable)
+          .where(inArray(commercePurchaseTable.id, purchaseIds)),
+        db
+          .select({
+            purchaseId: financialEventTable.purchaseId,
+            amountCents: financialEventTable.amountCents,
+          })
+          .from(financialEventTable)
+          .where(
+            and(
+              inArray(financialEventTable.purchaseId, purchaseIds),
+              eq(
+                financialEventTable.eventType,
+                FINANCIAL_EVENT_TYPE.REFUND_INITIATED,
+              ),
+            ),
           ),
-        )
-      refundedPurchaseIds = Array.from(
-        new Set(refundEvents.map((r) => r.purchaseId)),
+      ])
+
+      const purchaseTotals = new Map(
+        purchaseRows.map((p) => [p.id, p.totalCents]),
+      )
+      refundsByPurchaseId = computeRefundsByPurchase(
+        refundEvents,
+        purchaseTotals,
       )
     }
 
     return {
       registrations: filteredRegistrations,
       canRefund,
-      refundedPurchaseIds,
+      refundsByPurchaseId,
     }
   })
 

--- a/apps/wodsmith-start/src/server/commerce/fee-calculator.ts
+++ b/apps/wodsmith-start/src/server/commerce/fee-calculator.ts
@@ -2,13 +2,15 @@
  * Fee Calculator for TanStack Start
  * Handles competition registration fee calculation and revenue statistics.
  */
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, inArray, sql } from "drizzle-orm"
 import { getDb } from "@/db"
 import {
   COMMERCE_PURCHASE_STATUS,
   commercePurchaseTable,
   competitionDivisionFeesTable,
   competitionsTable,
+  FINANCIAL_EVENT_TYPE,
+  financialEventTable,
   scalingLevelsTable,
 } from "@/db/schema"
 
@@ -91,7 +93,13 @@ export async function getRegistrationFee(
 }
 
 /**
- * Revenue stats for a competition with fee breakdowns
+ * Revenue stats for a competition with fee breakdowns.
+ *
+ * `totalOrganizerNetCents` and `byDivision[].organizerNetCents` are the
+ * pre-refund net (sum of per-purchase organizerNetCents). Refunds are surfaced
+ * separately so the page can show a "Refunds" line/column and adjust the
+ * displayed Net = organizerNetCents − refundedCents without losing the
+ * pre-refund value used elsewhere in the dashboard.
  */
 export interface CompetitionRevenueStats {
   /** Total gross revenue collected from customers (in cents) */
@@ -100,8 +108,14 @@ export interface CompetitionRevenueStats {
   totalPlatformFeeCents: number
   /** Total Stripe processing fees */
   totalStripeFeeCents: number
-  /** Total net revenue for organizer after all fees */
+  /** Total net revenue for organizer after all fees, BEFORE refunds */
   totalOrganizerNetCents: number
+  /**
+   * Total cents refunded to athletes across this competition. Sourced from
+   * REFUND_INITIATED financial events; stored in cents as a positive number
+   * (events themselves are negative).
+   */
+  totalRefundedCents: number
   /** Number of completed purchases */
   purchaseCount: number
   /** Breakdown by division */
@@ -115,12 +129,136 @@ export interface CompetitionRevenueStats {
     platformFeeCents: number
     stripeFeeCents: number
     organizerNetCents: number
+    /** Cents refunded for purchases in this division (positive). */
+    refundedCents: number
   }>
 }
 
 /**
+ * Pure inputs for `aggregateRevenueStats`. Extracted so the rollup logic can
+ * be tested without going through Drizzle.
+ */
+export interface RevenueStatsInput {
+  purchases: Array<{
+    purchaseId: string
+    divisionId: string | null
+    totalCents: number
+    platformFeeCents: number
+    stripeFeeCents: number
+    organizerNetCents: number
+  }>
+  /**
+   * REFUND_INITIATED financial events. `amountCents` is signed (negative for
+   * refunds, per the financial_events sign convention) — this function
+   * tolerates either sign and rolls up the absolute value.
+   */
+  refundEvents: Array<{
+    purchaseId: string
+    amountCents: number
+  }>
+  divisionLabels: Map<string, string>
+  divisionFees: Map<string, number>
+  defaultFeeCents: number
+}
+
+/**
+ * Roll up purchases + refund events into a competition-level revenue stats
+ * shape, including per-division refund attribution.
+ *
+ * Refund events whose purchaseId isn't in `purchases` are ignored — they
+ * cannot be attributed to a division and would otherwise either crash or
+ * pollute an "Unknown" bucket.
+ */
+export function aggregateRevenueStats(
+  input: RevenueStatsInput,
+): CompetitionRevenueStats {
+  const purchaseIdToDivision = new Map<string, string>()
+  for (const p of input.purchases) {
+    purchaseIdToDivision.set(p.purchaseId, p.divisionId ?? "unknown")
+  }
+
+  // Sum refund cents per division (and overall). Skip events for unknown
+  // purchases; they have no division to attribute to.
+  let totalRefundedCents = 0
+  const refundedByDivision = new Map<string, number>()
+  for (const event of input.refundEvents) {
+    const divisionId = purchaseIdToDivision.get(event.purchaseId)
+    if (!divisionId) continue
+    const cents = Math.abs(event.amountCents)
+    totalRefundedCents += cents
+    refundedByDivision.set(
+      divisionId,
+      (refundedByDivision.get(divisionId) ?? 0) + cents,
+    )
+  }
+
+  let totalGrossCents = 0
+  let totalPlatformFeeCents = 0
+  let totalStripeFeeCents = 0
+  let totalOrganizerNetCents = 0
+
+  const divisionAggregates = new Map<
+    string,
+    {
+      purchaseCount: number
+      grossCents: number
+      platformFeeCents: number
+      stripeFeeCents: number
+      organizerNetCents: number
+    }
+  >()
+
+  for (const purchase of input.purchases) {
+    totalGrossCents += purchase.totalCents
+    totalPlatformFeeCents += purchase.platformFeeCents
+    totalStripeFeeCents += purchase.stripeFeeCents
+    totalOrganizerNetCents += purchase.organizerNetCents
+
+    const divisionId = purchase.divisionId ?? "unknown"
+    const existing = divisionAggregates.get(divisionId) ?? {
+      purchaseCount: 0,
+      grossCents: 0,
+      platformFeeCents: 0,
+      stripeFeeCents: 0,
+      organizerNetCents: 0,
+    }
+
+    divisionAggregates.set(divisionId, {
+      purchaseCount: existing.purchaseCount + 1,
+      grossCents: existing.grossCents + purchase.totalCents,
+      platformFeeCents: existing.platformFeeCents + purchase.platformFeeCents,
+      stripeFeeCents: existing.stripeFeeCents + purchase.stripeFeeCents,
+      organizerNetCents:
+        existing.organizerNetCents + purchase.organizerNetCents,
+    })
+  }
+
+  const byDivision = Array.from(divisionAggregates.entries()).map(
+    ([divisionId, stats]) => ({
+      divisionId,
+      divisionLabel: input.divisionLabels.get(divisionId) ?? "Unknown",
+      registrationFeeCents:
+        input.divisionFees.get(divisionId) ?? input.defaultFeeCents,
+      ...stats,
+      refundedCents: refundedByDivision.get(divisionId) ?? 0,
+    }),
+  )
+
+  return {
+    totalGrossCents,
+    totalPlatformFeeCents,
+    totalStripeFeeCents,
+    totalOrganizerNetCents,
+    totalRefundedCents,
+    purchaseCount: input.purchases.length,
+    byDivision,
+  }
+}
+
+/**
  * Get revenue stats for a competition
- * Aggregates all completed purchases with fee breakdowns
+ * Aggregates all completed purchases with fee breakdowns and per-division
+ * refunds (REFUND_INITIATED financial events).
  */
 export async function getCompetitionRevenueStats(
   competitionId: string,
@@ -130,6 +268,7 @@ export async function getCompetitionRevenueStats(
   // Get all completed purchases for this competition
   const purchases = await db
     .select({
+      purchaseId: commercePurchaseTable.id,
       divisionId: commercePurchaseTable.divisionId,
       totalCents: commercePurchaseTable.totalCents,
       platformFeeCents: commercePurchaseTable.platformFeeCents,
@@ -176,6 +315,31 @@ export async function getCompetitionRevenueStats(
           )
       : []
 
+  // Get refund events (REFUND_INITIATED) for the purchases in this comp.
+  // We use REFUND_INITIATED rather than REFUND_COMPLETED so the page reflects
+  // refunds the moment the organizer kicks them off, not after Stripe's
+  // settlement webhook lands. Both rows are eventually written; counting
+  // INITIATED avoids double-counting once COMPLETED arrives.
+  const purchaseIds = purchases.map((p) => p.purchaseId)
+  const refundEvents =
+    purchaseIds.length > 0
+      ? await db
+          .select({
+            purchaseId: financialEventTable.purchaseId,
+            amountCents: financialEventTable.amountCents,
+          })
+          .from(financialEventTable)
+          .where(
+            and(
+              inArray(financialEventTable.purchaseId, purchaseIds),
+              eq(
+                financialEventTable.eventType,
+                FINANCIAL_EVENT_TYPE.REFUND_INITIATED,
+              ),
+            ),
+          )
+      : []
+
   // Get competition default fee as fallback for divisions without specific fees
   const competition = await db.query.competitionsTable.findFirst({
     where: eq(competitionsTable.id, competitionId),
@@ -183,69 +347,11 @@ export async function getCompetitionRevenueStats(
   })
   const defaultFeeCents = competition?.defaultRegistrationFeeCents ?? 0
 
-  const divisionMap = new Map(divisions.map((d) => [d.id, d.label]))
-  const divisionFeeMap = new Map(
-    divisionFees.map((f) => [f.divisionId, f.feeCents]),
-  )
-
-  // Aggregate totals
-  let totalGrossCents = 0
-  let totalPlatformFeeCents = 0
-  let totalStripeFeeCents = 0
-  let totalOrganizerNetCents = 0
-
-  // Group by division
-  const divisionAggregates = new Map<
-    string,
-    {
-      purchaseCount: number
-      grossCents: number
-      platformFeeCents: number
-      stripeFeeCents: number
-      organizerNetCents: number
-    }
-  >()
-
-  for (const purchase of purchases) {
-    totalGrossCents += purchase.totalCents
-    totalPlatformFeeCents += purchase.platformFeeCents
-    totalStripeFeeCents += purchase.stripeFeeCents
-    totalOrganizerNetCents += purchase.organizerNetCents
-
-    const divisionId = purchase.divisionId ?? "unknown"
-    const existing = divisionAggregates.get(divisionId) ?? {
-      purchaseCount: 0,
-      grossCents: 0,
-      platformFeeCents: 0,
-      stripeFeeCents: 0,
-      organizerNetCents: 0,
-    }
-
-    divisionAggregates.set(divisionId, {
-      purchaseCount: existing.purchaseCount + 1,
-      grossCents: existing.grossCents + purchase.totalCents,
-      platformFeeCents: existing.platformFeeCents + purchase.platformFeeCents,
-      stripeFeeCents: existing.stripeFeeCents + purchase.stripeFeeCents,
-      organizerNetCents:
-        existing.organizerNetCents + purchase.organizerNetCents,
-    })
-  }
-
-  const byDivision = Array.from(divisionAggregates.entries()).map(
-    ([divisionId, stats]) => ({
-      divisionId,
-      divisionLabel: divisionMap.get(divisionId) ?? "Unknown",
-      registrationFeeCents: divisionFeeMap.get(divisionId) ?? defaultFeeCents,
-      ...stats,
-    }),
-  )
-
-  return {
-    totalGrossCents,
-    totalPlatformFeeCents,
-    totalStripeFeeCents,
-    totalOrganizerNetCents,
-    purchaseCount: purchases.length,
-    byDivision,
-  }
+  return aggregateRevenueStats({
+    purchases,
+    refundEvents,
+    divisionLabels: new Map(divisions.map((d) => [d.id, d.label])),
+    divisionFees: new Map(divisionFees.map((f) => [f.divisionId, f.feeCents])),
+    defaultFeeCents,
+  })
 }

--- a/apps/wodsmith-start/test/components/refund-status-badge.test.tsx
+++ b/apps/wodsmith-start/test/components/refund-status-badge.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { RefundStatusBadge } from "@/routes/compete/organizer/$competitionId/-components/refund-status-badge"
+
+// Mock lucide-react icons as simple spans (matches pattern from sibling tests)
+vi.mock("lucide-react", () => {
+	const icon =
+		(name: string) =>
+		({ className }: { className?: string }) => (
+			<span data-testid={`icon-${name}`} className={className} />
+		)
+	return {
+		RotateCcw: icon("rotate-ccw"),
+	}
+})
+
+describe("RefundStatusBadge", () => {
+	it("renders nothing when there is no refund", () => {
+		const { container } = render(
+			<RefundStatusBadge refundedCents={0} totalCents={10000} />,
+		)
+		expect(container).toBeEmptyDOMElement()
+	})
+
+	it("renders 'Refunded' when refunded amount equals total", () => {
+		render(<RefundStatusBadge refundedCents={10000} totalCents={10000} />)
+		expect(screen.getByText("Refunded")).toBeInTheDocument()
+	})
+
+	it("renders 'Refunded' when refunded amount exceeds total (defensive)", () => {
+		// Should never happen in practice (the refund flow rejects over-refund),
+		// but the badge should still degrade to "Refunded" rather than
+		// "Partially refunded" if it ever does.
+		render(<RefundStatusBadge refundedCents={11000} totalCents={10000} />)
+		expect(screen.getByText("Refunded")).toBeInTheDocument()
+	})
+
+	it("renders 'Partially refunded' when refunded amount is less than total", () => {
+		render(<RefundStatusBadge refundedCents={3000} totalCents={10000} />)
+		expect(screen.getByText(/Partially refunded/i)).toBeInTheDocument()
+	})
+
+	it("includes the refunded amount in the partial badge", () => {
+		// Organizers need to see how much has been refunded, not just that
+		// some refund happened — otherwise they'd have to click into the
+		// purchase to find out.
+		render(<RefundStatusBadge refundedCents={3000} totalCents={10000} />)
+		expect(screen.getByText(/\$30\.00/)).toBeInTheDocument()
+	})
+})

--- a/apps/wodsmith-start/test/components/revenue-stats-display.test.tsx
+++ b/apps/wodsmith-start/test/components/revenue-stats-display.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, within } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { RevenueStatsDisplay } from "@/routes/compete/organizer/$competitionId/-components/revenue-stats-display"
+import type { CompetitionRevenueStats } from "@/server-fns/commerce-fns"
+
+vi.mock("@tanstack/react-router", () => ({
+	Link: ({
+		children,
+		to,
+	}: {
+		children: React.ReactNode
+		to: string
+	}) => <a href={to}>{children}</a>,
+	useLocation: () => ({ pathname: "/" }),
+}))
+
+vi.mock("lucide-react", () => {
+	const icon =
+		(name: string) =>
+		({ className }: { className?: string }) => (
+			<span data-testid={`icon-${name}`} className={className} />
+		)
+	return {
+		AlertCircle: icon("alert"),
+		CreditCard: icon("credit-card"),
+		DollarSign: icon("dollar"),
+		RotateCcw: icon("rotate-ccw"),
+		TrendingUp: icon("trending-up"),
+		Users: icon("users"),
+	}
+})
+
+const baseStats: CompetitionRevenueStats = {
+	totalGrossCents: 30000,
+	totalPlatformFeeCents: 1800,
+	totalStripeFeeCents: 950,
+	totalOrganizerNetCents: 27250,
+	totalRefundedCents: 0,
+	purchaseCount: 3,
+	byDivision: [
+		{
+			divisionId: "div-rx",
+			divisionLabel: "RX",
+			purchaseCount: 2,
+			registrationFeeCents: 10000,
+			grossCents: 20000,
+			platformFeeCents: 1200,
+			stripeFeeCents: 630,
+			organizerNetCents: 18170,
+			refundedCents: 0,
+		},
+		{
+			divisionId: "div-scaled",
+			divisionLabel: "Scaled",
+			purchaseCount: 1,
+			registrationFeeCents: 10000,
+			grossCents: 10000,
+			platformFeeCents: 600,
+			stripeFeeCents: 320,
+			organizerNetCents: 9080,
+			refundedCents: 0,
+		},
+	],
+}
+
+describe("RevenueStatsDisplay refund handling", () => {
+	it("does not surface refund UI when there are no refunds", () => {
+		render(<RevenueStatsDisplay stats={baseStats} />)
+		// We use queryAllByText and assert the count is 0 — the column header
+		// shouldn't even render until a refund happens, otherwise organizers
+		// see a confusing zero-everywhere column on healthy competitions.
+		expect(screen.queryByText(/^Refunds$/)).not.toBeInTheDocument()
+	})
+
+	it("renders a 'Refunds' column in the per-division table when there are refunds", () => {
+		const stats: CompetitionRevenueStats = {
+			...baseStats,
+			totalRefundedCents: 5000,
+			byDivision: [
+				{...baseStats.byDivision[0]!, refundedCents: 5000},
+				{...baseStats.byDivision[1]!, refundedCents: 0},
+			],
+		}
+		render(<RevenueStatsDisplay stats={stats} />)
+		expect(screen.getByRole("columnheader", { name: /Refunds/i })).toBeInTheDocument()
+	})
+
+	it("shows the refund amount per division row", () => {
+		const stats: CompetitionRevenueStats = {
+			...baseStats,
+			totalRefundedCents: 5000,
+			byDivision: [
+				{...baseStats.byDivision[0]!, refundedCents: 5000},
+				{...baseStats.byDivision[1]!, refundedCents: 0},
+			],
+		}
+		render(<RevenueStatsDisplay stats={stats} />)
+		const rxRow = screen.getByText("RX").closest("tr") as HTMLElement
+		expect(rxRow).not.toBeNull()
+		expect(within(rxRow).getByText(/-?\$50\.00/)).toBeInTheDocument()
+	})
+
+	it("subtracts refunds from the per-division Net cell", () => {
+		// RX organizer net is $181.70 before refunds, $50 refunded → $131.70
+		// after refunds. The Net column reflects the post-refund number so the
+		// organizer doesn't have to compute it themselves.
+		const stats: CompetitionRevenueStats = {
+			...baseStats,
+			totalRefundedCents: 5000,
+			byDivision: [
+				{...baseStats.byDivision[0]!, refundedCents: 5000},
+				{...baseStats.byDivision[1]!, refundedCents: 0},
+			],
+		}
+		render(<RevenueStatsDisplay stats={stats} />)
+		const rxRow = screen.getByText("RX").closest("tr") as HTMLElement
+		expect(within(rxRow).getByText("$131.70")).toBeInTheDocument()
+	})
+
+	it("subtracts refunds from the top-level Your Net Revenue card", () => {
+		// $272.50 net pre-refund, $50 refunded → $222.50
+		const stats: CompetitionRevenueStats = {
+			...baseStats,
+			totalRefundedCents: 5000,
+			byDivision: [
+				{...baseStats.byDivision[0]!, refundedCents: 5000},
+				{...baseStats.byDivision[1]!, refundedCents: 0},
+			],
+		}
+		render(<RevenueStatsDisplay stats={stats} />)
+		// The post-refund net appears in two places (the summary card and the
+		// fee breakdown card) so any > 0 is sufficient to pin the contract.
+		expect(screen.getAllByText("$222.50").length).toBeGreaterThan(0)
+	})
+
+	it("renders a 'Refunds' line in the fee breakdown card", () => {
+		const stats: CompetitionRevenueStats = {
+			...baseStats,
+			totalRefundedCents: 5000,
+		}
+		render(<RevenueStatsDisplay stats={stats} />)
+		// Line label appears in the breakdown card alongside Stripe Processing
+		// and Platform Fee.
+		expect(screen.getAllByText(/Refunds/i).length).toBeGreaterThan(0)
+	})
+})

--- a/apps/wodsmith-start/test/server-fns/competition-detail-fns.refunds.test.ts
+++ b/apps/wodsmith-start/test/server-fns/competition-detail-fns.refunds.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Tests for refund-aware loader fields on getOrganizerRegistrationsFn.
+ *
+ * The loader returns a `refundsByPurchaseId` map so the athletes page can
+ * render "Refunded" / "Partially refunded" badges. The pure rollup function
+ * is extracted from the server fn for direct testing — the surrounding fetch
+ * code is a thin passthrough.
+ */
+import {describe, expect, it} from "vitest"
+import {computeRefundsByPurchase} from "@/server-fns/competition-detail-fns"
+
+describe("computeRefundsByPurchase", () => {
+	it("returns an empty map when there are no refund events", () => {
+		const result = computeRefundsByPurchase(
+			[],
+			new Map([["p1", 10000]]),
+		)
+		expect(result).toEqual({})
+	})
+
+	it("sums refund event amounts per purchase as positive cents", () => {
+		// Refund events store amountCents as negative (sign convention) but the
+		// UI expects positive cents — the pure function must normalize.
+		const result = computeRefundsByPurchase(
+			[
+				{purchaseId: "p1", amountCents: -3000},
+				{purchaseId: "p1", amountCents: -2000},
+			],
+			new Map([["p1", 10000]]),
+		)
+		expect(result).toEqual({
+			p1: {refundedCents: 5000, totalCents: 10000},
+		})
+	})
+
+	it("attaches the purchase totalCents so the UI can detect full refunds", () => {
+		// "Fully refunded" vs "Partially refunded" is decided client-side from
+		// (refundedCents, totalCents) — verifying the totalCents passes through
+		// pins the contract.
+		const result = computeRefundsByPurchase(
+			[{purchaseId: "p1", amountCents: -10000}],
+			new Map([["p1", 10000]]),
+		)
+		expect(result.p1?.totalCents).toBe(10000)
+	})
+
+	it("ignores refund events for purchases not in the totals map", () => {
+		// Defensive: an orphaned event from a deleted purchase should not crash
+		// or insert a meaningless entry.
+		const result = computeRefundsByPurchase(
+			[
+				{purchaseId: "p1", amountCents: -5000},
+				{purchaseId: "p-orphan", amountCents: -9999},
+			],
+			new Map([["p1", 10000]]),
+		)
+		expect(result).toEqual({
+			p1: {refundedCents: 5000, totalCents: 10000},
+		})
+		expect(result["p-orphan"]).toBeUndefined()
+	})
+
+	it("handles multiple purchases independently", () => {
+		const result = computeRefundsByPurchase(
+			[
+				{purchaseId: "p1", amountCents: -2000},
+				{purchaseId: "p2", amountCents: -5000},
+				{purchaseId: "p2", amountCents: -3000},
+			],
+			new Map([
+				["p1", 10000],
+				["p2", 8000],
+			]),
+		)
+		expect(result).toEqual({
+			p1: {refundedCents: 2000, totalCents: 10000},
+			p2: {refundedCents: 8000, totalCents: 8000},
+		})
+	})
+})

--- a/apps/wodsmith-start/test/server/commerce/fee-calculator-refunds.test.ts
+++ b/apps/wodsmith-start/test/server/commerce/fee-calculator-refunds.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for refund-aware revenue aggregation.
+ *
+ * The pure aggregation function is what powers the Organizer Revenue page.
+ * Refunds are sourced from REFUND_INITIATED financial events (negative
+ * amountCents) and rolled up per-division and at the competition level so the
+ * page can show a "Refunds" column and adjust net revenue.
+ */
+import {describe, expect, it} from "vitest"
+import {
+	aggregateRevenueStats,
+	type RevenueStatsInput,
+} from "@/server/commerce/fee-calculator"
+
+const purchase = (overrides: Partial<RevenueStatsInput["purchases"][number]>) => ({
+	purchaseId: "p1",
+	divisionId: "div-rx",
+	totalCents: 10000,
+	platformFeeCents: 600,
+	stripeFeeCents: 320,
+	organizerNetCents: 9080,
+	...overrides,
+})
+
+describe("aggregateRevenueStats", () => {
+	describe("with no refunds", () => {
+		it("returns zero refund totals at the top level", () => {
+			const stats = aggregateRevenueStats({
+				purchases: [purchase({})],
+				refundEvents: [],
+				divisionLabels: new Map([["div-rx", "RX"]]),
+				divisionFees: new Map([["div-rx", 10000]]),
+				defaultFeeCents: 0,
+			})
+
+			expect(stats.totalRefundedCents).toBe(0)
+		})
+
+		it("returns zero refundedCents per division", () => {
+			const stats = aggregateRevenueStats({
+				purchases: [purchase({})],
+				refundEvents: [],
+				divisionLabels: new Map([["div-rx", "RX"]]),
+				divisionFees: new Map([["div-rx", 10000]]),
+				defaultFeeCents: 0,
+			})
+
+			expect(stats.byDivision[0]?.refundedCents).toBe(0)
+		})
+	})
+
+	describe("with a single full refund", () => {
+		// Two RX purchases (one fully refunded, one paid). Refund amount equals
+		// the purchase total so "Net after refunds" should drop by exactly that
+		// amount.
+		const input: RevenueStatsInput = {
+			purchases: [
+				purchase({purchaseId: "p1", totalCents: 10000, organizerNetCents: 9080}),
+				purchase({purchaseId: "p2", totalCents: 10000, organizerNetCents: 9080}),
+			],
+			refundEvents: [
+				{purchaseId: "p1", amountCents: -10000}, // full refund
+			],
+			divisionLabels: new Map([["div-rx", "RX"]]),
+			divisionFees: new Map([["div-rx", 10000]]),
+			defaultFeeCents: 0,
+		}
+
+		it("sums refund amounts at the top level (absolute value)", () => {
+			const stats = aggregateRevenueStats(input)
+			expect(stats.totalRefundedCents).toBe(10000)
+		})
+
+		it("attributes the refund to the same division as the original purchase", () => {
+			const stats = aggregateRevenueStats(input)
+			const rx = stats.byDivision.find((d) => d.divisionId === "div-rx")
+			expect(rx?.refundedCents).toBe(10000)
+		})
+
+		it("leaves organizerNetCents at the pre-refund value (refund subtraction is a UI concern)", () => {
+			// The page subtracts refunds from net for the displayed "Net Revenue"
+			// number — but the field itself stays semantically "what we collected
+			// minus fees, before refunds" so it still reconciles with the
+			// per-purchase organizerNetCents column on the purchases ledger.
+			const stats = aggregateRevenueStats(input)
+			expect(stats.totalOrganizerNetCents).toBe(18160)
+			const rx = stats.byDivision.find((d) => d.divisionId === "div-rx")
+			expect(rx?.organizerNetCents).toBe(18160)
+		})
+	})
+
+	describe("with partial refunds across divisions", () => {
+		// Two divisions: RX (one purchase, $50 partial refund) and Scaled (one
+		// purchase, no refund). Each refund event MUST land in the correct
+		// division bucket — refunds attributed to a different division would
+		// silently distort the per-division totals.
+		const input: RevenueStatsInput = {
+			purchases: [
+				purchase({
+					purchaseId: "p-rx",
+					divisionId: "div-rx",
+					totalCents: 10000,
+					organizerNetCents: 9080,
+				}),
+				purchase({
+					purchaseId: "p-scaled",
+					divisionId: "div-scaled",
+					totalCents: 8000,
+					platformFeeCents: 520,
+					stripeFeeCents: 262,
+					organizerNetCents: 7218,
+				}),
+			],
+			refundEvents: [{purchaseId: "p-rx", amountCents: -5000}],
+			divisionLabels: new Map([
+				["div-rx", "RX"],
+				["div-scaled", "Scaled"],
+			]),
+			divisionFees: new Map([
+				["div-rx", 10000],
+				["div-scaled", 8000],
+			]),
+			defaultFeeCents: 0,
+		}
+
+		it("attributes refunds only to the division that owns the purchase", () => {
+			const stats = aggregateRevenueStats(input)
+			const rx = stats.byDivision.find((d) => d.divisionId === "div-rx")
+			const scaled = stats.byDivision.find((d) => d.divisionId === "div-scaled")
+			expect(rx?.refundedCents).toBe(5000)
+			expect(scaled?.refundedCents).toBe(0)
+		})
+
+		it("rolls all refund amounts up into totalRefundedCents", () => {
+			const stats = aggregateRevenueStats(input)
+			expect(stats.totalRefundedCents).toBe(5000)
+		})
+	})
+
+	describe("with multiple partial refunds on the same purchase", () => {
+		// $100 purchase with two partial refunds that together equal the total —
+		// must sum to a single $100 refund attribution, not double-count.
+		const input: RevenueStatsInput = {
+			purchases: [
+				purchase({
+					purchaseId: "p-multi",
+					divisionId: "div-rx",
+					totalCents: 10000,
+					organizerNetCents: 9080,
+				}),
+			],
+			refundEvents: [
+				{purchaseId: "p-multi", amountCents: -3000},
+				{purchaseId: "p-multi", amountCents: -7000},
+			],
+			divisionLabels: new Map([["div-rx", "RX"]]),
+			divisionFees: new Map([["div-rx", 10000]]),
+			defaultFeeCents: 0,
+		}
+
+		it("sums multiple refund events on the same purchase", () => {
+			const stats = aggregateRevenueStats(input)
+			const rx = stats.byDivision.find((d) => d.divisionId === "div-rx")
+			expect(rx?.refundedCents).toBe(10000)
+			expect(stats.totalRefundedCents).toBe(10000)
+		})
+	})
+
+	describe("with refund events for purchases not in the input", () => {
+		// Defensive: if a refund event references a purchaseId that isn't in the
+		// purchases list (e.g. from a soft-deleted/cancelled purchase), the
+		// rollup should ignore it rather than crash or attribute it to "Unknown".
+		const input: RevenueStatsInput = {
+			purchases: [
+				purchase({purchaseId: "p1", divisionId: "div-rx", totalCents: 10000}),
+			],
+			refundEvents: [
+				{purchaseId: "p1", amountCents: -2000},
+				{purchaseId: "p-orphan", amountCents: -9999},
+			],
+			divisionLabels: new Map([["div-rx", "RX"]]),
+			divisionFees: new Map([["div-rx", 10000]]),
+			defaultFeeCents: 0,
+		}
+
+		it("ignores refund events for unknown purchases", () => {
+			const stats = aggregateRevenueStats(input)
+			expect(stats.totalRefundedCents).toBe(2000)
+			const rx = stats.byDivision.find((d) => d.divisionId === "div-rx")
+			expect(rx?.refundedCents).toBe(2000)
+		})
+	})
+})

--- a/lat.md/organizer-dashboard.md
+++ b/lat.md/organizer-dashboard.md
@@ -186,6 +186,8 @@ Displays financial statistics for the competition including total revenue, platf
 
 Fetches revenue stats and Stripe connection status in parallel. Uses `RevenueStatsDisplay` component.
 
+Refunds are surfaced as a separate row/column. [[apps/wodsmith-start/src/server/commerce/fee-calculator.ts#getCompetitionRevenueStats]] sums REFUND_INITIATED financial events per purchase, attributes each to the purchase's division, and returns `totalRefundedCents` plus `byDivision[].refundedCents`. The display then shows a "Refunds" line in the fee-breakdown card and a "Refunds" column in the per-division table when any refund exists. "Your Net Revenue" is `totalOrganizerNetCents − totalRefundedCents` because refunds use `reverse_transfer` (organizer's account funds them) while the platform fee stays (`refund_application_fee: false`); only the refunded principal reduces organizer net. The pre-refund `organizerNetCents` field is preserved on each row so it still reconciles with per-purchase ledger totals — the post-refund Net is computed in the component, not the loader.
+
 ## Coupons
 
 Discount codes that reduce registration fees for athletes.

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -121,7 +121,7 @@ The Stripe idempotency key MUST stay stable across client retries; otherwise Str
 
 Callers can pass an `idempotencyToken` (UUID generated on click, replayed on timeout retry) — the key becomes `refund:${token}`. When omitted, the key is `refund:${purchaseId}:${requestedAmountCents}`, which is retry-safe for the full-refund path because the remaining-balance check rejects the retry before reaching Stripe but cannot distinguish two intentional partial refunds of the same amount. Partial-refund callers should always supply a token.
 
-The athletes loader returns `canRefund` (team capability) and `refundedPurchaseIds` (purchases with any prior refund) so the dropdown surface stays accurate. Once partial refunds are exposed in the UI, the loader should expose remaining balance instead of a binary refunded set.
+The athletes loader [[apps/wodsmith-start/src/server-fns/competition-detail-fns.ts#getOrganizerRegistrationsFn]] returns `canRefund` (team capability) and `refundsByPurchaseId` — a `Record<purchaseId, {refundedCents, totalCents}>` keyed off REFUND_INITIATED events. The loader uses INITIATED rather than INITIATED + COMPLETED so the totals don't double-count once Stripe's webhook lands. Per-purchase refund summaries let the athletes UI render a [[apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/refund-status-badge.tsx#RefundStatusBadge]] ("Refunded" when `refundedCents ≥ totalCents`, "Partially refunded ($X)" otherwise) and gate the dropdown's "Refund Registration" item on whether any refund is recorded.
 
 ## Division Transfer
 


### PR DESCRIPTION
## Summary

- **Athletes list**: new `RefundStatusBadge` renders **Refunded** (full) or **Partially refunded ($X.XX)** (partial) in both the mobile-card and desktop-table views, so organizers can see at a glance which registrations have been refunded.
- **Revenue page**: new **Refunds** line in the Fee Breakdown card and a **Refunds** column in the per-division table — both only render when refunds exist, so healthy comps don't grow a confusing zero column. Top-level "Your Net Revenue", the breakdown card's net, and the per-division Net column all subtract refunded principal only (platform fee stays since `refund_application_fee:false`).
- **Server**: `aggregateRevenueStats` extracted as a pure function (DB wrapper is now a thin passthrough), and `getOrganizerRegistrationsFn` now returns `refundsByPurchaseId: Record<id, {refundedCents, totalCents}>` in place of the binary `refundedPurchaseIds` set so the UI can detect partial vs full refunds. Both paths count `REFUND_INITIATED` only — not `REFUND_INITIATED + REFUND_COMPLETED` — to avoid double-counting once Stripe's `charge.refunded` webhook lands.

## TDD

25 new tests across 4 files (RED → GREEN), all passing alongside the existing 103 `registration-fns` tests:

- `test/server/commerce/fee-calculator-refunds.test.ts` — 9 tests for `aggregateRevenueStats` (no refunds, full, partial, multi-division attribution, multi-event same purchase, orphan events)
- `test/server-fns/competition-detail-fns.refunds.test.ts` — 5 tests for the `computeRefundsByPurchase` helper
- `test/components/refund-status-badge.test.tsx` — 5 tests for the badge variants
- `test/components/revenue-stats-display.test.tsx` — 6 tests for the revenue display refund handling (column header, per-division row, post-refund Net cards, breakdown line)

## Test plan

- [ ] On a Stripe Express test competition, refund a paid registration in full → "Refunded" red badge appears on the row in both mobile and desktop views
- [ ] Refund a paid registration partially (e.g. $30 of $100) → "Partially refunded ($30.00)" orange badge appears
- [ ] Open the Revenue page on the same competition → "Refunds" column appears in the per-division table with the correct division's row showing `-$X.XX`
- [ ] "Your Net Revenue" (top card) drops by the refunded principal but the platform/Stripe fees on that purchase stay accounted for
- [ ] Fee Breakdown card shows a new "Refunds" line below "Platform Fee"
- [ ] On a competition with no refunds, the page renders unchanged (no "Refunds" column or line)
- [ ] After issuing a refund, `router.invalidate()` refreshes the loader so the badge appears without a hard reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add refund visibility across the organizer UI: badges on the Athletes list and refunds on the Revenue page, with per-division attribution and post-refund net revenue. This helps organizers quickly see full vs partial refunds and how they affect payouts.

- **New Features**
  - Athletes list: added RefundStatusBadge — shows “Refunded” (full) or “Partially refunded ($X.XX)” — in both mobile cards and desktop rows.
  - Revenue page: added a Refunds line in the Fee Breakdown and a Refunds column in the per-division table (rendered only when refunds exist). Net Revenue subtracts refunded principal only; platform/Stripe fees remain.

- **Refactors**
  - Extracted aggregateRevenueStats as a pure function; `getCompetitionRevenueStats` now returns `totalRefundedCents` and per-division `refundedCents`.
  - `getOrganizerRegistrationsFn` now returns `refundsByPurchaseId: Record<purchaseId, { refundedCents, totalCents }>` (replaces `refundedPurchaseIds`) to drive badges and gate the refund action.
  - Refund totals are sourced from `REFUND_INITIATED` events only to avoid double-counting with later completion webhooks; amounts are normalized to positive cents.

<sup>Written for commit 3965c5d91d8ce4168030a6fc616dde280ff17d2e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added refund tracking and display on organizer revenue dashboard
  * Revenue breakdown and per-division table now show refund line items and amounts
  * Athlete registration page displays refund status indicators with full/partial amounts

* **Bug Fixes**
  * Fixed net revenue calculations to properly account for refunded amounts at competition and division levels

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/452)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->