### PR TITLE
Add CRM gym, contact, and interaction pages

### DIFF
--- a/apps/crm/alchemy.run.ts
+++ b/apps/crm/alchemy.run.ts
@@ -19,7 +19,7 @@ const db = await D1Database("db", {
 
 const r2Bucket = await R2Bucket("crm-files", {
   adopt: true,
-  dev: { remote: true },
+  dev: { remote: false },
   devDomain: stage !== "prod",
 })
 

--- a/apps/crm/scripts/seed-local-d1-from-duckdb.mjs
+++ b/apps/crm/scripts/seed-local-d1-from-duckdb.mjs
@@ -1,9 +1,15 @@
 import { createHash } from "node:crypto"
 import { existsSync, readdirSync, readFileSync } from "node:fs"
+import os from "node:os"
 import path from "node:path"
 import { spawnSync } from "node:child_process"
 
 const appRoot = process.cwd()
+const duckDbBin =
+	process.env.DUCKDB_BIN ??
+	(existsSync(path.join(os.homedir(), ".local/bin/duckdb"))
+		? path.join(os.homedir(), ".local/bin/duckdb")
+		: "duckdb")
 const workspaceDuckDb =
 	process.env.OPENCLAW_DUCKDB ??
 	"/Users/ianjones/.openclaw-dench/workspace/workspace.duckdb"
@@ -254,10 +260,14 @@ function findLocalD1(root) {
 }
 
 function queryDuckDb(query) {
-	const result = spawnSync("duckdb", [workspaceDuckDb, "-readonly", "-json", "-c", query], {
-		encoding: "utf8",
-		maxBuffer: 1024 * 1024 * 64,
-	})
+	const result = spawnSync(
+		duckDbBin,
+		[workspaceDuckDb, "-readonly", "-json", "-c", query],
+		{
+			encoding: "utf8",
+			maxBuffer: 1024 * 1024 * 64,
+		},
+	)
 
 	if (result.status !== 0) {
 		throw new Error(result.stderr || result.stdout)

--- a/apps/crm/src/routeTree.gen.ts
+++ b/apps/crm/src/routeTree.gen.ts
@@ -11,7 +11,10 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthenticatedInteractionsRouteImport } from './routes/_authenticated/interactions'
+import { Route as AuthenticatedGymsRouteImport } from './routes/_authenticated/gyms'
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
+import { Route as AuthenticatedContactsRouteImport } from './routes/_authenticated/contacts'
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
@@ -22,32 +25,64 @@ const IndexRoute = IndexRouteImport.update({
   path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AuthenticatedInteractionsRoute =
+  AuthenticatedInteractionsRouteImport.update({
+    id: '/interactions',
+    path: '/interactions',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedGymsRoute = AuthenticatedGymsRouteImport.update({
+  id: '/gyms',
+  path: '/gyms',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const AuthenticatedDashboardRoute = AuthenticatedDashboardRouteImport.update({
   id: '/dashboard',
   path: '/dashboard',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedContactsRoute = AuthenticatedContactsRouteImport.update({
+  id: '/contacts',
+  path: '/contacts',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/contacts': typeof AuthenticatedContactsRoute
   '/dashboard': typeof AuthenticatedDashboardRoute
+  '/gyms': typeof AuthenticatedGymsRoute
+  '/interactions': typeof AuthenticatedInteractionsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/contacts': typeof AuthenticatedContactsRoute
   '/dashboard': typeof AuthenticatedDashboardRoute
+  '/gyms': typeof AuthenticatedGymsRoute
+  '/interactions': typeof AuthenticatedInteractionsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/_authenticated/contacts': typeof AuthenticatedContactsRoute
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
+  '/_authenticated/gyms': typeof AuthenticatedGymsRoute
+  '/_authenticated/interactions': typeof AuthenticatedInteractionsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/dashboard'
+  fullPaths: '/' | '/contacts' | '/dashboard' | '/gyms' | '/interactions'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/dashboard'
-  id: '__root__' | '/' | '/_authenticated' | '/_authenticated/dashboard'
+  to: '/' | '/contacts' | '/dashboard' | '/gyms' | '/interactions'
+  id:
+    | '__root__'
+    | '/'
+    | '/_authenticated'
+    | '/_authenticated/contacts'
+    | '/_authenticated/dashboard'
+    | '/_authenticated/gyms'
+    | '/_authenticated/interactions'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -71,6 +106,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/_authenticated/interactions': {
+      id: '/_authenticated/interactions'
+      path: '/interactions'
+      fullPath: '/interactions'
+      preLoaderRoute: typeof AuthenticatedInteractionsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/gyms': {
+      id: '/_authenticated/gyms'
+      path: '/gyms'
+      fullPath: '/gyms'
+      preLoaderRoute: typeof AuthenticatedGymsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/dashboard': {
       id: '/_authenticated/dashboard'
       path: '/dashboard'
@@ -78,15 +127,28 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedDashboardRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/contacts': {
+      id: '/_authenticated/contacts'
+      path: '/contacts'
+      fullPath: '/contacts'
+      preLoaderRoute: typeof AuthenticatedContactsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
   }
 }
 
 interface AuthenticatedRouteChildren {
+  AuthenticatedContactsRoute: typeof AuthenticatedContactsRoute
   AuthenticatedDashboardRoute: typeof AuthenticatedDashboardRoute
+  AuthenticatedGymsRoute: typeof AuthenticatedGymsRoute
+  AuthenticatedInteractionsRoute: typeof AuthenticatedInteractionsRoute
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedContactsRoute: AuthenticatedContactsRoute,
   AuthenticatedDashboardRoute: AuthenticatedDashboardRoute,
+  AuthenticatedGymsRoute: AuthenticatedGymsRoute,
+  AuthenticatedInteractionsRoute: AuthenticatedInteractionsRoute,
 }
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/apps/crm/src/routes/_authenticated.tsx
+++ b/apps/crm/src/routes/_authenticated.tsx
@@ -1,11 +1,18 @@
 import {
   createFileRoute,
+  Link,
   Outlet,
   redirect,
   useNavigate,
 } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
-import { LogOut } from "lucide-react"
+import {
+  Building2,
+  Handshake,
+  LayoutDashboard,
+  LogOut,
+  Users,
+} from "lucide-react"
 import { checkAuthFn, logoutFn } from "@/server-fns/auth"
 
 export const Route = createFileRoute("/_authenticated")({
@@ -30,7 +37,7 @@ function AuthenticatedLayout() {
   return (
     <div className="min-h-screen bg-background text-foreground">
       <header className="border-b border-border">
-        <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+        <div className="mx-auto flex min-h-14 max-w-6xl flex-col gap-3 px-4 py-3 md:flex-row md:items-center md:justify-between">
           <div className="flex items-center gap-3">
             <img
               src="/wodsmith-logo-no-text.png"
@@ -40,6 +47,26 @@ function AuthenticatedLayout() {
             />
             <h1 className="text-base font-semibold">WODsmith CRM</h1>
           </div>
+          <nav className="flex flex-wrap items-center gap-1">
+            <NavLink
+              to="/dashboard"
+              icon={<LayoutDashboard className="h-4 w-4" />}
+            >
+              Dashboard
+            </NavLink>
+            <NavLink to="/gyms" icon={<Building2 className="h-4 w-4" />}>
+              Gyms
+            </NavLink>
+            <NavLink to="/contacts" icon={<Users className="h-4 w-4" />}>
+              Contacts
+            </NavLink>
+            <NavLink
+              to="/interactions"
+              icon={<Handshake className="h-4 w-4" />}
+            >
+              Interactions
+            </NavLink>
+          </nav>
           <button
             type="button"
             onClick={handleLogout}
@@ -55,5 +82,25 @@ function AuthenticatedLayout() {
         <Outlet />
       </main>
     </div>
+  )
+}
+
+function NavLink({
+  to,
+  icon,
+  children,
+}: {
+  to: "/dashboard" | "/gyms" | "/contacts" | "/interactions"
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <Link
+      to={to}
+      className="inline-flex h-9 items-center gap-2 rounded-md px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground [&.active]:bg-secondary [&.active]:text-foreground"
+    >
+      {icon}
+      {children}
+    </Link>
   )
 }

--- a/apps/crm/src/routes/_authenticated/contacts.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.tsx
@@ -1,0 +1,204 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { Plus, Search } from "lucide-react"
+import { useMemo, useState } from "react"
+import { createContactFn, getCrmDataFn } from "@/server-fns/crm"
+
+export const Route = createFileRoute("/_authenticated/contacts")({
+  loader: async () => getCrmDataFn(),
+  component: ContactsPage,
+})
+
+function ContactsPage() {
+  const { contacts, gyms } = Route.useLoaderData()
+  const router = useRouter()
+  const createContact = useServerFn(createContactFn)
+  const [query, setQuery] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  const filteredContacts = useMemo(() => {
+    const normalized = query.trim().toLowerCase()
+    if (!normalized) return contacts
+    return contacts.filter((contact) =>
+      [contact.fullName, contact.email, contact.phone, contact.companyName]
+        .filter((value): value is string => Boolean(value))
+        .some((value) => value.toLowerCase().includes(normalized)),
+    )
+  }, [contacts, query])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setSaving(true)
+    try {
+      await createContact({
+        data: {
+          fullName: String(form.get("fullName") ?? ""),
+          email: String(form.get("email") ?? ""),
+          phone: String(form.get("phone") ?? ""),
+          status: String(form.get("status") ?? ""),
+          companyId: String(form.get("companyId") ?? ""),
+          notes: String(form.get("notes") ?? ""),
+        },
+      })
+      event.currentTarget.reset()
+      await router.invalidate()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">Contacts</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Manage People entries and connect them to gym Company entries.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-lg border border-border p-4"
+      >
+        <div className="grid gap-3 md:grid-cols-4">
+          <TextInput name="fullName" label="Name" required />
+          <TextInput name="email" label="Email" />
+          <TextInput name="phone" label="Phone" />
+          <label className="space-y-1 text-sm font-medium">
+            <span>Gym</span>
+            <select
+              name="companyId"
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">No gym</option>
+              {gyms.map((gym) => (
+                <option key={gym.id} value={gym.id}>
+                  {gym.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <SelectInput
+            name="status"
+            label="Status"
+            options={["Lead", "Contacted", "Qualified", "Customer"]}
+          />
+          <div className="md:col-span-3">
+            <TextInput name="notes" label="Notes" />
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" />
+            {saving ? "Adding..." : "Add Contact"}
+          </button>
+        </div>
+      </form>
+
+      <div className="flex items-center gap-2 rounded-md border border-input px-3">
+        <Search className="h-4 w-4 text-muted-foreground" />
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search contacts"
+          className="h-10 flex-1 bg-transparent text-sm outline-none"
+        />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="w-full table-fixed text-left text-sm">
+          <thead className="bg-secondary text-secondary-foreground">
+            <tr>
+              <Th>Contact</Th>
+              <Th>Gym</Th>
+              <Th>Status</Th>
+              <Th>Phone</Th>
+              <Th>Notes</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {filteredContacts.map((contact) => (
+              <tr key={contact.id} className="align-top">
+                <Td>
+                  <p className="font-medium">{contact.fullName}</p>
+                  <p className="truncate text-muted-foreground">
+                    {contact.email || "No email"}
+                  </p>
+                </Td>
+                <Td>{contact.companyName || "-"}</Td>
+                <Td>{contact.status || "Lead"}</Td>
+                <Td>{contact.phone || "-"}</Td>
+                <Td>
+                  <p className="line-clamp-2 text-muted-foreground">
+                    {contact.notes || "-"}
+                  </p>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function TextInput({
+  name,
+  label,
+  required,
+}: {
+  name: string
+  label: string
+  required?: boolean
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <input
+        name={name}
+        required={required}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      />
+    </label>
+  )
+}
+
+function SelectInput({
+  name,
+  label,
+  options,
+}: {
+  name: string
+  label: string
+  options: string[]
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <select
+        name={name}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      >
+        <option value="">Choose</option>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="px-4 py-3 font-medium">{children}</th>
+}
+
+function Td({ children }: { children: React.ReactNode }) {
+  return <td className="px-4 py-3">{children}</td>
+}

--- a/apps/crm/src/routes/_authenticated/dashboard.tsx
+++ b/apps/crm/src/routes/_authenticated/dashboard.tsx
@@ -1,16 +1,117 @@
 import { createFileRoute } from "@tanstack/react-router"
+import { Building2, Handshake, Users } from "lucide-react"
+import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/_authenticated/dashboard")({
+  loader: async () => getCrmDataFn(),
   component: DashboardPage,
 })
 
 function DashboardPage() {
+  const { gyms, contacts, interactions } = Route.useLoaderData()
+  const activeGyms = gyms.filter((gym) => gym.status !== "Closed")
+  const recentInteractions = interactions.slice(0, 6)
+
   return (
-    <section className="max-w-2xl space-y-2">
-      <h2 className="text-xl font-semibold tracking-tight">CRM workspace</h2>
-      <p className="text-sm text-muted-foreground">
-        This app shell is ready for CRM-specific workflows.
-      </p>
+    <section className="space-y-8">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">CRM workspace</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Gym prospects, owner contacts, and outreach activity from the generic
+          CRM objects.
+        </p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <Metric
+          icon={<Building2 className="h-5 w-5" />}
+          label="Gyms"
+          value={activeGyms.length}
+        />
+        <Metric
+          icon={<Users className="h-5 w-5" />}
+          label="Contacts"
+          value={contacts.length}
+        />
+        <Metric
+          icon={<Handshake className="h-5 w-5" />}
+          label="Interactions"
+          value={interactions.length}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_1.15fr]">
+        <section className="rounded-lg border border-border">
+          <div className="border-b border-border px-4 py-3">
+            <h3 className="font-medium">Priority Gyms</h3>
+          </div>
+          <div className="divide-y divide-border">
+            {gyms.slice(0, 8).map((gym) => (
+              <div key={gym.id} className="px-4 py-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium">{gym.name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {gym.location || "No location"}
+                    </p>
+                  </div>
+                  <span className="rounded-md bg-secondary px-2 py-1 text-xs text-secondary-foreground">
+                    {gym.status || "Prospect"}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-border">
+          <div className="border-b border-border px-4 py-3">
+            <h3 className="font-medium">Recent Interactions</h3>
+          </div>
+          <div className="divide-y divide-border">
+            {recentInteractions.map((interaction) => (
+              <div
+                key={`${interaction.source}-${interaction.id}`}
+                className="px-4 py-3"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <p className="font-medium">{interaction.title}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {[interaction.companyName, interaction.contactName]
+                        .filter(Boolean)
+                        .join(" / ") || "Unassigned"}
+                    </p>
+                  </div>
+                  <span className="whitespace-nowrap text-xs text-muted-foreground">
+                    {interaction.date || interaction.source}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      </div>
     </section>
+  )
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number
+}) {
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-muted-foreground">{label}</p>
+        <span className="text-muted-foreground">{icon}</span>
+      </div>
+      <p className="mt-3 text-3xl font-semibold">{value}</p>
+    </div>
   )
 }

--- a/apps/crm/src/routes/_authenticated/gyms.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.tsx
@@ -1,0 +1,217 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { Plus, Search } from "lucide-react"
+import { useMemo, useState } from "react"
+import { createGymFn, getCrmDataFn } from "@/server-fns/crm"
+
+export const Route = createFileRoute("/_authenticated/gyms")({
+  loader: async () => getCrmDataFn(),
+  component: GymsPage,
+})
+
+function GymsPage() {
+  const { gyms } = Route.useLoaderData()
+  const router = useRouter()
+  const createGym = useServerFn(createGymFn)
+  const [query, setQuery] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  const filteredGyms = useMemo(() => {
+    const normalized = query.trim().toLowerCase()
+    if (!normalized) return gyms
+    return gyms.filter((gym) =>
+      [gym.name, gym.location, gym.ownerManager, gym.status, gym.relationship]
+        .filter((value): value is string => Boolean(value))
+        .some((value) => value.toLowerCase().includes(normalized)),
+    )
+  }, [gyms, query])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setSaving(true)
+    try {
+      await createGym({
+        data: {
+          name: String(form.get("name") ?? ""),
+          location: String(form.get("location") ?? ""),
+          website: String(form.get("website") ?? ""),
+          email: String(form.get("email") ?? ""),
+          phone: String(form.get("phone") ?? ""),
+          instagram: String(form.get("instagram") ?? ""),
+          ownerManager: String(form.get("ownerManager") ?? ""),
+          status: String(form.get("status") ?? ""),
+          priority: String(form.get("priority") ?? ""),
+          relationship: String(form.get("relationship") ?? ""),
+          notes: String(form.get("notes") ?? ""),
+        },
+      })
+      event.currentTarget.reset()
+      await router.invalidate()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <PageHeader
+        title="Gyms"
+        description="Manage the Company entries that represent gym prospects and customers."
+      />
+
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-lg border border-border p-4"
+      >
+        <div className="grid gap-3 md:grid-cols-4">
+          <TextInput name="name" label="Gym" required />
+          <TextInput name="location" label="Location" />
+          <TextInput name="ownerManager" label="Owner / Manager" />
+          <TextInput name="relationship" label="Relationship" />
+          <TextInput name="website" label="Website" />
+          <TextInput name="email" label="Email" />
+          <TextInput name="phone" label="Phone" />
+          <TextInput name="instagram" label="Instagram" />
+          <SelectInput
+            name="status"
+            label="Status"
+            options={["Prospect", "Outreach Sent", "Demo", "Customer"]}
+          />
+          <SelectInput
+            name="priority"
+            label="Priority"
+            options={["HIGH", "MED", "LOW"]}
+          />
+          <div className="md:col-span-2">
+            <TextInput name="notes" label="Notes" />
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" />
+            {saving ? "Adding..." : "Add Gym"}
+          </button>
+        </div>
+      </form>
+
+      <div className="flex items-center gap-2 rounded-md border border-input px-3">
+        <Search className="h-4 w-4 text-muted-foreground" />
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search gyms"
+          className="h-10 flex-1 bg-transparent text-sm outline-none"
+        />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="w-full table-fixed text-left text-sm">
+          <thead className="bg-secondary text-secondary-foreground">
+            <tr>
+              <Th>Gym</Th>
+              <Th>Location</Th>
+              <Th>Status</Th>
+              <Th>Owner</Th>
+              <Th>Contact</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {filteredGyms.map((gym) => (
+              <tr key={gym.id} className="align-top">
+                <Td>
+                  <p className="font-medium">{gym.name}</p>
+                  <p className="truncate text-muted-foreground">
+                    {gym.website || gym.instagram || "No web presence saved"}
+                  </p>
+                </Td>
+                <Td>{gym.location || "-"}</Td>
+                <Td>{gym.status || "Prospect"}</Td>
+                <Td>{gym.ownerManager || "-"}</Td>
+                <Td>
+                  <p>{gym.email || "-"}</p>
+                  <p className="text-muted-foreground">{gym.phone}</p>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function PageHeader({
+  title,
+  description,
+}: {
+  title: string
+  description: string
+}) {
+  return (
+    <div>
+      <h2 className="text-2xl font-semibold tracking-tight">{title}</h2>
+      <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+    </div>
+  )
+}
+
+function TextInput({
+  name,
+  label,
+  required,
+}: {
+  name: string
+  label: string
+  required?: boolean
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <input
+        name={name}
+        required={required}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      />
+    </label>
+  )
+}
+
+function SelectInput({
+  name,
+  label,
+  options,
+}: {
+  name: string
+  label: string
+  options: string[]
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <select
+        name={name}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      >
+        <option value="">Choose</option>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="px-4 py-3 font-medium">{children}</th>
+}
+
+function Td({ children }: { children: React.ReactNode }) {
+  return <td className="px-4 py-3">{children}</td>
+}

--- a/apps/crm/src/routes/_authenticated/interactions.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.tsx
@@ -1,0 +1,232 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { Plus, Search } from "lucide-react"
+import { useMemo, useState } from "react"
+import { createInteractionFn, getCrmDataFn } from "@/server-fns/crm"
+
+export const Route = createFileRoute("/_authenticated/interactions")({
+  loader: async () => getCrmDataFn(),
+  component: InteractionsPage,
+})
+
+function InteractionsPage() {
+  const { interactions, gyms, contacts } = Route.useLoaderData()
+  const router = useRouter()
+  const createInteraction = useServerFn(createInteractionFn)
+  const [query, setQuery] = useState("")
+  const [saving, setSaving] = useState(false)
+
+  const filteredInteractions = useMemo(() => {
+    const normalized = query.trim().toLowerCase()
+    if (!normalized) return interactions
+    return interactions.filter((interaction) =>
+      [
+        interaction.title,
+        interaction.companyName,
+        interaction.contactName,
+        interaction.channel,
+        interaction.status,
+        interaction.notes,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .some((value) => value.toLowerCase().includes(normalized)),
+    )
+  }, [interactions, query])
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setSaving(true)
+    try {
+      await createInteraction({
+        data: {
+          title: String(form.get("title") ?? ""),
+          date: String(form.get("date") ?? ""),
+          channel: String(form.get("channel") ?? ""),
+          status: String(form.get("status") ?? ""),
+          companyId: String(form.get("companyId") ?? ""),
+          contactId: String(form.get("contactId") ?? ""),
+          notes: String(form.get("notes") ?? ""),
+          content: String(form.get("content") ?? ""),
+        },
+      })
+      event.currentTarget.reset()
+      await router.invalidate()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">Interactions</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Track outreach and meeting history against gyms and contacts.
+        </p>
+      </div>
+
+      <form
+        onSubmit={handleSubmit}
+        className="rounded-lg border border-border p-4"
+      >
+        <div className="grid gap-3 md:grid-cols-4">
+          <TextInput name="title" label="Subject" required />
+          <TextInput name="date" label="Date" type="date" />
+          <SelectInput
+            name="channel"
+            label="Channel"
+            options={["Email", "Call", "Instagram", "In Person", "Demo"]}
+          />
+          <SelectInput
+            name="status"
+            label="Status"
+            options={["Planned", "Sent", "Completed", "No Response", "Replied"]}
+          />
+          <label className="space-y-1 text-sm font-medium">
+            <span>Gym</span>
+            <select
+              name="companyId"
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">No gym</option>
+              {gyms.map((gym) => (
+                <option key={gym.id} value={gym.id}>
+                  {gym.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="space-y-1 text-sm font-medium">
+            <span>Contact</span>
+            <select
+              name="contactId"
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+            >
+              <option value="">No contact</option>
+              {contacts.map((contact) => (
+                <option key={contact.id} value={contact.id}>
+                  {contact.fullName}
+                </option>
+              ))}
+            </select>
+          </label>
+          <TextInput name="notes" label="Notes" />
+          <TextInput name="content" label="Content" />
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" />
+            {saving ? "Adding..." : "Log Interaction"}
+          </button>
+        </div>
+      </form>
+
+      <div className="flex items-center gap-2 rounded-md border border-input px-3">
+        <Search className="h-4 w-4 text-muted-foreground" />
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search interactions"
+          className="h-10 flex-1 bg-transparent text-sm outline-none"
+        />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="w-full table-fixed text-left text-sm">
+          <thead className="bg-secondary text-secondary-foreground">
+            <tr>
+              <Th>Interaction</Th>
+              <Th>Date</Th>
+              <Th>Gym</Th>
+              <Th>Contact</Th>
+              <Th>Status</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {filteredInteractions.map((interaction) => (
+              <tr
+                key={`${interaction.source}-${interaction.id}`}
+                className="align-top"
+              >
+                <Td>
+                  <p className="font-medium">{interaction.title}</p>
+                  <p className="truncate text-muted-foreground">
+                    {interaction.channel || interaction.source}
+                  </p>
+                </Td>
+                <Td>{interaction.date || "-"}</Td>
+                <Td>{interaction.companyName || "-"}</Td>
+                <Td>{interaction.contactName || "-"}</Td>
+                <Td>{interaction.status || "-"}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function TextInput({
+  name,
+  label,
+  required,
+  type = "text",
+}: {
+  name: string
+  label: string
+  required?: boolean
+  type?: string
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <input
+        name={name}
+        type={type}
+        required={required}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      />
+    </label>
+  )
+}
+
+function SelectInput({
+  name,
+  label,
+  options,
+}: {
+  name: string
+  label: string
+  options: string[]
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <select
+        name={name}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      >
+        <option value="">Choose</option>
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="px-4 py-3 font-medium">{children}</th>
+}
+
+function Td({ children }: { children: React.ReactNode }) {
+  return <td className="px-4 py-3">{children}</td>
+}

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -1,0 +1,550 @@
+import { createServerFn } from "@tanstack/react-start"
+import { and, asc, desc, eq, inArray, sql } from "drizzle-orm"
+import { z } from "zod"
+import { getDb } from "@/db"
+import {
+  entriesTable,
+  entryFieldsTable,
+  entryRelationsTable,
+  fieldsTable,
+  objectsTable,
+} from "@/db/schema"
+import { requireAuth } from "@/server-fns/auth"
+
+type FieldValueMap = Record<string, string | null>
+
+const SQLITE_IN_CHUNK_SIZE = 50
+
+export type CrmGym = {
+  id: string
+  name: string
+  status: string | null
+  priority: string | null
+  relationship: string | null
+  location: string | null
+  website: string | null
+  email: string | null
+  phone: string | null
+  instagram: string | null
+  ownerManager: string | null
+  lastContacted: string | null
+  notes: string | null
+  updatedAt: string | null
+}
+
+export type CrmContact = {
+  id: string
+  fullName: string
+  email: string | null
+  phone: string | null
+  status: string | null
+  companyId: string | null
+  companyName: string | null
+  notes: string | null
+  updatedAt: string | null
+}
+
+export type CrmInteraction = {
+  id: string
+  source: "Meeting" | "Outreach"
+  title: string
+  date: string | null
+  channel: string | null
+  status: string | null
+  companyId: string | null
+  companyName: string | null
+  contactId: string | null
+  contactName: string | null
+  notes: string | null
+  content: string | null
+  updatedAt: string | null
+}
+
+const gymInputSchema = z.object({
+  name: z.string().min(1, "Gym name is required").max(255),
+  location: z.string().max(255).optional(),
+  website: z.string().max(500).optional(),
+  email: z.string().max(255).optional(),
+  phone: z.string().max(100).optional(),
+  instagram: z.string().max(255).optional(),
+  ownerManager: z.string().max(500).optional(),
+  status: z.string().max(100).optional(),
+  priority: z.string().max(50).optional(),
+  relationship: z.string().max(255).optional(),
+  notes: z.string().max(4000).optional(),
+})
+
+const contactInputSchema = z.object({
+  fullName: z.string().min(1, "Name is required").max(255),
+  email: z.string().max(255).optional(),
+  phone: z.string().max(100).optional(),
+  status: z.string().max(100).optional(),
+  companyId: z.string().optional(),
+  notes: z.string().max(4000).optional(),
+})
+
+const interactionInputSchema = z.object({
+  title: z.string().min(1, "Subject is required").max(255),
+  date: z.string().max(20).optional(),
+  channel: z.string().max(100).optional(),
+  status: z.string().max(100).optional(),
+  companyId: z.string().optional(),
+  contactId: z.string().optional(),
+  notes: z.string().max(4000).optional(),
+  content: z.string().max(10000).optional(),
+})
+
+function crmId() {
+  return crypto.randomUUID()
+}
+
+function clean(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function chunks<T>(values: T[], size: number) {
+  const result: T[][] = []
+  for (let index = 0; index < values.length; index += size) {
+    result.push(values.slice(index, index + size))
+  }
+  return result
+}
+
+async function getObject(name: string) {
+  const db = getDb()
+  const [object] = await db
+    .select()
+    .from(objectsTable)
+    .where(sql`lower(${objectsTable.name}) = ${name.toLowerCase()}`)
+    .limit(1)
+
+  if (!object) {
+    throw new Error(`CRM object not found: ${name}`)
+  }
+
+  return object
+}
+
+async function getFieldsByName(objectId: string) {
+  const db = getDb()
+  const fields = await db
+    .select()
+    .from(fieldsTable)
+    .where(eq(fieldsTable.objectId, objectId))
+    .orderBy(asc(fieldsTable.sortOrder), asc(fieldsTable.name))
+
+  return new Map(fields.map((field) => [field.name, field]))
+}
+
+async function getFieldValues(entryIds: string[]) {
+  if (entryIds.length === 0) return new Map<string, FieldValueMap>()
+
+  const db = getDb()
+  const rows = (
+    await Promise.all(
+      chunks(entryIds, SQLITE_IN_CHUNK_SIZE).map((entryIdChunk) =>
+        db
+          .select({
+            entryId: entryFieldsTable.entryId,
+            value: entryFieldsTable.value,
+            fieldName: fieldsTable.name,
+          })
+          .from(entryFieldsTable)
+          .innerJoin(fieldsTable, eq(entryFieldsTable.fieldId, fieldsTable.id))
+          .where(inArray(entryFieldsTable.entryId, entryIdChunk)),
+      ),
+    )
+  ).flat()
+
+  const values = new Map<string, FieldValueMap>()
+  for (const row of rows) {
+    const entryValues = values.get(row.entryId) ?? {}
+    entryValues[row.fieldName] = row.value
+    values.set(row.entryId, entryValues)
+  }
+
+  return values
+}
+
+async function getRelationTargets(entryIds: string[]) {
+  if (entryIds.length === 0) return new Map<string, Record<string, string[]>>()
+
+  const db = getDb()
+  const rows = (
+    await Promise.all(
+      chunks(entryIds, SQLITE_IN_CHUNK_SIZE).map((entryIdChunk) =>
+        db
+          .select({
+            sourceEntryId: entryRelationsTable.sourceEntryId,
+            targetEntryId: entryRelationsTable.targetEntryId,
+            fieldName: fieldsTable.name,
+          })
+          .from(entryRelationsTable)
+          .innerJoin(
+            fieldsTable,
+            eq(entryRelationsTable.fieldId, fieldsTable.id),
+          )
+          .where(inArray(entryRelationsTable.sourceEntryId, entryIdChunk))
+          .orderBy(asc(entryRelationsTable.sortOrder)),
+      ),
+    )
+  ).flat()
+
+  const relations = new Map<string, Record<string, string[]>>()
+  for (const row of rows) {
+    const entryRelations = relations.get(row.sourceEntryId) ?? {}
+    const targets = entryRelations[row.fieldName] ?? []
+    targets.push(row.targetEntryId)
+    entryRelations[row.fieldName] = targets
+    relations.set(row.sourceEntryId, entryRelations)
+  }
+
+  return relations
+}
+
+async function getEntryDisplayNames(entryIds: string[]) {
+  const uniqueIds = Array.from(new Set(entryIds.filter(Boolean)))
+  if (uniqueIds.length === 0) return new Map<string, string>()
+
+  const db = getDb()
+  const rows = (
+    await Promise.all(
+      chunks(uniqueIds, SQLITE_IN_CHUNK_SIZE).map((entryIdChunk) =>
+        db
+          .select({
+            entryId: entryFieldsTable.entryId,
+            value: entryFieldsTable.value,
+            fieldName: fieldsTable.name,
+          })
+          .from(entryFieldsTable)
+          .innerJoin(fieldsTable, eq(entryFieldsTable.fieldId, fieldsTable.id))
+          .where(inArray(entryFieldsTable.entryId, entryIdChunk)),
+      ),
+    )
+  ).flat()
+
+  const priority = ["Company Name", "Full Name", "Title", "Subject"]
+  const names = new Map<string, string>()
+  for (const fieldName of priority) {
+    for (const row of rows) {
+      if (row.fieldName === fieldName && row.value && !names.has(row.entryId)) {
+        names.set(row.entryId, row.value)
+      }
+    }
+  }
+
+  return names
+}
+
+async function listEntries(objectName: string, limit = 250) {
+  const db = getDb()
+  const object = await getObject(objectName)
+  const entries = await db
+    .select()
+    .from(entriesTable)
+    .where(eq(entriesTable.objectId, object.id))
+    .orderBy(desc(entriesTable.updatedAt), desc(entriesTable.createdAt))
+    .limit(limit)
+
+  const entryIds = entries.map((entry) => entry.id)
+  const [values, relations] = await Promise.all([
+    getFieldValues(entryIds),
+    getRelationTargets(entryIds),
+  ])
+
+  return { entries, values, relations }
+}
+
+async function upsertFieldValue(
+  entryId: string,
+  fieldId: string,
+  value: string | null,
+) {
+  const db = getDb()
+  await db
+    .insert(entryFieldsTable)
+    .values({
+      id: crmId(),
+      entryId,
+      fieldId,
+      value,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .onConflictDoUpdate({
+      target: [entryFieldsTable.entryId, entryFieldsTable.fieldId],
+      set: {
+        value,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      },
+    })
+}
+
+async function setRelation(
+  entryId: string,
+  fieldId: string,
+  targetEntryId: string | null,
+) {
+  const db = getDb()
+  await db
+    .delete(entryRelationsTable)
+    .where(
+      and(
+        eq(entryRelationsTable.sourceEntryId, entryId),
+        eq(entryRelationsTable.fieldId, fieldId),
+      ),
+    )
+
+  await upsertFieldValue(entryId, fieldId, targetEntryId)
+
+  if (!targetEntryId) return
+
+  await db.insert(entryRelationsTable).values({
+    id: crmId(),
+    sourceEntryId: entryId,
+    fieldId,
+    targetEntryId,
+    updatedAt: sql`CURRENT_TIMESTAMP`,
+  })
+}
+
+async function createEntry(objectName: string) {
+  const db = getDb()
+  const object = await getObject(objectName)
+  const entryId = crmId()
+  await db.insert(entriesTable).values({
+    id: entryId,
+    objectId: object.id,
+    updatedAt: sql`CURRENT_TIMESTAMP`,
+  })
+  return { entryId, object }
+}
+
+function requireField(
+  fields: Map<string, { id: string }>,
+  name: string,
+  objectName: string,
+) {
+  const field = fields.get(name)
+  if (!field) {
+    throw new Error(`CRM field not found on ${objectName}: ${name}`)
+  }
+  return field
+}
+
+export async function getCrmData() {
+  await requireAuth()
+
+  const [gymsData, contactsData, outreachData, meetingsData] =
+    await Promise.all([
+      listEntries("Company"),
+      listEntries("People"),
+      listEntries("Outreach"),
+      listEntries("Meeting"),
+    ])
+
+  const relationIds = [
+    ...contactsData.entries.flatMap(
+      (entry) => contactsData.relations.get(entry.id)?.Company ?? [],
+    ),
+    ...outreachData.entries.flatMap((entry) => [
+      ...(outreachData.relations.get(entry.id)?.Company ?? []),
+      ...(outreachData.relations.get(entry.id)?.Person ?? []),
+    ]),
+    ...meetingsData.entries.flatMap((entry) => [
+      ...(meetingsData.relations.get(entry.id)?.Company ?? []),
+      ...(meetingsData.relations.get(entry.id)?.Contact ?? []),
+    ]),
+  ]
+  const displayNames = await getEntryDisplayNames(relationIds)
+
+  const gyms: CrmGym[] = gymsData.entries.map((entry) => {
+    const values = gymsData.values.get(entry.id) ?? {}
+    return {
+      id: entry.id,
+      name: values["Company Name"] ?? "Untitled gym",
+      status: values["Wodsmith Status"] ?? values.Type ?? null,
+      priority: values.Priority ?? null,
+      relationship: values.Relationship ?? null,
+      location: values.Location ?? null,
+      website: values.Website ?? null,
+      email: values["Email Address"] ?? null,
+      phone: values["Phone Number"] ?? null,
+      instagram: values.Instagram ?? null,
+      ownerManager: values["Owner/Manager"] ?? null,
+      lastContacted: values["Last Contacted"] ?? null,
+      notes: values.Notes ?? null,
+      updatedAt: entry.updatedAt,
+    }
+  })
+
+  const contacts: CrmContact[] = contactsData.entries.map((entry) => {
+    const values = contactsData.values.get(entry.id) ?? {}
+    const companyId =
+      contactsData.relations.get(entry.id)?.Company?.[0] ??
+      values.Company ??
+      null
+    return {
+      id: entry.id,
+      fullName: values["Full Name"] ?? "Unnamed contact",
+      email: values["Email Address"] ?? null,
+      phone: values["Phone Number"] ?? null,
+      status: values.Status ?? null,
+      companyId,
+      companyName: companyId ? (displayNames.get(companyId) ?? null) : null,
+      notes: values.Notes ?? null,
+      updatedAt: entry.updatedAt,
+    }
+  })
+
+  const outreachInteractions: CrmInteraction[] = outreachData.entries.map(
+    (entry) => {
+      const values = outreachData.values.get(entry.id) ?? {}
+      const relations = outreachData.relations.get(entry.id) ?? {}
+      const companyId = relations.Company?.[0] ?? values.Company ?? null
+      const contactId = relations.Person?.[0] ?? values.Person ?? null
+      return {
+        id: entry.id,
+        source: "Outreach",
+        title: values.Subject ?? "Untitled outreach",
+        date: values["Date Sent"] ?? null,
+        channel: values.Channel ?? null,
+        status: values.Status ?? null,
+        companyId,
+        companyName: companyId ? (displayNames.get(companyId) ?? null) : null,
+        contactId,
+        contactName: contactId ? (displayNames.get(contactId) ?? null) : null,
+        notes: values.Notes ?? null,
+        content: values.Content ?? null,
+        updatedAt: entry.updatedAt,
+      }
+    },
+  )
+
+  const meetingInteractions: CrmInteraction[] = meetingsData.entries.map(
+    (entry) => {
+      const values = meetingsData.values.get(entry.id) ?? {}
+      const relations = meetingsData.relations.get(entry.id) ?? {}
+      const companyId = relations.Company?.[0] ?? values.Company ?? null
+      const contactId = relations.Contact?.[0] ?? values.Contact ?? null
+      return {
+        id: entry.id,
+        source: "Meeting",
+        title: values.Title ?? "Untitled meeting",
+        date: values.Date ?? null,
+        channel: values.Type ?? null,
+        status: values.Status ?? null,
+        companyId,
+        companyName: companyId ? (displayNames.get(companyId) ?? null) : null,
+        contactId,
+        contactName: contactId ? (displayNames.get(contactId) ?? null) : null,
+        notes: values.Notes ?? values.Outcome ?? null,
+        content: values.Outcome ?? null,
+        updatedAt: entry.updatedAt,
+      }
+    },
+  )
+
+  const interactions = [...outreachInteractions, ...meetingInteractions].sort(
+    (a, b) =>
+      new Date(b.date ?? b.updatedAt ?? 0).getTime() -
+      new Date(a.date ?? a.updatedAt ?? 0).getTime(),
+  )
+
+  return { gyms, contacts, interactions }
+}
+
+export const getCrmDataFn = createServerFn({ method: "GET" }).handler(
+  getCrmData,
+)
+
+export const createGymFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => gymInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    const { entryId, object } = await createEntry("Company")
+    const fields = await getFieldsByName(object.id)
+
+    const updates: Array<[string, string | null]> = [
+      ["Company Name", data.name],
+      ["Industry", "Fitness"],
+      ["Type", "Prospect"],
+      ["Location", clean(data.location)],
+      ["Website", clean(data.website)],
+      ["Email Address", clean(data.email)],
+      ["Phone Number", clean(data.phone)],
+      ["Instagram", clean(data.instagram)],
+      ["Owner/Manager", clean(data.ownerManager)],
+      ["Wodsmith Status", clean(data.status) ?? "Prospect"],
+      ["Priority", clean(data.priority)],
+      ["Relationship", clean(data.relationship)],
+      ["Notes", clean(data.notes)],
+    ]
+
+    for (const [fieldName, value] of updates) {
+      const field = fields.get(fieldName)
+      if (field) await upsertFieldValue(entryId, field.id, value)
+    }
+
+    return { id: entryId }
+  })
+
+export const createContactFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => contactInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    const { entryId, object } = await createEntry("People")
+    const fields = await getFieldsByName(object.id)
+
+    const updates: Array<[string, string | null]> = [
+      ["Full Name", data.fullName],
+      ["Email Address", clean(data.email)],
+      ["Phone Number", clean(data.phone)],
+      ["Status", clean(data.status) ?? "Lead"],
+      ["Notes", clean(data.notes)],
+    ]
+
+    for (const [fieldName, value] of updates) {
+      const field = fields.get(fieldName)
+      if (field) await upsertFieldValue(entryId, field.id, value)
+    }
+
+    const companyField = fields.get("Company")
+    if (companyField) {
+      await setRelation(entryId, companyField.id, clean(data.companyId))
+    }
+
+    return { id: entryId }
+  })
+
+export const createInteractionFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => interactionInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    const { entryId, object } = await createEntry("Outreach")
+    const fields = await getFieldsByName(object.id)
+
+    const updates: Array<[string, string | null]> = [
+      ["Subject", data.title],
+      ["Date Sent", clean(data.date) ?? new Date().toISOString().slice(0, 10)],
+      ["Channel", clean(data.channel) ?? "Email"],
+      ["Status", clean(data.status) ?? "Sent"],
+      ["Notes", clean(data.notes)],
+      ["Content", clean(data.content)],
+    ]
+
+    for (const [fieldName, value] of updates) {
+      const field = fields.get(fieldName)
+      if (field) await upsertFieldValue(entryId, field.id, value)
+    }
+
+    const companyField = fields.get("Company")
+    if (companyField) {
+      await setRelation(entryId, companyField.id, clean(data.companyId))
+    }
+
+    const personField = requireField(fields, "Person", "Outreach")
+    await setRelation(entryId, personField.id, clean(data.contactId))
+
+    return { id: entryId }
+  })

--- a/apps/crm/vite.config.ts
+++ b/apps/crm/vite.config.ts
@@ -32,7 +32,7 @@ const config = defineConfig({
   },
   ssr: {
     optimizeDeps: {
-      include: ["clsx", "tailwind-merge", "class-variance-authority"],
+      include: ["clsx", "tailwind-merge"],
     },
   },
 })


### PR DESCRIPTION
## Summary
- add CRM server functions that map generic Company, People, Outreach, and Meeting objects into gym/contact/interaction views
- add authenticated pages for managing gyms, contacts, and interactions, plus dashboard/nav updates
- batch D1 IN queries under the 100-param limit and improve local DuckDB seed/dev config

## Testing
- NODE24=/tmp/codex-node24/node-v24.13.0-darwin-x64; PATH="$NODE24/bin:$PATH" $NODE24/bin/node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit
- NODE24=/tmp/codex-node24/node-v24.13.0-darwin-x64; PATH="$NODE24/bin:$PATH" ./node_modules/.bin/biome check src/server-fns/crm.ts src/routes/_authenticated.tsx src/routes/_authenticated/dashboard.tsx src/routes/_authenticated/gyms.tsx src/routes/_authenticated/contacts.tsx src/routes/_authenticated/interactions.tsx scripts/seed-local-d1-from-duckdb.mjs vite.config.ts alchemy.run.ts
- git diff --check
- browser smoke test: dashboard, gyms, contacts, interactions load; local gym/contact/interaction create and search flows work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add authenticated CRM pages for gyms, contacts, and interactions, powered by server functions that map generic `Company`, `People`, `Outreach`, and `Meeting` objects into focused views. Adds a dashboard with metrics, a Priority Gyms list, and recent interactions, plus simple create and search flows.

- New Features
  - Server functions: `getCrmDataFn`, `createGymFn`, `createContactFn`, `createInteractionFn` with relation resolution and display-name mapping.
  - Pages: `/gyms`, `/contacts`, `/interactions` with add forms and search; dashboard shows metrics, Priority Gyms, and Recent Interactions.
  - Updated authenticated header/nav with links, icons, and a responsive layout.

- Refactors
  - Batch D1 `IN` reads to stay under SQLite param limits; more efficient field/relation fetching.
  - Seed script: support `DUCKDB_BIN` and auto-detect `~/.local/bin/duckdb`.
  - Local dev: `R2Bucket` `dev.remote` set to false.
  - Vite SSR optimizeDeps: keep `clsx`, `tailwind-merge`; remove `class-variance-authority`.

<sup>Written for commit 11e16cd9674757659f5bedf4ed40bcd7436319f2. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/476?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

