### PR TITLE
ci: pin CRM deploy Bun version

### DIFF
--- a/.github/workflows/deploy-crm.yml
+++ b/.github/workflows/deploy-crm.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -58,6 +58,8 @@ CRM deploys through its own GitHub Actions workflow so app changes do not depend
 
 `.github/workflows/deploy-crm.yml` triggers on pushes to `main` that touch `apps/crm/**` or the workflow itself, and can also be run manually. It deploys `apps/crm` with Alchemy using `pnpm run crm-deploy`, binding the production app to `https://crm.wodsmith.com`.
 
+The CRM deploy workflow pins Bun to match the main WODsmith deploy workflow, avoiding unverified runtime updates during Alchemy deployment.
+
 ### packages
 
 Shared packages consumed by apps.


### PR DESCRIPTION
## Summary
- pin the CRM deploy workflow to Bun 1.3.13, matching the main WODsmith deploy workflow
- document the runtime pin in lat.md

## Why
The merged CRM deploy job installed Bun 1.3.14 and crashed before Alchemy reached app code: https://github.com/wodsmith/thewodapp/actions/runs/26344667194/job/77552470720

## Verification
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crm check
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crm type-check
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH lat check

Note: GitNexus tools were not available in this Codex session, so I verified scope with normal Git diff/status instead.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the CRM deploy workflow to `Bun` 1.3.13 to match the main deploy and prevent the 1.3.14 crash during Alchemy deployment. Adds a note about the runtime pin in `lat.md/architecture.md`.

<sup>Written for commit 3ebe1871a35e1d6cf1d36f3abf5aeda83e0e2584. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/462?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Stabilized CRM deployment pipeline by pinning the Bun runtime version, preventing unverified runtime updates during deployment and ensuring consistent build behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->