### PR TITLE
Add CRM entity detail pages

### DIFF
--- a/apps/crm/src/routeTree.gen.ts
+++ b/apps/crm/src/routeTree.gen.ts
@@ -15,6 +15,9 @@ import { Route as AuthenticatedInteractionsRouteImport } from './routes/_authent
 import { Route as AuthenticatedGymsRouteImport } from './routes/_authenticated/gyms'
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
 import { Route as AuthenticatedContactsRouteImport } from './routes/_authenticated/contacts'
+import { Route as AuthenticatedInteractionsInteractionIdRouteImport } from './routes/_authenticated/interactions.$interactionId'
+import { Route as AuthenticatedGymsGymIdRouteImport } from './routes/_authenticated/gyms.$gymId'
+import { Route as AuthenticatedContactsContactIdRouteImport } from './routes/_authenticated/contacts.$contactId'
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
@@ -46,35 +49,77 @@ const AuthenticatedContactsRoute = AuthenticatedContactsRouteImport.update({
   path: '/contacts',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedInteractionsInteractionIdRoute =
+  AuthenticatedInteractionsInteractionIdRouteImport.update({
+    id: '/$interactionId',
+    path: '/$interactionId',
+    getParentRoute: () => AuthenticatedInteractionsRoute,
+  } as any)
+const AuthenticatedGymsGymIdRoute = AuthenticatedGymsGymIdRouteImport.update({
+  id: '/$gymId',
+  path: '/$gymId',
+  getParentRoute: () => AuthenticatedGymsRoute,
+} as any)
+const AuthenticatedContactsContactIdRoute =
+  AuthenticatedContactsContactIdRouteImport.update({
+    id: '/$contactId',
+    path: '/$contactId',
+    getParentRoute: () => AuthenticatedContactsRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/contacts': typeof AuthenticatedContactsRoute
+  '/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
-  '/gyms': typeof AuthenticatedGymsRoute
-  '/interactions': typeof AuthenticatedInteractionsRoute
+  '/gyms': typeof AuthenticatedGymsRouteWithChildren
+  '/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
+  '/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
+  '/interactions/$interactionId': typeof AuthenticatedInteractionsInteractionIdRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/contacts': typeof AuthenticatedContactsRoute
+  '/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
-  '/gyms': typeof AuthenticatedGymsRoute
-  '/interactions': typeof AuthenticatedInteractionsRoute
+  '/gyms': typeof AuthenticatedGymsRouteWithChildren
+  '/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
+  '/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
+  '/interactions/$interactionId': typeof AuthenticatedInteractionsInteractionIdRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
-  '/_authenticated/contacts': typeof AuthenticatedContactsRoute
+  '/_authenticated/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
-  '/_authenticated/gyms': typeof AuthenticatedGymsRoute
-  '/_authenticated/interactions': typeof AuthenticatedInteractionsRoute
+  '/_authenticated/gyms': typeof AuthenticatedGymsRouteWithChildren
+  '/_authenticated/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/_authenticated/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
+  '/_authenticated/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
+  '/_authenticated/interactions/$interactionId': typeof AuthenticatedInteractionsInteractionIdRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/contacts' | '/dashboard' | '/gyms' | '/interactions'
+  fullPaths:
+    | '/'
+    | '/contacts'
+    | '/dashboard'
+    | '/gyms'
+    | '/interactions'
+    | '/contacts/$contactId'
+    | '/gyms/$gymId'
+    | '/interactions/$interactionId'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/contacts' | '/dashboard' | '/gyms' | '/interactions'
+  to:
+    | '/'
+    | '/contacts'
+    | '/dashboard'
+    | '/gyms'
+    | '/interactions'
+    | '/contacts/$contactId'
+    | '/gyms/$gymId'
+    | '/interactions/$interactionId'
   id:
     | '__root__'
     | '/'
@@ -83,6 +128,9 @@ export interface FileRouteTypes {
     | '/_authenticated/dashboard'
     | '/_authenticated/gyms'
     | '/_authenticated/interactions'
+    | '/_authenticated/contacts/$contactId'
+    | '/_authenticated/gyms/$gymId'
+    | '/_authenticated/interactions/$interactionId'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -134,21 +182,81 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedContactsRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/interactions/$interactionId': {
+      id: '/_authenticated/interactions/$interactionId'
+      path: '/$interactionId'
+      fullPath: '/interactions/$interactionId'
+      preLoaderRoute: typeof AuthenticatedInteractionsInteractionIdRouteImport
+      parentRoute: typeof AuthenticatedInteractionsRoute
+    }
+    '/_authenticated/gyms/$gymId': {
+      id: '/_authenticated/gyms/$gymId'
+      path: '/$gymId'
+      fullPath: '/gyms/$gymId'
+      preLoaderRoute: typeof AuthenticatedGymsGymIdRouteImport
+      parentRoute: typeof AuthenticatedGymsRoute
+    }
+    '/_authenticated/contacts/$contactId': {
+      id: '/_authenticated/contacts/$contactId'
+      path: '/$contactId'
+      fullPath: '/contacts/$contactId'
+      preLoaderRoute: typeof AuthenticatedContactsContactIdRouteImport
+      parentRoute: typeof AuthenticatedContactsRoute
+    }
   }
 }
 
+interface AuthenticatedContactsRouteChildren {
+  AuthenticatedContactsContactIdRoute: typeof AuthenticatedContactsContactIdRoute
+}
+
+const AuthenticatedContactsRouteChildren: AuthenticatedContactsRouteChildren = {
+  AuthenticatedContactsContactIdRoute: AuthenticatedContactsContactIdRoute,
+}
+
+const AuthenticatedContactsRouteWithChildren =
+  AuthenticatedContactsRoute._addFileChildren(
+    AuthenticatedContactsRouteChildren,
+  )
+
+interface AuthenticatedGymsRouteChildren {
+  AuthenticatedGymsGymIdRoute: typeof AuthenticatedGymsGymIdRoute
+}
+
+const AuthenticatedGymsRouteChildren: AuthenticatedGymsRouteChildren = {
+  AuthenticatedGymsGymIdRoute: AuthenticatedGymsGymIdRoute,
+}
+
+const AuthenticatedGymsRouteWithChildren =
+  AuthenticatedGymsRoute._addFileChildren(AuthenticatedGymsRouteChildren)
+
+interface AuthenticatedInteractionsRouteChildren {
+  AuthenticatedInteractionsInteractionIdRoute: typeof AuthenticatedInteractionsInteractionIdRoute
+}
+
+const AuthenticatedInteractionsRouteChildren: AuthenticatedInteractionsRouteChildren =
+  {
+    AuthenticatedInteractionsInteractionIdRoute:
+      AuthenticatedInteractionsInteractionIdRoute,
+  }
+
+const AuthenticatedInteractionsRouteWithChildren =
+  AuthenticatedInteractionsRoute._addFileChildren(
+    AuthenticatedInteractionsRouteChildren,
+  )
+
 interface AuthenticatedRouteChildren {
-  AuthenticatedContactsRoute: typeof AuthenticatedContactsRoute
+  AuthenticatedContactsRoute: typeof AuthenticatedContactsRouteWithChildren
   AuthenticatedDashboardRoute: typeof AuthenticatedDashboardRoute
-  AuthenticatedGymsRoute: typeof AuthenticatedGymsRoute
-  AuthenticatedInteractionsRoute: typeof AuthenticatedInteractionsRoute
+  AuthenticatedGymsRoute: typeof AuthenticatedGymsRouteWithChildren
+  AuthenticatedInteractionsRoute: typeof AuthenticatedInteractionsRouteWithChildren
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
-  AuthenticatedContactsRoute: AuthenticatedContactsRoute,
+  AuthenticatedContactsRoute: AuthenticatedContactsRouteWithChildren,
   AuthenticatedDashboardRoute: AuthenticatedDashboardRoute,
-  AuthenticatedGymsRoute: AuthenticatedGymsRoute,
-  AuthenticatedInteractionsRoute: AuthenticatedInteractionsRoute,
+  AuthenticatedGymsRoute: AuthenticatedGymsRouteWithChildren,
+  AuthenticatedInteractionsRoute: AuthenticatedInteractionsRouteWithChildren,
 }
 
 const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(

--- a/apps/crm/src/routes/_authenticated.tsx
+++ b/apps/crm/src/routes/_authenticated.tsx
@@ -97,7 +97,10 @@ function CrmBreadcrumbs() {
   if (pathParts.length === 0 || pathParts[0] === "dashboard") return null
 
   const section = pathParts[0]
-  const detailLabel = getDetailLabel(section, matches.at(-1)?.loaderData)
+  const detailLabel = getDetailLabel({
+    section,
+    loaderData: matches.at(-1)?.loaderData,
+  })
   const crumbs = [
     { label: "Dashboard", to: "/dashboard" as const },
     { label: sectionLabel(section), to: `/${section}` },
@@ -136,7 +139,13 @@ function sectionLabel(section: string) {
   return section
 }
 
-function getDetailLabel(section: string, loaderData: unknown) {
+function getDetailLabel({
+  section,
+  loaderData,
+}: {
+  section: string
+  loaderData: unknown
+}) {
   if (!loaderData || typeof loaderData !== "object") return null
   if (
     !(

--- a/apps/crm/src/routes/_authenticated.tsx
+++ b/apps/crm/src/routes/_authenticated.tsx
@@ -3,11 +3,14 @@ import {
   Link,
   Outlet,
   redirect,
+  useLocation,
+  useMatches,
   useNavigate,
 } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import {
   Building2,
+  ChevronRight,
   Handshake,
   LayoutDashboard,
   LogOut,
@@ -79,10 +82,88 @@ function AuthenticatedLayout() {
         </div>
       </header>
       <main className="mx-auto max-w-6xl px-4 py-8">
+        <CrmBreadcrumbs />
         <Outlet />
       </main>
     </div>
   )
+}
+
+function CrmBreadcrumbs() {
+  const location = useLocation()
+  const matches = useMatches()
+  const pathParts = location.pathname.split("/").filter(Boolean)
+
+  if (pathParts.length === 0 || pathParts[0] === "dashboard") return null
+
+  const section = pathParts[0]
+  const detailLabel = getDetailLabel(section, matches.at(-1)?.loaderData)
+  const crumbs = [
+    { label: "Dashboard", to: "/dashboard" as const },
+    { label: sectionLabel(section), to: `/${section}` },
+  ]
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className="mb-5 flex flex-wrap items-center gap-1 text-sm text-muted-foreground"
+    >
+      {crumbs.map((crumb, index) => (
+        <span key={crumb.to} className="inline-flex items-center gap-1">
+          {index > 0 ? <ChevronRight className="h-3.5 w-3.5" /> : null}
+          <Link
+            to={crumb.to}
+            className="rounded-sm transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {crumb.label}
+          </Link>
+        </span>
+      ))}
+      {detailLabel ? (
+        <span className="inline-flex min-w-0 items-center gap-1 text-foreground">
+          <ChevronRight className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{detailLabel}</span>
+        </span>
+      ) : null}
+    </nav>
+  )
+}
+
+function sectionLabel(section: string) {
+  if (section === "gyms") return "Gyms"
+  if (section === "contacts") return "Contacts"
+  if (section === "interactions") return "Interactions"
+  return section
+}
+
+function getDetailLabel(section: string, loaderData: unknown) {
+  if (!loaderData || typeof loaderData !== "object") return null
+  if (
+    !(
+      "gym" in loaderData ||
+      "contact" in loaderData ||
+      "interaction" in loaderData
+    )
+  ) {
+    return null
+  }
+
+  if (section === "gyms" && "gym" in loaderData) {
+    return (loaderData.gym as { name?: string } | undefined)?.name ?? null
+  }
+  if (section === "contacts" && "contact" in loaderData) {
+    return (
+      (loaderData.contact as { fullName?: string } | undefined)?.fullName ??
+      null
+    )
+  }
+  if (section === "interactions" && "interaction" in loaderData) {
+    return (
+      (loaderData.interaction as { title?: string } | undefined)?.title ?? null
+    )
+  }
+
+  return null
 }
 
 function NavLink({

--- a/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
@@ -1,5 +1,12 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { Building2, Handshake, UserRound } from "lucide-react"
+import {
+  Building2,
+  Clock3,
+  Handshake,
+  Mail,
+  Phone,
+  UserRound,
+} from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/_authenticated/contacts/$contactId")({
@@ -34,18 +41,42 @@ function ContactDetailPage() {
         <h2 className="mt-1 text-3xl font-semibold tracking-tight">
           {contact.fullName}
         </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {[contact.status, contact.companyName].filter(Boolean).join(" • ")}
-        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <Badge value={contact.status || "Lead"} />
+          {contact.companyId && contact.companyName ? (
+            <Link
+              to="/gyms/$gymId"
+              params={{ gymId: contact.companyId }}
+              className="underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {contact.companyName}
+            </Link>
+          ) : null}
+        </div>
       </header>
 
       <section className="space-y-4 rounded-lg border border-border p-4">
-        <div className="flex flex-wrap gap-2">
-          <Fact label="Status" value={contact.status || "Lead"} />
-          <Fact label="Email" value={contact.email} />
-          <Fact label="Phone" value={contact.phone} />
-          <Fact label="Gym" value={contact.companyName} />
-          <Fact label="Updated" value={contact.updatedAt} />
+        <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
+          <MetaItem
+            icon={<Mail className="h-4 w-4" aria-hidden="true" />}
+            value={contact.email}
+            label="Email"
+          />
+          <MetaItem
+            icon={<Phone className="h-4 w-4" aria-hidden="true" />}
+            value={contact.phone}
+            label="Phone"
+          />
+          <MetaItem
+            icon={<Building2 className="h-4 w-4" aria-hidden="true" />}
+            value={contact.companyName}
+            label="Gym"
+          />
+          <MetaItem
+            icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
+            value={contact.updatedAt}
+            label="Updated"
+          />
         </div>
         {contact.notes ? <NoteBlock>{contact.notes}</NoteBlock> : null}
       </section>
@@ -108,15 +139,34 @@ function ContactDetailPage() {
   )
 }
 
-function Fact({ label, value }: { label: string; value: string | null }) {
+function Badge({ value }: { value: string | null }) {
   if (!value) return null
 
   return (
-    <span className="inline-flex max-w-full items-center gap-1.5 rounded-md bg-secondary px-2.5 py-1 text-sm">
-      <span className="text-xs font-medium uppercase text-muted-foreground">
-        {label}
-      </span>
-      <span className="truncate">{value}</span>
+    <span className="rounded-md bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+      {value}
+    </span>
+  )
+}
+
+function MetaItem({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string | null
+}) {
+  if (!value) return null
+
+  return (
+    <span
+      title={`${label}: ${value}`}
+      className="inline-flex min-w-0 items-center gap-2 rounded-md border border-border bg-background px-2.5 py-2 text-sm"
+    >
+      <span className="shrink-0 text-muted-foreground">{icon}</span>
+      <span className="min-w-0 truncate">{value}</span>
     </span>
   )
 }

--- a/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
@@ -43,14 +43,16 @@ function ContactDetailPage() {
         </h2>
         <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
           <Badge value={contact.status || "Lead"} />
-          {contact.companyId && contact.companyName ? (
+          {gym ? (
             <Link
               to="/gyms/$gymId"
-              params={{ gymId: contact.companyId }}
+              params={{ gymId: gym.id }}
               className="underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              {contact.companyName}
+              {gym.name}
             </Link>
+          ) : contact.companyName ? (
+            <span>{contact.companyName}</span>
           ) : null}
         </div>
       </header>

--- a/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
@@ -1,0 +1,170 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router"
+import { Building2, Handshake, Mail, Phone, UserRound } from "lucide-react"
+import { getCrmDataFn } from "@/server-fns/crm"
+
+export const Route = createFileRoute("/_authenticated/contacts/$contactId")({
+  loader: async ({ params }) => {
+    const data = await getCrmDataFn()
+    const contact = data.contacts.find((item) => item.id === params.contactId)
+    if (!contact) throw notFound()
+
+    const gym = contact.companyId
+      ? data.gyms.find((item) => item.id === contact.companyId)
+      : undefined
+    const interactions = data.interactions.filter(
+      (interaction) => interaction.contactId === contact.id,
+    )
+
+    return { contact, gym: gym ?? null, interactions }
+  },
+  notFoundComponent: () => <EntityNotFound label="Contact" />,
+  component: ContactDetailPage,
+})
+
+function ContactDetailPage() {
+  const { contact, gym, interactions } = Route.useLoaderData()
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <UserRound className="h-4 w-4" />
+          Contact
+        </div>
+        <h2 className="mt-1 text-3xl font-semibold tracking-tight">
+          {contact.fullName}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {[contact.status, contact.companyName].filter(Boolean).join(" • ")}
+        </p>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_18rem]">
+        <section className="rounded-lg border border-border p-4">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Details
+          </h3>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <Field label="Status" value={contact.status || "Lead"} />
+            <Field label="Updated" value={contact.updatedAt} />
+            <Field label="Notes" value={contact.notes} wide />
+          </div>
+        </section>
+
+        <aside className="space-y-3 rounded-lg border border-border p-4">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Contact
+          </h3>
+          <ContactLine
+            icon={<Mail className="h-4 w-4" />}
+            value={contact.email}
+          />
+          <ContactLine
+            icon={<Phone className="h-4 w-4" />}
+            value={contact.phone}
+          />
+        </aside>
+      </div>
+
+      <section className="rounded-lg border border-border">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold">
+          <Building2 className="h-4 w-4" />
+          Gym
+        </div>
+        {gym ? (
+          <div className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[1.5fr_1fr_1fr]">
+            <Link
+              to="/gyms/$gymId"
+              params={{ gymId: gym.id }}
+              className="font-medium underline-offset-4 hover:underline"
+            >
+              {gym.name}
+            </Link>
+            <span>{gym.location || "-"}</span>
+            <span>{gym.status || "Prospect"}</span>
+          </div>
+        ) : (
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No gym is linked to this contact yet.
+          </p>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-border">
+        <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold">
+          <Handshake className="h-4 w-4" />
+          Interactions
+        </div>
+        <div className="divide-y divide-border">
+          {interactions.length > 0 ? (
+            interactions.map((interaction) => (
+              <div
+                key={`${interaction.source}-${interaction.id}`}
+                className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[1.5fr_0.75fr_1fr]"
+              >
+                <Link
+                  to="/interactions/$interactionId"
+                  params={{ interactionId: interaction.id }}
+                  className="font-medium underline-offset-4 hover:underline"
+                >
+                  {interaction.title}
+                </Link>
+                <span>{interaction.date || "-"}</span>
+                <span>{interaction.status || interaction.channel || "-"}</span>
+              </div>
+            ))
+          ) : (
+            <p className="px-4 py-6 text-sm text-muted-foreground">
+              No interactions are linked to this contact yet.
+            </p>
+          )}
+        </div>
+      </section>
+    </section>
+  )
+}
+
+function Field({
+  label,
+  value,
+  wide,
+}: {
+  label: string
+  value: string | null
+  wide?: boolean
+}) {
+  return (
+    <div className={wide ? "md:col-span-2" : undefined}>
+      <dt className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 text-sm">{value || "-"}</dd>
+    </div>
+  )
+}
+
+function ContactLine({
+  icon,
+  value,
+}: {
+  icon: React.ReactNode
+  value: string | null
+}) {
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="text-muted-foreground">{icon}</span>
+      <span>{value || "-"}</span>
+    </div>
+  )
+}
+
+function EntityNotFound({ label }: { label: string }) {
+  return (
+    <section className="rounded-lg border border-border p-6">
+      <h2 className="text-xl font-semibold">{label} not found</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This CRM record may have been removed or has not been seeded yet.
+      </p>
+    </section>
+  )
+}

--- a/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { Building2, Handshake, Mail, Phone, UserRound } from "lucide-react"
+import { Building2, Handshake, UserRound } from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/_authenticated/contacts/$contactId")({
@@ -39,32 +39,16 @@ function ContactDetailPage() {
         </p>
       </header>
 
-      <div className="grid gap-4 lg:grid-cols-[1fr_18rem]">
-        <section className="rounded-lg border border-border p-4">
-          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
-            Details
-          </h3>
-          <div className="mt-4 grid gap-4 md:grid-cols-2">
-            <Field label="Status" value={contact.status || "Lead"} />
-            <Field label="Updated" value={contact.updatedAt} />
-            <Field label="Notes" value={contact.notes} wide />
-          </div>
-        </section>
-
-        <aside className="space-y-3 rounded-lg border border-border p-4">
-          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
-            Contact
-          </h3>
-          <ContactLine
-            icon={<Mail className="h-4 w-4" />}
-            value={contact.email}
-          />
-          <ContactLine
-            icon={<Phone className="h-4 w-4" />}
-            value={contact.phone}
-          />
-        </aside>
-      </div>
+      <section className="space-y-4 rounded-lg border border-border p-4">
+        <div className="flex flex-wrap gap-2">
+          <Fact label="Status" value={contact.status || "Lead"} />
+          <Fact label="Email" value={contact.email} />
+          <Fact label="Phone" value={contact.phone} />
+          <Fact label="Gym" value={contact.companyName} />
+          <Fact label="Updated" value={contact.updatedAt} />
+        </div>
+        {contact.notes ? <NoteBlock>{contact.notes}</NoteBlock> : null}
+      </section>
 
       <section className="rounded-lg border border-border">
         <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold">
@@ -124,36 +108,23 @@ function ContactDetailPage() {
   )
 }
 
-function Field({
-  label,
-  value,
-  wide,
-}: {
-  label: string
-  value: string | null
-  wide?: boolean
-}) {
+function Fact({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null
+
   return (
-    <div className={wide ? "md:col-span-2" : undefined}>
-      <dt className="text-xs font-medium uppercase text-muted-foreground">
+    <span className="inline-flex max-w-full items-center gap-1.5 rounded-md bg-secondary px-2.5 py-1 text-sm">
+      <span className="text-xs font-medium uppercase text-muted-foreground">
         {label}
-      </dt>
-      <dd className="mt-1 text-sm">{value || "-"}</dd>
-    </div>
+      </span>
+      <span className="truncate">{value}</span>
+    </span>
   )
 }
 
-function ContactLine({
-  icon,
-  value,
-}: {
-  icon: React.ReactNode
-  value: string | null
-}) {
+function NoteBlock({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex items-center gap-2 text-sm">
-      <span className="text-muted-foreground">{icon}</span>
-      <span>{value || "-"}</span>
+    <div className="border-t border-border pt-4 text-sm leading-6 text-muted-foreground">
+      {children}
     </div>
   )
 }

--- a/apps/crm/src/routes/_authenticated/contacts.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.tsx
@@ -1,4 +1,10 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router"
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useLocation,
+  useRouter,
+} from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import { Plus, Search } from "lucide-react"
 import { useMemo, useState } from "react"
@@ -11,6 +17,7 @@ export const Route = createFileRoute("/_authenticated/contacts")({
 
 function ContactsPage() {
   const { contacts, gyms } = Route.useLoaderData()
+  const location = useLocation()
   const router = useRouter()
   const createContact = useServerFn(createContactFn)
   const [query, setQuery] = useState("")
@@ -25,6 +32,10 @@ function ContactsPage() {
         .some((value) => value.toLowerCase().includes(normalized)),
     )
   }, [contacts, query])
+
+  if (location.pathname !== "/contacts") {
+    return <Outlet />
+  }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -125,12 +136,30 @@ function ContactsPage() {
             {filteredContacts.map((contact) => (
               <tr key={contact.id} className="align-top">
                 <Td>
-                  <p className="font-medium">{contact.fullName}</p>
+                  <Link
+                    to="/contacts/$contactId"
+                    params={{ contactId: contact.id }}
+                    className="font-medium text-foreground underline-offset-4 hover:underline"
+                  >
+                    {contact.fullName}
+                  </Link>
                   <p className="truncate text-muted-foreground">
                     {contact.email || "No email"}
                   </p>
                 </Td>
-                <Td>{contact.companyName || "-"}</Td>
+                <Td>
+                  {contact.companyId && contact.companyName ? (
+                    <Link
+                      to="/gyms/$gymId"
+                      params={{ gymId: contact.companyId }}
+                      className="underline-offset-4 hover:underline"
+                    >
+                      {contact.companyName}
+                    </Link>
+                  ) : (
+                    "-"
+                  )}
+                </Td>
                 <Td>{contact.status || "Lead"}</Td>
                 <Td>{contact.phone || "-"}</Td>
                 <Td>

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { Building2, Handshake, Mail, Phone, UserRound } from "lucide-react"
+import { Building2, Handshake, UserRound } from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/_authenticated/gyms/$gymId")({
@@ -53,30 +53,21 @@ function GymDetailPage() {
         </Link>
       </header>
 
-      <div className="grid gap-4 lg:grid-cols-[1fr_18rem]">
-        <section className="rounded-lg border border-border p-4">
-          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
-            Details
-          </h3>
-          <div className="mt-4 grid gap-4 md:grid-cols-2">
-            <Field label="Owner / Manager" value={gym.ownerManager} />
-            <Field label="Relationship" value={gym.relationship} />
-            <Field label="Website" value={gym.website} href={gym.website} />
-            <Field label="Instagram" value={gym.instagram} />
-            <Field label="Last contacted" value={gym.lastContacted} />
-            <Field label="Updated" value={gym.updatedAt} />
-            <Field label="Notes" value={gym.notes} wide />
-          </div>
-        </section>
-
-        <aside className="space-y-3 rounded-lg border border-border p-4">
-          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
-            Contact
-          </h3>
-          <ContactLine icon={<Mail className="h-4 w-4" />} value={gym.email} />
-          <ContactLine icon={<Phone className="h-4 w-4" />} value={gym.phone} />
-        </aside>
-      </div>
+      <section className="space-y-4 rounded-lg border border-border p-4">
+        <div className="flex flex-wrap gap-2">
+          <Fact label="Status" value={gym.status || "Prospect"} />
+          <Fact label="Priority" value={gym.priority} />
+          <Fact label="Owner" value={gym.ownerManager} />
+          <Fact label="Relationship" value={gym.relationship} />
+          <Fact label="Email" value={gym.email} />
+          <Fact label="Phone" value={gym.phone} />
+          <Fact label="Last touched" value={gym.lastContacted} />
+          <Fact label="Updated" value={gym.updatedAt} />
+          <Fact label="Instagram" value={gym.instagram} />
+          <Fact label="Website" value={gym.website} href={gym.website} />
+        </div>
+        {gym.notes ? <NoteBlock>{gym.notes}</NoteBlock> : null}
+      </section>
 
       <RelatedSection
         icon={<UserRound className="h-4 w-4" />}
@@ -121,51 +112,42 @@ function GymDetailPage() {
   )
 }
 
-function Field({
+function Fact({
   label,
   value,
   href,
-  wide,
 }: {
   label: string
   value: string | null
   href?: string | null
-  wide?: boolean
 }) {
+  if (!value) return null
+
   return (
-    <div className={wide ? "md:col-span-2" : undefined}>
-      <dt className="text-xs font-medium uppercase text-muted-foreground">
+    <span className="inline-flex max-w-full items-center gap-1.5 rounded-md bg-secondary px-2.5 py-1 text-sm">
+      <span className="text-xs font-medium uppercase text-muted-foreground">
         {label}
-      </dt>
-      <dd className="mt-1 text-sm">
-        {href && value ? (
-          <a
-            href={href.startsWith("http") ? href : `https://${href}`}
-            target="_blank"
-            rel="noreferrer"
-            className="underline-offset-4 hover:underline"
-          >
-            {value}
-          </a>
-        ) : (
-          value || "-"
-        )}
-      </dd>
-    </div>
+      </span>
+      {href ? (
+        <a
+          href={href.startsWith("http") ? href : `https://${href}`}
+          target="_blank"
+          rel="noreferrer"
+          className="truncate underline-offset-4 hover:underline"
+        >
+          {value}
+        </a>
+      ) : (
+        <span className="truncate">{value}</span>
+      )}
+    </span>
   )
 }
 
-function ContactLine({
-  icon,
-  value,
-}: {
-  icon: React.ReactNode
-  value: string | null
-}) {
+function NoteBlock({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex items-center gap-2 text-sm">
-      <span className="text-muted-foreground">{icon}</span>
-      <span>{value || "-"}</span>
+    <div className="border-t border-border pt-4 text-sm leading-6 text-muted-foreground">
+      {children}
     </div>
   )
 }

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -78,6 +78,7 @@ function GymDetailPage() {
             icon={<Handshake className="h-4 w-4" aria-hidden="true" />}
             value={gym.relationship}
             label="Relationship"
+            showLabel
           />
           <MetaItem
             icon={<Mail className="h-4 w-4" aria-hidden="true" />}
@@ -104,11 +105,13 @@ function GymDetailPage() {
             icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
             value={gym.lastContacted}
             label="Last contacted"
+            showLabel
           />
           <MetaItem
             icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
             value={gym.updatedAt}
             label="Updated"
+            showLabel
           />
         </div>
         {gym.notes ? <NoteBlock>{gym.notes}</NoteBlock> : null}
@@ -194,11 +197,13 @@ function MetaItem({
   label,
   value,
   href,
+  showLabel,
 }: {
   icon: React.ReactNode
   label: string
   value: string | null
   href?: string | null
+  showLabel?: boolean
 }) {
   if (!value) return null
 
@@ -208,6 +213,11 @@ function MetaItem({
       className="inline-flex min-w-0 items-center gap-2 rounded-md border border-border bg-background px-2.5 py-2 text-sm"
     >
       <span className="shrink-0 text-muted-foreground">{icon}</span>
+      {showLabel ? (
+        <span className="shrink-0 text-xs font-medium uppercase text-muted-foreground">
+          {label}
+        </span>
+      ) : null}
       {href ? (
         <a
           href={href.startsWith("http") ? href : `https://${href}`}

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -1,0 +1,218 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router"
+import { Building2, Handshake, Mail, Phone, UserRound } from "lucide-react"
+import { getCrmDataFn } from "@/server-fns/crm"
+
+export const Route = createFileRoute("/_authenticated/gyms/$gymId")({
+  loader: async ({ params }) => {
+    const data = await getCrmDataFn()
+    const gym = data.gyms.find((item) => item.id === params.gymId)
+    if (!gym) throw notFound()
+
+    const contacts = data.contacts.filter(
+      (contact) => contact.companyId === gym.id,
+    )
+    const contactIds = new Set(contacts.map((contact) => contact.id))
+    const interactions = data.interactions.filter(
+      (interaction) =>
+        interaction.companyId === gym.id ||
+        (interaction.contactId ? contactIds.has(interaction.contactId) : false),
+    )
+
+    return { gym, contacts, interactions }
+  },
+  notFoundComponent: () => <EntityNotFound label="Gym" />,
+  component: GymDetailPage,
+})
+
+function GymDetailPage() {
+  const { gym, contacts, interactions } = Route.useLoaderData()
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Building2 className="h-4 w-4" />
+            Gym
+          </div>
+          <h2 className="mt-1 text-3xl font-semibold tracking-tight">
+            {gym.name}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {[gym.location, gym.status, gym.priority]
+              .filter(Boolean)
+              .join(" • ")}
+          </p>
+        </div>
+        <Link
+          to="/interactions"
+          search={{}}
+          className="inline-flex h-10 items-center justify-center rounded-md border border-input px-4 text-sm font-medium hover:bg-accent"
+        >
+          View all interactions
+        </Link>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_18rem]">
+        <section className="rounded-lg border border-border p-4">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Details
+          </h3>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <Field label="Owner / Manager" value={gym.ownerManager} />
+            <Field label="Relationship" value={gym.relationship} />
+            <Field label="Website" value={gym.website} href={gym.website} />
+            <Field label="Instagram" value={gym.instagram} />
+            <Field label="Last contacted" value={gym.lastContacted} />
+            <Field label="Updated" value={gym.updatedAt} />
+            <Field label="Notes" value={gym.notes} wide />
+          </div>
+        </section>
+
+        <aside className="space-y-3 rounded-lg border border-border p-4">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Contact
+          </h3>
+          <ContactLine icon={<Mail className="h-4 w-4" />} value={gym.email} />
+          <ContactLine icon={<Phone className="h-4 w-4" />} value={gym.phone} />
+        </aside>
+      </div>
+
+      <RelatedSection
+        icon={<UserRound className="h-4 w-4" />}
+        title="Contacts"
+        empty="No contacts are linked to this gym yet."
+      >
+        {contacts.map((contact) => (
+          <RelatedRow key={contact.id}>
+            <Link
+              to="/contacts/$contactId"
+              params={{ contactId: contact.id }}
+              className="font-medium underline-offset-4 hover:underline"
+            >
+              {contact.fullName}
+            </Link>
+            <span>{contact.status || "Lead"}</span>
+            <span>{contact.email || contact.phone || "-"}</span>
+          </RelatedRow>
+        ))}
+      </RelatedSection>
+
+      <RelatedSection
+        icon={<Handshake className="h-4 w-4" />}
+        title="Interactions"
+        empty="No interactions are linked to this gym yet."
+      >
+        {interactions.map((interaction) => (
+          <RelatedRow key={`${interaction.source}-${interaction.id}`}>
+            <Link
+              to="/interactions/$interactionId"
+              params={{ interactionId: interaction.id }}
+              className="font-medium underline-offset-4 hover:underline"
+            >
+              {interaction.title}
+            </Link>
+            <span>{interaction.date || "-"}</span>
+            <span>{interaction.contactName || interaction.channel || "-"}</span>
+          </RelatedRow>
+        ))}
+      </RelatedSection>
+    </section>
+  )
+}
+
+function Field({
+  label,
+  value,
+  href,
+  wide,
+}: {
+  label: string
+  value: string | null
+  href?: string | null
+  wide?: boolean
+}) {
+  return (
+    <div className={wide ? "md:col-span-2" : undefined}>
+      <dt className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 text-sm">
+        {href && value ? (
+          <a
+            href={href.startsWith("http") ? href : `https://${href}`}
+            target="_blank"
+            rel="noreferrer"
+            className="underline-offset-4 hover:underline"
+          >
+            {value}
+          </a>
+        ) : (
+          value || "-"
+        )}
+      </dd>
+    </div>
+  )
+}
+
+function ContactLine({
+  icon,
+  value,
+}: {
+  icon: React.ReactNode
+  value: string | null
+}) {
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className="text-muted-foreground">{icon}</span>
+      <span>{value || "-"}</span>
+    </div>
+  )
+}
+
+function RelatedSection({
+  icon,
+  title,
+  empty,
+  children,
+}: {
+  icon: React.ReactNode
+  title: string
+  empty: string
+  children: React.ReactNode[]
+}) {
+  return (
+    <section className="rounded-lg border border-border">
+      <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold">
+        {icon}
+        {title}
+      </div>
+      <div className="divide-y divide-border">
+        {children.length > 0 ? (
+          children
+        ) : (
+          <p className="px-4 py-6 text-sm text-muted-foreground">{empty}</p>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function RelatedRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[1.5fr_0.75fr_1fr]">
+      {children}
+    </div>
+  )
+}
+
+function EntityNotFound({ label }: { label: string }) {
+  return (
+    <section className="rounded-lg border border-border p-6">
+      <h2 className="text-xl font-semibold">{label} not found</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This CRM record may have been removed or has not been seeded yet.
+      </p>
+    </section>
+  )
+}

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
 import {
   Building2,
-  Clock3,
   Globe2,
   Handshake,
   Instagram,
@@ -102,14 +101,13 @@ function GymDetailPage() {
             value={gym.instagram}
             label="Instagram"
           />
-          <MetaItem
-            icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
-            value={gym.updatedAt}
-            label="Updated"
-            showLabel
-          />
         </div>
         {gym.notes ? <NoteBlock>{gym.notes}</NoteBlock> : null}
+        {gym.updatedAt ? (
+          <p className="border-t border-border pt-3 text-xs text-muted-foreground">
+            Record updated {gym.updatedAt}
+          </p>
+        ) : null}
       </section>
 
       <RelatedSection

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -36,6 +36,7 @@ export const Route = createFileRoute("/_authenticated/gyms/$gymId")({
 
 function GymDetailPage() {
   const { gym, contacts, interactions } = Route.useLoaderData()
+  const latestInteraction = interactions[0]
 
   return (
     <section className="space-y-6">
@@ -103,12 +104,6 @@ function GymDetailPage() {
           />
           <MetaItem
             icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
-            value={gym.lastContacted}
-            label="Last contacted"
-            showLabel
-          />
-          <MetaItem
-            icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
             value={gym.updatedAt}
             label="Updated"
             showLabel
@@ -140,6 +135,10 @@ function GymDetailPage() {
       <RelatedSection
         icon={<Handshake className="h-4 w-4" />}
         title="Interactions"
+        summary={interactionSummary(
+          interactions.length,
+          latestInteraction?.date,
+        )}
         empty="No interactions are linked to this gym yet."
       >
         {interactions.map((interaction) => (
@@ -245,19 +244,26 @@ function NoteBlock({ children }: { children: React.ReactNode }) {
 function RelatedSection({
   icon,
   title,
+  summary,
   empty,
   children,
 }: {
   icon: React.ReactNode
   title: string
+  summary?: string
   empty: string
   children: React.ReactNode[]
 }) {
   return (
     <section className="rounded-lg border border-border">
-      <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold">
-        {icon}
-        {title}
+      <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <div className="flex items-center gap-2 text-sm font-semibold">
+          {icon}
+          {title}
+        </div>
+        {summary ? (
+          <p className="text-xs font-normal text-muted-foreground">{summary}</p>
+        ) : null}
       </div>
       <div className="divide-y divide-border">
         {children.length > 0 ? (
@@ -268,6 +274,15 @@ function RelatedSection({
       </div>
     </section>
   )
+}
+
+function interactionSummary(
+  count: number,
+  latestDate: string | null | undefined,
+) {
+  if (count === 0) return undefined
+  const countLabel = count === 1 ? "1 interaction" : `${count} interactions`
+  return latestDate ? `${countLabel} • latest ${latestDate}` : countLabel
 }
 
 function RelatedRow({ children }: { children: React.ReactNode }) {

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -1,5 +1,15 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { Building2, Handshake, UserRound } from "lucide-react"
+import {
+  Building2,
+  Clock3,
+  Globe2,
+  Handshake,
+  Instagram,
+  Mail,
+  MapPin,
+  Phone,
+  UserRound,
+} from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/_authenticated/gyms/$gymId")({
@@ -38,11 +48,15 @@ function GymDetailPage() {
           <h2 className="mt-1 text-3xl font-semibold tracking-tight">
             {gym.name}
           </h2>
-          <p className="mt-2 text-sm text-muted-foreground">
-            {[gym.location, gym.status, gym.priority]
-              .filter(Boolean)
-              .join(" • ")}
-          </p>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <MetaInline
+              icon={<MapPin className="h-4 w-4" aria-hidden="true" />}
+              value={gym.location}
+              label="Location"
+            />
+            <Badge value={gym.status || "Prospect"} />
+            <Badge value={gym.priority} />
+          </div>
         </div>
         <Link
           to="/interactions"
@@ -54,17 +68,48 @@ function GymDetailPage() {
       </header>
 
       <section className="space-y-4 rounded-lg border border-border p-4">
-        <div className="flex flex-wrap gap-2">
-          <Fact label="Status" value={gym.status || "Prospect"} />
-          <Fact label="Priority" value={gym.priority} />
-          <Fact label="Owner" value={gym.ownerManager} />
-          <Fact label="Relationship" value={gym.relationship} />
-          <Fact label="Email" value={gym.email} />
-          <Fact label="Phone" value={gym.phone} />
-          <Fact label="Last touched" value={gym.lastContacted} />
-          <Fact label="Updated" value={gym.updatedAt} />
-          <Fact label="Instagram" value={gym.instagram} />
-          <Fact label="Website" value={gym.website} href={gym.website} />
+        <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
+          <MetaItem
+            icon={<UserRound className="h-4 w-4" aria-hidden="true" />}
+            value={gym.ownerManager}
+            label="Owner or manager"
+          />
+          <MetaItem
+            icon={<Handshake className="h-4 w-4" aria-hidden="true" />}
+            value={gym.relationship}
+            label="Relationship"
+          />
+          <MetaItem
+            icon={<Mail className="h-4 w-4" aria-hidden="true" />}
+            value={gym.email}
+            label="Email"
+          />
+          <MetaItem
+            icon={<Phone className="h-4 w-4" aria-hidden="true" />}
+            value={gym.phone}
+            label="Phone"
+          />
+          <MetaItem
+            icon={<Globe2 className="h-4 w-4" aria-hidden="true" />}
+            value={gym.website}
+            label="Website"
+            href={gym.website}
+          />
+          <MetaItem
+            icon={<Instagram className="h-4 w-4" aria-hidden="true" />}
+            value={gym.instagram}
+            label="Instagram"
+          />
+          <MetaItem
+            icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
+            value={gym.lastContacted}
+            label="Last contacted"
+          />
+          <MetaItem
+            icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
+            value={gym.updatedAt}
+            label="Updated"
+          />
         </div>
         {gym.notes ? <NoteBlock>{gym.notes}</NoteBlock> : null}
       </section>
@@ -112,11 +157,45 @@ function GymDetailPage() {
   )
 }
 
-function Fact({
+function Badge({ value }: { value: string | null }) {
+  if (!value) return null
+
+  return (
+    <span className="rounded-md bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+      {value}
+    </span>
+  )
+}
+
+function MetaInline({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string | null
+}) {
+  if (!value) return null
+
+  return (
+    <span
+      title={`${label}: ${value}`}
+      className="inline-flex min-w-0 items-center gap-1.5"
+    >
+      {icon}
+      <span className="truncate">{value}</span>
+    </span>
+  )
+}
+
+function MetaItem({
+  icon,
   label,
   value,
   href,
 }: {
+  icon: React.ReactNode
   label: string
   value: string | null
   href?: string | null
@@ -124,21 +203,22 @@ function Fact({
   if (!value) return null
 
   return (
-    <span className="inline-flex max-w-full items-center gap-1.5 rounded-md bg-secondary px-2.5 py-1 text-sm">
-      <span className="text-xs font-medium uppercase text-muted-foreground">
-        {label}
-      </span>
+    <span
+      title={`${label}: ${value}`}
+      className="inline-flex min-w-0 items-center gap-2 rounded-md border border-border bg-background px-2.5 py-2 text-sm"
+    >
+      <span className="shrink-0 text-muted-foreground">{icon}</span>
       {href ? (
         <a
           href={href.startsWith("http") ? href : `https://${href}`}
           target="_blank"
           rel="noreferrer"
-          className="truncate underline-offset-4 hover:underline"
+          className="min-w-0 truncate underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
           {value}
         </a>
       ) : (
-        <span className="truncate">{value}</span>
+        <span className="min-w-0 truncate">{value}</span>
       )}
     </span>
   )

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -133,10 +133,10 @@ function GymDetailPage() {
       <RelatedSection
         icon={<Handshake className="h-4 w-4" />}
         title="Interactions"
-        summary={interactionSummary(
-          interactions.length,
-          latestInteraction?.date,
-        )}
+        summary={interactionSummary({
+          count: interactions.length,
+          latestDate: latestInteraction?.date,
+        })}
         empty="No interactions are linked to this gym yet."
       >
         {interactions.map((interaction) => (
@@ -274,10 +274,13 @@ function RelatedSection({
   )
 }
 
-function interactionSummary(
-  count: number,
-  latestDate: string | null | undefined,
-) {
+function interactionSummary({
+  count,
+  latestDate,
+}: {
+  count: number
+  latestDate: string | null | undefined
+}) {
   if (count === 0) return undefined
   const countLabel = count === 1 ? "1 interaction" : `${count} interactions`
   return latestDate ? `${countLabel} • latest ${latestDate}` : countLabel

--- a/apps/crm/src/routes/_authenticated/gyms.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.tsx
@@ -1,4 +1,10 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router"
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useLocation,
+  useRouter,
+} from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import { Plus, Search } from "lucide-react"
 import { useMemo, useState } from "react"
@@ -11,6 +17,7 @@ export const Route = createFileRoute("/_authenticated/gyms")({
 
 function GymsPage() {
   const { gyms } = Route.useLoaderData()
+  const location = useLocation()
   const router = useRouter()
   const createGym = useServerFn(createGymFn)
   const [query, setQuery] = useState("")
@@ -25,6 +32,10 @@ function GymsPage() {
         .some((value) => value.toLowerCase().includes(normalized)),
     )
   }, [gyms, query])
+
+  if (location.pathname !== "/gyms") {
+    return <Outlet />
+  }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -124,7 +135,13 @@ function GymsPage() {
             {filteredGyms.map((gym) => (
               <tr key={gym.id} className="align-top">
                 <Td>
-                  <p className="font-medium">{gym.name}</p>
+                  <Link
+                    to="/gyms/$gymId"
+                    params={{ gymId: gym.id }}
+                    className="font-medium text-foreground underline-offset-4 hover:underline"
+                  >
+                    {gym.name}
+                  </Link>
                   <p className="truncate text-muted-foreground">
                     {gym.website || gym.instagram || "No web presence saved"}
                   </p>

--- a/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
@@ -1,0 +1,171 @@
+import { createFileRoute, Link, notFound } from "@tanstack/react-router"
+import { Building2, CalendarDays, Handshake, UserRound } from "lucide-react"
+import { getCrmDataFn } from "@/server-fns/crm"
+
+export const Route = createFileRoute(
+  "/_authenticated/interactions/$interactionId",
+)({
+  loader: async ({ params }) => {
+    const data = await getCrmDataFn()
+    const interaction = data.interactions.find(
+      (item) => item.id === params.interactionId,
+    )
+    if (!interaction) throw notFound()
+
+    const gym = interaction.companyId
+      ? data.gyms.find((item) => item.id === interaction.companyId)
+      : undefined
+    const contact = interaction.contactId
+      ? data.contacts.find((item) => item.id === interaction.contactId)
+      : undefined
+
+    return { interaction, gym: gym ?? null, contact: contact ?? null }
+  },
+  notFoundComponent: () => <EntityNotFound label="Interaction" />,
+  component: InteractionDetailPage,
+})
+
+function InteractionDetailPage() {
+  const { interaction, gym, contact } = Route.useLoaderData()
+
+  return (
+    <section className="space-y-6">
+      <header>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Handshake className="h-4 w-4" />
+          {interaction.source}
+        </div>
+        <h2 className="mt-1 text-3xl font-semibold tracking-tight">
+          {interaction.title}
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {[interaction.date, interaction.channel, interaction.status]
+            .filter(Boolean)
+            .join(" • ")}
+        </p>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_18rem]">
+        <section className="rounded-lg border border-border p-4">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Details
+          </h3>
+          <div className="mt-4 grid gap-4 md:grid-cols-2">
+            <Field label="Date" value={interaction.date} />
+            <Field label="Channel" value={interaction.channel} />
+            <Field label="Status" value={interaction.status} />
+            <Field label="Updated" value={interaction.updatedAt} />
+            <Field label="Notes" value={interaction.notes} wide />
+            <Field label="Content" value={interaction.content} wide />
+          </div>
+        </section>
+
+        <aside className="space-y-3 rounded-lg border border-border p-4">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Timeline
+          </h3>
+          <div className="flex items-center gap-2 text-sm">
+            <CalendarDays className="h-4 w-4 text-muted-foreground" />
+            <span>{interaction.date || "No date"}</span>
+          </div>
+        </aside>
+      </div>
+
+      <section className="grid gap-4 md:grid-cols-2">
+        <AssociationCard
+          icon={<Building2 className="h-4 w-4" />}
+          title="Gym"
+          empty="No gym linked"
+        >
+          {gym ? (
+            <>
+              <Link
+                to="/gyms/$gymId"
+                params={{ gymId: gym.id }}
+                className="font-medium underline-offset-4 hover:underline"
+              >
+                {gym.name}
+              </Link>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {[gym.location, gym.status].filter(Boolean).join(" • ") || "-"}
+              </p>
+            </>
+          ) : null}
+        </AssociationCard>
+
+        <AssociationCard
+          icon={<UserRound className="h-4 w-4" />}
+          title="Contact"
+          empty="No contact linked"
+        >
+          {contact ? (
+            <>
+              <Link
+                to="/contacts/$contactId"
+                params={{ contactId: contact.id }}
+                className="font-medium underline-offset-4 hover:underline"
+              >
+                {contact.fullName}
+              </Link>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {contact.email || contact.phone || "-"}
+              </p>
+            </>
+          ) : null}
+        </AssociationCard>
+      </section>
+    </section>
+  )
+}
+
+function Field({
+  label,
+  value,
+  wide,
+}: {
+  label: string
+  value: string | null
+  wide?: boolean
+}) {
+  return (
+    <div className={wide ? "md:col-span-2" : undefined}>
+      <dt className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 whitespace-pre-wrap text-sm">{value || "-"}</dd>
+    </div>
+  )
+}
+
+function AssociationCard({
+  icon,
+  title,
+  empty,
+  children,
+}: {
+  icon: React.ReactNode
+  title: string
+  empty: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <h3 className="flex items-center gap-2 text-sm font-semibold uppercase text-muted-foreground">
+        {icon}
+        {title}
+      </h3>
+      <div className="mt-4 text-sm">{children || empty}</div>
+    </section>
+  )
+}
+
+function EntityNotFound({ label }: { label: string }) {
+  return (
+    <section className="rounded-lg border border-border p-6">
+      <h2 className="text-xl font-semibold">{label} not found</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        This CRM record may have been removed or has not been seeded yet.
+      </p>
+    </section>
+  )
+}

--- a/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
@@ -1,5 +1,12 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { Building2, Handshake, UserRound } from "lucide-react"
+import {
+  Building2,
+  CalendarDays,
+  Clock3,
+  Handshake,
+  Send,
+  UserRound,
+} from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute(
@@ -38,21 +45,39 @@ function InteractionDetailPage() {
         <h2 className="mt-1 text-3xl font-semibold tracking-tight">
           {interaction.title}
         </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {[interaction.date, interaction.channel, interaction.status]
-            .filter(Boolean)
-            .join(" • ")}
-        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+          <MetaInline
+            icon={<CalendarDays className="h-4 w-4" aria-hidden="true" />}
+            value={interaction.date}
+            label="Date"
+          />
+          <Badge value={interaction.channel} />
+          <Badge value={interaction.status} />
+        </div>
       </header>
 
       <section className="space-y-4 rounded-lg border border-border p-4">
-        <div className="flex flex-wrap gap-2">
-          <Fact label="Date" value={interaction.date} />
-          <Fact label="Channel" value={interaction.channel} />
-          <Fact label="Status" value={interaction.status} />
-          <Fact label="Gym" value={interaction.companyName} />
-          <Fact label="Contact" value={interaction.contactName} />
-          <Fact label="Updated" value={interaction.updatedAt} />
+        <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
+          <MetaItem
+            icon={<Building2 className="h-4 w-4" aria-hidden="true" />}
+            value={interaction.companyName}
+            label="Gym"
+          />
+          <MetaItem
+            icon={<UserRound className="h-4 w-4" aria-hidden="true" />}
+            value={interaction.contactName}
+            label="Contact"
+          />
+          <MetaItem
+            icon={<Send className="h-4 w-4" aria-hidden="true" />}
+            value={interaction.channel}
+            label="Channel"
+          />
+          <MetaItem
+            icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
+            value={interaction.updatedAt}
+            label="Updated"
+          />
         </div>
         {interaction.notes ? <NoteBlock>{interaction.notes}</NoteBlock> : null}
         {interaction.content ? (
@@ -107,15 +132,56 @@ function InteractionDetailPage() {
   )
 }
 
-function Fact({ label, value }: { label: string; value: string | null }) {
+function Badge({ value }: { value: string | null }) {
   if (!value) return null
 
   return (
-    <span className="inline-flex max-w-full items-center gap-1.5 rounded-md bg-secondary px-2.5 py-1 text-sm">
-      <span className="text-xs font-medium uppercase text-muted-foreground">
-        {label}
-      </span>
+    <span className="rounded-md bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+      {value}
+    </span>
+  )
+}
+
+function MetaInline({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string | null
+}) {
+  if (!value) return null
+
+  return (
+    <span
+      title={`${label}: ${value}`}
+      className="inline-flex min-w-0 items-center gap-1.5"
+    >
+      {icon}
       <span className="truncate">{value}</span>
+    </span>
+  )
+}
+
+function MetaItem({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: string | null
+}) {
+  if (!value) return null
+
+  return (
+    <span
+      title={`${label}: ${value}`}
+      className="inline-flex min-w-0 items-center gap-2 rounded-md border border-border bg-background px-2.5 py-2 text-sm"
+    >
+      <span className="shrink-0 text-muted-foreground">{icon}</span>
+      <span className="min-w-0 truncate">{value}</span>
     </span>
   )
 }

--- a/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router"
-import { Building2, CalendarDays, Handshake, UserRound } from "lucide-react"
+import { Building2, Handshake, UserRound } from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute(
@@ -45,31 +45,20 @@ function InteractionDetailPage() {
         </p>
       </header>
 
-      <div className="grid gap-4 lg:grid-cols-[1fr_18rem]">
-        <section className="rounded-lg border border-border p-4">
-          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
-            Details
-          </h3>
-          <div className="mt-4 grid gap-4 md:grid-cols-2">
-            <Field label="Date" value={interaction.date} />
-            <Field label="Channel" value={interaction.channel} />
-            <Field label="Status" value={interaction.status} />
-            <Field label="Updated" value={interaction.updatedAt} />
-            <Field label="Notes" value={interaction.notes} wide />
-            <Field label="Content" value={interaction.content} wide />
-          </div>
-        </section>
-
-        <aside className="space-y-3 rounded-lg border border-border p-4">
-          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
-            Timeline
-          </h3>
-          <div className="flex items-center gap-2 text-sm">
-            <CalendarDays className="h-4 w-4 text-muted-foreground" />
-            <span>{interaction.date || "No date"}</span>
-          </div>
-        </aside>
-      </div>
+      <section className="space-y-4 rounded-lg border border-border p-4">
+        <div className="flex flex-wrap gap-2">
+          <Fact label="Date" value={interaction.date} />
+          <Fact label="Channel" value={interaction.channel} />
+          <Fact label="Status" value={interaction.status} />
+          <Fact label="Gym" value={interaction.companyName} />
+          <Fact label="Contact" value={interaction.contactName} />
+          <Fact label="Updated" value={interaction.updatedAt} />
+        </div>
+        {interaction.notes ? <NoteBlock>{interaction.notes}</NoteBlock> : null}
+        {interaction.content ? (
+          <NoteBlock>{interaction.content}</NoteBlock>
+        ) : null}
+      </section>
 
       <section className="grid gap-4 md:grid-cols-2">
         <AssociationCard
@@ -118,21 +107,23 @@ function InteractionDetailPage() {
   )
 }
 
-function Field({
-  label,
-  value,
-  wide,
-}: {
-  label: string
-  value: string | null
-  wide?: boolean
-}) {
+function Fact({ label, value }: { label: string; value: string | null }) {
+  if (!value) return null
+
   return (
-    <div className={wide ? "md:col-span-2" : undefined}>
-      <dt className="text-xs font-medium uppercase text-muted-foreground">
+    <span className="inline-flex max-w-full items-center gap-1.5 rounded-md bg-secondary px-2.5 py-1 text-sm">
+      <span className="text-xs font-medium uppercase text-muted-foreground">
         {label}
-      </dt>
-      <dd className="mt-1 whitespace-pre-wrap text-sm">{value || "-"}</dd>
+      </span>
+      <span className="truncate">{value}</span>
+    </span>
+  )
+}
+
+function NoteBlock({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="whitespace-pre-wrap border-t border-border pt-4 text-sm leading-6 text-muted-foreground">
+      {children}
     </div>
   )
 }

--- a/apps/crm/src/routes/_authenticated/interactions.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.tsx
@@ -1,4 +1,10 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router"
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useLocation,
+  useRouter,
+} from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import { Plus, Search } from "lucide-react"
 import { useMemo, useState } from "react"
@@ -11,6 +17,7 @@ export const Route = createFileRoute("/_authenticated/interactions")({
 
 function InteractionsPage() {
   const { interactions, gyms, contacts } = Route.useLoaderData()
+  const location = useLocation()
   const router = useRouter()
   const createInteraction = useServerFn(createInteractionFn)
   const [query, setQuery] = useState("")
@@ -32,6 +39,10 @@ function InteractionsPage() {
         .some((value) => value.toLowerCase().includes(normalized)),
     )
   }, [interactions, query])
+
+  if (location.pathname !== "/interactions") {
+    return <Outlet />
+  }
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -154,14 +165,44 @@ function InteractionsPage() {
                 className="align-top"
               >
                 <Td>
-                  <p className="font-medium">{interaction.title}</p>
+                  <Link
+                    to="/interactions/$interactionId"
+                    params={{ interactionId: interaction.id }}
+                    className="font-medium text-foreground underline-offset-4 hover:underline"
+                  >
+                    {interaction.title}
+                  </Link>
                   <p className="truncate text-muted-foreground">
                     {interaction.channel || interaction.source}
                   </p>
                 </Td>
                 <Td>{interaction.date || "-"}</Td>
-                <Td>{interaction.companyName || "-"}</Td>
-                <Td>{interaction.contactName || "-"}</Td>
+                <Td>
+                  {interaction.companyId && interaction.companyName ? (
+                    <Link
+                      to="/gyms/$gymId"
+                      params={{ gymId: interaction.companyId }}
+                      className="underline-offset-4 hover:underline"
+                    >
+                      {interaction.companyName}
+                    </Link>
+                  ) : (
+                    "-"
+                  )}
+                </Td>
+                <Td>
+                  {interaction.contactId && interaction.contactName ? (
+                    <Link
+                      to="/contacts/$contactId"
+                      params={{ contactId: interaction.contactId }}
+                      className="underline-offset-4 hover:underline"
+                    >
+                      {interaction.contactName}
+                    </Link>
+                  ) : (
+                    "-"
+                  )}
+                </Td>
                 <Td>{interaction.status || "-"}</Td>
               </tr>
             ))}

--- a/apps/crm/src/routes/_authenticated/interactions.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.tsx
@@ -178,27 +178,35 @@ function InteractionsPage() {
                 </Td>
                 <Td>{interaction.date || "-"}</Td>
                 <Td>
-                  {interaction.companyId && interaction.companyName ? (
-                    <Link
-                      to="/gyms/$gymId"
-                      params={{ gymId: interaction.companyId }}
-                      className="underline-offset-4 hover:underline"
-                    >
-                      {interaction.companyName}
-                    </Link>
+                  {interaction.companyName ? (
+                    interaction.companyId ? (
+                      <Link
+                        to="/gyms/$gymId"
+                        params={{ gymId: interaction.companyId }}
+                        className="underline-offset-4 hover:underline"
+                      >
+                        {interaction.companyName}
+                      </Link>
+                    ) : (
+                      interaction.companyName
+                    )
                   ) : (
                     "-"
                   )}
                 </Td>
                 <Td>
-                  {interaction.contactId && interaction.contactName ? (
-                    <Link
-                      to="/contacts/$contactId"
-                      params={{ contactId: interaction.contactId }}
-                      className="underline-offset-4 hover:underline"
-                    >
-                      {interaction.contactName}
-                    </Link>
+                  {interaction.contactName ? (
+                    interaction.contactId ? (
+                      <Link
+                        to="/contacts/$contactId"
+                        params={{ contactId: interaction.contactId }}
+                        className="underline-offset-4 hover:underline"
+                      >
+                        {interaction.contactName}
+                      </Link>
+                    ) : (
+                      interaction.contactName
+                    )
                   ) : (
                     "-"
                   )}


### PR DESCRIPTION
## Summary
- add detail pages for gym, contact, and interaction records
- make list rows link into entity detail pages and add breadcrumbs for CRM navigation
- show associations between gyms, contacts, and interactions with denser record metadata
- derive gym contact recency from linked interactions and move record updated metadata to a quiet footer

## Testing
- NODE24=/tmp/codex-node24/node-v24.13.0-darwin-x64; PATH="$NODE24/bin:$PATH" $NODE24/bin/node node_modules/typescript/bin/tsc -p tsconfig.json --noEmit
- NODE24=/tmp/codex-node24/node-v24.13.0-darwin-x64; PATH="$NODE24/bin:$PATH" ./node_modules/.bin/biome check src/routes/_authenticated.tsx src/routes/_authenticated/gyms.tsx src/routes/_authenticated/contacts.tsx src/routes/_authenticated/interactions.tsx src/routes/_authenticated/gyms.$gymId.tsx src/routes/_authenticated/contacts.$contactId.tsx src/routes/_authenticated/interactions.$interactionId.tsx
- browser smoke test on gym detail page for record updated footer and interaction recency summary

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add detail pages for gyms, contacts, and interactions with breadcrumbs and nested routing. Lists now link to detail views and across related entities; gym pages show interaction recency and move “updated” info to a quiet footer.

- **New Features**
  - Gym detail: contacts and interactions sections; recency summary from linked interactions; updated date in footer.
  - Contact detail: linked gym and interactions.
  - Interaction detail: linked gym and contact; notes/content blocks.
  - CRM breadcrumbs across pages with dynamic detail labels; table rows link to details.
  - Router tree adds nested routes: `/gyms/$gymId`, `/contacts/$contactId`, `/interactions/$interactionId`; lists link company/contact cells when IDs exist.

<sup>Written for commit b26f7bc6d5158f6f1032b18a347c790d9da04881. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/477?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated detail pages for contacts, gyms, and interactions with comprehensive entity information.
  * Added breadcrumb navigation in the authenticated section for improved page tracking.
  * List items are now clickable links directing to respective detail pages.
  * Detail pages display related entities and interaction summaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->