### PR TITLE
fix: use Cloudflare AI Gateway binding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -219,7 +219,6 @@ jobs:
           # AI configuration (optional)
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-          CF_AIG_TOKEN: ${{ env.STAGE == 'prod' && secrets.CF_AIG_TOKEN_PROD || secrets.CF_AIG_TOKEN_DEMO }}
           # Stripe secrets - prod and demo get their respective keys
           STRIPE_API_KEY: ${{ env.STAGE == 'prod' && secrets.STRIPE_SECRET_KEY || (env.STAGE == 'demo' && secrets.STRIPE_SECRET_KEY_DEMO || '') }}
           STRIPE_SECRET_KEY: ${{ env.STAGE == 'prod' && secrets.STRIPE_SECRET_KEY || (env.STAGE == 'demo' && secrets.STRIPE_SECRET_KEY_DEMO || '') }}
@@ -313,7 +312,6 @@ jobs:
           # AI configuration (optional)
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           BRAINTRUST_API_KEY: ${{ secrets.BRAINTRUST_API_KEY }}
-          CF_AIG_TOKEN: ${{ secrets.CF_AIG_TOKEN_DEMO }}
           # Both point to same secret - STRIPE_API_KEY is for Alchemy webhook creation,
           # STRIPE_SECRET_KEY is for runtime API calls
           STRIPE_API_KEY: ${{ secrets.STRIPE_SECRET_KEY_DEMO }}

--- a/apps/wodsmith-start/.dev.vars.example
+++ b/apps/wodsmith-start/.dev.vars.example
@@ -25,9 +25,7 @@ VITE_APP_URL=http://localhost:5173
 ### Cloudflare AI Gateway
 # Required by the AI judge-scheduling agent (and any future AI features)
 # to route traffic through the managed gateway in alchemy.run.ts.
-# Create a token at https://dash.cloudflare.com/profile/api-tokens
-# with the "Workers AI" + "AI Gateway" permissions.
-CF_AIG_TOKEN=
+# Requests use the Cloudflare AI binding, so no runtime API token is needed.
 
 ### Other Cloudflare-specific secrets can be added here
 # TURNSTILE_SECRET_KEY=

--- a/apps/wodsmith-start/alchemy.run.ts
+++ b/apps/wodsmith-start/alchemy.run.ts
@@ -674,9 +674,6 @@ const website = await TanStackStart("app", {
       process.env.CLOUDFLARE_ACCOUNT_ID ??
       "317fb84f366ea1ab038ca90000953697",
     CF_AIG_GATEWAY: aiGatewayName,
-    /** CF API token with AI Gateway run permission. Required by the gateway provider. */
-    CF_AIG_TOKEN: alchemy.secret(process.env.CF_AIG_TOKEN!),
-
     // App configuration
     // biome-ignore lint/style/noNonNullAssertion: Required env vars validated at deploy time
     APP_URL: process.env.APP_URL!,

--- a/apps/wodsmith-start/src/agents/judge-scheduler-agent.ts
+++ b/apps/wodsmith-start/src/agents/judge-scheduler-agent.ts
@@ -185,10 +185,14 @@ export class JudgeSchedulerAgent extends Agent<Env, AgentState> {
       // Route all AI traffic through the Cloudflare AI Gateway so we get
       // logs/analytics/caching in the dashboard and a single integration
       // point for adding non-CF providers later (OpenAI, Anthropic, etc).
+      const gatewayBinding = this.env.AI.gateway(this.env.CF_AIG_GATEWAY)
       const aiGateway = createAiGateway({
-        accountId: this.env.CF_ACCOUNT_ID,
-        gateway: this.env.CF_AIG_GATEWAY,
-        apiKey: this.env.CF_AIG_TOKEN,
+        binding: {
+          run: (data) =>
+            gatewayBinding.run(
+              data as Parameters<typeof gatewayBinding.run>[0],
+            ),
+        },
       })
       const unified = createUnified()
       this.#abortController = new AbortController()

--- a/apps/wodsmith-start/src/types/env.d.ts
+++ b/apps/wodsmith-start/src/types/env.d.ts
@@ -22,8 +22,6 @@ declare global {
       CF_ACCOUNT_ID: string
       /** AI Gateway name from alchemy.run.ts */
       CF_AIG_GATEWAY: string
-      /** API token with AI Gateway permission */
-      CF_AIG_TOKEN: string
     }
   }
 }


### PR DESCRIPTION
## Summary
- route judge-scheduler AI requests through the Cloudflare AI Gateway binding instead of the HTTP/API-key path
- remove the runtime CF_AIG_TOKEN secret binding and workflow env entries
- update local env docs to note that the AI binding handles runtime authentication

## Context
The app deployed successfully, but runtime AI calls through AI Gateway returned Workers AI HTTP 401 authentication errors. The ai-gateway-provider README recommends the Cloudflare AI binding path for Workers runtime because it uses a pre-authenticated pipeline and does not require a Cloudflare API token.

Observed gateway response:

```json
{ "errors": [{ "code": 10000, "message": "Authentication error" }], "success": false }
```

## Validation
- pnpm --filter wodsmith-start type-check
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy.yml'); puts 'deploy.yml parses'"


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route judge-scheduler requests through the Cloudflare AI Gateway binding to fix Workers AI 401s and remove the need for a runtime `CF_AIG_TOKEN`. This uses the pre-authenticated binding path for runtime calls.

- **Bug Fixes**
  - Switched to `this.env.AI.gateway(this.env.CF_AIG_GATEWAY)` and passed the binding to the AI gateway client.
  - Removed `CF_AIG_TOKEN` from workflow env, `.dev.vars.example`, and `env.d.ts`.
  - Updated local env docs to note the binding handles authentication.

- **Migration**
  - No runtime token needed now; remove `CF_AIG_TOKEN` from local `.dev.vars` and any secrets.
  - Ensure the `CF_AIG_GATEWAY` binding is configured in the Worker.

<sup>Written for commit 6bce5caefeedbcb712e3eb412469e94d96129bca. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/473?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined Cloudflare AI Gateway integration by removing the separate API token requirement and using native bindings for simpler configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->