### PR TITLE
fix: use fresh CI database URL for Hyperdrive

### DIFF
--- a/apps/wodsmith-start/alchemy.run.ts
+++ b/apps/wodsmith-start/alchemy.run.ts
@@ -254,6 +254,27 @@ const psPassword = await PlanetScalePassword(`ps-password-${stage}`, {
   role: "admin",
 })
 
+const ciDatabaseUrl = process.env.DATABASE_URL
+  ? new URL(process.env.DATABASE_URL)
+  : undefined
+const hyperdriveOrigin = ciDatabaseUrl
+  ? {
+      host: ciDatabaseUrl.hostname,
+      database: ciDatabaseUrl.pathname.slice(1),
+      user: decodeURIComponent(ciDatabaseUrl.username),
+      password: decodeURIComponent(ciDatabaseUrl.password),
+      port: ciDatabaseUrl.port ? Number(ciDatabaseUrl.port) : 3306,
+      scheme: "mysql" as const,
+    }
+  : {
+      host: psPassword.host,
+      database: psDbName,
+      user: psPassword.username,
+      password: psPassword.password.unencrypted,
+      port: 3306,
+      scheme: "mysql" as const,
+    }
+
 /**
  * Cloudflare Hyperdrive for PlanetScale connection pooling and caching.
  *
@@ -266,14 +287,10 @@ const psPassword = await PlanetScalePassword(`ps-password-${stage}`, {
  * which exposes a `connectionString` for use with standard MySQL drivers (mysql2).
  */
 const hyperdrive = await Hyperdrive(`hyperdrive-${stage}`, {
-  origin: {
-    host: psPassword.host,
-    database: psDbName,
-    user: psPassword.username,
-    password: psPassword.password.unencrypted,
-    port: 3306,
-    scheme: "mysql",
-  },
+  // CI creates a fresh PlanetScale branch password before deploy and verifies it
+  // with drizzle-kit. Prefer that URL so stale Alchemy password state cannot
+  // make Cloudflare reject Hyperdrive updates during credential validation.
+  origin: hyperdriveOrigin,
   caching: {
     disabled: true,
   },


### PR DESCRIPTION
## Summary
- prefer the workflow-provided DATABASE_URL when building the Hyperdrive origin
- keep the Alchemy PlanetScalePassword resource declared as a fallback for deploys without DATABASE_URL
- add deploy context explaining why fresh CI credentials avoid stale password validation failures

## Context
The demo deploy still failed after reverting the dev Hyperdrive origin because Alchemy skipped ps-password-demo and reused stale PlanetScale password state. Cloudflare validates the Hyperdrive origin during updates and rejects the stale user with MySQL 1045.

Failing run after the revert: https://github.com/wodsmith/thewodapp/actions/runs/26346166388
Original failing run: https://github.com/wodsmith/thewodapp/actions/runs/26345481944/job/77554571710

## Validation
- pnpm --filter wodsmith-start type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Build Cloudflare `Hyperdrive` origin from the CI `DATABASE_URL` to use fresh PlanetScale credentials and avoid MySQL 1045 validation failures. Fall back to Alchemy `PlanetScalePassword` when no `DATABASE_URL`, with a brief deploy note on stale-password rejections.

<sup>Written for commit 97394cdb76db861776725877332e655391ae94f7. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/467?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

