### PR TITLE
fix: pass explicit API token to AI Gateway

### DIFF
--- a/apps/wodsmith-start/alchemy.run.ts
+++ b/apps/wodsmith-start/alchemy.run.ts
@@ -562,6 +562,7 @@ const aiGateway =
         gatewayName: `wodsmith-${stage}`,
         collectLogs: true,
         cacheTtl: 0,
+        apiToken: alchemy.secret(process.env.CLOUDFLARE_API_TOKEN!),
       })
 const aiGatewayName = aiGateway?.id ?? "wodsmith-gateway"
 


### PR DESCRIPTION
## Summary
- pass the Cloudflare API token explicitly to the Alchemy AiGateway resource
- keep the token wrapped with alchemy.secret so it is treated as secret material

## Context
After the Hyperdrive credential fix, demo deploy progressed to creating ai-gateway-demo and failed with:

> ai gateway get requires API token authentication. OAuth tokens from 'wrangler login' don't support this operation.

The deploy job already exposes CLOUDFLARE_API_TOKEN, so this makes the dependency explicit for the AiGateway resource.

Failing run: https://github.com/wodsmith/thewodapp/actions/runs/26346376394

## Validation
- pnpm --filter wodsmith-start type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the Cloudflare API token (`CLOUDFLARE_API_TOKEN`) explicitly to the AiGateway resource and wrap it with `alchemy.secret` so it’s treated as a secret. This switches the gateway to token auth in CI and fixes the demo deploy error: "ai gateway get requires API token authentication."

<sup>Written for commit 6376800d0861935891b5cc1c64b265c3b8311181. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/468?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

