### PR TITLE
Add CRM document relations backed by R2

### DIFF
--- a/apps/crm/.dev.vars.example
+++ b/apps/crm/.dev.vars.example
@@ -1,0 +1,5 @@
+# Cloudflare Workers development variables
+# Copy this file to .dev.vars for local Vite dev.
+
+CRM_AUTH_PASSWORD=dev-password
+CRM_SESSION_SECRET=dev-session-secret-change-in-production

--- a/apps/crm/package.json
+++ b/apps/crm/package.json
@@ -14,8 +14,8 @@
     "db:push": "drizzle-kit push",
     "db:generate": "drizzle-kit generate",
     "db:studio": "drizzle-kit studio",
-    "db:migrate:local": "wrangler d1 migrations apply crm-db-dev --local -c .alchemy/local/wrangler.jsonc",
-    "db:setup-local": "mkdir -p .alchemy/local/src/db && rm -f .alchemy/local/src/db/migrations && ln -sf ../../../../src/db/migrations .alchemy/local/src/db/migrations && pnpm db:migrate:local",
+    "db:migrate:local": "wrangler d1 migrations apply crm-db --local",
+    "db:setup-local": "pnpm db:migrate:local",
     "db:seed:local": "node scripts/seed-local-d1-from-duckdb.mjs",
     "alchemy:dev": "STAGE=dev bun alchemy.run.ts",
     "deploy": "bun alchemy.run.ts",
