### PR TITLE
Add CRM campaign workflow

### DIFF
--- a/apps/crm/src/components/metric-card.tsx
+++ b/apps/crm/src/components/metric-card.tsx
@@ -1,0 +1,19 @@
+export function MetricCard({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number
+}) {
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-muted-foreground">{label}</p>
+        <span className="text-muted-foreground">{icon}</span>
+      </div>
+      <p className="mt-3 text-3xl font-semibold">{value}</p>
+    </div>
+  )
+}

--- a/apps/crm/src/routeTree.gen.ts
+++ b/apps/crm/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as AuthenticatedInteractionsRouteImport } from './routes/_authent
 import { Route as AuthenticatedGymsRouteImport } from './routes/_authenticated/gyms'
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
 import { Route as AuthenticatedContactsRouteImport } from './routes/_authenticated/contacts'
+import { Route as AuthenticatedCampaignsRouteImport } from './routes/_authenticated/campaigns'
 import { Route as ApiCrmDocumentsRouteImport } from './routes/api/crm/documents'
 import { Route as ApiCrmAgentCapabilitiesRouteImport } from './routes/api/crm/agent-capabilities'
 import { Route as AuthenticatedInteractionsInteractionIdRouteImport } from './routes/_authenticated/interactions.$interactionId'
@@ -51,6 +52,11 @@ const AuthenticatedContactsRoute = AuthenticatedContactsRouteImport.update({
   path: '/contacts',
   getParentRoute: () => AuthenticatedRoute,
 } as any)
