### PR TITLE
ci: pass AI Gateway runtime tokens to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,6 +218,7 @@ jobs:
           # AI configuration (optional)
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+          CF_AIG_TOKEN: ${{ env.STAGE == 'prod' && secrets.CF_AIG_TOKEN_PROD || secrets.CF_AIG_TOKEN_DEMO }}
           # Stripe secrets - prod and demo get their respective keys
           STRIPE_API_KEY: ${{ env.STAGE == 'prod' && secrets.STRIPE_SECRET_KEY || (env.STAGE == 'demo' && secrets.STRIPE_SECRET_KEY_DEMO || '') }}
           STRIPE_SECRET_KEY: ${{ env.STAGE == 'prod' && secrets.STRIPE_SECRET_KEY || (env.STAGE == 'demo' && secrets.STRIPE_SECRET_KEY_DEMO || '') }}
@@ -310,6 +311,7 @@ jobs:
           # AI configuration (optional)
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
+          CF_AIG_TOKEN: ${{ secrets.CF_AIG_TOKEN_DEMO }}
           # Both point to same secret - STRIPE_API_KEY is for Alchemy webhook creation,
           # STRIPE_SECRET_KEY is for runtime API calls
           STRIPE_API_KEY: ${{ secrets.STRIPE_SECRET_KEY_DEMO }}


### PR DESCRIPTION
## Summary
- pass CF_AIG_TOKEN_PROD for manual prod deploys
- pass CF_AIG_TOKEN_DEMO for manual demo deploys and push-to-main demo deploys
- keep runtime AI Gateway credentials separate from the broader Cloudflare deploy token

## Required secrets
- CF_AIG_TOKEN_DEMO
- CF_AIG_TOKEN_PROD

## Context
The latest deploy successfully updated Hyperdrive and created ai-gateway-demo, then failed because alchemy.run.ts binds CF_AIG_TOKEN with alchemy.secret(process.env.CF_AIG_TOKEN!), but the workflow did not provide that env var.

Failing run: https://github.com/wodsmith/thewodapp/actions/runs/26351392372/job/77570250603

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml'); puts 'deploy.yml parses'"