@@ -23,6 +23,7 @@
     "crm-deploy": "STAGE=prod bun alchemy.run.ts"
   },
   "dependencies": {
+    "@cloudflare/vite-plugin": "^1.19.0",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-router": "^1.132.0",
     "@tanstack/react-start": "^1.132.0",

--- a/apps/crm/scripts/seed-local-d1-from-duckdb.mjs
+++ b/apps/crm/scripts/seed-local-d1-from-duckdb.mjs
@@ -15,8 +15,8 @@ const workspaceDuckDb =
 	"/Users/ianjones/.openclaw-dench/workspace/workspace.duckdb"
 const localD1 =
 	process.env.CRM_LOCAL_D1 ??
-	findLocalD1(path.join(appRoot, ".alchemy/local/.wrangler/state/v3/d1")) ??
-	findLocalD1(path.join(appRoot, ".wrangler/state/v3/d1"))
+	findLocalD1(path.join(appRoot, ".wrangler/state/v3/d1")) ??
+	findLocalD1(path.join(appRoot, ".alchemy/local/.wrangler/state/v3/d1"))
 
 if (!localD1) {
 	throw new Error("No local D1 sqlite file found. Run `pnpm alchemy:dev` first.")
@@ -145,13 +145,18 @@ const tables = {
 	},
 }
 
-const migrations = ["0000_initial-crm-schema.sql", "0001_entry-relations.sql"]
+const migrations = [
+  "0000_initial-crm-schema.sql",
+  "0001_entry-relations.sql",
+  "0002_document-entries.sql",
+]
 	.map((file) => readFileSync(path.join(appRoot, "src/db/migrations", file), "utf8"))
 	.join("\n")
 
 const sql = [
 	"PRAGMA foreign_keys = OFF;",
 	"DROP TABLE IF EXISTS entry_relations;",
+	"DROP TABLE IF EXISTS document_entries;",
 	"DROP TABLE IF EXISTS entry_fields;",
 	"DROP TABLE IF EXISTS statuses;",
 	"DROP TABLE IF EXISTS documents;",
@@ -232,6 +237,7 @@ const verification = runSqlite(
 		"UNION ALL SELECT 'entries', COUNT(*) FROM entries",
 		"UNION ALL SELECT 'entry_fields', COUNT(*) FROM entry_fields",
 		"UNION ALL SELECT 'entry_relations', COUNT(*) FROM entry_relations",
+		"UNION ALL SELECT 'document_entries', COUNT(*) FROM document_entries",
 		"UNION ALL SELECT 'statuses', COUNT(*) FROM statuses",
 		"UNION ALL SELECT 'documents', COUNT(*) FROM documents;",
 	].join("\n"),

--- a/apps/crm/src/components/entity-document-panel.tsx
+++ b/apps/crm/src/components/entity-document-panel.tsx
@@ -1,0 +1,328 @@
+import { useServerFn } from "@tanstack/react-start"
+import { Download, Eye, Loader2, Trash2, Upload, X } from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  deleteDocumentForEntryFn,
+  getDocumentDownloadUrlForEntryFn,
+  listDocumentsForEntryFn,
+  uploadDocumentForEntryFn,
+} from "@/server-fns/crm"
+
+type CrmDocument = {
+  id: string
+  title: string
+  filePath: string
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+type DocumentPreview = {
+  documentId: string
+  title: string
+  content: string
+}
+
+const PREVIEWABLE_EXTENSIONS = new Set(["csv", "json", "md", "markdown", "txt", "text"])
+const PREVIEWABLE_CONTENT_TYPES = [
+  "text/",
+  "application/csv",
+  "application/json",
+  "application/markdown",
+  "application/x-markdown",
+]
+
+export function EntityDocumentPanel({
+  entryId,
+  label,
+}: {
+  entryId: string
+  label: string
+}) {
+  const [documents, setDocuments] = useState<CrmDocument[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [documentTitle, setDocumentTitle] = useState("")
+  const [uploading, setUploading] = useState(false)
+  const [removingId, setRemovingId] = useState<string | null>(null)
+  const [preview, setPreview] = useState<DocumentPreview | null>(null)
+  const [previewingId, setPreviewingId] = useState<string | null>(null)
+  const [error, setError] = useState("")
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const listFn = useServerFn(listDocumentsForEntryFn)
+  const uploadFn = useServerFn(uploadDocumentForEntryFn)
+  const deleteFn = useServerFn(deleteDocumentForEntryFn)
+  const downloadFn = useServerFn(getDocumentDownloadUrlForEntryFn)
+
+  const loadDocuments = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const result = await listFn({ data: { entryId } })
+      setDocuments(
+        result.map((document) => ({
+          ...document,
+          title: document.title ?? "Untitled",
+        })),
+      )
+    } finally {
+      setIsLoading(false)
+    }
+  }, [entryId, listFn])
+
+  useEffect(() => {
+    void loadDocuments()
+  }, [loadDocuments])
+
+  const readFileAsBase64 = async (file: File): Promise<string> => {
+    const arrayBuffer = await file.arrayBuffer()
+    const bytes = new Uint8Array(arrayBuffer)
+    let binary = ""
+    for (let index = 0; index < bytes.length; index += 1) {
+      binary += String.fromCharCode(bytes[index])
+    }
+    return btoa(binary)
+  }
+
+  const handleUpload = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!selectedFile) {
+      setError("Select a file first")
+      return
+    }
+
+    setError("")
+    setUploading(true)
+
+    try {
+      const fileBase64 = await readFileAsBase64(selectedFile)
+      await uploadFn({
+        data: {
+          entryId,
+          fileName: selectedFile.name,
+          fileBase64,
+          fileSize: selectedFile.size,
+          contentType: selectedFile.type || "application/octet-stream",
+          title: documentTitle.trim() || undefined,
+        },
+      })
+      setSelectedFile(null)
+      setDocumentTitle("")
+      if (fileInputRef.current) {
+        fileInputRef.current.value = ""
+      }
+      await loadDocuments()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Upload failed")
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const handleDelete = async (documentId: string) => {
+    setRemovingId(documentId)
+    try {
+      await deleteFn({ data: { documentId, entryId } })
+      setDocuments((current) => current.filter((doc) => doc.id !== documentId))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Delete failed")
+    } finally {
+      setRemovingId(null)
+    }
+  }
+
+  const handleDownload = async (documentId: string, fileName: string) => {
+    const result = await downloadFn({ data: { documentId } })
+    const binaryString = atob(result.base64)
+    const bytes = new Uint8Array(binaryString.length)
+    for (let index = 0; index < binaryString.length; index += 1) {
+      bytes[index] = binaryString.charCodeAt(index)
+    }
+    const blob = new Blob([bytes], { type: result.contentType })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement("a")
+    anchor.href = url
+    anchor.download = fileName
+    anchor.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const handlePreview = async (documentId: string, fileName: string) => {
+    setError("")
+    setPreviewingId(documentId)
+    try {
+      const result = await downloadFn({ data: { documentId } })
+      if (!isPreviewableFile(fileName, result.contentType)) {
+        setError("This file type cannot be previewed.")
+        return
+      }
+
+      const binaryString = atob(result.base64)
+      const bytes = new Uint8Array(binaryString.length)
+      for (let index = 0; index < binaryString.length; index += 1) {
+        bytes[index] = binaryString.charCodeAt(index)
+      }
+
+      setPreview({
+        documentId,
+        title: fileName,
+        content: new TextDecoder().decode(bytes),
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Preview failed")
+    } finally {
+      setPreviewingId(null)
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-border">
+      <div className="flex items-center justify-between border-b border-border px-4 py-3">
+        <h3 className="text-sm font-semibold">Documents for {label}</h3>
+        <span className="text-xs text-muted-foreground">R2-backed</span>
+      </div>
+
+      <form
+        onSubmit={handleUpload}
+        className="space-y-3 border-b border-border px-4 py-3"
+      >
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Attach a file
+        </p>
+        <div className="flex flex-col gap-2 md:flex-row md:items-end">
+          <label className="space-y-1 text-sm font-medium md:w-1/3">
+            <span className="sr-only">Title</span>
+            <input
+              value={documentTitle}
+              onChange={(event) => setDocumentTitle(event.target.value)}
+              placeholder="Optional document label"
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+            />
+          </label>
+          <label className="space-y-1 text-sm font-medium md:flex-1">
+            <span className="sr-only">File</span>
+            <input
+              ref={fileInputRef}
+              type="file"
+              onChange={(event) =>
+                setSelectedFile(event.target.files?.[0] ?? null)
+              }
+              className="h-10 w-full rounded-md border border-input bg-background px-2 text-sm outline-none"
+              required
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={uploading}
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            {uploading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Uploading...
+              </>
+            ) : (
+              <>
+                <Upload className="h-4 w-4" />
+                Upload
+              </>
+            )}
+          </button>
+        </div>
+        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+      </form>
+
+      <div className="divide-y divide-border">
+        {isLoading ? (
+          <div className="flex items-center gap-2 px-4 py-4 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading documents...
+          </div>
+        ) : documents.length > 0 ? (
+          documents.map((document) => (
+            <div
+              key={document.id}
+              className="grid gap-2 px-4 py-3 md:grid-cols-[1fr_auto_auto_auto] md:items-center"
+            >
+              <div>
+                <p className="text-sm font-medium">{document.title}</p>
+                <p className="truncate text-xs text-muted-foreground">
+                  {document.filePath}
+                </p>
+              </div>
+              {isPreviewableFile(document.title, null) ||
+              isPreviewableFile(document.filePath, null) ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    void handlePreview(document.id, document.title)
+                  }
+                  disabled={previewingId === document.id}
+                  className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-input px-3 text-sm text-muted-foreground hover:bg-accent disabled:opacity-50"
+                >
+                  {previewingId === document.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                  View
+                </button>
+              ) : null}
+              <button
+                type="button"
+                onClick={() => void handleDownload(document.id, document.title)}
+                className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-input px-3 text-sm text-muted-foreground hover:bg-accent"
+              >
+                <Download className="h-4 w-4" />
+                Download
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleDelete(document.id)}
+                disabled={removingId === document.id}
+                className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-destructive/30 text-destructive hover:bg-destructive/10"
+              >
+                {removingId === document.id ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Trash2 className="h-4 w-4" />
+                )}
+                {removingId === document.id ? "Removing..." : "Remove"}
+              </button>
+            </div>
+          ))
+        ) : (
+          <p className="px-4 py-4 text-sm text-muted-foreground">
+            No documents yet.
+          </p>
+        )}
+      </div>
+      {preview ? (
+        <div className="border-t border-border">
+          <div className="flex items-center justify-between gap-3 px-4 py-3">
+            <p className="truncate text-sm font-medium">{preview.title}</p>
+            <button
+              type="button"
+              onClick={() => setPreview(null)}
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-input text-muted-foreground hover:bg-accent"
+              aria-label="Close preview"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <pre className="max-h-96 overflow-auto border-t border-border bg-secondary/40 p-4 text-xs leading-5 text-foreground">
+            {preview.content}
+          </pre>
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+function isPreviewableFile(fileName: string, contentType: string | null) {
+  const extension = fileName.split(".").pop()?.toLowerCase()
+  if (extension && PREVIEWABLE_EXTENSIONS.has(extension)) return true
+  if (!contentType) return false
+  return PREVIEWABLE_CONTENT_TYPES.some((type) =>
+    contentType.toLowerCase().startsWith(type),
+  )
+}

--- a/apps/crm/src/components/entity-document-panel.tsx
+++ b/apps/crm/src/components/entity-document-panel.tsx
@@ -181,7 +181,7 @@ export function EntityDocumentPanel({
 
   return (
     <section className="overflow-hidden rounded-lg border border-border">
-      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border px-4 py-4">
+      <div className="border-b border-border px-4 py-4">
         <div className="min-w-0">
           <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
             Documents
@@ -190,9 +190,6 @@ export function EntityDocumentPanel({
             Attachments for {label}
           </h3>
         </div>
-        <span className="inline-flex h-7 shrink-0 items-center rounded-full border border-border bg-secondary px-2.5 text-xs font-medium text-muted-foreground">
-          R2-backed
-        </span>
       </div>
 
       <form

--- a/apps/crm/src/components/entity-document-panel.tsx
+++ b/apps/crm/src/components/entity-document-panel.tsx
@@ -1,6 +1,6 @@
 import { useServerFn } from "@tanstack/react-start"
-import { Download, Eye, Loader2, Trash2, Upload, X } from "lucide-react"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { Download, Eye, FileText, Loader2, Trash2, Upload, X } from "lucide-react"
+import { useCallback, useEffect, useId, useRef, useState } from "react"
 import {
   deleteDocumentForEntryFn,
   getDocumentDownloadUrlForEntryFn,
@@ -47,6 +47,8 @@ export function EntityDocumentPanel({
   const [preview, setPreview] = useState<DocumentPreview | null>(null)
   const [previewingId, setPreviewingId] = useState<string | null>(null)
   const [error, setError] = useState("")
+  const titleInputId = useId()
+  const fileInputId = useId()
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   const listFn = useServerFn(listDocumentsForEntryFn)
@@ -119,6 +121,9 @@ export function EntityDocumentPanel({
   }
 
   const handleDelete = async (documentId: string) => {
+    const shouldDelete = window.confirm("Remove this document from the record?")
+    if (!shouldDelete) return
+
     setRemovingId(documentId)
     try {
       await deleteFn({ data: { documentId, entryId } })
@@ -175,141 +180,186 @@ export function EntityDocumentPanel({
   }
 
   return (
-    <section className="rounded-lg border border-border">
-      <div className="flex items-center justify-between border-b border-border px-4 py-3">
-        <h3 className="text-sm font-semibold">Documents for {label}</h3>
-        <span className="text-xs text-muted-foreground">R2-backed</span>
+    <section className="overflow-hidden rounded-lg border border-border">
+      <div className="flex flex-wrap items-start justify-between gap-3 border-b border-border px-4 py-4">
+        <div className="min-w-0">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Documents
+          </p>
+          <h3 className="mt-1 text-sm font-semibold text-foreground text-pretty">
+            Attachments for {label}
+          </h3>
+        </div>
+        <span className="inline-flex h-7 shrink-0 items-center rounded-full border border-border bg-secondary px-2.5 text-xs font-medium text-muted-foreground">
+          R2-backed
+        </span>
       </div>
 
       <form
         onSubmit={handleUpload}
-        className="space-y-3 border-b border-border px-4 py-3"
+        className="space-y-3 border-b border-border bg-secondary/20 px-4 py-4"
       >
-        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
           Attach a file
         </p>
-        <div className="flex flex-col gap-2 md:flex-row md:items-end">
-          <label className="space-y-1 text-sm font-medium md:w-1/3">
-            <span className="sr-only">Title</span>
+        <div className="grid gap-3 md:grid-cols-[minmax(10rem,0.85fr)_minmax(12rem,1.15fr)_auto] md:items-end">
+          <div className="space-y-1.5">
+            <label
+              htmlFor={titleInputId}
+              className="text-xs font-medium text-muted-foreground"
+            >
+              Label
+            </label>
             <input
+              id={titleInputId}
+              name="documentTitle"
               value={documentTitle}
               onChange={(event) => setDocumentTitle(event.target.value)}
-              placeholder="Optional document label"
-              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+              placeholder="Optional document label…"
+              autoComplete="off"
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             />
-          </label>
-          <label className="space-y-1 text-sm font-medium md:flex-1">
-            <span className="sr-only">File</span>
+          </div>
+          <div className="space-y-1.5">
+            <label
+              htmlFor={fileInputId}
+              className="text-xs font-medium text-muted-foreground"
+            >
+              File
+            </label>
             <input
+              id={fileInputId}
+              name="documentFile"
               ref={fileInputRef}
               type="file"
               onChange={(event) =>
                 setSelectedFile(event.target.files?.[0] ?? null)
               }
-              className="h-10 w-full rounded-md border border-input bg-background px-2 text-sm outline-none"
+              autoComplete="off"
+              className="h-10 w-full rounded-md border border-input bg-background px-2 text-sm file:mr-3 file:h-8 file:rounded-md file:border-0 file:bg-secondary file:px-3 file:text-xs file:font-medium file:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               required
             />
-          </label>
+          </div>
           <button
             type="submit"
             disabled={uploading}
-            className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+            className="inline-flex h-10 items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
           >
             {uploading ? (
               <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                Uploading...
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Uploading…
               </>
             ) : (
               <>
-                <Upload className="h-4 w-4" />
+                <Upload className="h-4 w-4" aria-hidden="true" />
                 Upload
               </>
             )}
           </button>
         </div>
-        {error ? <p className="text-sm text-destructive">{error}</p> : null}
+        {error ? (
+          <p className="text-sm text-destructive" aria-live="polite">
+            {error}
+          </p>
+        ) : null}
       </form>
 
       <div className="divide-y divide-border">
         {isLoading ? (
           <div className="flex items-center gap-2 px-4 py-4 text-sm text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Loading documents...
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading documents…
           </div>
         ) : documents.length > 0 ? (
           documents.map((document) => (
             <div
               key={document.id}
-              className="grid gap-2 px-4 py-3 md:grid-cols-[1fr_auto_auto_auto] md:items-center"
+              className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-center"
             >
-              <div>
-                <p className="text-sm font-medium">{document.title}</p>
-                <p className="truncate text-xs text-muted-foreground">
-                  {document.filePath}
-                </p>
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border bg-secondary text-muted-foreground">
+                  <FileText className="h-4 w-4" aria-hidden="true" />
+                </span>
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium text-foreground">
+                    {document.title}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground" translate="no">
+                    {document.filePath}
+                  </p>
+                </div>
               </div>
-              {isPreviewableFile(document.title, null) ||
-              isPreviewableFile(document.filePath, null) ? (
+              <div className="flex flex-wrap gap-2 md:justify-end">
+                {isPreviewableFile(document.title, null) ||
+                isPreviewableFile(document.filePath, null) ? (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      void handlePreview(document.id, document.title)
+                    }
+                    disabled={previewingId === document.id}
+                    className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-input bg-background px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
+                  >
+                    {previewingId === document.id ? (
+                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    ) : (
+                      <Eye className="h-4 w-4" aria-hidden="true" />
+                    )}
+                    View
+                  </button>
+                ) : null}
                 <button
                   type="button"
-                  onClick={() =>
-                    void handlePreview(document.id, document.title)
-                  }
-                  disabled={previewingId === document.id}
-                  className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-input px-3 text-sm text-muted-foreground hover:bg-accent disabled:opacity-50"
+                  onClick={() => void handleDownload(document.id, document.title)}
+                  className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-input bg-background px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
-                  {previewingId === document.id ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Eye className="h-4 w-4" />
-                  )}
-                  View
+                  <Download className="h-4 w-4" aria-hidden="true" />
+                  Download
                 </button>
-              ) : null}
-              <button
-                type="button"
-                onClick={() => void handleDownload(document.id, document.title)}
-                className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-input px-3 text-sm text-muted-foreground hover:bg-accent"
-              >
-                <Download className="h-4 w-4" />
-                Download
-              </button>
-              <button
-                type="button"
-                onClick={() => void handleDelete(document.id)}
-                disabled={removingId === document.id}
-                className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-destructive/30 text-destructive hover:bg-destructive/10"
-              >
-                {removingId === document.id ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Trash2 className="h-4 w-4" />
-                )}
-                {removingId === document.id ? "Removing..." : "Remove"}
-              </button>
+                <button
+                  type="button"
+                  onClick={() => void handleDelete(document.id)}
+                  disabled={removingId === document.id}
+                  className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-destructive/30 bg-background px-3 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2 disabled:opacity-50"
+                >
+                  {removingId === document.id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                  )}
+                  {removingId === document.id ? "Removing…" : "Remove"}
+                </button>
+              </div>
             </div>
           ))
         ) : (
-          <p className="px-4 py-4 text-sm text-muted-foreground">
-            No documents yet.
-          </p>
+          <div className="px-4 py-6 text-sm text-muted-foreground">
+            No documents yet. Upload a file to keep it with this record.
+          </div>
         )}
       </div>
       {preview ? (
         <div className="border-t border-border">
-          <div className="flex items-center justify-between gap-3 px-4 py-3">
-            <p className="truncate text-sm font-medium">{preview.title}</p>
+          <div className="flex items-center justify-between gap-3 bg-secondary/20 px-4 py-3">
+            <div className="min-w-0">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                Preview
+              </p>
+              <p className="truncate text-sm font-medium text-foreground">
+                {preview.title}
+              </p>
+            </div>
             <button
               type="button"
               onClick={() => setPreview(null)}
-              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-input text-muted-foreground hover:bg-accent"
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-input bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               aria-label="Close preview"
             >
-              <X className="h-4 w-4" />
+              <X className="h-4 w-4" aria-hidden="true" />
             </button>
           </div>
-          <pre className="max-h-96 overflow-auto border-t border-border bg-secondary/40 p-4 text-xs leading-5 text-foreground">
+          <pre className="max-h-96 overflow-auto border-t border-border bg-background p-4 text-xs leading-5 text-foreground">
             {preview.content}
           </pre>
         </div>

--- a/apps/crm/src/db/migrations/0002_document-entries.sql
+++ b/apps/crm/src/db/migrations/0002_document-entries.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `document_entries` (
+	`id` text PRIMARY KEY NOT NULL,
+	`document_id` text NOT NULL,
+	`entry_id` text NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY (`document_id`) REFERENCES `documents`(`id`) ON UPDATE no action ON DELETE cascade,
+	FOREIGN KEY (`entry_id`) REFERENCES `entries`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `document_entries_document_id_unique` ON `document_entries` (`document_id`);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `document_entries_entry_id_document_id_unique` ON `document_entries` (`entry_id`,`document_id`);

--- a/apps/crm/src/db/migrations/meta/_journal.json
+++ b/apps/crm/src/db/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1779570966670,
       "tag": "0001_entry-relations",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1780011110000,
+      "tag": "0002_document-entries",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/crm/src/db/schema.ts
+++ b/apps/crm/src/db/schema.ts
@@ -168,6 +168,31 @@ export const documentsTable = sqliteTable(
   (table) => [uniqueIndex("documents_file_path_unique").on(table.filePath)],
 )
 
+export const documentEntriesTable = sqliteTable(
+  "document_entries",
+  {
+    id: id(),
+    documentId: text("document_id")
+      .notNull()
+      .references(() => documentsTable.id, {
+        onDelete: "cascade",
+      }),
+    entryId: text("entry_id")
+      .notNull()
+      .references(() => entriesTable.id, {
+        onDelete: "cascade",
+      }),
+    ...timestamps,
+  },
+  (table) => [
+    uniqueIndex("document_entries_document_id_unique").on(table.documentId),
+    uniqueIndex("document_entries_entry_id_document_id_unique").on(
+      table.entryId,
+      table.documentId,
+    ),
+  ],
+)
+
 export type CrmObject = typeof objectsTable.$inferSelect
 export type NewCrmObject = typeof objectsTable.$inferInsert
 export type CrmField = typeof fieldsTable.$inferSelect
@@ -181,4 +206,6 @@ export type NewCrmEntryRelation = typeof entryRelationsTable.$inferInsert
 export type CrmStatus = typeof statusesTable.$inferSelect
 export type NewCrmStatus = typeof statusesTable.$inferInsert
 export type CrmDocument = typeof documentsTable.$inferSelect
+export type CrmDocumentEntry = typeof documentEntriesTable.$inferSelect
 export type NewCrmDocument = typeof documentsTable.$inferInsert
+export type NewCrmDocumentEntry = typeof documentEntriesTable.$inferInsert

--- a/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
@@ -8,6 +8,7 @@ import {
   UserRound,
 } from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
+import { EntityDocumentPanel } from "@/components/entity-document-panel"
 
 export const Route = createFileRoute("/_authenticated/contacts/$contactId")({
   loader: async ({ params }) => {
@@ -137,6 +138,8 @@ function ContactDetailPage() {
           )}
         </div>
       </section>
+
+      <EntityDocumentPanel entryId={contact.id} label={contact.fullName} />
     </section>
   )
 }

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -10,6 +10,7 @@ import {
   UserRound,
 } from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
+import { EntityDocumentPanel } from "@/components/entity-document-panel"
 
 export const Route = createFileRoute("/_authenticated/gyms/$gymId")({
   loader: async ({ params }) => {
@@ -153,6 +154,8 @@ function GymDetailPage() {
           </RelatedRow>
         ))}
       </RelatedSection>
+
+      <EntityDocumentPanel entryId={gym.id} label={gym.name} />
     </section>
   )
 }

--- a/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
@@ -8,6 +8,7 @@ import {
   UserRound,
 } from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
+import { EntityDocumentPanel } from "@/components/entity-document-panel"
 
 export const Route = createFileRoute(
   "/_authenticated/interactions/$interactionId",
@@ -128,6 +129,11 @@ function InteractionDetailPage() {
           ) : null}
         </AssociationCard>
       </section>
+
+      <EntityDocumentPanel
+        entryId={interaction.id}
+        label={interaction.title || interaction.source}
+      />
     </section>
   )
 }

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -6,14 +6,19 @@ import {
   entriesTable,
   entryFieldsTable,
   entryRelationsTable,
+  documentEntriesTable,
   fieldsTable,
   objectsTable,
+  documentsTable,
 } from "@/db/schema"
 import { requireAuth } from "@/server-fns/auth"
+import { getR2Bucket } from "@/lib/env"
 
 type FieldValueMap = Record<string, string | null>
 
 const SQLITE_IN_CHUNK_SIZE = 50
+const MAX_DOCUMENT_BYTES = 10 * 1024 * 1024
+const MAX_DOCUMENT_BASE64_LENGTH = Math.ceil(MAX_DOCUMENT_BYTES / 3) * 4
 
 export type CrmGym = {
   id: string
@@ -60,6 +65,14 @@ export type CrmInteraction = {
   updatedAt: string | null
 }
 
+export type CrmDocument = {
+  id: string
+  title: string
+  filePath: string
+  createdAt: string | null
+  updatedAt: string | null
+}
+
 const gymInputSchema = z.object({
   name: z.string().min(1, "Gym name is required").max(255),
   location: z.string().max(255).optional(),
@@ -94,6 +107,23 @@ const interactionInputSchema = z.object({
   content: z.string().max(10000).optional(),
 })
 
+const documentUploadSchema = z.object({
+  entryId: z.string().min(1, "Entry ID is required"),
+  fileName: z.string().min(1, "File name is required"),
+  fileBase64: z.string().max(MAX_DOCUMENT_BASE64_LENGTH),
+  contentType: z.string().optional(),
+  fileSize: z.number().int().optional(),
+  title: z.string().max(255).optional(),
+})
+
+const entryDocumentListSchema = z.object({
+  entryId: z.string().min(1, "Entry ID is required"),
+})
+
+const documentIdSchema = z.object({
+  documentId: z.string().min(1, "Document ID is required"),
+})
+
 function crmId() {
   return crypto.randomUUID()
 }
@@ -101,6 +131,38 @@ function crmId() {
 function clean(value: string | null | undefined) {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
+}
+
+async function assertEntryExists(entryId: string) {
+  const db = getDb()
+  const [entry] = await db
+    .select({ id: entriesTable.id })
+    .from(entriesTable)
+    .where(eq(entriesTable.id, entryId))
+    .limit(1)
+
+  if (!entry) {
+    throw new Error(`CRM entry not found: ${entryId}`)
+  }
+
+  return entry
+}
+
+function sanitizeFileName(fileName: string) {
+  return fileName
+    .trim()
+    .replaceAll(/[^a-zA-Z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 120) || "document"
+}
+
+function decodeBase64(fileBase64: string) {
+  const binaryString = atob(fileBase64)
+  const bytes = new Uint8Array(binaryString.length)
+  for (let index = 0; index < binaryString.length; index += 1) {
+    bytes[index] = binaryString.charCodeAt(index)
+  }
+  return bytes
 }
 
 function chunks<T>(values: T[], size: number) {
@@ -235,6 +297,25 @@ async function getEntryDisplayNames(entryIds: string[]) {
   }
 
   return names
+}
+
+async function listDocumentsForEntry(entryId: string) {
+  const db = getDb()
+  return db
+    .select({
+      id: documentsTable.id,
+      title: documentsTable.title,
+      filePath: documentsTable.filePath,
+      createdAt: documentsTable.createdAt,
+      updatedAt: documentsTable.updatedAt,
+    })
+    .from(documentEntriesTable)
+    .innerJoin(
+      documentsTable,
+      eq(documentEntriesTable.documentId, documentsTable.id),
+    )
+    .where(eq(documentEntriesTable.entryId, entryId))
+    .orderBy(desc(documentEntriesTable.createdAt))
 }
 
 async function listEntries(objectName: string, limit = 250) {
@@ -547,4 +628,139 @@ export const createInteractionFn = createServerFn({ method: "POST" })
     await setRelation(entryId, personField.id, clean(data.contactId))
 
     return { id: entryId }
+  })
+
+export const listDocumentsForEntryFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => entryDocumentListSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    return listDocumentsForEntry(data.entryId)
+  })
+
+export const uploadDocumentForEntryFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => documentUploadSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    await assertEntryExists(data.entryId)
+
+    const bytes = decodeBase64(data.fileBase64)
+    if (data.fileSize && bytes.byteLength > MAX_DOCUMENT_BYTES) {
+      throw new Error("File too large (max 10 MB)")
+    }
+
+    const fileName = sanitizeFileName(data.fileName)
+    const datePrefix = new Date().toISOString().slice(0, 7)
+    const r2Key = `crm-documents/${datePrefix}/${crmId()}-${fileName}`
+
+    await getR2Bucket().put(r2Key, bytes.buffer, {
+      httpMetadata: {
+        contentType: data.contentType || "application/octet-stream",
+      },
+    })
+
+    const db = getDb()
+    const [document] = await db
+      .insert(documentsTable)
+      .values({
+        id: crmId(),
+        title: data.title || fileName,
+        filePath: r2Key,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .returning()
+
+    if (!document) {
+      throw new Error("Unable to create document")
+    }
+
+    await db.insert(documentEntriesTable).values({
+      id: crmId(),
+      documentId: document.id,
+      entryId: data.entryId,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+
+    return document
+  })
+
+export const deleteDocumentForEntryFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => {
+    return documentIdSchema
+      .extend({ entryId: z.string().min(1, "Entry ID is required") })
+      .parse(data)
+  })
+  .handler(async ({ data }) => {
+    await requireAuth()
+    const db = getDb()
+
+    const [documentRelation] = await db
+      .select({
+        filePath: documentsTable.filePath,
+      })
+      .from(documentEntriesTable)
+      .innerJoin(
+        documentsTable,
+        eq(documentEntriesTable.documentId, documentsTable.id),
+      )
+      .where(
+        and(
+          eq(documentEntriesTable.documentId, data.documentId),
+          eq(documentEntriesTable.entryId, data.entryId),
+        ),
+      )
+      .limit(1)
+
+    if (!documentRelation) {
+      throw new Error("Document link not found")
+    }
+
+    await db
+      .delete(documentEntriesTable)
+      .where(eq(documentEntriesTable.documentId, data.documentId))
+
+    await getR2Bucket().delete(documentRelation.filePath)
+    await db.delete(documentsTable).where(eq(documentsTable.id, data.documentId))
+
+    return { success: true }
+  })
+
+export const getDocumentDownloadUrlForEntryFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) => documentIdSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    const db = getDb()
+
+    const [document] = await db
+      .select({
+        fileName: documentsTable.title,
+        filePath: documentsTable.filePath,
+      })
+      .from(documentsTable)
+      .where(eq(documentsTable.id, data.documentId))
+      .limit(1)
+
+    if (!document) {
+      throw new Error("Document not found")
+    }
+
+    const object = await getR2Bucket().get(document.filePath)
+    if (!object) {
+      throw new Error("File not found in storage")
+    }
+
+    const arrayBuffer = await object.arrayBuffer()
+    const bytes = new Uint8Array(arrayBuffer)
+    const chunks: string[] = []
+    const chunkSize = 0x8000
+    for (let index = 0; index < bytes.length; index += chunkSize) {
+      chunks.push(String.fromCharCode(...bytes.subarray(index, index + chunkSize)))
+    }
+
+    return {
+      base64: btoa(chunks.join("")),
+      fileName: document.fileName,
+      contentType: object.httpMetadata?.contentType || "application/octet-stream",
+    }
   })

--- a/apps/crm/vite.config.ts
+++ b/apps/crm/vite.config.ts
@@ -1,17 +1,13 @@
+import { cloudflare } from "@cloudflare/vite-plugin"
 import tailwindcss from "@tailwindcss/vite"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import viteReact from "@vitejs/plugin-react"
-import alchemy from "alchemy/cloudflare/tanstack-start"
 import { defineConfig } from "vite"
 import viteTsConfigPaths from "vite-tsconfig-paths"
 
 const config = defineConfig({
   plugins: [
-    alchemy({
-      persistState: {
-        path: "./.alchemy/local/.wrangler/state",
-      },
-    }),
+    cloudflare({ viteEnvironment: { name: "ssr" } }),
     viteTsConfigPaths({
       projects: ["./tsconfig.json"],
     }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
 
   apps/crm:
     dependencies:
+      '@cloudflare/vite-plugin':
+        specifier: ^1.19.0
+        version: 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
       '@tailwindcss/vite':
         specifier: ^4.0.6
         version: 4.1.18(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))
@@ -47,10 +50,10 @@ importers:
         version: 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start':
         specifier: ^1.132.0
-        version: 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)
+        version: 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
       alchemy:
         specifier: 'catalog:'
-        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
+        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(stripe@17.7.0)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -145,7 +148,7 @@ importers:
         version: 3.9.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       alchemy:
         specifier: 'catalog:'
-        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(stripe@17.7.0)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
+        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
@@ -2961,9 +2964,6 @@ packages:
 
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
-
-  '@emnapi/runtime@1.7.1':
-    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -13390,21 +13390,21 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 4.2.1
 
   '@ai-sdk/provider-utils@3.0.12(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 4.2.1
 
   '@ai-sdk/provider-utils@4.0.0(zod@4.2.1)':
     dependencies:
       '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 4.2.1
 
   '@ai-sdk/provider-utils@4.0.14(zod@4.2.1)':
@@ -17325,10 +17325,10 @@ snapshots:
       dotenv: 16.5.0
       eciesjs: 0.4.14
       execa: 5.1.1
-      fdir: 6.5.0(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.4)
       ignore: 5.3.2
       object-treeify: 1.1.33
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       which: 4.0.0
     optional: true
 
@@ -17357,11 +17357,6 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.4.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.7.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -18131,7 +18126,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -18781,56 +18776,6 @@ snapshots:
 
   '@oozcitak/util@10.0.0': {}
 
-  '@opennextjs/aws@3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
-    dependencies:
-      '@ast-grep/napi': 0.40.0
-      '@aws-sdk/client-cloudfront': 3.398.0
-      '@aws-sdk/client-dynamodb': 3.808.0
-      '@aws-sdk/client-lambda': 3.808.0
-      '@aws-sdk/client-s3': 3.808.0
-      '@aws-sdk/client-sqs': 3.808.0
-      '@node-minify/core': 8.0.6
-      '@node-minify/terser': 8.0.6
-      '@tsconfig/node18': 1.0.3
-      aws4fetch: 1.0.20
-      chalk: 5.6.2
-      cookie: 1.1.1
-      esbuild: 0.25.4
-      express: 5.2.1
-      next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      path-to-regexp: 6.3.0
-      urlpattern-polyfill: 10.1.0
-      yaml: 2.8.2
-    transitivePeerDependencies:
-      - aws-crt
-      - supports-color
-    optional: true
-
-  '@opennextjs/aws@3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))':
-    dependencies:
-      '@ast-grep/napi': 0.40.0
-      '@aws-sdk/client-cloudfront': 3.398.0
-      '@aws-sdk/client-dynamodb': 3.808.0
-      '@aws-sdk/client-lambda': 3.808.0
-      '@aws-sdk/client-s3': 3.808.0
-      '@aws-sdk/client-sqs': 3.808.0
-      '@node-minify/core': 8.0.6
-      '@node-minify/terser': 8.0.6
-      '@tsconfig/node18': 1.0.3
-      aws4fetch: 1.0.20
-      chalk: 5.6.2
-      cookie: 1.1.1
-      esbuild: 0.25.4
-      express: 5.2.1
-      next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      path-to-regexp: 6.3.0
-      urlpattern-polyfill: 10.1.0
-      yaml: 2.8.2
-    transitivePeerDependencies:
-      - aws-crt
-      - supports-color
-    optional: true
-
   '@opennextjs/aws@3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@ast-grep/napi': 0.40.0
@@ -18860,29 +18805,11 @@ snapshots:
     dependencies:
       '@ast-grep/napi': 0.40.0
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@opennextjs/aws': 3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       cloudflare: 4.5.0
       enquirer: 2.4.1
       glob: 12.0.0
       next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      ts-tqdm: 0.8.6
-      wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
-      yargs: 18.0.0
-    transitivePeerDependencies:
-      - aws-crt
-      - encoding
-      - supports-color
-    optional: true
-
-  '@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))':
-    dependencies:
-      '@ast-grep/napi': 0.40.0
-      '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))
-      cloudflare: 4.5.0
-      enquirer: 2.4.1
-      glob: 12.0.0
-      next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
       ts-tqdm: 0.8.6
       wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
       yargs: 18.0.0
@@ -21156,16 +21083,6 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  '@tanstack/react-start-client@1.145.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@tanstack/router-core': 1.144.0
-      '@tanstack/start-client-core': 1.145.0
-      react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
-      tiny-invariant: 1.3.3
-      tiny-warning: 1.0.3
-
   '@tanstack/react-start-server@1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@tanstack/history': 1.141.0
@@ -21178,17 +21095,25 @@ snapshots:
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/react-start-server@1.145.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)':
+  '@tanstack/react-start@1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))':
     dependencies:
-      '@tanstack/history': 1.141.0
-      '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@tanstack/router-core': 1.144.0
+      '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-start-client': 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/react-start-server': 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@tanstack/router-utils': 1.143.11
       '@tanstack/start-client-core': 1.145.0
+      '@tanstack/start-plugin-core': 1.145.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
       '@tanstack/start-server-core': 1.145.0
-      react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
+      pathe: 2.0.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
     transitivePeerDependencies:
+      - '@rsbuild/core'
       - crossws
+      - supports-color
+      - vite-plugin-solid
+      - webpack
 
   '@tanstack/react-start@1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)':
     dependencies:
@@ -21202,26 +21127,6 @@ snapshots:
       pathe: 2.0.3
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - crossws
-      - supports-color
-      - vite-plugin-solid
-      - webpack
-
-  '@tanstack/react-start@1.145.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))':
-    dependencies:
-      '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@tanstack/react-start-client': 1.145.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@tanstack/react-start-server': 1.145.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      '@tanstack/router-utils': 1.143.11
-      '@tanstack/start-client-core': 1.145.0
-      '@tanstack/start-plugin-core': 1.145.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
-      '@tanstack/start-server-core': 1.145.0
-      pathe: 2.0.3
-      react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
       vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@rsbuild/core'
@@ -21290,6 +21195,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@tanstack/router-plugin@1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
+      '@babel/template': 7.27.2
+      '@babel/traverse': 7.28.5
+      '@babel/types': 7.28.5
+      '@tanstack/router-core': 1.144.0
+      '@tanstack/router-generator': 1.144.0
+      '@tanstack/router-utils': 1.143.11
+      '@tanstack/virtual-file-routes': 1.141.0
+      babel-dead-code-elimination: 1.0.11
+      chokidar: 3.6.0
+      unplugin: 2.3.11
+      zod: 3.25.76
+    optionalDependencies:
+      '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
+      webpack: 5.102.1(esbuild@0.19.12)
+    transitivePeerDependencies:
+      - supports-color
+
   '@tanstack/router-plugin@1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)':
     dependencies:
       '@babel/core': 7.28.5
@@ -21310,29 +21238,6 @@ snapshots:
       '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
       webpack: 5.102.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@tanstack/router-plugin@1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))':
-    dependencies:
-      '@babel/core': 7.28.5
-      '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
-      '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
-      '@tanstack/router-core': 1.144.0
-      '@tanstack/router-generator': 1.144.0
-      '@tanstack/router-utils': 1.143.11
-      '@tanstack/virtual-file-routes': 1.141.0
-      babel-dead-code-elimination: 1.0.11
-      chokidar: 3.6.0
-      unplugin: 2.3.11
-      zod: 3.25.76
-    optionalDependencies:
-      '@tanstack/react-router': 1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
-      webpack: 5.102.1(esbuild@0.19.12)
     transitivePeerDependencies:
       - supports-color
 
@@ -21387,7 +21292,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.143.8': {}
 
-  '@tanstack/start-plugin-core@1.145.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)':
+  '@tanstack/start-plugin-core@1.145.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.28.5
@@ -21395,7 +21300,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.144.0
       '@tanstack/router-generator': 1.144.0
-      '@tanstack/router-plugin': 1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)
+      '@tanstack/router-plugin': 1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
       '@tanstack/router-utils': 1.143.11
       '@tanstack/start-client-core': 1.145.0
       '@tanstack/start-server-core': 1.145.0
@@ -21418,7 +21323,7 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
-  '@tanstack/start-plugin-core@1.145.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))':
+  '@tanstack/start-plugin-core@1.145.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.28.5
@@ -21426,7 +21331,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.144.0
       '@tanstack/router-generator': 1.144.0
-      '@tanstack/router-plugin': 1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
+      '@tanstack/router-plugin': 1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)
       '@tanstack/router-utils': 1.143.11
       '@tanstack/start-client-core': 1.145.0
       '@tanstack/start-server-core': 1.145.0
@@ -22167,80 +22072,6 @@ snapshots:
       - utf-8-validate
       - workerd
 
-  alchemy@0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)):
-    dependencies:
-      '@aws-sdk/credential-providers': 3.958.0
-      '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20251217.0)
-      '@cloudflare/workers-types': 4.20251205.0
-      '@iarna/toml': 2.2.5
-      '@octokit/rest': 21.1.1
-      '@smithy/node-config-provider': 4.3.7
-      '@smithy/types': 4.11.0
-      aws4fetch: 1.0.20
-      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20251205.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)
-      env-paths: 3.0.0
-      esbuild: 0.25.10
-      execa: 9.6.1
-      fast-json-patch: 3.1.1
-      fast-xml-parser: 5.3.3
-      find-process: 2.0.0
-      glob: 10.5.0
-      jszip: 3.10.1
-      libsodium-wrappers: 0.7.15
-      miniflare: 4.20251217.0
-      neverthrow: 8.2.0
-      open: 10.2.0
-      openapi-types: 12.1.3
-      pathe: 2.0.3
-      picocolors: 1.1.1
-      proper-lockfile: 4.1.2
-      signal-exit: 4.1.0
-      unenv: 2.0.0-rc.21
-      wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
-      ws: 8.18.3
-      yaml: 2.8.2
-    optionalDependencies:
-      '@aws-sdk/client-dynamodb': 3.808.0
-      '@aws-sdk/client-lambda': 3.808.0
-      '@aws-sdk/client-s3': 3.808.0
-      '@aws-sdk/client-sqs': 3.808.0
-      '@aws-sdk/client-sts': 3.398.0
-      '@cloudflare/vite-plugin': 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
-      '@opennextjs/cloudflare': 1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@electric-sql/pglite'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - aws-crt
-      - better-sqlite3
-      - bufferutil
-      - bun-types
-      - expo-sqlite
-      - gel
-      - knex
-      - kysely
-      - mysql2
-      - pg
-      - postgres
-      - prisma
-      - sql.js
-      - sqlite3
-      - utf-8-validate
-      - workerd
-
   alchemy@0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)):
     dependencies:
       '@aws-sdk/credential-providers': 3.958.0
@@ -22281,6 +22112,80 @@ snapshots:
       '@aws-sdk/client-sts': 3.398.0
       '@cloudflare/vite-plugin': 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
       '@opennextjs/cloudflare': 1.14.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
+      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@electric-sql/pglite'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+      - utf-8-validate
+      - workerd
+
+  alchemy@0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0):
+    dependencies:
+      '@aws-sdk/credential-providers': 3.958.0
+      '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20251217.0)
+      '@cloudflare/workers-types': 4.20251205.0
+      '@iarna/toml': 2.2.5
+      '@octokit/rest': 21.1.1
+      '@smithy/node-config-provider': 4.3.7
+      '@smithy/types': 4.11.0
+      aws4fetch: 1.0.20
+      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20251205.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)
+      env-paths: 3.0.0
+      esbuild: 0.25.10
+      execa: 9.6.1
+      fast-json-patch: 3.1.1
+      fast-xml-parser: 5.3.3
+      find-process: 2.0.0
+      glob: 10.5.0
+      jszip: 3.10.1
+      libsodium-wrappers: 0.7.15
+      miniflare: 4.20251217.0
+      neverthrow: 8.2.0
+      open: 10.2.0
+      openapi-types: 12.1.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      proper-lockfile: 4.1.2
+      signal-exit: 4.1.0
+      unenv: 2.0.0-rc.21
+      wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
+      ws: 8.18.3
+      yaml: 2.8.2
+    optionalDependencies:
+      '@aws-sdk/client-dynamodb': 3.808.0
+      '@aws-sdk/client-lambda': 3.808.0
+      '@aws-sdk/client-s3': 3.808.0
+      '@aws-sdk/client-sqs': 3.808.0
+      '@aws-sdk/client-sts': 3.398.0
+      '@cloudflare/vite-plugin': 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
+      '@opennextjs/cloudflare': 1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
       vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -23785,7 +23690,7 @@ snapshots:
 
   eventsource@3.0.7:
     dependencies:
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
 
   evlog@2.8.0(ai@6.0.77(zod@4.2.1))(express@5.2.1)(hono@4.11.9)(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)):
     optionalDependencies:
@@ -23973,6 +23878,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+    optional: true
 
   feed@4.2.2:
     dependencies:
@@ -25152,10 +25062,6 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  lucide-react@0.544.0(react@19.2.4):
-    dependencies:
-      react: 19.2.4
-
   lz-string@1.5.0: {}
 
   magic-string@0.30.17:
@@ -25912,32 +25818,6 @@ snapshots:
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.3)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.7
-      '@next/swc-darwin-x64': 15.5.7
-      '@next/swc-linux-arm64-gnu': 15.5.7
-      '@next/swc-linux-arm64-musl': 15.5.7
-      '@next/swc-linux-x64-gnu': 15.5.7
-      '@next/swc-linux-x64-musl': 15.5.7
-      '@next/swc-win32-arm64-msvc': 15.5.7
-      '@next/swc-win32-x64-msvc': 15.5.7
-      '@opentelemetry/api': 1.9.0
-      '@playwright/test': 1.57.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-    optional: true
-
-  next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@next/env': 15.5.7
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001762
-      postcss: 8.4.31
-      react: 19.2.4
-      react-dom: 19.2.3(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.5.7
       '@next/swc-darwin-x64': 15.5.7
@@ -27854,14 +27734,6 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
-    optionalDependencies:
-      '@babel/core': 7.28.5
-    optional: true
-
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.4):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.28.5
     optional: true


### PR DESCRIPTION
## Summary

- add top-level CRM document-entry relation table and migration
- store uploaded document data in R2 and link documents to CRM entities
- add reusable document panel to interactions, contacts, and gyms with upload, download, delete, and text/CSV/Markdown/JSON preview
- switch CRM dev Vite config to the standard Cloudflare Vite plugin path

## Notes

- local dev was verified on port 3002 with the Cloudflare Vite plugin and local D1/R2 bindings
- pnpm was not available in this shell, so pnpm-lock.yaml still needs to be refreshed by running pnpm install
- the Drizzle migration journal was updated, but a generated 0002 snapshot should be considered before merge if this repo expects Drizzle metadata snapshots

## Testing

- tsc --noEmit
- biome check src/components/entity-document-panel.tsx

<!-- This is an auto-generated description by cubic. -->

***

## Summary by cubic

Adds R2-backed document storage with a new `document_entries` relation and a polished document panel on contacts, gyms, and interactions. Dev build uses `@cloudflare/vite-plugin` for SSR.

- **New Features**
  - Added `document_entries` table and migration; files stored in R2 and linked to entries.
  - New EntityDocumentPanel with upload, text/CSV/Markdown/JSON preview, download, delete; removed R2 label in UI.
  - Server functions: `listDocumentsForEntryFn`, `uploadDocumentForEntryFn` (10 MB limit), `deleteDocumentForEntryFn`, `getDocumentDownloadUrlForEntryFn`.
  - Panel integrated into Contact, Gym, and Interaction detail pages.

- **Migration**
  - Apply D1 migration `0002_document-entries.sql`.
  - Configure R2; copy `.dev.vars.example` to `.dev.vars` and set `CRM_AUTH_PASSWORD`, `CRM_SESSION_SECRET`.
  - Run `pnpm install`; reseed if needed (`pnpm db:seed:local`).
  - Local `wrangler d1` migrate script simplified to `crm-db`.

<sup>Written for commit 9e407e1717f5aef99c618bf6e40b949d2bf65a32. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/479?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

- **Add CRM document relations backed by R2** :point\_left: <!-- branch-stack -->
  - \#480
