### PR TITLE
Add CRM campaign audience builder

### DIFF
--- a/apps/crm/src/routeTree.gen.ts
+++ b/apps/crm/src/routeTree.gen.ts
@@ -21,6 +21,8 @@ import { Route as ApiCrmAgentCapabilitiesRouteImport } from './routes/api/crm/ag
 import { Route as AuthenticatedInteractionsInteractionIdRouteImport } from './routes/_authenticated/interactions.$interactionId'
 import { Route as AuthenticatedGymsGymIdRouteImport } from './routes/_authenticated/gyms.$gymId'
 import { Route as AuthenticatedContactsContactIdRouteImport } from './routes/_authenticated/contacts.$contactId'
+import { Route as AuthenticatedCampaignsCampaignIdRouteImport } from './routes/_authenticated/campaigns.$campaignId'
+import { Route as AuthenticatedCampaignsCampaignIdAudienceRouteImport } from './routes/_authenticated/campaigns.$campaignId.audience'
 
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
@@ -84,47 +86,65 @@ const AuthenticatedContactsContactIdRoute =
     path: '/$contactId',
     getParentRoute: () => AuthenticatedContactsRoute,
   } as any)
+const AuthenticatedCampaignsCampaignIdRoute =
+  AuthenticatedCampaignsCampaignIdRouteImport.update({
+    id: '/$campaignId',
+    path: '/$campaignId',
+    getParentRoute: () => AuthenticatedCampaignsRoute,
+  } as any)
+const AuthenticatedCampaignsCampaignIdAudienceRoute =
+  AuthenticatedCampaignsCampaignIdAudienceRouteImport.update({
+    id: '/audience',
+    path: '/audience',
+    getParentRoute: () => AuthenticatedCampaignsCampaignIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/campaigns': typeof AuthenticatedCampaignsRoute
+  '/campaigns': typeof AuthenticatedCampaignsRouteWithChildren
   '/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/gyms': typeof AuthenticatedGymsRouteWithChildren
   '/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/campaigns/$campaignId': typeof AuthenticatedCampaignsCampaignIdRouteWithChildren
   '/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
   '/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
   '/interactions/$interactionId': typeof AuthenticatedInteractionsInteractionIdRoute
   '/api/crm/agent-capabilities': typeof ApiCrmAgentCapabilitiesRoute
   '/api/crm/documents': typeof ApiCrmDocumentsRoute
+  '/campaigns/$campaignId/audience': typeof AuthenticatedCampaignsCampaignIdAudienceRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/campaigns': typeof AuthenticatedCampaignsRoute
+  '/campaigns': typeof AuthenticatedCampaignsRouteWithChildren
   '/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/gyms': typeof AuthenticatedGymsRouteWithChildren
   '/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/campaigns/$campaignId': typeof AuthenticatedCampaignsCampaignIdRouteWithChildren
   '/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
   '/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
   '/interactions/$interactionId': typeof AuthenticatedInteractionsInteractionIdRoute
   '/api/crm/agent-capabilities': typeof ApiCrmAgentCapabilitiesRoute
   '/api/crm/documents': typeof ApiCrmDocumentsRoute
+  '/campaigns/$campaignId/audience': typeof AuthenticatedCampaignsCampaignIdAudienceRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
-  '/_authenticated/campaigns': typeof AuthenticatedCampaignsRoute
+  '/_authenticated/campaigns': typeof AuthenticatedCampaignsRouteWithChildren
   '/_authenticated/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
   '/_authenticated/gyms': typeof AuthenticatedGymsRouteWithChildren
   '/_authenticated/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/_authenticated/campaigns/$campaignId': typeof AuthenticatedCampaignsCampaignIdRouteWithChildren
   '/_authenticated/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
   '/_authenticated/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
   '/_authenticated/interactions/$interactionId': typeof AuthenticatedInteractionsInteractionIdRoute
   '/api/crm/agent-capabilities': typeof ApiCrmAgentCapabilitiesRoute
   '/api/crm/documents': typeof ApiCrmDocumentsRoute
+  '/_authenticated/campaigns/$campaignId/audience': typeof AuthenticatedCampaignsCampaignIdAudienceRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -135,11 +155,13 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/gyms'
     | '/interactions'
+    | '/campaigns/$campaignId'
     | '/contacts/$contactId'
     | '/gyms/$gymId'
     | '/interactions/$interactionId'
     | '/api/crm/agent-capabilities'
     | '/api/crm/documents'
+    | '/campaigns/$campaignId/audience'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -148,11 +170,13 @@ export interface FileRouteTypes {
     | '/dashboard'
     | '/gyms'
     | '/interactions'
+    | '/campaigns/$campaignId'
     | '/contacts/$contactId'
     | '/gyms/$gymId'
     | '/interactions/$interactionId'
     | '/api/crm/agent-capabilities'
     | '/api/crm/documents'
+    | '/campaigns/$campaignId/audience'
   id:
     | '__root__'
     | '/'
@@ -162,11 +186,13 @@ export interface FileRouteTypes {
     | '/_authenticated/dashboard'
     | '/_authenticated/gyms'
     | '/_authenticated/interactions'
+    | '/_authenticated/campaigns/$campaignId'
     | '/_authenticated/contacts/$contactId'
     | '/_authenticated/gyms/$gymId'
     | '/_authenticated/interactions/$interactionId'
     | '/api/crm/agent-capabilities'
     | '/api/crm/documents'
+    | '/_authenticated/campaigns/$campaignId/audience'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -262,8 +288,52 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedContactsContactIdRouteImport
       parentRoute: typeof AuthenticatedContactsRoute
     }
+    '/_authenticated/campaigns/$campaignId': {
+      id: '/_authenticated/campaigns/$campaignId'
+      path: '/$campaignId'
+      fullPath: '/campaigns/$campaignId'
+      preLoaderRoute: typeof AuthenticatedCampaignsCampaignIdRouteImport
+      parentRoute: typeof AuthenticatedCampaignsRoute
+    }
+    '/_authenticated/campaigns/$campaignId/audience': {
+      id: '/_authenticated/campaigns/$campaignId/audience'
+      path: '/audience'
+      fullPath: '/campaigns/$campaignId/audience'
+      preLoaderRoute: typeof AuthenticatedCampaignsCampaignIdAudienceRouteImport
+      parentRoute: typeof AuthenticatedCampaignsCampaignIdRoute
+    }
   }
 }
+
+interface AuthenticatedCampaignsCampaignIdRouteChildren {
+  AuthenticatedCampaignsCampaignIdAudienceRoute: typeof AuthenticatedCampaignsCampaignIdAudienceRoute
+}
+
+const AuthenticatedCampaignsCampaignIdRouteChildren: AuthenticatedCampaignsCampaignIdRouteChildren =
+  {
+    AuthenticatedCampaignsCampaignIdAudienceRoute:
+      AuthenticatedCampaignsCampaignIdAudienceRoute,
+  }
+
+const AuthenticatedCampaignsCampaignIdRouteWithChildren =
+  AuthenticatedCampaignsCampaignIdRoute._addFileChildren(
+    AuthenticatedCampaignsCampaignIdRouteChildren,
+  )
+
+interface AuthenticatedCampaignsRouteChildren {
+  AuthenticatedCampaignsCampaignIdRoute: typeof AuthenticatedCampaignsCampaignIdRouteWithChildren
+}
+
+const AuthenticatedCampaignsRouteChildren: AuthenticatedCampaignsRouteChildren =
+  {
+    AuthenticatedCampaignsCampaignIdRoute:
+      AuthenticatedCampaignsCampaignIdRouteWithChildren,
+  }
+
+const AuthenticatedCampaignsRouteWithChildren =
+  AuthenticatedCampaignsRoute._addFileChildren(
+    AuthenticatedCampaignsRouteChildren,
+  )
 
 interface AuthenticatedContactsRouteChildren {
   AuthenticatedContactsContactIdRoute: typeof AuthenticatedContactsContactIdRoute
@@ -305,7 +375,7 @@ const AuthenticatedInteractionsRouteWithChildren =
   )
 
 interface AuthenticatedRouteChildren {
-  AuthenticatedCampaignsRoute: typeof AuthenticatedCampaignsRoute
+  AuthenticatedCampaignsRoute: typeof AuthenticatedCampaignsRouteWithChildren
   AuthenticatedContactsRoute: typeof AuthenticatedContactsRouteWithChildren
   AuthenticatedDashboardRoute: typeof AuthenticatedDashboardRoute
   AuthenticatedGymsRoute: typeof AuthenticatedGymsRouteWithChildren
@@ -313,7 +383,7 @@ interface AuthenticatedRouteChildren {
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
-  AuthenticatedCampaignsRoute: AuthenticatedCampaignsRoute,
+  AuthenticatedCampaignsRoute: AuthenticatedCampaignsRouteWithChildren,
   AuthenticatedContactsRoute: AuthenticatedContactsRouteWithChildren,
   AuthenticatedDashboardRoute: AuthenticatedDashboardRoute,
   AuthenticatedGymsRoute: AuthenticatedGymsRouteWithChildren,

--- a/apps/crm/src/routes/_authenticated/campaigns.$campaignId.audience.tsx
+++ b/apps/crm/src/routes/_authenticated/campaigns.$campaignId.audience.tsx
@@ -1,0 +1,513 @@
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  useRouter,
+} from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import {
+  Building2,
+  Check,
+  Search,
+  UserRound,
+  UsersRound,
+  X,
+} from "lucide-react"
+import { useMemo, useState } from "react"
+import {
+  type CrmContact,
+  type CrmGym,
+  getCrmDataFn,
+  updateCampaignAudienceFn,
+} from "@/server-fns/crm"
+
+type AudienceCandidate =
+  | { type: "gym"; item: CrmGym }
+  | { type: "contact"; item: CrmContact }
+
+type CandidateType = "all" | "gyms" | "contacts"
+
+export const Route = createFileRoute(
+  "/_authenticated/campaigns/$campaignId/audience",
+)({
+  loader: async ({ params }) => {
+    const data = await getCrmDataFn()
+    const campaign = data.campaigns.find(
+      (item) => item.id === params.campaignId,
+    )
+    if (!campaign) throw notFound()
+
+    return {
+      campaign,
+      gyms: data.gyms,
+      contacts: data.contacts,
+    }
+  },
+  notFoundComponent: () => <EntityNotFound label="Campaign" />,
+  component: CampaignAudienceBuilderPage,
+})
+
+function CampaignAudienceBuilderPage() {
+  const { campaign, gyms, contacts } = Route.useLoaderData()
+  const router = useRouter()
+  const updateCampaignAudience = useServerFn(updateCampaignAudienceFn)
+  const [query, setQuery] = useState("")
+  const [candidateType, setCandidateType] = useState<CandidateType>("all")
+  const [statusFilter, setStatusFilter] = useState("")
+  const [selectedGymIds, setSelectedGymIds] = useState(campaign.audienceGymIds)
+  const [selectedContactIds, setSelectedContactIds] = useState(
+    campaign.audienceContactIds,
+  )
+  const [activeCandidateKey, setActiveCandidateKey] = useState<string | null>(
+    selectedContactIds[0]
+      ? `contact:${selectedContactIds[0]}`
+      : selectedGymIds[0]
+        ? `gym:${selectedGymIds[0]}`
+        : null,
+  )
+  const [saving, setSaving] = useState(false)
+
+  const selectedGymSet = new Set(selectedGymIds)
+  const selectedContactSet = new Set(selectedContactIds)
+  const candidates = useMemo<AudienceCandidate[]>(
+    () => [
+      ...gyms.map((item) => ({ type: "gym" as const, item })),
+      ...contacts.map((item) => ({ type: "contact" as const, item })),
+    ],
+    [gyms, contacts],
+  )
+  const statusOptions = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          candidates
+            .map((candidate) => candidate.item.status)
+            .filter((value): value is string => Boolean(value)),
+        ),
+      ).sort(),
+    [candidates],
+  )
+  const filteredCandidates = useMemo(() => {
+    const normalized = query.trim().toLowerCase()
+    return candidates.filter((candidate) => {
+      if (candidateType === "gyms" && candidate.type !== "gym") return false
+      if (candidateType === "contacts" && candidate.type !== "contact") {
+        return false
+      }
+      if (statusFilter && candidate.item.status !== statusFilter) return false
+      if (!normalized) return true
+      return candidateSearchText(candidate).includes(normalized)
+    })
+  }, [candidates, candidateType, query, statusFilter])
+  const selectedGyms = gyms.filter((gym) => selectedGymSet.has(gym.id))
+  const selectedContacts = contacts.filter((contact) =>
+    selectedContactSet.has(contact.id),
+  )
+  const activeCandidate =
+    candidates.find(
+      (candidate) => candidateKey(candidate) === activeCandidateKey,
+    ) ??
+    filteredCandidates[0] ??
+    candidates[0]
+
+  function toggleCandidate(candidate: AudienceCandidate) {
+    if (candidate.type === "gym") {
+      setSelectedGymIds((current) =>
+        current.includes(candidate.item.id)
+          ? current.filter((id) => id !== candidate.item.id)
+          : [...current, candidate.item.id],
+      )
+      return
+    }
+
+    setSelectedContactIds((current) =>
+      current.includes(candidate.item.id)
+        ? current.filter((id) => id !== candidate.item.id)
+        : [...current, candidate.item.id],
+    )
+  }
+
+  async function handleSave() {
+    setSaving(true)
+    try {
+      await updateCampaignAudience({
+        data: {
+          campaignId: campaign.id,
+          audienceGymIds: selectedGymIds,
+          audienceContactIds: selectedContactIds,
+        },
+      })
+      await router.invalidate()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <UsersRound className="h-4 w-4" />
+            Audience Builder
+          </div>
+          <h2 className="mt-1 text-3xl font-semibold tracking-tight">
+            {campaign.name}
+          </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {selectedGyms.length} gyms and {selectedContacts.length} contacts
+            selected.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            to="/campaigns/$campaignId"
+            params={{ campaignId: campaign.id }}
+            className="inline-flex h-10 items-center rounded-md border border-input px-4 text-sm font-medium hover:bg-accent"
+          >
+            Campaign
+          </Link>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            <Check className="h-4 w-4" />
+            {saving ? "Saving..." : "Save Audience"}
+          </button>
+        </div>
+      </header>
+
+      <section className="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
+        <div className="space-y-4">
+          <div className="rounded-lg border border-border p-4">
+            <div className="grid gap-3 md:grid-cols-[1fr_180px_180px]">
+              <div className="flex h-10 items-center gap-2 rounded-md border border-input px-3">
+                <Search className="h-4 w-4 text-muted-foreground" />
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search names, locations, emails, notes"
+                  className="h-full min-w-0 flex-1 bg-transparent text-sm outline-none"
+                />
+              </div>
+              <select
+                value={candidateType}
+                onChange={(event) =>
+                  setCandidateType(event.target.value as CandidateType)
+                }
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+              >
+                <option value="all">Gyms and contacts</option>
+                <option value="gyms">Gyms only</option>
+                <option value="contacts">Contacts only</option>
+              </select>
+              <select
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value)}
+                className="h-10 rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+              >
+                <option value="">Any status</option>
+                {statusOptions.map((status) => (
+                  <option key={status} value={status}>
+                    {status}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          <div className="overflow-hidden rounded-lg border border-border">
+            <div className="border-b border-border px-4 py-3 text-sm text-muted-foreground">
+              {filteredCandidates.length} matches
+            </div>
+            <div className="max-h-[min(760px,calc(100vh-22rem))] divide-y divide-border overflow-y-auto">
+              {filteredCandidates.map((candidate) => {
+                const selected = isSelected(
+                  candidate,
+                  selectedGymSet,
+                  selectedContactSet,
+                )
+                return (
+                  <button
+                    key={candidateKey(candidate)}
+                    type="button"
+                    onClick={() =>
+                      setActiveCandidateKey(candidateKey(candidate))
+                    }
+                    className="grid w-full gap-3 px-4 py-3 text-left text-sm hover:bg-accent md:grid-cols-[32px_1fr_120px]"
+                  >
+                    <span className="mt-1 text-muted-foreground">
+                      {candidate.type === "gym" ? (
+                        <Building2 className="h-4 w-4" />
+                      ) : (
+                        <UserRound className="h-4 w-4" />
+                      )}
+                    </span>
+                    <span className="min-w-0">
+                      <span className="block font-medium">
+                        {candidateLabel(candidate)}
+                      </span>
+                      <span className="block truncate text-muted-foreground">
+                        {candidateDescription(candidate)}
+                      </span>
+                    </span>
+                    <span
+                      className={`inline-flex h-8 items-center justify-center rounded-md border px-3 text-xs font-medium ${
+                        selected
+                          ? "border-primary bg-primary text-primary-foreground"
+                          : "border-input"
+                      }`}
+                    >
+                      {selected ? "Selected" : "Preview"}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+
+        <aside className="space-y-4 xl:sticky xl:top-4">
+          <CandidatePanel
+            candidate={activeCandidate}
+            selected={
+              activeCandidate
+                ? isSelected(
+                    activeCandidate,
+                    selectedGymSet,
+                    selectedContactSet,
+                  )
+                : false
+            }
+            onToggle={() => activeCandidate && toggleCandidate(activeCandidate)}
+          />
+          <SelectedAudience
+            gyms={selectedGyms}
+            contacts={selectedContacts}
+            onRemoveGym={(id) =>
+              setSelectedGymIds((current) =>
+                current.filter((item) => item !== id),
+              )
+            }
+            onRemoveContact={(id) =>
+              setSelectedContactIds((current) =>
+                current.filter((item) => item !== id),
+              )
+            }
+          />
+        </aside>
+      </section>
+    </section>
+  )
+}
+
+function CandidatePanel({
+  candidate,
+  selected,
+  onToggle,
+}: {
+  candidate: AudienceCandidate | undefined
+  selected: boolean
+  onToggle: () => void
+}) {
+  if (!candidate) {
+    return (
+      <section className="rounded-lg border border-border p-4 text-sm text-muted-foreground">
+        Select a gym or contact to preview details.
+      </section>
+    )
+  }
+
+  return (
+    <section className="rounded-lg border border-border p-4">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground">
+            {candidate.type}
+          </p>
+          <h3 className="mt-1 text-lg font-semibold">
+            {candidateLabel(candidate)}
+          </h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {candidateDescription(candidate)}
+          </p>
+        </div>
+        {candidate.type === "gym" ? (
+          <Building2 className="h-5 w-5 text-muted-foreground" />
+        ) : (
+          <UserRound className="h-5 w-5 text-muted-foreground" />
+        )}
+      </div>
+      <div className="space-y-2 text-sm">
+        {candidateDetails(candidate).map(([label, value]) =>
+          value ? (
+            <div key={label} className="grid grid-cols-[110px_1fr] gap-3">
+              <span className="text-muted-foreground">{label}</span>
+              <span className="min-w-0 break-words">{value}</span>
+            </div>
+          ) : null,
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={`mt-4 inline-flex h-10 w-full items-center justify-center gap-2 rounded-md px-4 text-sm font-medium ${
+          selected
+            ? "border border-input bg-background hover:bg-accent"
+            : "bg-primary text-primary-foreground"
+        }`}
+      >
+        {selected ? <X className="h-4 w-4" /> : <Check className="h-4 w-4" />}
+        {selected ? "Remove from Audience" : "Add to Audience"}
+      </button>
+    </section>
+  )
+}
+
+function SelectedAudience({
+  gyms,
+  contacts,
+  onRemoveGym,
+  onRemoveContact,
+}: {
+  gyms: CrmGym[]
+  contacts: CrmContact[]
+  onRemoveGym: (id: string) => void
+  onRemoveContact: (id: string) => void
+}) {
+  return (
+    <section className="rounded-lg border border-border">
+      <div className="border-b border-border px-4 py-3">
+        <h3 className="font-medium">Selected Audience</h3>
+      </div>
+      <div className="max-h-80 divide-y divide-border overflow-auto">
+        {[
+          ...gyms.map((item) => ({ type: "gym" as const, item })),
+          ...contacts.map((item) => ({ type: "contact" as const, item })),
+        ].map((candidate) => (
+          <div
+            key={candidateKey(candidate)}
+            className="flex items-center justify-between gap-3 px-4 py-3 text-sm"
+          >
+            <div className="min-w-0">
+              <p className="truncate font-medium">
+                {candidateLabel(candidate)}
+              </p>
+              <p className="truncate text-muted-foreground">
+                {candidate.type === "gym" ? "Gym" : "Contact"}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() =>
+                candidate.type === "gym"
+                  ? onRemoveGym(candidate.item.id)
+                  : onRemoveContact(candidate.item.id)
+              }
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-input hover:bg-accent"
+              aria-label={`Remove ${candidateLabel(candidate)}`}
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        ))}
+        {gyms.length === 0 && contacts.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-muted-foreground">
+            No audience selected yet.
+          </p>
+        ) : null}
+      </div>
+    </section>
+  )
+}
+
+function candidateKey(candidate: AudienceCandidate) {
+  return `${candidate.type}:${candidate.item.id}`
+}
+
+function candidateLabel(candidate: AudienceCandidate) {
+  return candidate.type === "gym"
+    ? candidate.item.name
+    : candidate.item.fullName
+}
+
+function candidateDescription(candidate: AudienceCandidate) {
+  if (candidate.type === "gym") {
+    return [
+      candidate.item.location,
+      candidate.item.status,
+      candidate.item.priority,
+    ]
+      .filter(Boolean)
+      .join(" / ")
+  }
+  return [
+    candidate.item.companyName,
+    candidate.item.email,
+    candidate.item.status,
+  ]
+    .filter(Boolean)
+    .join(" / ")
+}
+
+function candidateSearchText(candidate: AudienceCandidate) {
+  return [
+    candidateLabel(candidate),
+    candidateDescription(candidate),
+    ...candidateDetails(candidate).map(([, value]) => value),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase()
+}
+
+function candidateDetails(
+  candidate: AudienceCandidate,
+): Array<[string, string | null]> {
+  if (candidate.type === "gym") {
+    return [
+      ["Location", candidate.item.location],
+      ["Status", candidate.item.status],
+      ["Priority", candidate.item.priority],
+      ["Relationship", candidate.item.relationship],
+      ["Owner", candidate.item.ownerManager],
+      ["Email", candidate.item.email],
+      ["Phone", candidate.item.phone],
+      ["Website", candidate.item.website],
+      ["Instagram", candidate.item.instagram],
+      ["Last Contacted", candidate.item.lastContacted],
+      ["Notes", candidate.item.notes],
+    ]
+  }
+
+  return [
+    ["Company", candidate.item.companyName],
+    ["Status", candidate.item.status],
+    ["Email", candidate.item.email],
+    ["Phone", candidate.item.phone],
+    ["Notes", candidate.item.notes],
+  ]
+}
+
+function isSelected(
+  candidate: AudienceCandidate,
+  selectedGymSet: Set<string>,
+  selectedContactSet: Set<string>,
+) {
+  return candidate.type === "gym"
+    ? selectedGymSet.has(candidate.item.id)
+    : selectedContactSet.has(candidate.item.id)
+}
+
+function EntityNotFound({ label }: { label: string }) {
+  return (
+    <section className="rounded-lg border border-border p-6">
+      <h2 className="text-xl font-semibold">{label} not found</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        The record may have been deleted or moved.
+      </p>
+    </section>
+  )
+}

--- a/apps/crm/src/routes/_authenticated/campaigns.$campaignId.audience.tsx
+++ b/apps/crm/src/routes/_authenticated/campaigns.$campaignId.audience.tsx
@@ -1,3 +1,4 @@
+// `@lat`: [[crm-campaigns]]
 import {
   createFileRoute,
   Link,
@@ -27,6 +28,7 @@ type AudienceCandidate =
 
 type CandidateType = "all" | "gyms" | "contacts"
 
+// `@lat`: [[crm-campaigns]]
 export const Route = createFileRoute(
   "/_authenticated/campaigns/$campaignId/audience",
 )({
@@ -66,6 +68,7 @@ function CampaignAudienceBuilderPage() {
         : null,
   )
   const [saving, setSaving] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const selectedGymSet = new Set(selectedGymIds)
   const selectedContactSet = new Set(selectedContactIds)
@@ -104,11 +107,9 @@ function CampaignAudienceBuilderPage() {
     selectedContactSet.has(contact.id),
   )
   const activeCandidate =
-    candidates.find(
+    filteredCandidates.find(
       (candidate) => candidateKey(candidate) === activeCandidateKey,
-    ) ??
-    filteredCandidates[0] ??
-    candidates[0]
+    ) ?? filteredCandidates[0]
 
   function toggleCandidate(candidate: AudienceCandidate) {
     if (candidate.type === "gym") {
@@ -128,6 +129,7 @@ function CampaignAudienceBuilderPage() {
   }
 
   async function handleSave() {
+    setErrorMessage(null)
     setSaving(true)
     try {
       await updateCampaignAudience({
@@ -138,6 +140,10 @@ function CampaignAudienceBuilderPage() {
         },
       })
       await router.invalidate()
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error ? error.message : "Audience could not be saved.",
+      )
     } finally {
       setSaving(false)
     }
@@ -178,6 +184,11 @@ function CampaignAudienceBuilderPage() {
           </button>
         </div>
       </header>
+      {errorMessage ? (
+        <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {errorMessage}
+        </p>
+      ) : null}
 
       <section className="grid items-start gap-4 xl:grid-cols-[minmax(0,1fr)_360px]">
         <div className="space-y-4">
@@ -224,11 +235,11 @@ function CampaignAudienceBuilderPage() {
             </div>
             <div className="max-h-[min(760px,calc(100vh-22rem))] divide-y divide-border overflow-y-auto">
               {filteredCandidates.map((candidate) => {
-                const selected = isSelected(
+                const selected = isSelected({
                   candidate,
                   selectedGymSet,
                   selectedContactSet,
-                )
+                })
                 return (
                   <button
                     key={candidateKey(candidate)}
@@ -274,11 +285,11 @@ function CampaignAudienceBuilderPage() {
             candidate={activeCandidate}
             selected={
               activeCandidate
-                ? isSelected(
-                    activeCandidate,
+                ? isSelected({
+                    candidate: activeCandidate,
                     selectedGymSet,
                     selectedContactSet,
-                  )
+                  })
                 : false
             }
             onToggle={() => activeCandidate && toggleCandidate(activeCandidate)}
@@ -491,11 +502,15 @@ function candidateDetails(
   ]
 }
 
-function isSelected(
-  candidate: AudienceCandidate,
-  selectedGymSet: Set<string>,
-  selectedContactSet: Set<string>,
-) {
+function isSelected({
+  candidate,
+  selectedGymSet,
+  selectedContactSet,
+}: {
+  candidate: AudienceCandidate
+  selectedGymSet: Set<string>
+  selectedContactSet: Set<string>
+}) {
   return candidate.type === "gym"
     ? selectedGymSet.has(candidate.item.id)
     : selectedContactSet.has(candidate.item.id)

--- a/apps/crm/src/routes/_authenticated/campaigns.$campaignId.tsx
+++ b/apps/crm/src/routes/_authenticated/campaigns.$campaignId.tsx
@@ -1,0 +1,566 @@
+import {
+  createFileRoute,
+  Link,
+  notFound,
+  Outlet,
+  useLocation,
+  useRouter,
+} from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import {
+  CalendarDays,
+  Check,
+  Clipboard,
+  Mail,
+  Megaphone,
+  Plus,
+  Send,
+  UsersRound,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { createCampaignTouchFn, getCrmDataFn } from "@/server-fns/crm"
+
+const TOUCH_CHANNEL_OPTIONS = ["Email", "Instagram", "Facebook", "LinkedIn"]
+const TOUCH_STATUS_OPTIONS = ["Planned", "Drafted", "Sent", "Posted"]
+const OWNER_OPTIONS = ["Ian", "Zac"]
+
+export const Route = createFileRoute("/_authenticated/campaigns/$campaignId")({
+  loader: async ({ params }) => {
+    const data = await getCrmDataFn()
+    const campaign = data.campaigns.find(
+      (item) => item.id === params.campaignId,
+    )
+    if (!campaign) throw notFound()
+
+    const audienceGyms = data.gyms.filter((gym) =>
+      campaign.audienceGymIds.includes(gym.id),
+    )
+    const audienceContacts = data.contacts.filter((contact) =>
+      campaign.audienceContactIds.includes(contact.id),
+    )
+    const audienceGymIds = new Set(audienceGyms.map((gym) => gym.id))
+    const campaignTouches = data.campaignTouches
+      .filter((touch) => touch.campaignId === campaign.id)
+      .sort((a, b) => touchDateValue(a.date) - touchDateValue(b.date))
+
+    return {
+      campaign,
+      audienceGyms,
+      audienceContacts,
+      campaignTouches,
+      relatedContacts: data.contacts.filter(
+        (contact) =>
+          campaign.audienceContactIds.includes(contact.id) ||
+          (contact.companyId ? audienceGymIds.has(contact.companyId) : false),
+      ),
+    }
+  },
+  notFoundComponent: () => <EntityNotFound label="Campaign" />,
+  component: CampaignDetailPage,
+})
+
+function CampaignDetailPage() {
+  const {
+    campaign,
+    audienceGyms,
+    audienceContacts,
+    campaignTouches,
+    relatedContacts,
+  } = Route.useLoaderData()
+  const location = useLocation()
+  const router = useRouter()
+  const createCampaignTouch = useServerFn(createCampaignTouchFn)
+  const [saving, setSaving] = useState(false)
+  const [channel, setChannel] = useState("Email")
+  const [selectedSourceId, setSelectedSourceId] = useState(
+    audienceContacts[0]?.id ?? audienceGyms[0]?.id ?? "",
+  )
+  const [copiedKey, setCopiedKey] = useState<string | null>(null)
+
+  const sources = useMemo(
+    () => [
+      ...audienceContacts.map((contact) => ({
+        id: contact.id,
+        type: "contact" as const,
+        label: contact.fullName,
+        companyId: contact.companyId,
+        companyName: contact.companyName,
+        email: contact.email,
+      })),
+      ...audienceGyms.map((gym) => ({
+        id: gym.id,
+        type: "gym" as const,
+        label: gym.name,
+        companyId: gym.id,
+        companyName: gym.name,
+        email: gym.email,
+      })),
+    ],
+    [audienceContacts, audienceGyms],
+  )
+  const selectedSource = sources.find(
+    (source) => source.id === selectedSourceId,
+  )
+  const template = buildTemplate({
+    channel,
+    campaignName: campaign.name,
+    campaignGoal: campaign.goal,
+    source: selectedSource,
+  })
+
+  useEffect(() => {
+    if (
+      selectedSourceId &&
+      sources.some((source) => source.id === selectedSourceId)
+    ) {
+      return
+    }
+    setSelectedSourceId(sources[0]?.id ?? "")
+  }, [selectedSourceId, sources])
+
+  if (location.pathname !== `/campaigns/${campaign.id}`) {
+    return <Outlet />
+  }
+
+  async function handleTouchSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = new FormData(event.currentTarget)
+    const source = sources.find(
+      (item) => item.id === String(form.get("sourceId") ?? ""),
+    )
+    setSaving(true)
+    try {
+      await createCampaignTouch({
+        data: {
+          campaignId: campaign.id,
+          title: String(form.get("title") ?? ""),
+          channel: String(form.get("channel") ?? ""),
+          owner: String(form.get("owner") ?? "Ian") as "Ian" | "Zac",
+          status: String(form.get("status") ?? ""),
+          dueDate: String(form.get("dueDate") ?? ""),
+          companyId: source?.companyId ?? "",
+          contactId: source?.type === "contact" ? source.id : "",
+          notes: String(form.get("notes") ?? ""),
+          content: template.body,
+        },
+      })
+      event.currentTarget.reset()
+      setSelectedSourceId(sources[0]?.id ?? "")
+      await router.invalidate()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function copyTemplate(key: string, value: string) {
+    await navigator.clipboard.writeText(value)
+    setCopiedKey(key)
+    window.setTimeout(() => setCopiedKey(null), 1400)
+  }
+
+  return (
+    <section className="space-y-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+        <div>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Megaphone className="h-4 w-4" />
+            Campaign
+          </div>
+          <h2 className="mt-1 text-3xl font-semibold tracking-tight">
+            {campaign.name}
+          </h2>
+          <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
+            <Badge value={campaign.status || "Planning"} />
+            <Badge value={campaign.owner || "Ian"} />
+            <span>{formatRange(campaign.startDate, campaign.endDate)}</span>
+          </div>
+        </div>
+        <Link
+          to="/campaigns/$campaignId/audience"
+          params={{ campaignId: campaign.id }}
+          className="inline-flex h-10 items-center justify-center rounded-md border border-input px-4 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Build Audience
+        </Link>
+      </header>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <Metric
+          icon={<UsersRound className="h-5 w-5" />}
+          label="Gyms"
+          value={audienceGyms.length}
+        />
+        <Metric
+          icon={<UsersRound className="h-5 w-5" />}
+          label="Contacts"
+          value={audienceContacts.length}
+        />
+        <Metric
+          icon={<CalendarDays className="h-5 w-5" />}
+          label="Scheduled"
+          value={campaignTouches.length}
+        />
+      </div>
+
+      {campaign.goal ? (
+        <section className="rounded-lg border border-border p-4 text-sm text-muted-foreground">
+          {campaign.goal}
+        </section>
+      ) : null}
+
+      <form
+        onSubmit={handleTouchSubmit}
+        className="rounded-lg border border-border p-4"
+      >
+        <div className="mb-4 flex items-center gap-2">
+          <Send className="h-4 w-4 text-muted-foreground" />
+          <h3 className="font-medium">Schedule an Interaction</h3>
+        </div>
+        <div className="grid gap-3 md:grid-cols-4">
+          <SelectInput
+            name="sourceId"
+            label="Source"
+            value={selectedSourceId}
+            onChange={setSelectedSourceId}
+            options={sources.map((source) => source.label)}
+            optionValues={sources.map((source) => source.id)}
+          />
+          <TextInput
+            name="title"
+            label="Touch"
+            defaultValue={`${channel}: ${campaign.name}`}
+            required
+          />
+          <SelectInput
+            name="channel"
+            label="Channel"
+            value={channel}
+            onChange={setChannel}
+            options={TOUCH_CHANNEL_OPTIONS}
+          />
+          <SelectInput
+            name="status"
+            label="Status"
+            options={TOUCH_STATUS_OPTIONS}
+          />
+          <SelectInput name="owner" label="Owner" options={OWNER_OPTIONS} />
+          <TextInput name="dueDate" label="Due" type="date" />
+          <div className="md:col-span-2">
+            <TextInput name="notes" label="Notes" />
+          </div>
+        </div>
+        <div className="mt-4 flex justify-end">
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" />
+            {saving ? "Scheduling..." : "Schedule Interaction"}
+          </button>
+        </div>
+      </form>
+
+      <section className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
+        <div className="rounded-lg border border-border">
+          <div className="border-b border-border px-4 py-3">
+            <h3 className="font-medium">Scheduled Interactions</h3>
+          </div>
+          <div className="divide-y divide-border">
+            {campaignTouches.length > 0 ? (
+              campaignTouches.map((touch) => (
+                <div
+                  key={touch.id}
+                  className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[1fr_120px_120px]"
+                >
+                  <Link
+                    to="/interactions/$interactionId"
+                    params={{ interactionId: touch.id }}
+                    className="font-medium underline-offset-4 hover:underline"
+                  >
+                    {touch.title}
+                  </Link>
+                  <span className="text-muted-foreground">
+                    {touch.date || "-"}
+                  </span>
+                  <span className="text-muted-foreground">
+                    {touch.status || "-"}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <p className="px-4 py-6 text-sm text-muted-foreground">
+                No interactions scheduled for this campaign yet.
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-border p-4">
+          <div className="mb-3 flex items-center justify-between gap-3">
+            <div>
+              <h3 className="font-medium">Quick Actions</h3>
+              <p className="text-sm text-muted-foreground">
+                {selectedSource?.label ?? "Choose a source"} template
+              </p>
+            </div>
+            <Mail className="h-5 w-5 text-muted-foreground" />
+          </div>
+          {channel === "Email" ? (
+            <div className="mb-3 rounded-md bg-secondary px-3 py-2 text-sm">
+              <span className="font-medium">Subject:</span> {template.subject}
+            </div>
+          ) : null}
+          <pre className="max-h-80 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-background p-3 text-sm">
+            {template.body}
+          </pre>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {channel === "Email" ? (
+              <CopyButton
+                copied={copiedKey === "subject"}
+                onClick={() => copyTemplate("subject", template.subject)}
+              >
+                Subject
+              </CopyButton>
+            ) : null}
+            <CopyButton
+              copied={copiedKey === "body"}
+              onClick={() => copyTemplate("body", template.body)}
+            >
+              Body
+            </CopyButton>
+          </div>
+        </div>
+      </section>
+
+      <RelatedSection title="Audience Sources">
+        {[...relatedContacts, ...audienceGyms].map((item) => (
+          <RelatedRow key={item.id}>
+            {"fullName" in item ? (
+              <Link
+                to="/contacts/$contactId"
+                params={{ contactId: item.id }}
+                className="font-medium underline-offset-4 hover:underline"
+              >
+                {item.fullName}
+              </Link>
+            ) : (
+              <Link
+                to="/gyms/$gymId"
+                params={{ gymId: item.id }}
+                className="font-medium underline-offset-4 hover:underline"
+              >
+                {item.name}
+              </Link>
+            )}
+            <span>
+              {"companyName" in item ? item.companyName || "Contact" : "Gym"}
+            </span>
+            <span>{"email" in item ? item.email || "-" : "-"}</span>
+          </RelatedRow>
+        ))}
+      </RelatedSection>
+    </section>
+  )
+}
+
+function buildTemplate({
+  channel,
+  campaignName,
+  campaignGoal,
+  source,
+}: {
+  channel: string
+  campaignName: string
+  campaignGoal: string | null
+  source:
+    | {
+        type: "contact" | "gym"
+        label: string
+        companyName: string | null
+      }
+    | undefined
+}) {
+  const firstName = source?.label.split(" ")[0] ?? "there"
+  const gymName = source?.companyName ?? source?.label ?? "your gym"
+  const goalLine = campaignGoal ? `\n\nContext: ${campaignGoal}` : ""
+
+  if (channel === "Email") {
+    return {
+      subject: `${campaignName} for ${gymName}`,
+      body: `Hey ${firstName},\n\nI wanted to reach out about ${campaignName}. I think it could be a strong fit for ${gymName} and wanted to see if it is worth a quick conversation.${goalLine}\n\nWould you be open to taking a look?\n\nIan`,
+    }
+  }
+
+  return {
+    subject: campaignName,
+    body: `Hey ${firstName}, wanted to share ${campaignName} with ${gymName}. I think it could be a good fit. Open to a quick chat?`,
+  }
+}
+
+function touchDateValue(date: string | null) {
+  if (!date) return Number.MAX_SAFE_INTEGER
+  const value = new Date(date).getTime()
+  return Number.isNaN(value) ? Number.MAX_SAFE_INTEGER : value
+}
+
+function formatRange(startDate: string | null, endDate: string | null) {
+  if (startDate && endDate) return `${startDate} to ${endDate}`
+  return startDate ?? endDate ?? "No dates"
+}
+
+function Badge({ value }: { value: string | null }) {
+  if (!value) return null
+  return (
+    <span className="rounded-md bg-secondary px-2 py-0.5 text-xs font-medium text-secondary-foreground">
+      {value}
+    </span>
+  )
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode
+  label: string
+  value: number
+}) {
+  return (
+    <div className="rounded-lg border border-border p-4">
+      <div className="mb-2 text-muted-foreground">{icon}</div>
+      <div className="text-2xl font-semibold">{value}</div>
+      <div className="text-sm text-muted-foreground">{label}</div>
+    </div>
+  )
+}
+
+function TextInput({
+  name,
+  label,
+  required,
+  type = "text",
+  defaultValue,
+}: {
+  name: string
+  label: string
+  required?: boolean
+  type?: string
+  defaultValue?: string
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <input
+        name={name}
+        required={required}
+        type={type}
+        defaultValue={defaultValue}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      />
+    </label>
+  )
+}
+
+function SelectInput({
+  name,
+  label,
+  options,
+  optionValues,
+  required,
+  value,
+  onChange,
+}: {
+  name: string
+  label: string
+  options: string[]
+  optionValues?: string[]
+  required?: boolean
+  value?: string
+  onChange?: (value: string) => void
+}) {
+  return (
+    <label className="space-y-1 text-sm font-medium">
+      <span>{label}</span>
+      <select
+        name={name}
+        required={required}
+        value={value}
+        onChange={(event) => onChange?.(event.target.value)}
+        className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
+      >
+        <option value="">Choose...</option>
+        {options.map((option, index) => (
+          <option
+            key={optionValues?.[index] ?? option}
+            value={optionValues?.[index] ?? option}
+          >
+            {option}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function CopyButton({
+  children,
+  copied,
+  onClick,
+}: {
+  children: React.ReactNode
+  copied: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex h-9 items-center gap-2 rounded-md border border-input px-3 text-sm font-medium hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      {copied ? (
+        <Check className="h-4 w-4" />
+      ) : (
+        <Clipboard className="h-4 w-4" />
+      )}
+      {copied ? "Copied" : `Copy ${children}`}
+    </button>
+  )
+}
+
+function RelatedSection({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) {
+  return (
+    <section className="rounded-lg border border-border">
+      <div className="border-b border-border px-4 py-3">
+        <h3 className="font-medium">{title}</h3>
+      </div>
+      <div className="divide-y divide-border">{children}</div>
+    </section>
+  )
+}
+
+function RelatedRow({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="grid gap-2 px-4 py-3 text-sm md:grid-cols-[1fr_160px_220px]">
+      {children}
+    </div>
+  )
+}
+
+function EntityNotFound({ label }: { label: string }) {
+  return (
+    <section className="rounded-lg border border-border p-6">
+      <h2 className="text-xl font-semibold">{label} not found</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        The record may have been deleted or moved.
+      </p>
+    </section>
+  )
+}

--- a/apps/crm/src/routes/_authenticated/campaigns.$campaignId.tsx
+++ b/apps/crm/src/routes/_authenticated/campaigns.$campaignId.tsx
@@ -1,3 +1,4 @@
+// `@lat`: [[crm-campaigns]]
 import {
   createFileRoute,
   Link,
@@ -24,6 +25,7 @@ const TOUCH_CHANNEL_OPTIONS = ["Email", "Instagram", "Facebook", "LinkedIn"]
 const TOUCH_STATUS_OPTIONS = ["Planned", "Drafted", "Sent", "Posted"]
 const OWNER_OPTIONS = ["Ian", "Zac"]
 
+// `@lat`: [[crm-campaigns]]
 export const Route = createFileRoute("/_authenticated/campaigns/$campaignId")({
   loader: async ({ params }) => {
     const data = await getCrmDataFn()
@@ -72,6 +74,8 @@ function CampaignDetailPage() {
   const createCampaignTouch = useServerFn(createCampaignTouchFn)
   const [saving, setSaving] = useState(false)
   const [channel, setChannel] = useState("Email")
+  const [touchTitle, setTouchTitle] = useState(`Email: ${campaign.name}`)
+  const [submitError, setSubmitError] = useState<string | null>(null)
   const [selectedSourceId, setSelectedSourceId] = useState(
     audienceContacts[0]?.id ?? audienceGyms[0]?.id ?? "",
   )
@@ -108,6 +112,7 @@ function CampaignDetailPage() {
     source: selectedSource,
   })
 
+  // `@lat`: [[crm-campaigns]]
   useEffect(() => {
     if (
       selectedSourceId &&
@@ -118,6 +123,11 @@ function CampaignDetailPage() {
     setSelectedSourceId(sources[0]?.id ?? "")
   }, [selectedSourceId, sources])
 
+  useEffect(() => {
+    setTouchTitle(`${channel}: ${campaign.name}`)
+  }, [campaign.name, channel])
+
+  // `@lat`: [[crm-campaigns]]
   if (location.pathname !== `/campaigns/${campaign.id}`) {
     return <Outlet />
   }
@@ -128,12 +138,18 @@ function CampaignDetailPage() {
     const source = sources.find(
       (item) => item.id === String(form.get("sourceId") ?? ""),
     )
+    if (!source) {
+      setSubmitError("Choose an audience source before scheduling.")
+      return
+    }
+
+    setSubmitError(null)
     setSaving(true)
     try {
       await createCampaignTouch({
         data: {
           campaignId: campaign.id,
-          title: String(form.get("title") ?? ""),
+          title: touchTitle,
           channel: String(form.get("channel") ?? ""),
           owner: String(form.get("owner") ?? "Ian") as "Ian" | "Zac",
           status: String(form.get("status") ?? ""),
@@ -152,10 +168,14 @@ function CampaignDetailPage() {
     }
   }
 
-  async function copyTemplate(key: string, value: string) {
-    await navigator.clipboard.writeText(value)
-    setCopiedKey(key)
-    window.setTimeout(() => setCopiedKey(null), 1400)
+  async function copyTemplate({ key, value }: { key: string; value: string }) {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopiedKey(key)
+      window.setTimeout(() => setCopiedKey(null), 1400)
+    } catch {
+      setCopiedKey(null)
+    }
   }
 
   return (
@@ -172,9 +192,15 @@ function CampaignDetailPage() {
           <div className="mt-2 flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
             <Badge value={campaign.status || "Planning"} />
             <Badge value={campaign.owner || "Ian"} />
-            <span>{formatRange(campaign.startDate, campaign.endDate)}</span>
+            <span>
+              {formatRange({
+                startDate: campaign.startDate,
+                endDate: campaign.endDate,
+              })}
+            </span>
           </div>
         </div>
+        {/* `@lat`: [[crm-campaigns]] */}
         <Link
           to="/campaigns/$campaignId/audience"
           params={{ campaignId: campaign.id }}
@@ -224,11 +250,13 @@ function CampaignDetailPage() {
             onChange={setSelectedSourceId}
             options={sources.map((source) => source.label)}
             optionValues={sources.map((source) => source.id)}
+            required
           />
           <TextInput
             name="title"
             label="Touch"
-            defaultValue={`${channel}: ${campaign.name}`}
+            value={touchTitle}
+            onChange={setTouchTitle}
             required
           />
           <SelectInput
@@ -249,10 +277,13 @@ function CampaignDetailPage() {
             <TextInput name="notes" label="Notes" />
           </div>
         </div>
+        {submitError ? (
+          <p className="mt-3 text-sm text-destructive">{submitError}</p>
+        ) : null}
         <div className="mt-4 flex justify-end">
           <button
             type="submit"
-            disabled={saving}
+            disabled={saving || !selectedSourceId}
             className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50"
           >
             <Plus className="h-4 w-4" />
@@ -318,14 +349,18 @@ function CampaignDetailPage() {
             {channel === "Email" ? (
               <CopyButton
                 copied={copiedKey === "subject"}
-                onClick={() => copyTemplate("subject", template.subject)}
+                onClick={() =>
+                  copyTemplate({ key: "subject", value: template.subject })
+                }
               >
                 Subject
               </CopyButton>
             ) : null}
             <CopyButton
               copied={copiedKey === "body"}
-              onClick={() => copyTemplate("body", template.body)}
+              onClick={() =>
+                copyTemplate({ key: "body", value: template.body })
+              }
             >
               Body
             </CopyButton>
@@ -404,7 +439,13 @@ function touchDateValue(date: string | null) {
   return Number.isNaN(value) ? Number.MAX_SAFE_INTEGER : value
 }
 
-function formatRange(startDate: string | null, endDate: string | null) {
+function formatRange({
+  startDate,
+  endDate,
+}: {
+  startDate: string | null
+  endDate: string | null
+}) {
   if (startDate && endDate) return `${startDate} to ${endDate}`
   return startDate ?? endDate ?? "No dates"
 }
@@ -442,12 +483,16 @@ function TextInput({
   required,
   type = "text",
   defaultValue,
+  value,
+  onChange,
 }: {
   name: string
   label: string
   required?: boolean
   type?: string
   defaultValue?: string
+  value?: string
+  onChange?: (value: string) => void
 }) {
   return (
     <label className="space-y-1 text-sm font-medium">
@@ -457,6 +502,8 @@ function TextInput({
         required={required}
         type={type}
         defaultValue={defaultValue}
+        value={value}
+        onChange={(event) => onChange?.(event.target.value)}
         className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm outline-none focus:ring-2 focus:ring-ring"
       />
     </label>

--- a/apps/crm/src/routes/_authenticated/campaigns.tsx
+++ b/apps/crm/src/routes/_authenticated/campaigns.tsx
@@ -1,4 +1,10 @@
-import { createFileRoute, useRouter } from "@tanstack/react-router"
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useLocation,
+  useRouter,
+} from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import { CalendarDays, Mail, Megaphone, Plus, Search, Send } from "lucide-react"
 import { useMemo, useState } from "react"
@@ -37,7 +43,8 @@ export const Route = createFileRoute("/_authenticated/campaigns")({
 })
 
 function CampaignsPage() {
-  const { campaigns, campaignTouches, gyms, contacts } = Route.useLoaderData()
+  const { campaigns, campaignTouches } = Route.useLoaderData()
+  const location = useLocation()
   const router = useRouter()
   const createCampaign = useServerFn(createCampaignFn)
   const createCampaignTouch = useServerFn(createCampaignTouchFn)
@@ -69,6 +76,10 @@ function CampaignsPage() {
     )
     .sort((a, b) => touchDateValue(a.date) - touchDateValue(b.date))
     .slice(0, 8)
+
+  if (location.pathname !== "/campaigns") {
+    return <Outlet />
+  }
 
   // `@lat`: [[crm-campaigns]]
   async function handleCampaignSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -164,19 +175,6 @@ function CampaignsPage() {
           <div className="md:col-span-3">
             <TextArea name="goal" label="Goal" required />
           </div>
-          <MultiSelect
-            name="audienceGymIds"
-            label="Audience Gyms"
-            options={gyms.map((gym) => ({ value: gym.id, label: gym.name }))}
-          />
-          <MultiSelect
-            name="audienceContactIds"
-            label="Audience Contacts"
-            options={contacts.map((contact) => ({
-              value: contact.id,
-              label: contact.fullName,
-            }))}
-          />
         </div>
         <div className="mt-4 flex justify-end">
           <button
@@ -256,7 +254,13 @@ function CampaignsPage() {
             {filteredCampaigns.map((campaign) => (
               <tr key={campaign.id} className="align-top">
                 <Td>
-                  <p className="font-medium">{campaign.name}</p>
+                  <Link
+                    to="/campaigns/$campaignId"
+                    params={{ campaignId: campaign.id }}
+                    className="font-medium underline-offset-4 hover:underline"
+                  >
+                    {campaign.name}
+                  </Link>
                   <p className="text-muted-foreground">
                     {campaign.status || "Planning"}
                   </p>
@@ -267,6 +271,13 @@ function CampaignsPage() {
                   <p className="text-muted-foreground">
                     {campaign.audienceContactIds.length} contacts
                   </p>
+                  <Link
+                    to="/campaigns/$campaignId/audience"
+                    params={{ campaignId: campaign.id }}
+                    className="mt-1 inline-flex text-xs font-medium underline-offset-4 hover:underline"
+                  >
+                    Build audience
+                  </Link>
                 </Td>
                 <Td>{campaign.touchCount}</Td>
                 <Td>
@@ -391,33 +402,6 @@ function SelectInput({
             value={optionValues?.[index] ?? option}
           >
             {option}
-          </option>
-        ))}
-      </select>
-    </label>
-  )
-}
-
-function MultiSelect({
-  name,
-  label,
-  options,
-}: {
-  name: string
-  label: string
-  options: Array<{ value: string; label: string }>
-}) {
-  return (
-    <label className="space-y-1 text-sm font-medium md:col-span-2">
-      <span>{label}</span>
-      <select
-        multiple
-        name={name}
-        className="min-h-32 w-full rounded-md border border-input bg-background px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-ring"
-      >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
           </option>
         ))}
       </select>

--- a/apps/crm/src/routes/_authenticated/campaigns.tsx
+++ b/apps/crm/src/routes/_authenticated/campaigns.tsx
@@ -77,6 +77,7 @@ function CampaignsPage() {
     .sort((a, b) => touchDateValue(a.date) - touchDateValue(b.date))
     .slice(0, 8)
 
+  // `@lat`: [[crm-campaigns]]
   if (location.pathname !== "/campaigns") {
     return <Outlet />
   }
@@ -254,6 +255,7 @@ function CampaignsPage() {
             {filteredCampaigns.map((campaign) => (
               <tr key={campaign.id} className="align-top">
                 <Td>
+                  {/* `@lat`: [[crm-campaigns]] */}
                   <Link
                     to="/campaigns/$campaignId"
                     params={{ campaignId: campaign.id }}
@@ -271,6 +273,7 @@ function CampaignsPage() {
                   <p className="text-muted-foreground">
                     {campaign.audienceContactIds.length} contacts
                   </p>
+                  {/* `@lat`: [[crm-campaigns]] */}
                   <Link
                     to="/campaigns/$campaignId/audience"
                     params={{ campaignId: campaign.id }}

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -156,6 +156,7 @@ const campaignInputSchema = z.object({
   audienceContactIds: z.array(z.string()).default([]),
 })
 
+// `@lat`: [[crm-campaigns]]
 const campaignAudienceUpdateSchema = z.object({
   campaignId: z.string().min(1, "Campaign ID is required"),
   audienceGymIds: z.array(z.string()).default([]),
@@ -1254,6 +1255,7 @@ export const createCampaignFn = createServerFn({ method: "POST" })
     return { id: entryId }
   })
 
+// `@lat`: [[crm-campaigns]]
 export const updateCampaignAudienceFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => campaignAudienceUpdateSchema.parse(data))
   .handler(async ({ data }) => {
@@ -1317,12 +1319,16 @@ export const createCampaignTouchFn = createServerFn({ method: "POST" })
 
     const companyField = fields.get("Company")
     if (companyField) {
-      await setRelation(entryId, companyField.id, clean(data.companyId))
+      const companyId = clean(data.companyId)
+      if (companyId) await assertEntriesInObject([companyId], "Company")
+      await setRelation(entryId, companyField.id, companyId)
     }
 
     const personField = fields.get("Person")
     if (personField) {
-      await setRelation(entryId, personField.id, clean(data.contactId))
+      const contactId = clean(data.contactId)
+      if (contactId) await assertEntriesInObject([contactId], "People")
+      await setRelation(entryId, personField.id, contactId)
     }
 
     return { id: entryId }

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -156,6 +156,12 @@ const campaignInputSchema = z.object({
   audienceContactIds: z.array(z.string()).default([]),
 })
 
+const campaignAudienceUpdateSchema = z.object({
+  campaignId: z.string().min(1, "Campaign ID is required"),
+  audienceGymIds: z.array(z.string()).default([]),
+  audienceContactIds: z.array(z.string()).default([]),
+})
+
 // `@lat`: [[crm-campaigns]]
 const campaignTouchInputSchema = z.object({
   campaignId: z.string().min(1, "Campaign ID is required"),
@@ -164,7 +170,10 @@ const campaignTouchInputSchema = z.object({
   owner: z.enum(["Ian", "Zac"]).optional(),
   status: z.string().max(100).optional(),
   dueDate: z.string().max(20).optional(),
+  companyId: z.string().optional(),
+  contactId: z.string().optional(),
   notes: z.string().max(4000).optional(),
+  content: z.string().max(10000).optional(),
 })
 
 export const documentUploadSchema = z.object({
@@ -266,6 +275,16 @@ async function assertEntryInObject(entryId: string, objectId: string) {
 async function assertCampaignEntry(entryId: string) {
   const campaignObject = await getObject("Campaign")
   await assertEntryInObject(entryId, campaignObject.id)
+}
+
+async function assertEntriesInObject(entryIds: string[], objectName: string) {
+  if (entryIds.length === 0) return
+  const object = await getObject(objectName)
+  await Promise.all(
+    Array.from(new Set(entryIds)).map((entryId) =>
+      assertEntryInObject(entryId, object.id),
+    ),
+  )
 }
 
 function sanitizeFileName(fileName: string) {
@@ -1235,6 +1254,39 @@ export const createCampaignFn = createServerFn({ method: "POST" })
     return { id: entryId }
   })
 
+export const updateCampaignAudienceFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => campaignAudienceUpdateSchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    await ensureCampaignSchema()
+    await assertCampaignEntry(data.campaignId)
+    await assertEntriesInObject(data.audienceGymIds, "Company")
+    await assertEntriesInObject(data.audienceContactIds, "People")
+
+    const campaignObject = await getObject("Campaign")
+    const fields = await getFieldsByName(campaignObject.id)
+    const audienceGymsField = requireField(fields, "Audience Gyms", "Campaign")
+    const audienceContactsField = requireField(
+      fields,
+      "Audience Contacts",
+      "Campaign",
+    )
+
+    await setRelations(
+      data.campaignId,
+      audienceGymsField.id,
+      data.audienceGymIds,
+    )
+    await setRelations(
+      data.campaignId,
+      audienceContactsField.id,
+      data.audienceContactIds,
+    )
+    await touchEntry(data.campaignId)
+
+    return { id: data.campaignId }
+  })
+
 // `@lat`: [[crm-campaigns]]
 export const createCampaignTouchFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => campaignTouchInputSchema.parse(data))
@@ -1251,6 +1303,7 @@ export const createCampaignTouchFn = createServerFn({ method: "POST" })
       ["Owner", clean(data.owner) ?? "Ian"],
       ["Status", clean(data.status) ?? "Planned"],
       ["Notes", clean(data.notes)],
+      ["Content", clean(data.content)],
     ]
 
     for (const [fieldName, value] of updates) {
@@ -1261,6 +1314,16 @@ export const createCampaignTouchFn = createServerFn({ method: "POST" })
     const campaignField = requireField(fields, "Campaign", "Outreach")
     await assertCampaignEntry(data.campaignId)
     await setRelation(entryId, campaignField.id, data.campaignId)
+
+    const companyField = fields.get("Company")
+    if (companyField) {
+      await setRelation(entryId, companyField.id, clean(data.companyId))
+    }
+
+    const personField = fields.get("Person")
+    if (personField) {
+      await setRelation(entryId, personField.id, clean(data.contactId))
+    }
 
     return { id: entryId }
   })


### PR DESCRIPTION
## Summary
- Add campaign detail and audience-builder routes
- Let users search/filter gyms and contacts, preview details, build a live campaign audience, and save it back to the campaign
- Add campaign touch scheduling with source-aware email/social template quick actions

## Verification
- Biome check on touched CRM files
- tsc --noEmit for apps/crm
- vite build for apps/crm

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a campaign detail page and a dedicated audience builder to create, preview, and save campaign audiences, and to schedule touches with source-aware templates. Touches now store content and link to related company/person, and the campaigns list routes into the new pages.

- **New Features**
  - New nested routes: `/campaigns/$campaignId` and `/campaigns/$campaignId/audience` via `@tanstack/react-router`.
  - Audience builder: search by text, filter by type/status, preview details, select/deselect, and save via `updateCampaignAudienceFn`.
  - Campaign detail: audience metrics, scheduled interactions list, quick templates (email/social) with copy subject/body, and a scheduling form that picks a source and sets channel/status/owner/due/notes.
  - `createCampaignTouchFn` now saves template content and sets `Company`/`Person` relations when available.
  - Campaigns list links to the new detail and audience pages; audience multi-selects were removed from the create form.

<sup>Written for commit 09cdb550573f669e582606c113627be0ca284394. Summary will update on new commits. <a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/483?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated campaign detail pages with scheduling/interaction creation and detailed campaign metrics.
  * New campaign audience builder page for searching, filtering, selecting, and saving gyms & contacts.
  * Preview panel for candidate details and selected-audience management.

* **Improvements**
  * Campaign names and “Build audience” links navigate to the new sub-pages.
  * Template preview with copy-to-clipboard and automatic personalization included.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->