### PR TITLE
Update homepage draft competition CTA

### DIFF
--- a/apps/wodsmith-start/src/components/landing/compete-hero.tsx
+++ b/apps/wodsmith-start/src/components/landing/compete-hero.tsx
@@ -24,20 +24,21 @@ export function CompeteHero({ session }: CompeteHeroProps) {
         {/* Proof nugget - visible above the fold */}
         <div className="mb-8 inline-flex items-center rounded-full border border-border bg-secondary px-4 py-1.5 font-medium text-sm">
           <span className="mr-2 h-2 w-2 animate-pulse rounded-full bg-amber-500" />
-          Built with comp organizers running multi-location series
+          Free drafts, public previews, paid registration when you are ready
         </div>
 
         {/* Headline - names the villain */}
         <h1 className="mb-12 font-mono text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl text-balance">
-          Run a smooth competition
+          Draft a competition
           <br className="hidden md:block" />
           <span className="text-primary">without spreadsheet ops</span>
         </h1>
 
         {/* Subheadline - the promise */}
         <p className="mx-auto mb-10 max-w-2xl text-lg text-muted-foreground md:text-xl text-balance">
-          No more volunteer scheduling chaos. WODsmith Compete handles the
-          backend nightmare so you can focus on what matters.
+          Build the shell for free, generate a public preview, and see your
+          setup confidence right away. Approval only gates paid registration
+          when it applies.
         </p>
 
         {/* CTAs */}
@@ -48,7 +49,7 @@ export function CompeteHero({ session }: CompeteHeroProps) {
                 isLoggedIn ? "/compete/organizer" : "/compete/organizer/onboard"
               }
             >
-              Request Access
+              Create a Free Draft Competition
               <ArrowRight className="ml-2 h-4 w-4" />
             </Link>
           </Button>
@@ -68,7 +69,7 @@ export function CompeteHero({ session }: CompeteHeroProps) {
 
         {/* Friction clarifier */}
         <p className="mt-4 text-sm text-muted-foreground">
-          No credit card required. Platform fee applies to paid registrations.
+          No credit card required. Drafts and previews are free.
         </p>
       </div>
     </section>

--- a/apps/wodsmith-start/src/components/landing/compete-hero.tsx
+++ b/apps/wodsmith-start/src/components/landing/compete-hero.tsx
@@ -49,7 +49,7 @@ export function CompeteHero({ session }: CompeteHeroProps) {
                 isLoggedIn ? "/compete/organizer" : "/compete/organizer/onboard"
               }
             >
-              Create a Free Draft Competition
+              Create your First Draft Competition
               <ArrowRight className="ml-2 h-4 w-4" />
             </Link>
           </Button>

--- a/apps/wodsmith-start/src/components/landing/final-cta.tsx
+++ b/apps/wodsmith-start/src/components/landing/final-cta.tsx
@@ -46,7 +46,7 @@ export function FinalCTA({ session }: FinalCTAProps) {
                     : "/compete/organizer/onboard"
                 }
               >
-                Create a Free Draft Competition
+                Create your First Draft Competition
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>

--- a/apps/wodsmith-start/src/components/landing/final-cta.tsx
+++ b/apps/wodsmith-start/src/components/landing/final-cta.tsx
@@ -23,13 +23,13 @@ export function FinalCTA({ session }: FinalCTAProps) {
 
           {/* Headline */}
           <h2 className="mb-4 font-mono text-3xl font-bold tracking-tight sm:text-4xl">
-            Ready to run your next comp without the chaos?
+            Ready to see your competition take shape?
           </h2>
 
           {/* Promise */}
           <p className="mb-8 text-lg text-background/70 dark:text-muted-foreground">
-            Get started with a demo. We'll help you migrate from spreadsheets
-            and make sure your athletes trust the results.
+            Create a free draft, review the readiness checklist, and share a
+            public preview before you open paid registration.
           </p>
 
           {/* CTAs */}
@@ -46,7 +46,7 @@ export function FinalCTA({ session }: FinalCTAProps) {
                     : "/compete/organizer/onboard"
                 }
               >
-                Request Access
+                Create a Free Draft Competition
                 <ArrowRight className="ml-2 h-4 w-4" />
               </Link>
             </Button>
@@ -62,8 +62,8 @@ export function FinalCTA({ session }: FinalCTAProps) {
 
           {/* Friction clarifier */}
           <p className="mt-6 text-sm text-background/50 dark:text-muted-foreground">
-            No credit card required. Platform fee applies to paid registrations.
-            Concierge onboarding included.
+            No credit card required. Approval only gates paid registration when
+            needed.
           </p>
         </div>
       </div>

--- a/apps/wodsmith-start/src/components/landing/product-cards.tsx
+++ b/apps/wodsmith-start/src/components/landing/product-cards.tsx
@@ -14,10 +14,12 @@ const athleteFeatures = [
 ]
 
 const organizerFeatures = [
+  "Create a free draft competition before approval",
+  "Generate a public preview while registration stays closed",
+  "Use readiness checks to see what is missing",
   "Heat scheduling with venues and lane assignments",
   "Score entry and leaderboards by division",
-  "Athlete registration with Stripe payments",
-  "Track registration revenue and platform fees",
+  "Open paid registration after approval and payout setup",
 ]
 
 interface ProductCardsProps {
@@ -54,7 +56,7 @@ export function ProductCards({ session }: ProductCardsProps) {
             One Platform, Two Powerful Tools
           </h2>
           <p className="text-lg text-muted-foreground">
-            Whether you are chasing a new PR or hosting the next big throwdown,
+            Whether you are chasing a new PR or drafting the next big throwdown,
             we have the specialized tools you need.
           </p>
         </div>
@@ -167,7 +169,7 @@ export function ProductCards({ session }: ProductCardsProps) {
                       : "/compete/organizer/onboard"
                   }
                 >
-                  Host Your Competition
+                  Create a Free Draft Competition
                   <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover/btn:translate-x-1" />
                 </Link>
               </Button>

--- a/apps/wodsmith-start/src/components/landing/product-cards.tsx
+++ b/apps/wodsmith-start/src/components/landing/product-cards.tsx
@@ -169,7 +169,7 @@ export function ProductCards({ session }: ProductCardsProps) {
                       : "/compete/organizer/onboard"
                   }
                 >
-                  Create a Free Draft Competition
+                  Create your First Draft Competition
                   <ArrowRight className="ml-2 h-4 w-4 transition-transform group-hover/btn:translate-x-1" />
                 </Link>
               </Button>

--- a/apps/wodsmith-start/src/components/landing/two-audiences.tsx
+++ b/apps/wodsmith-start/src/components/landing/two-audiences.tsx
@@ -215,7 +215,7 @@ export function TwoAudiences({ session }: TwoAudiencesProps) {
                       : "/compete/organizer/onboard"
                   }
                 >
-                  Create a Free Draft Competition
+                  Create your First Draft Competition
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Link>
               </Button>

--- a/apps/wodsmith-start/src/components/landing/two-audiences.tsx
+++ b/apps/wodsmith-start/src/components/landing/two-audiences.tsx
@@ -9,6 +9,7 @@ import {
   ClipboardCheck,
   FileText,
   Filter,
+  type LucideIcon,
   Trophy,
   Users,
 } from "lucide-react"
@@ -16,7 +17,16 @@ import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import type { SessionValidationResult } from "@/types"
 
-const athleteFeatures = [
+interface AudienceFeature {
+  icon: LucideIcon
+  title: string
+  description: string
+  available: boolean
+  label?: string
+  labelNote?: string
+}
+
+const athleteFeatures: AudienceFeature[] = [
   {
     icon: Filter,
     title: "My Division View",
@@ -42,30 +52,29 @@ const athleteFeatures = [
   },
 ]
 
-const organizerFeatures = [
+const organizerFeatures: AudienceFeature[] = [
   {
     icon: ClipboardCheck,
-    title: "Score Verification",
+    title: "Draft Readiness Checklist",
     description:
-      "Validation checks catch common mistakes. Publish controls per event/division.",
+      "See what is complete, what is missing, and how confident the setup is before athletes register.",
     available: true,
-    labelNote: "Photo evidence coming",
+    labelNote: "Appears as soon as you start",
   },
   {
     icon: Users,
-    title: "Volunteer and Judge scheduling",
+    title: "Public Preview",
     description:
-      "Assign judges by availability with conflict detection. Rotation patterns built in.",
+      "Generate a shareable competition page from the draft before registration opens.",
     available: true,
-    labelNote: "Verified credentials coming",
+    labelNote: "Free while you refine",
   },
   {
     icon: FileText,
-    title: "Audit Trail",
+    title: "Paid Registration Controls",
     description:
-      "Track who entered, edited, and verified scores. Complete history of changes.",
-    available: false,
-    label: "Coming soon",
+      "Keep registration closed until pricing, payout, and organizer approval are ready.",
+    available: true,
   },
 ]
 
@@ -156,7 +165,7 @@ export function TwoAudiences({ session }: TwoAudiencesProps) {
                   For Organizers
                 </span>
                 <h3 className="font-mono text-2xl font-bold">
-                  Run smooth operations
+                  Start with a draft
                 </h3>
               </div>
             </div>
@@ -206,7 +215,7 @@ export function TwoAudiences({ session }: TwoAudiencesProps) {
                       : "/compete/organizer/onboard"
                   }
                 >
-                  Host Your Competition
+                  Create a Free Draft Competition
                   <ArrowRight className="ml-2 h-4 w-4" />
                 </Link>
               </Button>

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -108,6 +108,14 @@ API routes for webhooks (Stripe, auth callbacks), cron jobs, file uploads, and i
 
 Public pages use per-route `head` configs for metadata, Open Graph, Twitter cards, and canonical URLs. Structured data uses JSON-LD via the [[apps/wodsmith-start/src/components/json-ld.tsx#JsonLd]] component, which escapes `<`, `>`, `&`, and Unicode line separators to prevent script-breakout XSS.
 
+### Landing Page
+
+The homepage presents WODsmith Compete as a self-serve draft-first workflow for organizers.
+
+The primary public CTA is "Create a Free Draft Competition" in [[apps/wodsmith-start/src/components/landing/compete-hero.tsx#CompeteHero]] and [[apps/wodsmith-start/src/components/landing/final-cta.tsx#FinalCTA]]. The page explains that anyone can create a free draft and public preview, while approval applies only before opening paid registration when needed.
+
+Organizer support sections, including [[apps/wodsmith-start/src/components/landing/two-audiences.tsx#TwoAudiences]], reinforce the immediate checklist and confidence state so first use feels self-serve instead of gated by a demo request.
+
 ### Page Metadata
 
 Every public route defines a `head` function with title, description, OG/Twitter tags, and canonical link.

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -112,7 +112,7 @@ Public pages use per-route `head` configs for metadata, Open Graph, Twitter card
 
 The homepage presents WODsmith Compete as a self-serve draft-first workflow for organizers.
 
-The primary public CTA is "Create a Free Draft Competition" in [[apps/wodsmith-start/src/components/landing/compete-hero.tsx#CompeteHero]] and [[apps/wodsmith-start/src/components/landing/final-cta.tsx#FinalCTA]]. The page explains that anyone can create a free draft and public preview, while approval applies only before opening paid registration when needed.
+The primary public CTA is "Create your First Draft Competition" in [[apps/wodsmith-start/src/components/landing/compete-hero.tsx#CompeteHero]] and [[apps/wodsmith-start/src/components/landing/final-cta.tsx#FinalCTA]]. The page explains that anyone can create a free draft and public preview, while approval applies only before opening paid registration when needed.
 
 Organizer support sections, including [[apps/wodsmith-start/src/components/landing/two-audiences.tsx#TwoAudiences]], reinforce the immediate checklist and confidence state so first use feels self-serve instead of gated by a demo request.
 


### PR DESCRIPTION
## Summary
- Replace public homepage CTAs from request/host language to "Create a Free Draft Competition"
- Reframe organizer homepage copy around free drafts, public previews, readiness confidence, and paid-registration approval gates
- Document the draft-first landing page intent in lat.md architecture notes

## Verification
- lat check
- pnpm --filter wodsmith-start exec biome check --write src/components/landing/compete-hero.tsx src/components/landing/final-cta.tsx src/components/landing/two-audiences.tsx src/components/landing/product-cards.tsx
- pnpm --filter wodsmith-start type-check
- pre-push hook: pnpm lint and pnpm type-check
- GitNexus impact + staged detect-changes: LOW risk, 0 affected processes

## Notes
- Local browser verification was blocked because Vite requires apps/wodsmith-start/.alchemy/local/wrangler.jsonc, which is not generated in this worktree without running the app's Alchemy dev setup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make "Create your First Draft Competition" the primary homepage CTA and refine copy to push a draft-first flow. Emphasizes free drafts, public previews, readiness checks, and approval only before paid registration; architecture notes updated.

- New Features
  - Refined CTAs, headlines, friction copy, and organizer features to draft-first messaging in `apps/wodsmith-start/src/components/landing/compete-hero.tsx`, `final-cta.tsx`, `product-cards.tsx`, and `two-audiences.tsx`.
  - Documented the landing-page intent and CTA placement in `lat.md/architecture.md`.

- Refactors
  - Typed audience feature config using `AudienceFeature` and `LucideIcon` in `two-audiences.tsx`.

<sup>Written for commit 17b18786c8e3002282e5c7e55ef1000994e101db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Landing Page Updates**
  * Refreshed landing page marketing messaging to emphasize creating free draft competitions without requiring a credit card
  * Updated primary call-to-action buttons across marketing components
  * Enhanced organizer feature descriptions to highlight draft-first workflows and public preview capabilities

* **Documentation**
  * Added landing page architecture documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wodsmith/thewodapp/pull/487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->