### PR TITLE
ci: pin bun to 1.3.13 in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,6 +160,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -224,6 +226,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Bun 1.3.14 segfaults on startup in the Ubuntu CI runner, breaking `bun alchemy.run.ts` before deploy can run (see run 25830555531). Pin to 1.3.13, the last version proven green on this runner.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin Bun to 1.3.13 in the deploy workflow to stop CI crashes on the Ubuntu runner and unblock deploys.

- **Bug Fixes**
  - Set `bun-version: 1.3.13` in both deploy jobs using `oven-sh/setup-bun@v2`.
  - Prevents the 1.3.14 startup segfault that breaks `bun alchemy.run.ts`.

<sup>Written for commit 38f194d04f0db2e7ab6f1c328ba1f7007b06c8b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

