### PR TITLE
ci: increase deploy build heap

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,6 +200,7 @@ jobs:
       - name: Deploy with Alchemy
         run: pnpm run deploy
         env:
+          NODE_OPTIONS: --max-old-space-size=5120
           STAGE: ${{ env.STAGE }}
           DATABASE_URL: ${{ env.DATABASE_URL }}
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -294,6 +295,7 @@ jobs:
       - name: Deploy with Alchemy
         run: pnpm run deploy
         env:
+          NODE_OPTIONS: --max-old-space-size=5120
           STAGE: demo
           CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- set NODE_OPTIONS=--max-old-space-size=5120 for both Alchemy deploy steps
- let the Vite build spawned by Alchemy use more heap in GitHub Actions

## Context
The latest deploy cleared Hyperdrive, AI Gateway, and runtime token setup, then failed while rendering the SSR Vite build with:

> FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory

Failing run: https://github.com/wodsmith/thewodapp/actions/runs/26353009692

## Validation
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml'); puts 'deploy.yml parses'"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set NODE_OPTIONS=--max-old-space-size=5120 for both Alchemy deploy steps so the `Vite` SSR build has enough memory in GitHub Actions. Prevents OOM failures during deploy.

<sup>Written for commit f746d14020e86befc5dd32a822e7ea47639e5383. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/472?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

