### PR TITLE
ci: prepare database URL for manual deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -167,10 +167,41 @@ jobs:
         run: pnpm install --frozen-lockfile
         working-directory: .
 
+      - name: Setup pscale
+        uses: planetscale/setup-pscale-action@v1
+
+      - name: Generate PlanetScale branch password
+        env:
+          PLANETSCALE_SERVICE_TOKEN_ID: ${{ secrets.PLANETSCALE_SERVICE_TOKEN_ID }}
+          PLANETSCALE_SERVICE_TOKEN: ${{ secrets.PLANETSCALE_SERVICE_TOKEN }}
+        run: |
+          branch="${STAGE}"
+          if [ "$branch" = "prod" ]; then
+            branch="main"
+          fi
+
+          response=$(pscale password create ${{ secrets.PLANETSCALE_DATABASE_NAME }} "$branch" "" -f json --org ${{ secrets.PLANETSCALE_ORGANIZATION }})
+
+          id=$(echo "$response" | jq -r '.id')
+          host=$(echo "$response" | jq -r '.access_host_url')
+          username=$(echo "$response" | jq -r '.username')
+          password=$(echo "$response" | jq -r '.plain_text')
+          echo "PASSWORD_ID=$id" >> $GITHUB_ENV
+          database_url="mysql://$username:$password@$host/${{ secrets.PLANETSCALE_DATABASE_NAME }}"
+          echo "DATABASE_URL=$database_url" >> $GITHUB_ENV
+          echo "::add-mask::$database_url"
+
+      - name: Push schema to PlanetScale branch
+        run: pnpm --filter wodsmith-start exec drizzle-kit push
+        working-directory: .
+        env:
+          DATABASE_URL: ${{ env.DATABASE_URL }}
+
       - name: Deploy with Alchemy
         run: pnpm run deploy
         env:
           STAGE: ${{ env.STAGE }}
+          DATABASE_URL: ${{ env.DATABASE_URL }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           ALCHEMY_PASSWORD: ${{ secrets.ALCHEMY_PASSWORD }}


### PR DESCRIPTION
## Summary
- generate a fresh PlanetScale branch password in the workflow_dispatch deploy path
- use branch main for prod and the selected stage name for non-prod deploys
- push schema using the generated DATABASE_URL before Alchemy deploy
- pass DATABASE_URL into Alchemy so manual deploys use fresh Hyperdrive origin credentials

## Context
Manual deploys were using the generic deploy job, which did not set DATABASE_URL or PASSWORD_ID. That made alchemy.run.ts fall back to stale Alchemy-managed PlanetScale password credentials and Hyperdrive failed with MySQL 1045.

Failing manual run: https://github.com/wodsmith/thewodapp/actions/runs/26346717532/job/77557753988

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml'); puts 'deploy.yml parses'"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD deployment workflow to provision and utilize branch-specific database instances for schema management and runtime deployment. Enhanced environment variable configuration to include database connection details during deployment processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->