### PR TITLE
fix: pin CRM React versions

### DIFF
--- a/apps/crm/package.json
+++ b/apps/crm/package.json
@@ -30,8 +30,8 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.39.3",
     "lucide-react": "^0.544.0",
-    "react": "^19.2.3",
-    "react-dom": "^19.2.3",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
     "tailwind-merge": "^2.6.0",
     "tailwindcss": "^4.0.6",
     "zod": "^4.2.1"

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -61,6 +61,8 @@ CRM deploys through its own GitHub Actions workflow so app changes do not depend
 
 The CRM deploy workflow pins Bun to match the main WODsmith deploy workflow, avoiding unverified runtime updates during Alchemy deployment.
 
+CRM pins `react` and `react-dom` to identical exact versions because Cloudflare Worker upload validation rejects bundles with mismatched React package versions.
+
 ### packages
 
 Shared packages consumed by apps.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,13 @@ importers:
         version: 4.1.18(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))
       '@tanstack/react-router':
         specifier: ^1.132.0
-        version: 1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+        version: 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start':
         specifier: ^1.132.0
-        version: 1.145.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
+        version: 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)
       alchemy:
         specifier: 'catalog:'
-        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
+        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -59,13 +59,13 @@ importers:
         version: 0.39.3(@cloudflare/workers-types@4.20251205.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(mysql2@3.16.2)
       lucide-react:
         specifier: ^0.544.0
-        version: 0.544.0(react@19.2.4)
+        version: 0.544.0(react@19.2.3)
       react:
-        specifier: ^19.2.3
-        version: 19.2.4
+        specifier: 19.2.3
+        version: 19.2.3
       react-dom:
-        specifier: ^19.2.3
-        version: 19.2.3(react@19.2.4)
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0


### PR DESCRIPTION
## Summary
- pin CRM react and react-dom to the same exact version
- update the CRM lockfile importer so TanStack/Alchemy resolve against that same React version
- document the deploy constraint in lat.md

## Why
Cloudflare Worker validation rejects the CRM bundle when react and react-dom resolve to different patch versions. The failed deploy saw react 19.2.4 with react-dom 19.2.3.

## Verification
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crm check
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crm type-check
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crm build
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH lat check
- node -p "require('./apps/crm/node_modules/react/package.json').version + ' / ' + require('./apps/crm/node_modules/react-dom/package.json').version" => 19.2.3 / 19.2.3

Note: the local build completed successfully, but Wrangler could not write its debug log under ~/Library/Preferences in the sandbox. That log-write EPERM did not change the build exit code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins CRM `react` and `react-dom` to the exact same version (19.2.3) to prevent Cloudflare Worker deploy rejections from mismatched React versions. Lockfile updates ensure all React consumers resolve to 19.2.3 and the deploy constraint is documented.

- **Bug Fixes**
  - Pin `react` and `react-dom` to `19.2.3` in `apps/crm/package.json` (no caret).
  - Align lockfile so `@tanstack/react-router`, `@tanstack/react-start`, and `alchemy` resolve against `react@19.2.3`.
  - Add `lat.md/architecture.md` note explaining CRM requires identical React package versions.

<sup>Written for commit 324dfef11e9628c5c7f99d4c6977bc3aaf52d134. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/466?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

