### PR TITLE
Add editable CRM object detail views

### DIFF
--- a/apps/crm/src/components/entity-edit-panel.tsx
+++ b/apps/crm/src/components/entity-edit-panel.tsx
@@ -1,0 +1,577 @@
+import { useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { Save, X } from "lucide-react"
+import { useEffect, useState } from "react"
+import {
+  type CrmContact,
+  type CrmGym,
+  type CrmInteraction,
+  updateContactFn,
+  updateGymFn,
+  updateInteractionFn,
+} from "@/server-fns/crm"
+
+type SaveState = "idle" | "dirty" | "saving" | "saved" | "error"
+
+const GYM_STATUS_OPTIONS = [
+  "Prospect",
+  "Warm Prospect",
+  "Outreach Sent",
+  "Demo Scheduled",
+  "Demo Complete",
+  "Current User",
+  "Active Partner",
+  "Customer",
+  "Not Now",
+  "Closed/Lost",
+]
+
+const GYM_PRIORITY_OPTIONS = ["High", "Medium", "Low"]
+
+const GYM_RELATIONSHIP_OPTIONS = [
+  "Cold Lead",
+  "Warm Prospect",
+  "Intro Made",
+  "Outreach Sent",
+  "Demo Scheduled",
+  "Demo Complete",
+  "MWFC Host",
+  "Active Partner",
+  "Customer",
+  "Not Now",
+]
+
+const CONTACT_STATUS_OPTIONS = [
+  "Lead",
+  "Contacted",
+  "Qualified",
+  "Active",
+  "Customer",
+  "Inactive",
+  "Do Not Contact",
+]
+
+const INTERACTION_CHANNEL_OPTIONS = [
+  "Email",
+  "Call",
+  "Text",
+  "Instagram",
+  "In Person",
+  "Demo",
+  "Meeting",
+  "Referral",
+]
+
+const INTERACTION_STATUS_OPTIONS = [
+  "Planned",
+  "Sent",
+  "Completed",
+  "No Response",
+  "Replied",
+  "Follow Up",
+  "Not Interested",
+]
+
+export function GymEditPanel({
+  gym,
+  onCancel,
+  onSaved,
+}: {
+  gym: CrmGym
+  onCancel: () => void
+  onSaved: () => void
+}) {
+  const router = useRouter()
+  const updateGym = useServerFn(updateGymFn)
+  const [state, setState] = useState<SaveState>("idle")
+  const [error, setError] = useState<string | null>(null)
+
+  useUnsavedChanges(state === "dirty")
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setState("saving")
+    setError(null)
+    try {
+      await updateGym({
+        data: {
+          id: gym.id,
+          name: field(form, "name"),
+          location: field(form, "location"),
+          website: field(form, "website"),
+          crossfitPage: field(form, "crossfitPage"),
+          email: field(form, "email"),
+          phone: field(form, "phone"),
+          instagram: field(form, "instagram"),
+          ownerManager: field(form, "ownerManager"),
+          status: field(form, "status"),
+          priority: field(form, "priority"),
+          relationship: field(form, "relationship"),
+          notes: field(form, "notes"),
+        },
+      })
+      await router.invalidate()
+      setState("saved")
+      onSaved()
+    } catch (caught) {
+      setError(messageFor(caught))
+      setState("error")
+    }
+  }
+
+  return (
+    <EditPanel
+      title="Edit Gym"
+      state={state}
+      error={error}
+      onSubmit={handleSubmit}
+      onChange={() => setState("dirty")}
+      onCancel={onCancel}
+    >
+      <TextField name="name" label="Gym" defaultValue={gym.name} required />
+      <TextField name="location" label="Location" defaultValue={gym.location} />
+      <TextField
+        name="ownerManager"
+        label="Owner or Manager"
+        defaultValue={gym.ownerManager}
+      />
+      <SelectField
+        name="relationship"
+        label="Relationship"
+        defaultValue={gym.relationship}
+        emptyLabel="No Relationship"
+        options={optionsWithCurrent(GYM_RELATIONSHIP_OPTIONS, gym.relationship)}
+      />
+      <TextField name="website" label="Website" defaultValue={gym.website} />
+      <TextField
+        name="crossfitPage"
+        label="CrossFit Page"
+        defaultValue={gym.crossfitPage}
+      />
+      <TextField
+        name="email"
+        label="Email"
+        type="email"
+        defaultValue={gym.email}
+      />
+      <TextField
+        name="phone"
+        label="Phone"
+        type="tel"
+        defaultValue={gym.phone}
+      />
+      <TextField
+        name="instagram"
+        label="Instagram"
+        defaultValue={gym.instagram}
+      />
+      <SelectField
+        name="status"
+        label="Status"
+        defaultValue={gym.status}
+        emptyLabel="No Status"
+        options={optionsWithCurrent(GYM_STATUS_OPTIONS, gym.status)}
+      />
+      <SelectField
+        name="priority"
+        label="Priority"
+        defaultValue={gym.priority}
+        emptyLabel="No Priority"
+        options={optionsWithCurrent(GYM_PRIORITY_OPTIONS, gym.priority)}
+      />
+      <TextareaField name="notes" label="Notes" defaultValue={gym.notes} />
+    </EditPanel>
+  )
+}
+
+export function ContactEditPanel({
+  contact,
+  gyms,
+  onCancel,
+  onSaved,
+}: {
+  contact: CrmContact
+  gyms: CrmGym[]
+  onCancel: () => void
+  onSaved: () => void
+}) {
+  const router = useRouter()
+  const updateContact = useServerFn(updateContactFn)
+  const [state, setState] = useState<SaveState>("idle")
+  const [error, setError] = useState<string | null>(null)
+
+  useUnsavedChanges(state === "dirty")
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setState("saving")
+    setError(null)
+    try {
+      await updateContact({
+        data: {
+          id: contact.id,
+          fullName: field(form, "fullName"),
+          email: field(form, "email"),
+          phone: field(form, "phone"),
+          status: field(form, "status"),
+          companyId: field(form, "companyId"),
+          notes: field(form, "notes"),
+        },
+      })
+      await router.invalidate()
+      setState("saved")
+      onSaved()
+    } catch (caught) {
+      setError(messageFor(caught))
+      setState("error")
+    }
+  }
+
+  return (
+    <EditPanel
+      title="Edit Contact"
+      state={state}
+      error={error}
+      onSubmit={handleSubmit}
+      onChange={() => setState("dirty")}
+      onCancel={onCancel}
+    >
+      <TextField
+        name="fullName"
+        label="Name"
+        defaultValue={contact.fullName}
+        required
+      />
+      <TextField
+        name="email"
+        label="Email"
+        type="email"
+        defaultValue={contact.email}
+      />
+      <TextField
+        name="phone"
+        label="Phone"
+        type="tel"
+        defaultValue={contact.phone}
+      />
+      <SelectField
+        name="companyId"
+        label="Gym"
+        defaultValue={contact.companyId}
+        emptyLabel="No Gym"
+        options={gyms.map((gym) => ({ label: gym.name, value: gym.id }))}
+      />
+      <SelectField
+        name="status"
+        label="Status"
+        defaultValue={contact.status}
+        emptyLabel="No Status"
+        options={optionsWithCurrent(CONTACT_STATUS_OPTIONS, contact.status)}
+      />
+      <TextareaField name="notes" label="Notes" defaultValue={contact.notes} />
+    </EditPanel>
+  )
+}
+
+export function InteractionEditPanel({
+  interaction,
+  gyms,
+  contacts,
+  onCancel,
+  onSaved,
+}: {
+  interaction: CrmInteraction
+  gyms: CrmGym[]
+  contacts: CrmContact[]
+  onCancel: () => void
+  onSaved: () => void
+}) {
+  const router = useRouter()
+  const updateInteraction = useServerFn(updateInteractionFn)
+  const [state, setState] = useState<SaveState>("idle")
+  const [error, setError] = useState<string | null>(null)
+
+  useUnsavedChanges(state === "dirty")
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setState("saving")
+    setError(null)
+    try {
+      await updateInteraction({
+        data: {
+          id: interaction.id,
+          source: interaction.source,
+          title: field(form, "title"),
+          date: field(form, "date"),
+          channel: field(form, "channel"),
+          status: field(form, "status"),
+          companyId: field(form, "companyId"),
+          contactId: field(form, "contactId"),
+          notes: field(form, "notes"),
+          content: field(form, "content"),
+        },
+      })
+      await router.invalidate()
+      setState("saved")
+      onSaved()
+    } catch (caught) {
+      setError(messageFor(caught))
+      setState("error")
+    }
+  }
+
+  return (
+    <EditPanel
+      title="Edit Interaction"
+      state={state}
+      error={error}
+      onSubmit={handleSubmit}
+      onChange={() => setState("dirty")}
+      onCancel={onCancel}
+    >
+      <TextField
+        name="title"
+        label="Subject"
+        defaultValue={interaction.title}
+        required
+      />
+      <TextField
+        name="date"
+        label="Date"
+        type="date"
+        defaultValue={interaction.date}
+      />
+      <SelectField
+        name="channel"
+        label="Channel"
+        defaultValue={interaction.channel}
+        emptyLabel="No Channel"
+        options={optionsWithCurrent(
+          INTERACTION_CHANNEL_OPTIONS,
+          interaction.channel,
+        )}
+      />
+      <SelectField
+        name="status"
+        label="Status"
+        defaultValue={interaction.status}
+        emptyLabel="No Status"
+        options={optionsWithCurrent(
+          INTERACTION_STATUS_OPTIONS,
+          interaction.status,
+        )}
+      />
+      <SelectField
+        name="companyId"
+        label="Gym"
+        defaultValue={interaction.companyId}
+        emptyLabel="No Gym"
+        options={gyms.map((gym) => ({ label: gym.name, value: gym.id }))}
+      />
+      <SelectField
+        name="contactId"
+        label="Contact"
+        defaultValue={interaction.contactId}
+        emptyLabel="No Contact"
+        options={contacts.map((contact) => ({
+          label: contact.fullName,
+          value: contact.id,
+        }))}
+      />
+      <TextareaField
+        name="notes"
+        label="Notes"
+        defaultValue={interaction.notes}
+      />
+      <TextareaField
+        name="content"
+        label={interaction.source === "Meeting" ? "Outcome" : "Content"}
+        defaultValue={interaction.content}
+      />
+    </EditPanel>
+  )
+}
+
+function EditPanel({
+  title,
+  state,
+  error,
+  onSubmit,
+  onChange,
+  onCancel,
+  children,
+}: {
+  title: string
+  state: SaveState
+  error: string | null
+  onSubmit: React.FormEventHandler<HTMLFormElement>
+  onChange: React.FormEventHandler<HTMLFormElement>
+  onCancel: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+          {title}
+        </h3>
+        <p className="text-xs text-muted-foreground" aria-live="polite">
+          {statusLabel(state)}
+        </p>
+      </div>
+      <form onSubmit={onSubmit} onChange={onChange} className="space-y-4">
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {children}
+        </div>
+        {error ? (
+          <p className="text-sm text-destructive" aria-live="polite">
+            {error}
+          </p>
+        ) : null}
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex h-10 items-center gap-2 rounded-md border border-input bg-background px-4 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={state === "saving"}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-50"
+          >
+            <Save className="h-4 w-4" aria-hidden="true" />
+            {state === "saving" ? "Saving…" : "Save Changes"}
+          </button>
+        </div>
+      </form>
+    </section>
+  )
+}
+
+function optionsWithCurrent(options: string[], current: string | null) {
+  const values =
+    current && !options.includes(current) ? [current, ...options] : options
+  return values.map((value) => ({ label: value, value }))
+}
+
+function TextField({
+  name,
+  label,
+  defaultValue,
+  required,
+  type = "text",
+}: {
+  name: string
+  label: string
+  defaultValue?: string | null
+  required?: boolean
+  type?: string
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <input
+        name={name}
+        type={type}
+        defaultValue={defaultValue ?? ""}
+        required={required}
+        autoComplete="off"
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+    </label>
+  )
+}
+
+function SelectField({
+  name,
+  label,
+  defaultValue,
+  emptyLabel,
+  options,
+}: {
+  name: string
+  label: string
+  defaultValue?: string | null
+  emptyLabel: string
+  options: Array<{ label: string; value: string }>
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <select
+        name={name}
+        defaultValue={defaultValue ?? ""}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        <option value="">{emptyLabel}</option>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function TextareaField({
+  name,
+  label,
+  defaultValue,
+}: {
+  name: string
+  label: string
+  defaultValue?: string | null
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium md:col-span-2 xl:col-span-3">
+      <span>{label}</span>
+      <textarea
+        name={name}
+        defaultValue={defaultValue ?? ""}
+        rows={4}
+        autoComplete="off"
+        className="min-h-24 w-full resize-y rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      />
+    </label>
+  )
+}
+
+function field(form: FormData, name: string) {
+  return String(form.get(name) ?? "")
+}
+
+function messageFor(error: unknown) {
+  return error instanceof Error
+    ? error.message
+    : "Could not save changes. Review the fields and try again."
+}
+
+function statusLabel(state: SaveState) {
+  if (state === "dirty") return "Unsaved changes"
+  if (state === "saving") return "Saving…"
+  if (state === "saved") return "Saved"
+  if (state === "error") return "Save failed"
+  return "Ready to edit"
+}
+
+function useUnsavedChanges(enabled: boolean) {
+  useEffect(() => {
+    if (!enabled) return
+
+    function handleBeforeUnload(event: BeforeUnloadEvent) {
+      event.preventDefault()
+      event.returnValue = ""
+    }
+
+    window.addEventListener("beforeunload", handleBeforeUnload)
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload)
+  }, [enabled])
+}

--- a/apps/crm/src/components/entity-edit-panel.tsx
+++ b/apps/crm/src/components/entity-edit-panel.tsx
@@ -116,7 +116,7 @@ export function GymEditPanel({
       onSaved()
     } catch (caught) {
       setError(messageFor(caught))
-      setState("error")
+      setState("dirty")
     }
   }
 
@@ -225,7 +225,7 @@ export function ContactEditPanel({
       onSaved()
     } catch (caught) {
       setError(messageFor(caught))
-      setState("error")
+      setState("dirty")
     }
   }
 
@@ -320,7 +320,7 @@ export function InteractionEditPanel({
       onSaved()
     } catch (caught) {
       setError(messageFor(caught))
-      setState("error")
+      setState("dirty")
     }
   }
 

--- a/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.$contactId.tsx
@@ -4,11 +4,14 @@ import {
   Clock3,
   Handshake,
   Mail,
+  Pencil,
   Phone,
   UserRound,
 } from "lucide-react"
-import { getCrmDataFn } from "@/server-fns/crm"
+import { useState } from "react"
 import { EntityDocumentPanel } from "@/components/entity-document-panel"
+import { ContactEditPanel } from "@/components/entity-edit-panel"
+import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/_authenticated/contacts/$contactId")({
   loader: async ({ params }) => {
@@ -23,66 +26,87 @@ export const Route = createFileRoute("/_authenticated/contacts/$contactId")({
       (interaction) => interaction.contactId === contact.id,
     )
 
-    return { contact, gym: gym ?? null, interactions }
+    return { contact, gym: gym ?? null, interactions, gyms: data.gyms }
   },
   notFoundComponent: () => <EntityNotFound label="Contact" />,
   component: ContactDetailPage,
 })
 
 function ContactDetailPage() {
-  const { contact, gym, interactions } = Route.useLoaderData()
+  const { contact, gym, interactions, gyms } = Route.useLoaderData()
+  const [isEditing, setIsEditing] = useState(false)
 
   return (
     <section className="space-y-6">
-      <header>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <UserRound className="h-4 w-4" />
-          Contact
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <UserRound className="h-4 w-4" />
+            Contact
+          </div>
+          <h2 className="mt-1 text-3xl font-semibold tracking-tight">
+            {contact.fullName}
+          </h2>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <Badge value={contact.status || "Lead"} />
+            {gym ? (
+              <Link
+                to="/gyms/$gymId"
+                params={{ gymId: gym.id }}
+                className="underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {gym.name}
+              </Link>
+            ) : contact.companyName ? (
+              <span>{contact.companyName}</span>
+            ) : null}
+          </div>
         </div>
-        <h2 className="mt-1 text-3xl font-semibold tracking-tight">
-          {contact.fullName}
-        </h2>
-        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-          <Badge value={contact.status || "Lead"} />
-          {gym ? (
-            <Link
-              to="/gyms/$gymId"
-              params={{ gymId: gym.id }}
-              className="underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              {gym.name}
-            </Link>
-          ) : contact.companyName ? (
-            <span>{contact.companyName}</span>
-          ) : null}
-        </div>
+        <button
+          type="button"
+          onClick={() => setIsEditing((current) => !current)}
+          aria-pressed={isEditing}
+          className="inline-flex h-10 items-center gap-2 rounded-md border border-input px-4 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Pencil className="h-4 w-4" aria-hidden="true" />
+          {isEditing ? "Viewing" : "Edit"}
+        </button>
       </header>
 
-      <section className="space-y-4 rounded-lg border border-border p-4">
-        <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
-          <MetaItem
-            icon={<Mail className="h-4 w-4" aria-hidden="true" />}
-            value={contact.email}
-            label="Email"
-          />
-          <MetaItem
-            icon={<Phone className="h-4 w-4" aria-hidden="true" />}
-            value={contact.phone}
-            label="Phone"
-          />
-          <MetaItem
-            icon={<Building2 className="h-4 w-4" aria-hidden="true" />}
-            value={contact.companyName}
-            label="Gym"
-          />
-          <MetaItem
-            icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
-            value={contact.updatedAt}
-            label="Updated"
-          />
-        </div>
-        {contact.notes ? <NoteBlock>{contact.notes}</NoteBlock> : null}
-      </section>
+      {isEditing ? (
+        <ContactEditPanel
+          contact={contact}
+          gyms={gyms}
+          onCancel={() => setIsEditing(false)}
+          onSaved={() => setIsEditing(false)}
+        />
+      ) : (
+        <section className="space-y-4 rounded-lg border border-border p-4">
+          <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
+            <MetaItem
+              icon={<Mail className="h-4 w-4" aria-hidden="true" />}
+              value={contact.email}
+              label="Email"
+            />
+            <MetaItem
+              icon={<Phone className="h-4 w-4" aria-hidden="true" />}
+              value={contact.phone}
+              label="Phone"
+            />
+            <MetaItem
+              icon={<Building2 className="h-4 w-4" aria-hidden="true" />}
+              value={contact.companyName}
+              label="Gym"
+            />
+            <MetaItem
+              icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
+              value={contact.updatedAt}
+              label="Updated"
+            />
+          </div>
+          {contact.notes ? <NoteBlock>{contact.notes}</NoteBlock> : null}
+        </section>
+      )}
 
       <section className="rounded-lg border border-border">
         <div className="flex items-center gap-2 border-b border-border px-4 py-3 text-sm font-semibold">

--- a/apps/crm/src/routes/_authenticated/contacts.tsx
+++ b/apps/crm/src/routes/_authenticated/contacts.tsx
@@ -10,6 +10,16 @@ import { Plus, Search } from "lucide-react"
 import { useMemo, useState } from "react"
 import { createContactFn, getCrmDataFn } from "@/server-fns/crm"
 
+const CONTACT_STATUS_OPTIONS = [
+  "Lead",
+  "Contacted",
+  "Qualified",
+  "Active",
+  "Customer",
+  "Inactive",
+  "Do Not Contact",
+]
+
 export const Route = createFileRoute("/_authenticated/contacts")({
   loader: async () => getCrmDataFn(),
   component: ContactsPage,
@@ -93,7 +103,7 @@ function ContactsPage() {
           <SelectInput
             name="status"
             label="Status"
-            options={["Lead", "Contacted", "Qualified", "Customer"]}
+            options={CONTACT_STATUS_OPTIONS}
           />
           <div className="md:col-span-3">
             <TextInput name="notes" label="Notes" />
@@ -106,7 +116,7 @@ function ContactsPage() {
             className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
           >
             <Plus className="h-4 w-4" />
-            {saving ? "Adding..." : "Add Contact"}
+            {saving ? "Adding…" : "Add Contact"}
           </button>
         </div>
       </form>
@@ -213,7 +223,7 @@ function SelectInput({
         name={name}
         className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
       >
-        <option value="">Choose</option>
+        <option value="">Choose…</option>
         {options.map((option) => (
           <option key={option} value={option}>
             {option}

--- a/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.$gymId.tsx
@@ -7,10 +7,13 @@ import {
   Instagram,
   Mail,
   MapPin,
+  Pencil,
   Phone,
   UserRound,
 } from "lucide-react"
+import { useState } from "react"
 import { EntityDocumentPanel } from "@/components/entity-document-panel"
+import { GymEditPanel } from "@/components/entity-edit-panel"
 import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/_authenticated/gyms/$gymId")({
@@ -37,6 +40,7 @@ export const Route = createFileRoute("/_authenticated/gyms/$gymId")({
 
 function GymDetailPage() {
   const { gym, contacts, interactions } = Route.useLoaderData()
+  const [isEditing, setIsEditing] = useState(false)
   const latestInteraction = interactions[0]
 
   return (
@@ -60,71 +64,90 @@ function GymDetailPage() {
             <Badge value={gym.priority} />
           </div>
         </div>
-        <Link
-          to="/interactions"
-          search={{}}
-          className="inline-flex h-10 items-center justify-center rounded-md border border-input px-4 text-sm font-medium hover:bg-accent"
-        >
-          View all interactions
-        </Link>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setIsEditing((current) => !current)}
+            aria-pressed={isEditing}
+            className="inline-flex h-10 items-center gap-2 rounded-md border border-input px-4 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <Pencil className="h-4 w-4" aria-hidden="true" />
+            {isEditing ? "Viewing" : "Edit"}
+          </button>
+          <Link
+            to="/interactions"
+            search={{}}
+            className="inline-flex h-10 items-center justify-center rounded-md border border-input px-4 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            View All Interactions
+          </Link>
+        </div>
       </header>
 
-      <section className="space-y-4 rounded-lg border border-border p-4">
-        <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
-          <MetaItem
-            icon={<UserRound className="h-4 w-4" aria-hidden="true" />}
-            value={gym.ownerManager}
-            label="Owner or manager"
-          />
-          <MetaItem
-            icon={<Handshake className="h-4 w-4" aria-hidden="true" />}
-            value={gym.relationship}
-            label="Relationship"
-            showLabel
-          />
-          <MetaItem
-            icon={<Mail className="h-4 w-4" aria-hidden="true" />}
-            value={gym.email}
-            label="Email"
-          />
-          <MetaItem
-            icon={<Phone className="h-4 w-4" aria-hidden="true" />}
-            value={gym.phone}
-            label="Phone"
-          />
-          <MetaItem
-            icon={<Globe2 className="h-4 w-4" aria-hidden="true" />}
-            value={gym.website}
-            label="Website"
-            href={gym.website}
-          />
-          {/* `@lat`: [[crm-crossfit-metadata]] */}
-          <MetaItem
-            icon={<Globe2 className="h-4 w-4" aria-hidden="true" />}
-            value={gym.crossfitPage}
-            label="CrossFit Page"
-            href={gym.crossfitPage}
-            showLabel
-          />
-          <MetaItem
-            icon={<Hash className="h-4 w-4" aria-hidden="true" />}
-            value={gym.crossfitAffiliateNumber}
-            label="Affiliate"
-            showLabel
-          />
-          <MetaItem
-            icon={<Instagram className="h-4 w-4" aria-hidden="true" />}
-            value={gym.instagram}
-            label="Instagram"
-          />
-        </div>
-        {gym.notes ? <NoteBlock>{gym.notes}</NoteBlock> : null}
-        {gym.updatedAt ? (
-          <p className="border-t border-border pt-3 text-xs text-muted-foreground">
-            Record updated {gym.updatedAt}
-          </p>
-        ) : null}
-      </section>
+      {isEditing ? (
+        <GymEditPanel
+          gym={gym}
+          onCancel={() => setIsEditing(false)}
+          onSaved={() => setIsEditing(false)}
+        />
+      ) : (
+        <section className="space-y-4 rounded-lg border border-border p-4">
+          <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
+            <MetaItem
+              icon={<UserRound className="h-4 w-4" aria-hidden="true" />}
+              value={gym.ownerManager}
+              label="Owner or manager"
+            />
+            <MetaItem
+              icon={<Handshake className="h-4 w-4" aria-hidden="true" />}
+              value={gym.relationship}
+              label="Relationship"
+              showLabel
+            />
+            <MetaItem
+              icon={<Mail className="h-4 w-4" aria-hidden="true" />}
+              value={gym.email}
+              label="Email"
+            />
+            <MetaItem
+              icon={<Phone className="h-4 w-4" aria-hidden="true" />}
+              value={gym.phone}
+              label="Phone"
+            />
+            <MetaItem
+              icon={<Globe2 className="h-4 w-4" aria-hidden="true" />}
+              value={gym.website}
+              label="Website"
+              href={gym.website}
+            />
+            {/* `@lat`: [[crm-crossfit-metadata]] */}
+            <MetaItem
+              icon={<Globe2 className="h-4 w-4" aria-hidden="true" />}
+              value={gym.crossfitPage}
+              label="CrossFit Page"
+              href={gym.crossfitPage}
+              showLabel
+            />
+            <MetaItem
+              icon={<Hash className="h-4 w-4" aria-hidden="true" />}
+              value={gym.crossfitAffiliateNumber}
+              label="Affiliate"
+              showLabel
+            />
+            <MetaItem
+              icon={<Instagram className="h-4 w-4" aria-hidden="true" />}
+              value={gym.instagram}
+              label="Instagram"
+            />
+          </div>
+          {gym.notes ? <NoteBlock>{gym.notes}</NoteBlock> : null}
+          {gym.updatedAt ? (
+            <p className="border-t border-border pt-3 text-xs text-muted-foreground">
+              Record updated {gym.updatedAt}
+            </p>
+          ) : null}
+        </section>
+      )}
 
       <RelatedSection
         icon={<UserRound className="h-4 w-4" />}

--- a/apps/crm/src/routes/_authenticated/gyms.tsx
+++ b/apps/crm/src/routes/_authenticated/gyms.tsx
@@ -10,6 +10,34 @@ import { Plus, Search } from "lucide-react"
 import { useMemo, useState } from "react"
 import { createGymFn, getCrmDataFn } from "@/server-fns/crm"
 
+const GYM_STATUS_OPTIONS = [
+  "Prospect",
+  "Warm Prospect",
+  "Outreach Sent",
+  "Demo Scheduled",
+  "Demo Complete",
+  "Current User",
+  "Active Partner",
+  "Customer",
+  "Not Now",
+  "Closed/Lost",
+]
+
+const GYM_PRIORITY_OPTIONS = ["High", "Medium", "Low"]
+
+const GYM_RELATIONSHIP_OPTIONS = [
+  "Cold Lead",
+  "Warm Prospect",
+  "Intro Made",
+  "Outreach Sent",
+  "Demo Scheduled",
+  "Demo Complete",
+  "MWFC Host",
+  "Active Partner",
+  "Customer",
+  "Not Now",
+]
+
 export const Route = createFileRoute("/_authenticated/gyms")({
   loader: async () => getCrmDataFn(),
   component: GymsPage,
@@ -90,7 +118,11 @@ function GymsPage() {
           <TextInput name="name" label="Gym" required />
           <TextInput name="location" label="Location" />
           <TextInput name="ownerManager" label="Owner / Manager" />
-          <TextInput name="relationship" label="Relationship" />
+          <SelectInput
+            name="relationship"
+            label="Relationship"
+            options={GYM_RELATIONSHIP_OPTIONS}
+          />
           <TextInput name="website" label="Website" />
           {/* `@lat`: [[crm-crossfit-metadata]] */}
           <TextInput name="crossfitPage" label="CrossFit Page" />
@@ -100,12 +132,12 @@ function GymsPage() {
           <SelectInput
             name="status"
             label="Status"
-            options={["Prospect", "Outreach Sent", "Demo", "Customer"]}
+            options={GYM_STATUS_OPTIONS}
           />
           <SelectInput
             name="priority"
             label="Priority"
-            options={["HIGH", "MED", "LOW"]}
+            options={GYM_PRIORITY_OPTIONS}
           />
           <div className="md:col-span-2">
             <TextInput name="notes" label="Notes" />
@@ -118,7 +150,7 @@ function GymsPage() {
             className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
           >
             <Plus className="h-4 w-4" />
-            {saving ? "Adding..." : "Add Gym"}
+            {saving ? "Adding…" : "Add Gym"}
           </button>
         </div>
       </form>
@@ -231,7 +263,7 @@ function SelectInput({
         name={name}
         className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
       >
-        <option value="">Choose</option>
+        <option value="">Choose…</option>
         {options.map((option) => (
           <option key={option} value={option}>
             {option}

--- a/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.$interactionId.tsx
@@ -4,11 +4,14 @@ import {
   CalendarDays,
   Clock3,
   Handshake,
+  Pencil,
   Send,
   UserRound,
 } from "lucide-react"
-import { getCrmDataFn } from "@/server-fns/crm"
+import { useState } from "react"
 import { EntityDocumentPanel } from "@/components/entity-document-panel"
+import { InteractionEditPanel } from "@/components/entity-edit-panel"
+import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute(
   "/_authenticated/interactions/$interactionId",
@@ -27,64 +30,94 @@ export const Route = createFileRoute(
       ? data.contacts.find((item) => item.id === interaction.contactId)
       : undefined
 
-    return { interaction, gym: gym ?? null, contact: contact ?? null }
+    return {
+      interaction,
+      gym: gym ?? null,
+      contact: contact ?? null,
+      gyms: data.gyms,
+      contacts: data.contacts,
+    }
   },
   notFoundComponent: () => <EntityNotFound label="Interaction" />,
   component: InteractionDetailPage,
 })
 
 function InteractionDetailPage() {
-  const { interaction, gym, contact } = Route.useLoaderData()
+  const { interaction, gym, contact, gyms, contacts } = Route.useLoaderData()
+  const [isEditing, setIsEditing] = useState(false)
 
   return (
     <section className="space-y-6">
-      <header>
-        <div className="flex items-center gap-2 text-sm text-muted-foreground">
-          <Handshake className="h-4 w-4" />
-          {interaction.source}
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Handshake className="h-4 w-4" />
+            {interaction.source}
+          </div>
+          <h2 className="mt-1 text-3xl font-semibold tracking-tight">
+            {interaction.title}
+          </h2>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <MetaInline
+              icon={<CalendarDays className="h-4 w-4" aria-hidden="true" />}
+              value={interaction.date}
+              label="Date"
+            />
+            <Badge value={interaction.channel} />
+            <Badge value={interaction.status} />
+          </div>
         </div>
-        <h2 className="mt-1 text-3xl font-semibold tracking-tight">
-          {interaction.title}
-        </h2>
-        <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-          <MetaInline
-            icon={<CalendarDays className="h-4 w-4" aria-hidden="true" />}
-            value={interaction.date}
-            label="Date"
-          />
-          <Badge value={interaction.channel} />
-          <Badge value={interaction.status} />
-        </div>
+        <button
+          type="button"
+          onClick={() => setIsEditing((current) => !current)}
+          aria-pressed={isEditing}
+          className="inline-flex h-10 items-center gap-2 rounded-md border border-input px-4 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Pencil className="h-4 w-4" aria-hidden="true" />
+          {isEditing ? "Viewing" : "Edit"}
+        </button>
       </header>
 
-      <section className="space-y-4 rounded-lg border border-border p-4">
-        <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
-          <MetaItem
-            icon={<Building2 className="h-4 w-4" aria-hidden="true" />}
-            value={interaction.companyName}
-            label="Gym"
-          />
-          <MetaItem
-            icon={<UserRound className="h-4 w-4" aria-hidden="true" />}
-            value={interaction.contactName}
-            label="Contact"
-          />
-          <MetaItem
-            icon={<Send className="h-4 w-4" aria-hidden="true" />}
-            value={interaction.channel}
-            label="Channel"
-          />
-          <MetaItem
-            icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
-            value={interaction.updatedAt}
-            label="Updated"
-          />
-        </div>
-        {interaction.notes ? <NoteBlock>{interaction.notes}</NoteBlock> : null}
-        {interaction.content ? (
-          <NoteBlock>{interaction.content}</NoteBlock>
-        ) : null}
-      </section>
+      {isEditing ? (
+        <InteractionEditPanel
+          interaction={interaction}
+          gyms={gyms}
+          contacts={contacts}
+          onCancel={() => setIsEditing(false)}
+          onSaved={() => setIsEditing(false)}
+        />
+      ) : (
+        <section className="space-y-4 rounded-lg border border-border p-4">
+          <div className="grid gap-3 text-sm md:grid-cols-2 xl:grid-cols-3">
+            <MetaItem
+              icon={<Building2 className="h-4 w-4" aria-hidden="true" />}
+              value={interaction.companyName}
+              label="Gym"
+            />
+            <MetaItem
+              icon={<UserRound className="h-4 w-4" aria-hidden="true" />}
+              value={interaction.contactName}
+              label="Contact"
+            />
+            <MetaItem
+              icon={<Send className="h-4 w-4" aria-hidden="true" />}
+              value={interaction.channel}
+              label="Channel"
+            />
+            <MetaItem
+              icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}
+              value={interaction.updatedAt}
+              label="Updated"
+            />
+          </div>
+          {interaction.notes ? (
+            <NoteBlock>{interaction.notes}</NoteBlock>
+          ) : null}
+          {interaction.content ? (
+            <NoteBlock>{interaction.content}</NoteBlock>
+          ) : null}
+        </section>
+      )}
 
       <section className="grid gap-4 md:grid-cols-2">
         <AssociationCard

--- a/apps/crm/src/routes/_authenticated/interactions.tsx
+++ b/apps/crm/src/routes/_authenticated/interactions.tsx
@@ -10,6 +10,27 @@ import { Plus, Search } from "lucide-react"
 import { useMemo, useState } from "react"
 import { createInteractionFn, getCrmDataFn } from "@/server-fns/crm"
 
+const INTERACTION_CHANNEL_OPTIONS = [
+  "Email",
+  "Call",
+  "Text",
+  "Instagram",
+  "In Person",
+  "Demo",
+  "Meeting",
+  "Referral",
+]
+
+const INTERACTION_STATUS_OPTIONS = [
+  "Planned",
+  "Sent",
+  "Completed",
+  "No Response",
+  "Replied",
+  "Follow Up",
+  "Not Interested",
+]
+
 export const Route = createFileRoute("/_authenticated/interactions")({
   loader: async () => getCrmDataFn(),
   component: InteractionsPage,
@@ -87,12 +108,12 @@ function InteractionsPage() {
           <SelectInput
             name="channel"
             label="Channel"
-            options={["Email", "Call", "Instagram", "In Person", "Demo"]}
+            options={INTERACTION_CHANNEL_OPTIONS}
           />
           <SelectInput
             name="status"
             label="Status"
-            options={["Planned", "Sent", "Completed", "No Response", "Replied"]}
+            options={INTERACTION_STATUS_OPTIONS}
           />
           <label className="space-y-1 text-sm font-medium">
             <span>Gym</span>
@@ -132,7 +153,7 @@ function InteractionsPage() {
             className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
           >
             <Plus className="h-4 w-4" />
-            {saving ? "Adding..." : "Log Interaction"}
+            {saving ? "Adding…" : "Log Interaction"}
           </button>
         </div>
       </form>
@@ -261,7 +282,7 @@ function SelectInput({
         name={name}
         className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
       >
-        <option value="">Choose</option>
+        <option value="">Choose…</option>
         {options.map((option) => (
           <option key={option} value={option}>
             {option}

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -90,6 +90,10 @@ const gymInputSchema = z.object({
   notes: z.string().max(4000).optional(),
 })
 
+const gymUpdateSchema = gymInputSchema.extend({
+  id: z.string().min(1, "Gym ID is required"),
+})
+
 const contactInputSchema = z.object({
   fullName: z.string().min(1, "Name is required").max(255),
   email: z.string().max(255).optional(),
@@ -97,6 +101,10 @@ const contactInputSchema = z.object({
   status: z.string().max(100).optional(),
   companyId: z.string().optional(),
   notes: z.string().max(4000).optional(),
+})
+
+const contactUpdateSchema = contactInputSchema.extend({
+  id: z.string().min(1, "Contact ID is required"),
 })
 
 const interactionInputSchema = z.object({
@@ -108,6 +116,11 @@ const interactionInputSchema = z.object({
   contactId: z.string().optional(),
   notes: z.string().max(4000).optional(),
   content: z.string().max(10000).optional(),
+})
+
+const interactionUpdateSchema = interactionInputSchema.extend({
+  id: z.string().min(1, "Interaction ID is required"),
+  source: z.enum(["Meeting", "Outreach"]),
 })
 
 export const documentUploadSchema = z.object({
@@ -506,6 +519,14 @@ async function setRelation(
   })
 }
 
+async function touchEntry(entryId: string) {
+  const db = getDb()
+  await db
+    .update(entriesTable)
+    .set({ updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(eq(entriesTable.id, entryId))
+}
+
 async function createEntry(objectName: string) {
   const db = getDb()
   const object = await getObject(objectName)
@@ -698,6 +719,44 @@ export const createGymFn = createServerFn({ method: "POST" })
     return { id: entryId }
   })
 
+export const updateGymFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => gymUpdateSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    await assertEntryExists(data.id)
+    const object = await getObject("Company")
+    await ensureField({
+      objectId: object.id,
+      name: "CrossFit Page",
+      type: "url",
+      sortOrder: 70,
+    })
+    const fields = await getFieldsByName(object.id)
+
+    const updates: Array<[string, string | null]> = [
+      ["Company Name", data.name],
+      ["Location", clean(data.location)],
+      ["Website", clean(data.website)],
+      ["CrossFit Page", clean(data.crossfitPage)],
+      ["Email Address", clean(data.email)],
+      ["Phone Number", clean(data.phone)],
+      ["Instagram", clean(data.instagram)],
+      ["Owner/Manager", clean(data.ownerManager)],
+      ["Wodsmith Status", clean(data.status)],
+      ["Priority", clean(data.priority)],
+      ["Relationship", clean(data.relationship)],
+      ["Notes", clean(data.notes)],
+    ]
+
+    for (const [fieldName, value] of updates) {
+      const field = fields.get(fieldName)
+      if (field) await upsertFieldValue(data.id, field.id, value)
+    }
+
+    await touchEntry(data.id)
+    return { id: data.id }
+  })
+
 export const createContactFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => contactInputSchema.parse(data))
   .handler(async ({ data }) => {
@@ -724,6 +783,36 @@ export const createContactFn = createServerFn({ method: "POST" })
     }
 
     return { id: entryId }
+  })
+
+export const updateContactFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => contactUpdateSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    await assertEntryExists(data.id)
+    const object = await getObject("People")
+    const fields = await getFieldsByName(object.id)
+
+    const updates: Array<[string, string | null]> = [
+      ["Full Name", data.fullName],
+      ["Email Address", clean(data.email)],
+      ["Phone Number", clean(data.phone)],
+      ["Status", clean(data.status)],
+      ["Notes", clean(data.notes)],
+    ]
+
+    for (const [fieldName, value] of updates) {
+      const field = fields.get(fieldName)
+      if (field) await upsertFieldValue(data.id, field.id, value)
+    }
+
+    const companyField = fields.get("Company")
+    if (companyField) {
+      await setRelation(data.id, companyField.id, clean(data.companyId))
+    }
+
+    await touchEntry(data.id)
+    return { id: data.id }
   })
 
 export const createInteractionFn = createServerFn({ method: "POST" })
@@ -756,6 +845,55 @@ export const createInteractionFn = createServerFn({ method: "POST" })
     await setRelation(entryId, personField.id, clean(data.contactId))
 
     return { id: entryId }
+  })
+
+export const updateInteractionFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => interactionUpdateSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    await assertEntryExists(data.id)
+    const objectName = data.source === "Meeting" ? "Meeting" : "Outreach"
+    const object = await getObject(objectName)
+    const fields = await getFieldsByName(object.id)
+
+    const updates: Array<[string, string | null]> =
+      data.source === "Meeting"
+        ? [
+            ["Title", data.title],
+            ["Date", clean(data.date)],
+            ["Type", clean(data.channel)],
+            ["Status", clean(data.status)],
+            ["Notes", clean(data.notes)],
+            ["Outcome", clean(data.content)],
+          ]
+        : [
+            ["Subject", data.title],
+            ["Date Sent", clean(data.date)],
+            ["Channel", clean(data.channel)],
+            ["Status", clean(data.status)],
+            ["Notes", clean(data.notes)],
+            ["Content", clean(data.content)],
+          ]
+
+    for (const [fieldName, value] of updates) {
+      const field = fields.get(fieldName)
+      if (field) await upsertFieldValue(data.id, field.id, value)
+    }
+
+    const companyField = fields.get("Company")
+    if (companyField) {
+      await setRelation(data.id, companyField.id, clean(data.companyId))
+    }
+
+    const contactField = fields.get(
+      data.source === "Meeting" ? "Contact" : "Person",
+    )
+    if (contactField) {
+      await setRelation(data.id, contactField.id, clean(data.contactId))
+    }
+
+    await touchEntry(data.id)
+    return { id: data.id }
   })
 
 export const listDocumentsForEntryFn = createServerFn({ method: "GET" })

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -201,6 +201,23 @@ async function assertEntryExists(entryId: string) {
   return entry
 }
 
+async function assertEntryInObject(entryId: string, objectId: string) {
+  const db = getDb()
+  const [entry] = await db
+    .select({ id: entriesTable.id })
+    .from(entriesTable)
+    .where(
+      and(eq(entriesTable.id, entryId), eq(entriesTable.objectId, objectId)),
+    )
+    .limit(1)
+
+  if (!entry) {
+    throw new Error(`CRM entry not found in expected object: ${entryId}`)
+  }
+
+  return entry
+}
+
 function sanitizeFileName(fileName: string) {
   return (
     fileName
@@ -723,8 +740,8 @@ export const updateGymFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => gymUpdateSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    await assertEntryExists(data.id)
     const object = await getObject("Company")
+    await assertEntryInObject(data.id, object.id)
     await ensureField({
       objectId: object.id,
       name: "CrossFit Page",
@@ -789,8 +806,8 @@ export const updateContactFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => contactUpdateSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    await assertEntryExists(data.id)
     const object = await getObject("People")
+    await assertEntryInObject(data.id, object.id)
     const fields = await getFieldsByName(object.id)
 
     const updates: Array<[string, string | null]> = [
@@ -851,9 +868,9 @@ export const updateInteractionFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => interactionUpdateSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    await assertEntryExists(data.id)
     const objectName = data.source === "Meeting" ? "Meeting" : "Outreach"
     const object = await getObject(objectName)
+    await assertEntryInObject(data.id, object.id)
     const fields = await getFieldsByName(object.id)
 
     const updates: Array<[string, string | null]> =


### PR DESCRIPTION
## Summary
- add reusable edit panels for CRM gyms, contacts, and interactions
- add update server functions that preserve relation fields and CrossFit metadata
- switch detail pages between read-only display and edit mode
- use select menus for status, priority, relationship, and interaction channel/status fields

## Validation
- TypeScript: `tsc --noEmit` passed in the clean PR worktree with linked local dependencies
- Biome: targeted check passed for touched CRM files
- Browser smoke: verified gym detail page edit toggle and select menus locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make CRM detail pages editable for Gyms, Contacts, and Interactions with in-place forms. Updates now validate input and verify object ownership while preserving relations and CrossFit metadata.

- New Features
  - Added reusable edit panels with Save/Cancel, save state indicators, and an unsaved-changes guard.
  - Implemented `updateGymFn`, `updateContactFn`, and `updateInteractionFn` with schema validation, object checks, and Meeting/Outreach field mapping; upserts fields, preserves Company/Contact relations, touches updated timestamps, and ensures the CrossFit Page field exists.
  - Detail pages toggle between View/Edit; select menus for gym status/priority/relationship, contact status, and interaction channel/status; link gyms and contacts in interactions and contacts.
  - On save, routes invalidate to refresh data; centralized option lists and small UX copy tweaks (“Adding…”, “Choose…”).

<sup>Written for commit 26cef071958f86f4a37a35f5f4245c187f36c647. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/481?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline edit mode on gym, contact, and interaction detail pages with Edit/View toggle and save/cancel flows
  * Editable forms for gyms/contacts/interactions with validation, error reporting, and unsaved-changes warning
  * Forms populate full gym/contact option lists for related-field selection

* **UI/UX Updates**
  * Centralized selectable option lists for statuses/channels/relationships
  * Button and placeholder text use ellipsis characters for saving/placeholder states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->