+const AuthenticatedCampaignsRoute = AuthenticatedCampaignsRouteImport.update({
+  id: '/campaigns',
+  path: '/campaigns',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const ApiCrmDocumentsRoute = ApiCrmDocumentsRouteImport.update({
   id: '/api/crm/documents',
   path: '/api/crm/documents',
@@ -81,6 +87,7 @@ const AuthenticatedContactsContactIdRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/campaigns': typeof AuthenticatedCampaignsRoute
   '/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/gyms': typeof AuthenticatedGymsRouteWithChildren
@@ -93,6 +100,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/campaigns': typeof AuthenticatedCampaignsRoute
   '/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/gyms': typeof AuthenticatedGymsRouteWithChildren
@@ -107,6 +115,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/_authenticated/campaigns': typeof AuthenticatedCampaignsRoute
   '/_authenticated/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
   '/_authenticated/gyms': typeof AuthenticatedGymsRouteWithChildren
@@ -121,6 +130,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/campaigns'
     | '/contacts'
     | '/dashboard'
     | '/gyms'
@@ -133,6 +143,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/campaigns'
     | '/contacts'
     | '/dashboard'
     | '/gyms'
@@ -146,6 +157,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_authenticated'
+    | '/_authenticated/campaigns'
     | '/_authenticated/contacts'
     | '/_authenticated/dashboard'
     | '/_authenticated/gyms'
@@ -206,6 +218,13 @@ declare module '@tanstack/react-router' {
       path: '/contacts'
       fullPath: '/contacts'
       preLoaderRoute: typeof AuthenticatedContactsRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/campaigns': {
+      id: '/_authenticated/campaigns'
+      path: '/campaigns'
+      fullPath: '/campaigns'
+      preLoaderRoute: typeof AuthenticatedCampaignsRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/api/crm/documents': {
@@ -286,6 +305,7 @@ const AuthenticatedInteractionsRouteWithChildren =
   )
 
 interface AuthenticatedRouteChildren {
+  AuthenticatedCampaignsRoute: typeof AuthenticatedCampaignsRoute
   AuthenticatedContactsRoute: typeof AuthenticatedContactsRouteWithChildren
   AuthenticatedDashboardRoute: typeof AuthenticatedDashboardRoute
   AuthenticatedGymsRoute: typeof AuthenticatedGymsRouteWithChildren
@@ -293,6 +313,7 @@ interface AuthenticatedRouteChildren {
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedCampaignsRoute: AuthenticatedCampaignsRoute,
   AuthenticatedContactsRoute: AuthenticatedContactsRouteWithChildren,
   AuthenticatedDashboardRoute: AuthenticatedDashboardRoute,
   AuthenticatedGymsRoute: AuthenticatedGymsRouteWithChildren,

--- a/apps/crm/src/routes/_authenticated.tsx
+++ b/apps/crm/src/routes/_authenticated.tsx
@@ -70,6 +70,7 @@ function AuthenticatedLayout() {
             >
               Interactions
             </NavLink>
+            {/* // `@lat`: [[crm-campaigns]] */}
             <NavLink to="/campaigns" icon={<Megaphone className="h-4 w-4" />}>
               Campaigns
             </NavLink>
@@ -140,6 +141,7 @@ function sectionLabel(section: string) {
   if (section === "gyms") return "Gyms"
   if (section === "contacts") return "Contacts"
   if (section === "interactions") return "Interactions"
+  // `@lat`: [[crm-campaigns]]
   if (section === "campaigns") return "Campaigns"
   return section
 }
@@ -185,6 +187,7 @@ function NavLink({
   icon,
   children,
 }: {
+  // `@lat`: [[crm-campaigns]]
   to: "/dashboard" | "/gyms" | "/contacts" | "/interactions" | "/campaigns"
   icon: React.ReactNode
   children: React.ReactNode

--- a/apps/crm/src/routes/_authenticated.tsx
+++ b/apps/crm/src/routes/_authenticated.tsx
@@ -14,6 +14,7 @@ import {
   Handshake,
   LayoutDashboard,
   LogOut,
+  Megaphone,
   Users,
 } from "lucide-react"
 import { checkAuthFn, logoutFn } from "@/server-fns/auth"
@@ -68,6 +69,9 @@ function AuthenticatedLayout() {
               icon={<Handshake className="h-4 w-4" />}
             >
               Interactions
+            </NavLink>
+            <NavLink to="/campaigns" icon={<Megaphone className="h-4 w-4" />}>
+              Campaigns
             </NavLink>
           </nav>
           <button
@@ -136,6 +140,7 @@ function sectionLabel(section: string) {
   if (section === "gyms") return "Gyms"
   if (section === "contacts") return "Contacts"
   if (section === "interactions") return "Interactions"
+  if (section === "campaigns") return "Campaigns"
   return section
 }
 
@@ -180,7 +185,7 @@ function NavLink({
   icon,
   children,
 }: {
-  to: "/dashboard" | "/gyms" | "/contacts" | "/interactions"
+  to: "/dashboard" | "/gyms" | "/contacts" | "/interactions" | "/campaigns"
   icon: React.ReactNode
   children: React.ReactNode
 }) {

--- a/apps/crm/src/routes/_authenticated/campaigns.tsx
+++ b/apps/crm/src/routes/_authenticated/campaigns.tsx
@@ -1,0 +1,440 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { CalendarDays, Mail, Megaphone, Plus, Search, Send } from "lucide-react"
+import { useMemo, useState } from "react"
+import {
+  createCampaignFn,
+  createCampaignTouchFn,
+  getCrmDataFn,
+} from "@/server-fns/crm"
+
+const CAMPAIGN_STATUS_OPTIONS = ["Planning", "Active", "Paused", "Completed"]
+const TOUCH_CHANNEL_OPTIONS = [
+  "Email",
+  "Instagram",
+  "Facebook",
+  "LinkedIn",
+  "Call",
+  "Other",
+]
+const TOUCH_STATUS_OPTIONS = [
+  "Planned",
+  "Drafted",
+  "Sent",
+  "Posted",
+  "Completed",
+  "Skipped",
+]
+const OWNER_OPTIONS = ["Ian", "Zac"]
+
+export const Route = createFileRoute("/_authenticated/campaigns")({
+  loader: async () => getCrmDataFn(),
+  component: CampaignsPage,
+})
+
+function CampaignsPage() {
+  const { campaigns, campaignTouches, gyms, contacts } = Route.useLoaderData()
+  const router = useRouter()
+  const createCampaign = useServerFn(createCampaignFn)
+  const createCampaignTouch = useServerFn(createCampaignTouchFn)
+  const [query, setQuery] = useState("")
+  const [savingCampaign, setSavingCampaign] = useState(false)
+  const [savingTouch, setSavingTouch] = useState(false)
+
+  const filteredCampaigns = useMemo(() => {
+    const normalized = query.trim().toLowerCase()
+    if (!normalized) return campaigns
+    return campaigns.filter((campaign) =>
+      [
+        campaign.name,
+        campaign.status,
+        campaign.owner,
+        campaign.goal,
+        ...campaign.audienceGymNames,
+        ...campaign.audienceContactNames,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .some((value) => value.toLowerCase().includes(normalized)),
+    )
+  }, [campaigns, query])
+
+  const nextTouches = campaignTouches
+    .filter(
+      (touch) => touch.status !== "Completed" && touch.status !== "Skipped",
+    )
+    .slice(0, 8)
+
+  async function handleCampaignSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setSavingCampaign(true)
+    try {
+      await createCampaign({
+        data: {
+          name: String(form.get("name") ?? ""),
+          status: String(form.get("status") ?? ""),
+          owner: String(form.get("owner") ?? "Ian") as "Ian" | "Zac",
+          goal: String(form.get("goal") ?? ""),
+          startDate: String(form.get("startDate") ?? ""),
+          endDate: String(form.get("endDate") ?? ""),
+          audienceGymIds: form.getAll("audienceGymIds").map(String),
+          audienceContactIds: form.getAll("audienceContactIds").map(String),
+        },
+      })
+      event.currentTarget.reset()
+      await router.invalidate()
+    } finally {
+      setSavingCampaign(false)
+    }
+  }
+
+  async function handleTouchSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    setSavingTouch(true)
+    try {
+      await createCampaignTouch({
+        data: {
+          campaignId: String(form.get("campaignId") ?? ""),
+          title: String(form.get("title") ?? ""),
+          channel: String(form.get("channel") ?? ""),
+          owner: String(form.get("owner") ?? "Ian") as "Ian" | "Zac",
+          status: String(form.get("status") ?? ""),
+          dueDate: String(form.get("dueDate") ?? ""),
+          notes: String(form.get("notes") ?? ""),
+        },
+      })
+      event.currentTarget.reset()
+      await router.invalidate()
+    } finally {
+      setSavingTouch(false)
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold tracking-tight">Campaigns</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Plan manual marketing pushes with a goal, selected gym/contact
+          audience, and email or social interactions.
+        </p>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Metric
+          icon={<Megaphone className="h-5 w-5" />}
+          label="Campaigns"
+          value={campaigns.length}
+        />
+        <Metric
+          icon={<Send className="h-5 w-5" />}
+          label="Campaign interactions"
+          value={campaignTouches.length}
+        />
+        <Metric
+          icon={<CalendarDays className="h-5 w-5" />}
+          label="Next up"
+          value={nextTouches.length}
+        />
+      </div>
+
+      <form
+        onSubmit={handleCampaignSubmit}
+        className="rounded-lg border border-border p-4"
+      >
+        <div className="grid gap-3 md:grid-cols-4">
+          <TextInput name="name" label="Campaign" required />
+          <SelectInput
+            name="status"
+            label="Status"
+            options={CAMPAIGN_STATUS_OPTIONS}
+          />
+          <SelectInput name="owner" label="Owner" options={OWNER_OPTIONS} />
+          <TextInput name="startDate" label="Start" type="date" />
+          <TextInput name="endDate" label="End" type="date" />
+          <div className="md:col-span-3">
+            <TextArea name="goal" label="Goal" required />
+          </div>
+          <MultiSelect
+            name="audienceGymIds"
+            label="Audience Gyms"
+            options={gyms.map((gym) => ({ value: gym.id, label: gym.name }))}
+          />
+          <MultiSelect
+            name="audienceContactIds"
+            label="Audience Contacts"
+            options={contacts.map((contact) => ({
+              value: contact.id,
+              label: contact.fullName,
+            }))}
+          />
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="submit"
+            disabled={savingCampaign}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" />
+            {savingCampaign ? "Creating..." : "Create Campaign"}
+          </button>
+        </div>
+      </form>
+
+      <form
+        onSubmit={handleTouchSubmit}
+        className="rounded-lg border border-border p-4"
+      >
+        <div className="grid gap-3 md:grid-cols-4">
+          <SelectInput
+            name="campaignId"
+            label="Campaign"
+            options={campaigns.map((campaign) => campaign.name)}
+            optionValues={campaigns.map((campaign) => campaign.id)}
+            required
+          />
+          <TextInput name="title" label="Touch" required />
+          <SelectInput
+            name="channel"
+            label="Channel"
+            options={TOUCH_CHANNEL_OPTIONS}
+          />
+          <SelectInput
+            name="status"
+            label="Status"
+            options={TOUCH_STATUS_OPTIONS}
+          />
+          <SelectInput name="owner" label="Owner" options={OWNER_OPTIONS} />
+          <TextInput name="dueDate" label="Due" type="date" />
+          <div className="md:col-span-2">
+            <TextInput name="notes" label="Notes" />
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="submit"
+            disabled={savingTouch || campaigns.length === 0}
+            className="inline-flex h-10 items-center gap-2 rounded-md border border-input bg-background px-4 text-sm font-medium disabled:opacity-50"
+          >
+            <Mail className="h-4 w-4" />
+            {savingTouch ? "Adding..." : "Add Interaction"}
+          </button>
+        </div>
+      </form>
+
+      <div className="flex items-center gap-2 rounded-md border border-input px-3">
+        <Search className="h-4 w-4 text-muted-foreground" />
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search campaigns"
+          className="h-10 flex-1 bg-transparent text-sm outline-none"
+        />
+      </div>
+
+      <div className="overflow-hidden rounded-lg border border-border">
+        <table className="w-full table-fixed text-left text-sm">
+          <thead className="bg-secondary text-secondary-foreground">
+            <tr>
+              <Th>Campaign</Th>
+              <Th>Owner</Th>
+              <Th>Audience</Th>
+              <Th>Interactions</Th>
+              <Th>Goal</Th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-border">
+            {filteredCampaigns.map((campaign) => (
+              <tr key={campaign.id} className="align-top">
+                <Td>
+                  <p className="font-medium">{campaign.name}</p>
+                  <p className="text-muted-foreground">
+                    {campaign.status || "Planning"}
+                  </p>
+                </Td>
+                <Td>{campaign.owner || "Ian"}</Td>
+                <Td>
+                  <p>{campaign.audienceGymIds.length} gyms</p>
+                  <p className="text-muted-foreground">
+                    {campaign.audienceContactIds.length} contacts
+                  </p>
+                </Td>
+                <Td>{campaign.touchCount}</Td>
+                <Td>
+                  <p className="line-clamp-2 text-muted-foreground">
+                    {campaign.goal || "-"}
+                  </p>
+                </Td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {nextTouches.length > 0 ? (
+        <section className="rounded-lg border border-border">
+          <div className="border-b border-border px-4 py-3">
+            <h3 className="font-medium">Upcoming Campaign Interactions</h3>
+          </div>
+          <div className="divide-y divide-border">
+            {nextTouches.map((touch) => (
+              <div
+                key={touch.id}
+                className="flex items-start justify-between gap-3 px-4 py-3 text-sm"
+              >
+                <div>
+                  <p className="font-medium">{touch.title}</p>
+                  <p className="text-muted-foreground">
+                    {[touch.campaignName, touch.channel, touch.owner]
+                      .filter(Boolean)
+                      .join(" / ")}
+                  </p>
+                </div>
+                <span className="whitespace-nowrap text-muted-foreground">
+                  {touch.date || touch.status || "Planned"}
+                </span>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </section>
+  )
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number
+}) {
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-medium text-muted-foreground">{label}</p>
+        <span className="text-muted-foreground">{icon}</span>
+      </div>
+      <p className="mt-3 text-3xl font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function TextInput({
+  name,
+  label,
+  required,
+  type = "text",
+}: {
+  name: string
+  label: string
+  required?: boolean
+  type?: string
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <input
+        name={name}
+        required={required}
+        type={type}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      />
+    </label>
+  )
+}
+
+function TextArea({
+  name,
+  label,
+  required,
+}: {
+  name: string
+  label: string
+  required?: boolean
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <textarea
+        name={name}
+        required={required}
+        rows={3}
+        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+      />
+    </label>
+  )
+}
+
+function SelectInput({
+  name,
+  label,
+  options,
+  optionValues,
+  required,
+}: {
+  name: string
+  label: string
+  options: string[]
+  optionValues?: string[]
+  required?: boolean
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <select
+        name={name}
+        required={required}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      >
+        <option value="">Choose...</option>
+        {options.map((option, index) => (
+          <option
+            key={optionValues?.[index] ?? option}
+            value={optionValues?.[index] ?? option}
+          >
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function MultiSelect({
+  name,
+  label,
+  options,
+}: {
+  name: string
+  label: string
+  options: Array<{ value: string; label: string }>
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium md:col-span-2">
+      <span>{label}</span>
+      <select
+        multiple
+        name={name}
+        className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
+      >
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function Th({ children }: { children: React.ReactNode }) {
+  return <th className="px-4 py-3 font-medium">{children}</th>
+}
+
+function Td({ children }: { children: React.ReactNode }) {
+  return <td className="px-4 py-3">{children}</td>
+}

--- a/apps/crm/src/routes/_authenticated/campaigns.tsx
+++ b/apps/crm/src/routes/_authenticated/campaigns.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, useRouter } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import { CalendarDays, Mail, Megaphone, Plus, Search, Send } from "lucide-react"
 import { useMemo, useState } from "react"
+import { MetricCard } from "@/components/metric-card"
 import {
   createCampaignFn,
   createCampaignTouchFn,
@@ -26,8 +27,11 @@ const TOUCH_STATUS_OPTIONS = [
   "Skipped",
 ]
 const OWNER_OPTIONS = ["Ian", "Zac"]
+const UPCOMING_TOUCH_STATUSES = new Set(["Planned", "Drafted", "Follow Up"])
 
+// `@lat`: [[crm-campaigns]]
 export const Route = createFileRoute("/_authenticated/campaigns")({
+  // `@lat`: [[crm-campaigns]]
   loader: async () => getCrmDataFn(),
   component: CampaignsPage,
 })
@@ -58,12 +62,15 @@ function CampaignsPage() {
     )
   }, [campaigns, query])
 
-  const nextTouches = campaignTouches
-    .filter(
-      (touch) => touch.status !== "Completed" && touch.status !== "Skipped",
+  // `@lat`: [[crm-campaigns]]
+  const nextTouches = [...campaignTouches]
+    .filter((touch) =>
+      touch.status ? UPCOMING_TOUCH_STATUSES.has(touch.status) : true,
     )
+    .sort((a, b) => touchDateValue(a.date) - touchDateValue(b.date))
     .slice(0, 8)
 
+  // `@lat`: [[crm-campaigns]]
   async function handleCampaignSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const form = new FormData(event.currentTarget)
@@ -88,6 +95,7 @@ function CampaignsPage() {
     }
   }
 
+  // `@lat`: [[crm-campaigns]]
   async function handleTouchSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const form = new FormData(event.currentTarget)
@@ -122,17 +130,17 @@ function CampaignsPage() {
       </div>
 
       <div className="grid gap-4 md:grid-cols-3">
-        <Metric
+        <MetricCard
           icon={<Megaphone className="h-5 w-5" />}
           label="Campaigns"
           value={campaigns.length}
         />
-        <Metric
+        <MetricCard
           icon={<Send className="h-5 w-5" />}
           label="Campaign interactions"
           value={campaignTouches.length}
         />
-        <Metric
+        <MetricCard
           icon={<CalendarDays className="h-5 w-5" />}
           label="Next up"
           value={nextTouches.length}
@@ -303,24 +311,10 @@ function CampaignsPage() {
   )
 }
 
-function Metric({
-  icon,
-  label,
-  value,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: number
-}) {
-  return (
-    <div className="rounded-lg border border-border p-4">
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-medium text-muted-foreground">{label}</p>
-        <span className="text-muted-foreground">{icon}</span>
-      </div>
-      <p className="mt-3 text-3xl font-semibold">{value}</p>
-    </div>
-  )
+function touchDateValue(date: string | null) {
+  if (!date) return Number.MAX_SAFE_INTEGER
+  const value = new Date(date).getTime()
+  return Number.isNaN(value) ? Number.MAX_SAFE_INTEGER : value
 }
 
 function TextInput({

--- a/apps/crm/src/routes/_authenticated/dashboard.tsx
+++ b/apps/crm/src/routes/_authenticated/dashboard.tsx
@@ -1,7 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { Building2, Handshake, Megaphone, Users } from "lucide-react"
+import { MetricCard } from "@/components/metric-card"
 import { getCrmDataFn } from "@/server-fns/crm"
 
+// `@lat`: [[crm-campaigns]]
 export const Route = createFileRoute("/_authenticated/dashboard")({
   loader: async () => getCrmDataFn(),
   component: DashboardPage,
@@ -23,22 +25,22 @@ function DashboardPage() {
       </div>
 
       <div className="grid gap-3 md:grid-cols-4">
-        <Metric
+        <MetricCard
           icon={<Building2 className="h-5 w-5" />}
           label="Gyms"
           value={activeGyms.length}
         />
-        <Metric
+        <MetricCard
           icon={<Users className="h-5 w-5" />}
           label="Contacts"
           value={contacts.length}
         />
-        <Metric
+        <MetricCard
           icon={<Handshake className="h-5 w-5" />}
           label="Interactions"
           value={interactions.length}
         />
-        <Metric
+        <MetricCard
           icon={<Megaphone className="h-5 w-5" />}
           label="Campaigns"
           value={campaigns.length}
@@ -98,25 +100,5 @@ function DashboardPage() {
         </section>
       </div>
     </section>
-  )
-}
-
-function Metric({
-  icon,
-  label,
-  value,
-}: {
-  icon: React.ReactNode
-  label: string
-  value: number
-}) {
-  return (
-    <div className="rounded-lg border border-border p-4">
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-medium text-muted-foreground">{label}</p>
-        <span className="text-muted-foreground">{icon}</span>
-      </div>
-      <p className="mt-3 text-3xl font-semibold">{value}</p>
-    </div>
   )
 }

--- a/apps/crm/src/routes/_authenticated/dashboard.tsx
+++ b/apps/crm/src/routes/_authenticated/dashboard.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router"
-import { Building2, Handshake, Users } from "lucide-react"
+import { Building2, Handshake, Megaphone, Users } from "lucide-react"
 import { getCrmDataFn } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/_authenticated/dashboard")({
@@ -8,7 +8,7 @@ export const Route = createFileRoute("/_authenticated/dashboard")({
 })
 
 function DashboardPage() {
-  const { gyms, contacts, interactions } = Route.useLoaderData()
+  const { gyms, contacts, interactions, campaigns } = Route.useLoaderData()
   const activeGyms = gyms.filter((gym) => gym.status !== "Closed")
   const recentInteractions = interactions.slice(0, 6)
 
@@ -22,7 +22,7 @@ function DashboardPage() {
         </p>
       </div>
 
-      <div className="grid gap-3 md:grid-cols-3">
+      <div className="grid gap-3 md:grid-cols-4">
         <Metric
           icon={<Building2 className="h-5 w-5" />}
           label="Gyms"
@@ -37,6 +37,11 @@ function DashboardPage() {
           icon={<Handshake className="h-5 w-5" />}
           label="Interactions"
           value={interactions.length}
+        />
+        <Metric
+          icon={<Megaphone className="h-5 w-5" />}
+          label="Campaigns"
+          value={campaigns.length}
         />
       </div>
 

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -62,8 +62,27 @@ export type CrmInteraction = {
   companyName: string | null
   contactId: string | null
   contactName: string | null
+  campaignId: string | null
+  campaignName: string | null
+  owner: string | null
   notes: string | null
   content: string | null
+  updatedAt: string | null
+}
+
+export type CrmCampaign = {
+  id: string
+  name: string
+  status: string | null
+  owner: string | null
+  goal: string | null
+  startDate: string | null
+  endDate: string | null
+  audienceGymIds: string[]
+  audienceContactIds: string[]
+  audienceGymNames: string[]
+  audienceContactNames: string[]
+  touchCount: number
   updatedAt: string | null
 }
 
@@ -112,8 +131,10 @@ const interactionInputSchema = z.object({
   date: z.string().max(20).optional(),
   channel: z.string().max(100).optional(),
   status: z.string().max(100).optional(),
+  owner: z.enum(["Ian", "Zac"]).optional(),
   companyId: z.string().optional(),
   contactId: z.string().optional(),
+  campaignId: z.string().optional(),
   notes: z.string().max(4000).optional(),
   content: z.string().max(10000).optional(),
 })
@@ -121,6 +142,27 @@ const interactionInputSchema = z.object({
 const interactionUpdateSchema = interactionInputSchema.extend({
   id: z.string().min(1, "Interaction ID is required"),
   source: z.enum(["Meeting", "Outreach"]),
+})
+
+const campaignInputSchema = z.object({
+  name: z.string().min(1, "Campaign name is required").max(255),
+  status: z.string().max(100).optional(),
+  owner: z.enum(["Ian", "Zac"]).optional(),
+  goal: z.string().max(4000).optional(),
+  startDate: z.string().max(20).optional(),
+  endDate: z.string().max(20).optional(),
+  audienceGymIds: z.array(z.string()).default([]),
+  audienceContactIds: z.array(z.string()).default([]),
+})
+
+const campaignTouchInputSchema = z.object({
+  campaignId: z.string().min(1, "Campaign ID is required"),
+  title: z.string().min(1, "Touch title is required").max(255),
+  channel: z.string().max(100).optional(),
+  owner: z.enum(["Ian", "Zac"]).optional(),
+  status: z.string().max(100).optional(),
+  dueDate: z.string().max(20).optional(),
+  notes: z.string().max(4000).optional(),
 })
 
 export const documentUploadSchema = z.object({
@@ -276,11 +318,15 @@ async function ensureField({
   name,
   type,
   sortOrder,
+  relatedObjectId,
+  relationshipType,
 }: {
   objectId: string
   name: string
   type: string
   sortOrder: number
+  relatedObjectId?: string | null
+  relationshipType?: string | null
 }) {
   const db = getDb()
   await db
@@ -290,12 +336,131 @@ async function ensureField({
       objectId,
       name,
       type,
+      relatedObjectId,
+      relationshipType,
       sortOrder,
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .onConflictDoNothing({
       target: [fieldsTable.objectId, fieldsTable.name],
     })
+}
+
+async function ensureObject({
+  name,
+  description,
+  icon,
+  sortOrder,
+  displayField,
+}: {
+  name: string
+  description: string
+  icon: string
+  sortOrder: number
+  displayField: string
+}) {
+  const db = getDb()
+  await db
+    .insert(objectsTable)
+    .values({
+      id: crmId(),
+      name,
+      description,
+      icon,
+      sortOrder,
+      displayField,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+    .onConflictDoNothing({ target: objectsTable.name })
+
+  return getObject(name)
+}
+
+async function ensureCampaignSchema() {
+  const [companyObject, peopleObject] = await Promise.all([
+    getObject("Company"),
+    getObject("People"),
+  ])
+  const campaignObject = await ensureObject({
+    name: "Campaign",
+    description:
+      "Marketing campaign workspace for goals, audience, and manual touches.",
+    icon: "megaphone",
+    sortOrder: 40,
+    displayField: "Campaign Name",
+  })
+  const outreachObject = await getObject("Outreach")
+
+  await Promise.all([
+    ensureField({
+      objectId: campaignObject.id,
+      name: "Campaign Name",
+      type: "text",
+      sortOrder: 10,
+    }),
+    ensureField({
+      objectId: campaignObject.id,
+      name: "Status",
+      type: "select",
+      sortOrder: 20,
+    }),
+    ensureField({
+      objectId: campaignObject.id,
+      name: "Owner",
+      type: "select",
+      sortOrder: 30,
+    }),
+    ensureField({
+      objectId: campaignObject.id,
+      name: "Goal",
+      type: "longText",
+      sortOrder: 40,
+    }),
+    ensureField({
+      objectId: campaignObject.id,
+      name: "Start Date",
+      type: "date",
+      sortOrder: 50,
+    }),
+    ensureField({
+      objectId: campaignObject.id,
+      name: "End Date",
+      type: "date",
+      sortOrder: 60,
+    }),
+    ensureField({
+      objectId: campaignObject.id,
+      name: "Audience Gyms",
+      type: "relation",
+      relatedObjectId: companyObject.id,
+      relationshipType: "many",
+      sortOrder: 70,
+    }),
+    ensureField({
+      objectId: campaignObject.id,
+      name: "Audience Contacts",
+      type: "relation",
+      relatedObjectId: peopleObject.id,
+      relationshipType: "many",
+      sortOrder: 80,
+    }),
+    ensureField({
+      objectId: outreachObject.id,
+      name: "Campaign",
+      type: "relation",
+      relatedObjectId: campaignObject.id,
+      relationshipType: "one",
+      sortOrder: 80,
+    }),
+    ensureField({
+      objectId: outreachObject.id,
+      name: "Owner",
+      type: "select",
+      sortOrder: 90,
+    }),
+  ])
+
+  return { campaignObject }
 }
 
 async function getFieldValues(entryIds: string[]) {
@@ -385,7 +550,13 @@ async function getEntryDisplayNames(entryIds: string[]) {
     )
   ).flat()
 
-  const priority = ["Company Name", "Full Name", "Title", "Subject"]
+  const priority = [
+    "Company Name",
+    "Full Name",
+    "Campaign Name",
+    "Title",
+    "Subject",
+  ]
   const names = new Map<string, string>()
   for (const fieldName of priority) {
     for (const row of rows) {
@@ -536,6 +707,39 @@ async function setRelation(
   })
 }
 
+async function setRelations(
+  entryId: string,
+  fieldId: string,
+  targetEntryIds: string[],
+) {
+  const db = getDb()
+  const uniqueTargetIds = Array.from(new Set(targetEntryIds.map(clean))).filter(
+    (value): value is string => Boolean(value),
+  )
+
+  await db
+    .delete(entryRelationsTable)
+    .where(
+      and(
+        eq(entryRelationsTable.sourceEntryId, entryId),
+        eq(entryRelationsTable.fieldId, fieldId),
+      ),
+    )
+
+  await upsertFieldValue(entryId, fieldId, uniqueTargetIds.join(","))
+
+  for (const [index, targetEntryId] of uniqueTargetIds.entries()) {
+    await db.insert(entryRelationsTable).values({
+      id: crmId(),
+      sourceEntryId: entryId,
+      fieldId,
+      targetEntryId,
+      sortOrder: index,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    })
+  }
+}
+
 async function touchEntry(entryId: string) {
   const db = getDb()
   await db
@@ -570,13 +774,15 @@ function requireField(
 
 export async function getCrmData() {
   await requireAuth()
+  await ensureCampaignSchema()
 
-  const [gymsData, contactsData, outreachData, meetingsData] =
+  const [gymsData, contactsData, outreachData, meetingsData, campaignsData] =
     await Promise.all([
       listEntries("Company"),
       listEntries("People"),
       listEntries("Outreach"),
       listEntries("Meeting"),
+      listEntries("Campaign"),
     ])
 
   const relationIds = [
@@ -586,10 +792,15 @@ export async function getCrmData() {
     ...outreachData.entries.flatMap((entry) => [
       ...(outreachData.relations.get(entry.id)?.Company ?? []),
       ...(outreachData.relations.get(entry.id)?.Person ?? []),
+      ...(outreachData.relations.get(entry.id)?.Campaign ?? []),
     ]),
     ...meetingsData.entries.flatMap((entry) => [
       ...(meetingsData.relations.get(entry.id)?.Company ?? []),
       ...(meetingsData.relations.get(entry.id)?.Contact ?? []),
+    ]),
+    ...campaignsData.entries.flatMap((entry) => [
+      ...(campaignsData.relations.get(entry.id)?.["Audience Gyms"] ?? []),
+      ...(campaignsData.relations.get(entry.id)?.["Audience Contacts"] ?? []),
     ]),
   ]
   const displayNames = await getEntryDisplayNames(relationIds)
@@ -643,6 +854,7 @@ export async function getCrmData() {
       const relations = outreachData.relations.get(entry.id) ?? {}
       const companyId = relations.Company?.[0] ?? values.Company ?? null
       const contactId = relations.Person?.[0] ?? values.Person ?? null
+      const campaignId = relations.Campaign?.[0] ?? values.Campaign ?? null
       return {
         id: entry.id,
         source: "Outreach",
@@ -654,6 +866,11 @@ export async function getCrmData() {
         companyName: companyId ? (displayNames.get(companyId) ?? null) : null,
         contactId,
         contactName: contactId ? (displayNames.get(contactId) ?? null) : null,
+        campaignId,
+        campaignName: campaignId
+          ? (displayNames.get(campaignId) ?? null)
+          : null,
+        owner: values.Owner ?? null,
         notes: values.Notes ?? null,
         content: values.Content ?? null,
         updatedAt: entry.updatedAt,
@@ -678,6 +895,9 @@ export async function getCrmData() {
         companyName: companyId ? (displayNames.get(companyId) ?? null) : null,
         contactId,
         contactName: contactId ? (displayNames.get(contactId) ?? null) : null,
+        campaignId: null,
+        campaignName: null,
+        owner: null,
         notes: values.Notes ?? values.Outcome ?? null,
         content: values.Outcome ?? null,
         updatedAt: entry.updatedAt,
@@ -691,7 +911,44 @@ export async function getCrmData() {
       new Date(a.date ?? a.updatedAt ?? 0).getTime(),
   )
 
-  return { gyms, contacts, interactions }
+  const campaignTouches = interactions.filter(
+    (interaction) =>
+      interaction.source === "Outreach" && interaction.campaignId,
+  )
+
+  const touchCounts = campaignTouches.reduce((counts, touch) => {
+    if (!touch.campaignId) return counts
+    counts.set(touch.campaignId, (counts.get(touch.campaignId) ?? 0) + 1)
+    return counts
+  }, new Map<string, number>())
+
+  const campaigns: CrmCampaign[] = campaignsData.entries.map((entry) => {
+    const values = campaignsData.values.get(entry.id) ?? {}
+    const relations = campaignsData.relations.get(entry.id) ?? {}
+    const audienceGymIds = relations["Audience Gyms"] ?? []
+    const audienceContactIds = relations["Audience Contacts"] ?? []
+    return {
+      id: entry.id,
+      name: values["Campaign Name"] ?? "Untitled campaign",
+      status: values.Status ?? null,
+      owner: values.Owner ?? null,
+      goal: values.Goal ?? null,
+      startDate: values["Start Date"] ?? null,
+      endDate: values["End Date"] ?? null,
+      audienceGymIds,
+      audienceContactIds,
+      audienceGymNames: audienceGymIds.map(
+        (id) => displayNames.get(id) ?? "Unknown gym",
+      ),
+      audienceContactNames: audienceContactIds.map(
+        (id) => displayNames.get(id) ?? "Unknown contact",
+      ),
+      touchCount: touchCounts.get(entry.id) ?? 0,
+      updatedAt: entry.updatedAt,
+    }
+  })
+
+  return { gyms, contacts, interactions, campaigns, campaignTouches }
 }
 
 export const getCrmDataFn = createServerFn({ method: "GET" }).handler(
@@ -844,6 +1101,7 @@ export const createInteractionFn = createServerFn({ method: "POST" })
       ["Date Sent", clean(data.date) ?? new Date().toISOString().slice(0, 10)],
       ["Channel", clean(data.channel) ?? "Email"],
       ["Status", clean(data.status) ?? "Sent"],
+      ["Owner", clean(data.owner)],
       ["Notes", clean(data.notes)],
       ["Content", clean(data.content)],
     ]
@@ -860,6 +1118,11 @@ export const createInteractionFn = createServerFn({ method: "POST" })
 
     const personField = requireField(fields, "Person", "Outreach")
     await setRelation(entryId, personField.id, clean(data.contactId))
+
+    const campaignField = fields.get("Campaign")
+    if (campaignField) {
+      await setRelation(entryId, campaignField.id, clean(data.campaignId))
+    }
 
     return { id: entryId }
   })
@@ -888,6 +1151,7 @@ export const updateInteractionFn = createServerFn({ method: "POST" })
             ["Date Sent", clean(data.date)],
             ["Channel", clean(data.channel)],
             ["Status", clean(data.status)],
+            ["Owner", clean(data.owner)],
             ["Notes", clean(data.notes)],
             ["Content", clean(data.content)],
           ]
@@ -909,8 +1173,80 @@ export const updateInteractionFn = createServerFn({ method: "POST" })
       await setRelation(data.id, contactField.id, clean(data.contactId))
     }
 
+    const campaignField = fields.get("Campaign")
+    if (campaignField) {
+      await setRelation(data.id, campaignField.id, clean(data.campaignId))
+    }
+
     await touchEntry(data.id)
     return { id: data.id }
+  })
+
+export const createCampaignFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => campaignInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    await ensureCampaignSchema()
+    const { entryId, object } = await createEntry("Campaign")
+    const fields = await getFieldsByName(object.id)
+
+    const updates: Array<[string, string | null]> = [
+      ["Campaign Name", data.name],
+      ["Status", clean(data.status) ?? "Planning"],
+      ["Owner", clean(data.owner) ?? "Ian"],
+      ["Goal", clean(data.goal)],
+      ["Start Date", clean(data.startDate)],
+      ["End Date", clean(data.endDate)],
+    ]
+
+    for (const [fieldName, value] of updates) {
+      const field = fields.get(fieldName)
+      if (field) await upsertFieldValue(entryId, field.id, value)
+    }
+
+    const audienceGymsField = requireField(fields, "Audience Gyms", "Campaign")
+    await setRelations(entryId, audienceGymsField.id, data.audienceGymIds)
+
+    const audienceContactsField = requireField(
+      fields,
+      "Audience Contacts",
+      "Campaign",
+    )
+    await setRelations(
+      entryId,
+      audienceContactsField.id,
+      data.audienceContactIds,
+    )
+
+    return { id: entryId }
+  })
+
+export const createCampaignTouchFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => campaignTouchInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    await ensureCampaignSchema()
+    const { entryId, object } = await createEntry("Outreach")
+    const fields = await getFieldsByName(object.id)
+
+    const updates: Array<[string, string | null]> = [
+      ["Subject", data.title],
+      ["Date Sent", clean(data.dueDate)],
+      ["Channel", clean(data.channel) ?? "Email"],
+      ["Owner", clean(data.owner) ?? "Ian"],
+      ["Status", clean(data.status) ?? "Planned"],
+      ["Notes", clean(data.notes)],
+    ]
+
+    for (const [fieldName, value] of updates) {
+      const field = fields.get(fieldName)
+      if (field) await upsertFieldValue(entryId, field.id, value)
+    }
+
+    const campaignField = requireField(fields, "Campaign", "Outreach")
+    await setRelation(entryId, campaignField.id, data.campaignId)
+
+    return { id: entryId }
   })
 
 export const listDocumentsForEntryFn = createServerFn({ method: "GET" })

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -70,7 +70,7 @@ export type CrmInteraction = {
   updatedAt: string | null
 }
 
-export type CrmCampaign = {
+export interface CrmCampaign {
   id: string
   name: string
   status: string | null
@@ -144,6 +144,7 @@ const interactionUpdateSchema = interactionInputSchema.extend({
   source: z.enum(["Meeting", "Outreach"]),
 })
 
+// `@lat`: [[crm-campaigns]]
 const campaignInputSchema = z.object({
   name: z.string().min(1, "Campaign name is required").max(255),
   status: z.string().max(100).optional(),
@@ -155,6 +156,7 @@ const campaignInputSchema = z.object({
   audienceContactIds: z.array(z.string()).default([]),
 })
 
+// `@lat`: [[crm-campaigns]]
 const campaignTouchInputSchema = z.object({
   campaignId: z.string().min(1, "Campaign ID is required"),
   title: z.string().min(1, "Touch title is required").max(255),
@@ -258,6 +260,12 @@ async function assertEntryInObject(entryId: string, objectId: string) {
   }
 
   return entry
+}
+
+// `@lat`: [[crm-campaigns]]
+async function assertCampaignEntry(entryId: string) {
+  const campaignObject = await getObject("Campaign")
+  await assertEntryInObject(entryId, campaignObject.id)
 }
 
 function sanitizeFileName(fileName: string) {
@@ -376,6 +384,7 @@ async function ensureObject({
   return getObject(name)
 }
 
+// `@lat`: [[crm-campaigns]]
 async function ensureCampaignSchema() {
   const [companyObject, peopleObject] = await Promise.all([
     getObject("Company"),
@@ -1121,7 +1130,9 @@ export const createInteractionFn = createServerFn({ method: "POST" })
 
     const campaignField = fields.get("Campaign")
     if (campaignField) {
-      await setRelation(entryId, campaignField.id, clean(data.campaignId))
+      const campaignId = clean(data.campaignId)
+      if (campaignId) await assertCampaignEntry(campaignId)
+      await setRelation(entryId, campaignField.id, campaignId)
     }
 
     return { id: entryId }
@@ -1175,13 +1186,16 @@ export const updateInteractionFn = createServerFn({ method: "POST" })
 
     const campaignField = fields.get("Campaign")
     if (campaignField) {
-      await setRelation(data.id, campaignField.id, clean(data.campaignId))
+      const campaignId = clean(data.campaignId)
+      if (campaignId) await assertCampaignEntry(campaignId)
+      await setRelation(data.id, campaignField.id, campaignId)
     }
 
     await touchEntry(data.id)
     return { id: data.id }
   })
 
+// `@lat`: [[crm-campaigns]]
 export const createCampaignFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => campaignInputSchema.parse(data))
   .handler(async ({ data }) => {
@@ -1221,6 +1235,7 @@ export const createCampaignFn = createServerFn({ method: "POST" })
     return { id: entryId }
   })
 
+// `@lat`: [[crm-campaigns]]
 export const createCampaignTouchFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => campaignTouchInputSchema.parse(data))
   .handler(async ({ data }) => {
@@ -1244,6 +1259,7 @@ export const createCampaignTouchFn = createServerFn({ method: "POST" })
     }
 
     const campaignField = requireField(fields, "Campaign", "Outreach")
+    await assertCampaignEntry(data.campaignId)
     await setRelation(entryId, campaignField.id, data.campaignId)
 
     return { id: entryId }

--- a/lat.md/crm-campaigns.md
+++ b/lat.md/crm-campaigns.md
@@ -1,0 +1,7 @@
+# CRM campaign workflow
+
+The CRM represents marketing campaigns as generic CRM entries with a goal, owner, status, date window, and selected gym/contact audiences.
+
+Campaign interactions are stored as Outreach interactions linked back to a Campaign entry. This keeps manual email and social touches in the normal interaction history while allowing campaign pages to roll up planned and completed activity.
+
+Campaign "next up" views should show unresolved campaign-linked Outreach interactions ordered by nearest scheduled date first.

--- a/lat.md/lat.md
+++ b/lat.md/lat.md
@@ -9,3 +9,4 @@ This directory defines the high-level concepts, business logic, and architecture
 - [[series-event-templates]] — Series event templates: define once, sync to all competitions
 - [[competition-invites]] — Qualification sources, roster, and email-locked invite rounds (ADR-0011)
 - [[crm-crossfit-metadata]] — CRM gym CrossFit profile URLs and derived affiliate metadata
+- [[crm-campaigns]] — CRM marketing campaigns, audience selection, and campaign-linked Outreach interactions


### PR DESCRIPTION
## Summary
- add a Campaigns CRM workspace for campaign goals, owner/status/dates, and gym/contact audience selection
- link campaign touch planning to Outreach interactions instead of a separate touch object
- surface campaign counts in the dashboard and add Campaigns navigation/route wiring

## Verification
- PATH=/Users/ianjones/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/ianjones/.cargo/bin:/Users/ianjones/.nix-profile/bin:/Users/ianjones/.codex/tmp/arg0/codex-arg06c0q8G:/Applications/Codex.app/Contents/Resources ./node_modules/.bin/tsc --noEmit
- PATH=/Users/ianjones/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/ianjones/.cargo/bin:/Users/ianjones/.nix-profile/bin:/Users/ianjones/.codex/tmp/arg0/codex-arg06c0q8G:/Applications/Codex.app/Contents/Resources ./node_modules/.bin/biome check src/server-fns/crm.ts src/routes/_authenticated.tsx src/routes/_authenticated/dashboard.tsx src/routes/_authenticated/campaigns.tsx src/routeTree.gen.ts
- Browser smoke test: created a campaign, added a campaign-linked Outreach interaction, verified campaign counts/upcoming list, then cleaned local smoke-test rows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CRM Campaigns workspace to plan campaigns, select audiences, and track campaign-linked Outreach interactions. Includes a new Campaigns page, navigation, and dashboard metrics.

- **New Features**
  - New Campaigns page (/campaigns) with forms to create campaigns (goal, owner/status/dates, audience) and add campaign-linked interactions.
  - Audience multi-select for gyms and contacts; searchable table with interaction counts; “Upcoming Campaign Interactions” ordered by due date.
  - Outreach interactions now support a `Campaign` relation and `Owner`; campaign touches are stored as `Outreach` entries with channel/status/due date.
  - Server adds `createCampaignFn`, `createCampaignTouchFn`, and expands `getCrmDataFn` to return `campaigns` and `campaignTouches`; runtime schema ensures the `Campaign` object, audience relations, and `Outreach.Campaign` relation.
  - Dashboard shows campaign count; sidebar adds a Campaigns link.

<sup>Written for commit 2417104d2b26c2ea20985f5119130a8689e7a4ea. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/482?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Campaign management page enabling creation of campaigns with audience selection, goal definitions, and date ranges.
  * Searchable campaign overview table displaying status, owner, audience details, and interaction counts.
  * Campaign interaction tracking with form to log new interactions.
  * Updated dashboard with campaign metrics in the overview.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->