### PR TITLE
Fix Code Mode MCP server function results

### DIFF
--- a/apps/crm/alchemy.run.ts
+++ b/apps/crm/alchemy.run.ts
@@ -1,5 +1,10 @@
 import alchemy from "alchemy"
-import { D1Database, R2Bucket, TanStackStart } from "alchemy/cloudflare"
+import {
+  D1Database,
+  DurableObjectNamespace,
+  R2Bucket,
+  TanStackStart,
+} from "alchemy/cloudflare"
 import { CloudflareStateStore } from "alchemy/state"
 
 const stage = process.env.STAGE ?? "dev"
@@ -23,6 +28,11 @@ const r2Bucket = await R2Bucket("crm-files", {
   devDomain: stage !== "prod",
 })
 
+const crmMcp = DurableObjectNamespace("crm-mcp", {
+  className: "CrmMcp",
+  sqlite: true,
+})
+
 function getDomains(currentStage: string): string[] | undefined {
   if (currentStage === "prod") {
     return ["crm.wodsmith.com"]
@@ -33,6 +43,7 @@ function getDomains(currentStage: string): string[] | undefined {
 const website = await TanStackStart("app", {
   bindings: {
     DB: db,
+    CRM_MCP: crmMcp,
     R2_BUCKET: r2Bucket,
     // biome-ignore lint/style/noNonNullAssertion: Set at deploy time
     APP_URL: process.env.APP_URL!,

--- a/apps/crm/alchemy.run.ts
+++ b/apps/crm/alchemy.run.ts
@@ -1,10 +1,5 @@
 import alchemy from "alchemy"
-import {
-  D1Database,
-  DurableObjectNamespace,
-  R2Bucket,
-  TanStackStart,
-} from "alchemy/cloudflare"
+import { D1Database, R2Bucket, TanStackStart } from "alchemy/cloudflare"
 import { CloudflareStateStore } from "alchemy/state"
 
 const stage = process.env.STAGE ?? "dev"
@@ -28,12 +23,6 @@ const r2Bucket = await R2Bucket("crm-files", {
   devDomain: stage !== "prod",
 })
 
-// `@lat`: [[architecture]]
-const crmMcp = DurableObjectNamespace("crm-mcp", {
-  className: "CrmMcp",
-  sqlite: true,
-})
-
 function getDomains(currentStage: string): string[] | undefined {
   if (currentStage === "prod") {
     return ["crm.wodsmith.com"]
@@ -44,8 +33,6 @@ function getDomains(currentStage: string): string[] | undefined {
 const website = await TanStackStart("app", {
   bindings: {
     DB: db,
-    // `@lat`: [[architecture]]
-    CRM_MCP: crmMcp,
     R2_BUCKET: r2Bucket,
     // biome-ignore lint/style/noNonNullAssertion: Set at deploy time
     APP_URL: process.env.APP_URL!,

--- a/apps/crm/alchemy.run.ts
+++ b/apps/crm/alchemy.run.ts
@@ -28,6 +28,7 @@ const r2Bucket = await R2Bucket("crm-files", {
   devDomain: stage !== "prod",
 })
 
+// `@lat`: [[architecture]]
 const crmMcp = DurableObjectNamespace("crm-mcp", {
   className: "CrmMcp",
   sqlite: true,
@@ -43,6 +44,7 @@ function getDomains(currentStage: string): string[] | undefined {
 const website = await TanStackStart("app", {
   bindings: {
     DB: db,
+    // `@lat`: [[architecture]]
     CRM_MCP: crmMcp,
     R2_BUCKET: r2Bucket,
     // biome-ignore lint/style/noNonNullAssertion: Set at deploy time

--- a/apps/crm/package.json
+++ b/apps/crm/package.json
@@ -24,9 +24,11 @@
   },
   "dependencies": {
     "@cloudflare/vite-plugin": "^1.19.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-router": "^1.132.0",
     "@tanstack/react-start": "^1.132.0",
+    "agents": "^0.12.4",
     "alchemy": "catalog:",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.39.3",

--- a/apps/crm/package.json
+++ b/apps/crm/package.json
@@ -28,7 +28,6 @@
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-router": "^1.132.0",
     "@tanstack/react-start": "^1.132.0",
-    "agents": "^0.12.4",
     "alchemy": "catalog:",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.39.3",

--- a/apps/crm/src/components/entity-document-panel.tsx
+++ b/apps/crm/src/components/entity-document-panel.tsx
@@ -1,5 +1,13 @@
 import { useServerFn } from "@tanstack/react-start"
-import { Download, Eye, FileText, Loader2, Trash2, Upload, X } from "lucide-react"
+import {
+  Download,
+  Eye,
+  FileText,
+  Loader2,
+  Trash2,
+  Upload,
+  X,
+} from "lucide-react"
 import { useCallback, useEffect, useId, useRef, useState } from "react"
 import {
   deleteDocumentForEntryFn,
@@ -22,7 +30,14 @@ type DocumentPreview = {
   content: string
 }
 
-const PREVIEWABLE_EXTENSIONS = new Set(["csv", "json", "md", "markdown", "txt", "text"])
+const PREVIEWABLE_EXTENSIONS = new Set([
+  "csv",
+  "json",
+  "md",
+  "markdown",
+  "txt",
+  "text",
+])
 const PREVIEWABLE_CONTENT_TYPES = [
   "text/",
   "application/csv",
@@ -289,7 +304,10 @@ export function EntityDocumentPanel({
                   <p className="truncate text-sm font-medium text-foreground">
                     {document.title}
                   </p>
-                  <p className="truncate text-xs text-muted-foreground" translate="no">
+                  <p
+                    className="truncate text-xs text-muted-foreground"
+                    translate="no"
+                  >
                     {document.filePath}
                   </p>
                 </div>
@@ -306,7 +324,10 @@ export function EntityDocumentPanel({
                     className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-input bg-background px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50"
                   >
                     {previewingId === document.id ? (
-                      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                      <Loader2
+                        className="h-4 w-4 animate-spin"
+                        aria-hidden="true"
+                      />
                     ) : (
                       <Eye className="h-4 w-4" aria-hidden="true" />
                     )}
@@ -315,7 +336,9 @@ export function EntityDocumentPanel({
                 ) : null}
                 <button
                   type="button"
-                  onClick={() => void handleDownload(document.id, document.title)}
+                  onClick={() =>
+                    void handleDownload(document.id, document.title)
+                  }
                   className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-input bg-background px-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 >
                   <Download className="h-4 w-4" aria-hidden="true" />
@@ -328,7 +351,10 @@ export function EntityDocumentPanel({
                   className="inline-flex h-9 items-center justify-center gap-1 rounded-md border border-destructive/30 bg-background px-3 text-sm font-medium text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive focus-visible:ring-offset-2 disabled:opacity-50"
                 >
                   {removingId === document.id ? (
-                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    <Loader2
+                      className="h-4 w-4 animate-spin"
+                      aria-hidden="true"
+                    />
                   ) : (
                     <Trash2 className="h-4 w-4" aria-hidden="true" />
                   )}

--- a/apps/crm/src/env.d.ts
+++ b/apps/crm/src/env.d.ts
@@ -3,6 +3,7 @@
 declare namespace Cloudflare {
   interface Env {
     DB: D1Database
+    // `@lat`: [[architecture]]
     CRM_MCP: DurableObjectNamespace
     R2_BUCKET: R2Bucket
     APP_URL: string

--- a/apps/crm/src/env.d.ts
+++ b/apps/crm/src/env.d.ts
@@ -3,8 +3,6 @@
 declare namespace Cloudflare {
   interface Env {
     DB: D1Database
-    // `@lat`: [[architecture]]
-    CRM_MCP: DurableObjectNamespace
     R2_BUCKET: R2Bucket
     APP_URL: string
     NODE_ENV: string

--- a/apps/crm/src/env.d.ts
+++ b/apps/crm/src/env.d.ts
@@ -3,6 +3,7 @@
 declare namespace Cloudflare {
   interface Env {
     DB: D1Database
+    CRM_MCP: DurableObjectNamespace
     R2_BUCKET: R2Bucket
     APP_URL: string
     NODE_ENV: string

--- a/apps/crm/src/lib/mcp-handler.ts
+++ b/apps/crm/src/lib/mcp-handler.ts
@@ -1,0 +1,18 @@
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
+import { createCrmMcpServer } from "@/mcp"
+import { isAuthenticatedRequest } from "@/server-fns/auth"
+
+export async function handleMcpRequest(request: Request) {
+  // `@lat`: [[auth]]
+  if (!(await isAuthenticatedRequest(request))) {
+    return new Response("Unauthorized", { status: 401 })
+  }
+
+  const server = createCrmMcpServer()
+  const transport = new WebStandardStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  })
+
+  await server.connect(transport)
+  return transport.handleRequest(request)
+}

--- a/apps/crm/src/mcp.ts
+++ b/apps/crm/src/mcp.ts
@@ -1,0 +1,326 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { McpAgent } from "agents/mcp"
+import { z } from "zod"
+import {
+  createCampaign,
+  createCampaignTouch,
+  createContact,
+  createGym,
+  createInteraction,
+  deleteCampaign,
+  deleteContact,
+  deleteGym,
+  deleteInteraction,
+  readCrmData,
+  updateCampaign,
+  updateCampaignAudience,
+  updateContact,
+  updateGym,
+  updateInteraction,
+} from "@/server-fns/crm"
+
+const ownerSchema = z.enum(["Ian", "Zac"])
+const nullableString = z.string().optional()
+
+const gymSchema = z.object({
+  action: z.enum(["create", "update", "delete"]),
+  id: z.string().optional(),
+  name: nullableString,
+  location: nullableString,
+  website: nullableString,
+  crossfitPage: nullableString,
+  email: nullableString,
+  phone: nullableString,
+  instagram: nullableString,
+  ownerManager: nullableString,
+  status: nullableString,
+  priority: nullableString,
+  relationship: nullableString,
+  notes: nullableString,
+})
+
+const contactSchema = z.object({
+  action: z.enum(["create", "update", "delete"]),
+  id: z.string().optional(),
+  fullName: nullableString,
+  email: nullableString,
+  phone: nullableString,
+  status: nullableString,
+  companyId: nullableString,
+  notes: nullableString,
+})
+
+const interactionSchema = z.object({
+  action: z.enum(["create", "update", "delete"]),
+  id: z.string().optional(),
+  source: z.enum(["Meeting", "Outreach"]).optional(),
+  title: nullableString,
+  date: nullableString,
+  channel: nullableString,
+  status: nullableString,
+  owner: ownerSchema.optional(),
+  companyId: nullableString,
+  contactId: nullableString,
+  campaignId: nullableString,
+  notes: nullableString,
+  content: nullableString,
+})
+
+const campaignSchema = z.object({
+  action: z.enum(["create", "update", "delete", "update_audience"]),
+  id: z.string().optional(),
+  name: nullableString,
+  status: nullableString,
+  owner: ownerSchema.optional(),
+  goal: nullableString,
+  startDate: nullableString,
+  endDate: nullableString,
+  audienceGymIds: z.array(z.string()).optional(),
+  audienceContactIds: z.array(z.string()).optional(),
+})
+
+function jsonResponse(value: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(value, null, 2),
+      },
+    ],
+  }
+}
+
+function requireValue<T>(value: T | null | undefined, label: string): T {
+  if (value === null || value === undefined || value === "") {
+    throw new Error(`${label} is required`)
+  }
+  return value
+}
+
+function filterCrmData(
+  data: Awaited<ReturnType<typeof readCrmData>>,
+  query?: string,
+) {
+  const normalized = query?.trim().toLowerCase()
+  if (!normalized) return data
+
+  const matches = (values: Array<string | null | undefined>) =>
+    values.some((value) => value?.toLowerCase().includes(normalized))
+
+  return {
+    gyms: data.gyms.filter((gym) =>
+      matches([gym.name, gym.location, gym.email, gym.status, gym.notes]),
+    ),
+    contacts: data.contacts.filter((contact) =>
+      matches([
+        contact.fullName,
+        contact.email,
+        contact.phone,
+        contact.companyName,
+        contact.notes,
+      ]),
+    ),
+    interactions: data.interactions.filter((interaction) =>
+      matches([
+        interaction.title,
+        interaction.companyName,
+        interaction.contactName,
+        interaction.campaignName,
+        interaction.notes,
+        interaction.content,
+      ]),
+    ),
+    campaigns: data.campaigns.filter((campaign) =>
+      matches([
+        campaign.name,
+        campaign.status,
+        campaign.owner,
+        campaign.goal,
+        ...campaign.audienceGymNames,
+        ...campaign.audienceContactNames,
+      ]),
+    ),
+  }
+}
+
+export class CrmMcp extends McpAgent {
+  server = new McpServer({
+    name: "wodsmith-crm",
+    version: "1.0.0",
+  })
+
+  async init() {
+    this.server.tool(
+      "get_crm_context",
+      "List CRM records and navigation targets. Use query to narrow results before updating records.",
+      {
+        query: z.string().optional(),
+        includeCampaignTouches: z.boolean().optional(),
+      },
+      async ({ query, includeCampaignTouches }) => {
+        const data = await readCrmData()
+        const filtered = filterCrmData(data, query)
+        return jsonResponse({
+          ...filtered,
+          campaignTouches: includeCampaignTouches
+            ? data.campaignTouches
+            : undefined,
+          navigation: {
+            dashboard: "/dashboard",
+            gyms: "/gyms",
+            contacts: "/contacts",
+            interactions: "/interactions",
+            campaigns: "/campaigns",
+            gymDetail: "/gyms/:gymId",
+            contactDetail: "/contacts/:contactId",
+            interactionDetail: "/interactions/:interactionId",
+            campaignDetail: "/campaigns/:campaignId",
+            campaignAudience: "/campaigns/:campaignId/audience",
+          },
+        })
+      },
+    )
+
+    this.server.tool(
+      "manage_gym",
+      "Create, update, or delete a gym/company based on the user's intent.",
+      gymSchema.shape,
+      async (input) => {
+        if (input.action === "delete") {
+          return jsonResponse(
+            await deleteGym({ id: requireValue(input.id, "id") }),
+          )
+        }
+        if (input.action === "create") {
+          return jsonResponse(
+            await createGym({
+              ...input,
+              name: requireValue(input.name, "name"),
+            }),
+          )
+        }
+        return jsonResponse(
+          await updateGym({
+            ...input,
+            id: requireValue(input.id, "id"),
+            name: requireValue(input.name, "name"),
+          }),
+        )
+      },
+    )
+
+    this.server.tool(
+      "manage_contact",
+      "Create, update, or delete a contact based on the user's intent.",
+      contactSchema.shape,
+      async (input) => {
+        if (input.action === "delete") {
+          return jsonResponse(
+            await deleteContact({ id: requireValue(input.id, "id") }),
+          )
+        }
+        if (input.action === "create") {
+          return jsonResponse(
+            await createContact({
+              ...input,
+              fullName: requireValue(input.fullName, "fullName"),
+            }),
+          )
+        }
+        return jsonResponse(
+          await updateContact({
+            ...input,
+            id: requireValue(input.id, "id"),
+            fullName: requireValue(input.fullName, "fullName"),
+          }),
+        )
+      },
+    )
+
+    this.server.tool(
+      "manage_interaction",
+      "Create, update, or delete a meeting/outreach interaction based on the user's intent.",
+      interactionSchema.shape,
+      async (input) => {
+        if (input.action === "delete") {
+          return jsonResponse(
+            await deleteInteraction({ id: requireValue(input.id, "id") }),
+          )
+        }
+        if (input.action === "create") {
+          return jsonResponse(
+            await createInteraction({
+              ...input,
+              title: requireValue(input.title, "title"),
+            }),
+          )
+        }
+        return jsonResponse(
+          await updateInteraction({
+            ...input,
+            id: requireValue(input.id, "id"),
+            source: requireValue(input.source, "source"),
+            title: requireValue(input.title, "title"),
+          }),
+        )
+      },
+    )
+
+    this.server.tool(
+      "manage_campaign",
+      "Create, update, delete, or change campaign audience based on the user's intent.",
+      campaignSchema.shape,
+      async (input) => {
+        if (input.action === "delete") {
+          return jsonResponse(
+            await deleteCampaign({ id: requireValue(input.id, "id") }),
+          )
+        }
+        if (input.action === "update_audience") {
+          return jsonResponse(
+            await updateCampaignAudience({
+              campaignId: requireValue(input.id, "id"),
+              audienceGymIds: input.audienceGymIds ?? [],
+              audienceContactIds: input.audienceContactIds ?? [],
+            }),
+          )
+        }
+        if (input.action === "create") {
+          return jsonResponse(
+            await createCampaign({
+              ...input,
+              name: requireValue(input.name, "name"),
+              audienceGymIds: input.audienceGymIds ?? [],
+              audienceContactIds: input.audienceContactIds ?? [],
+            }),
+          )
+        }
+        return jsonResponse(
+          await updateCampaign({
+            ...input,
+            id: requireValue(input.id, "id"),
+            name: requireValue(input.name, "name"),
+          }),
+        )
+      },
+    )
+
+    this.server.tool(
+      "plan_campaign_touch",
+      "Add a planned outreach touch to a campaign, optionally tied to a gym/contact.",
+      {
+        campaignId: z.string(),
+        title: z.string(),
+        channel: z.string().optional(),
+        owner: ownerSchema.optional(),
+        status: z.string().optional(),
+        dueDate: z.string().optional(),
+        companyId: z.string().optional(),
+        contactId: z.string().optional(),
+        notes: z.string().optional(),
+        content: z.string().optional(),
+      },
+      async (input) => jsonResponse(await createCampaignTouch(input)),
+    )
+  }
+}

--- a/apps/crm/src/mcp.ts
+++ b/apps/crm/src/mcp.ts
@@ -1,5 +1,4 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-import { McpAgent } from "agents/mcp"
 import { z } from "zod"
 import {
   createCampaign,
@@ -201,214 +200,214 @@ async function applyCampaignInteractionActions({
   return results
 }
 
-export class CrmMcp extends McpAgent {
-  server = new McpServer({
+export function createCrmMcpServer() {
+  const server = new McpServer({
     name: "wodsmith-crm",
     version: "1.0.0",
   })
 
-  async init() {
-    // `@lat`: [[architecture]]
-    this.server.tool(
-      "get_crm_context",
-      "List CRM records and navigation targets. Use query to narrow results before updating records.",
-      {
-        query: z.string().optional(),
-        includeCampaignTouches: z.boolean().optional(),
-      },
-      async ({ query, includeCampaignTouches }) => {
-        const data = await readCrmData()
-        const filtered = filterCrmData(data, query)
-        return jsonResponse({
-          ...filtered,
-          campaignTouches: includeCampaignTouches
-            ? data.campaignTouches
-            : undefined,
-          navigation: {
-            dashboard: "/dashboard",
-            gyms: "/gyms",
-            contacts: "/contacts",
-            interactions: "/interactions",
-            campaigns: "/campaigns",
-            gymDetail: "/gyms/:gymId",
-            contactDetail: "/contacts/:contactId",
-            interactionDetail: "/interactions/:interactionId",
-            campaignDetail: "/campaigns/:campaignId",
-            campaignAudience: "/campaigns/:campaignId/audience",
-          },
-        })
-      },
-    )
+  // `@lat`: [[architecture]]
+  server.tool(
+    "get_crm_context",
+    "List CRM records and navigation targets. Use query to narrow results before updating records.",
+    {
+      query: z.string().optional(),
+      includeCampaignTouches: z.boolean().optional(),
+    },
+    async ({ query, includeCampaignTouches }) => {
+      const data = await readCrmData()
+      const filtered = filterCrmData(data, query)
+      return jsonResponse({
+        ...filtered,
+        campaignTouches: includeCampaignTouches
+          ? data.campaignTouches
+          : undefined,
+        navigation: {
+          dashboard: "/dashboard",
+          gyms: "/gyms",
+          contacts: "/contacts",
+          interactions: "/interactions",
+          campaigns: "/campaigns",
+          gymDetail: "/gyms/:gymId",
+          contactDetail: "/contacts/:contactId",
+          interactionDetail: "/interactions/:interactionId",
+          campaignDetail: "/campaigns/:campaignId",
+          campaignAudience: "/campaigns/:campaignId/audience",
+        },
+      })
+    },
+  )
 
-    // `@lat`: [[architecture]]
-    this.server.tool(
-      "manage_gym",
-      "Create, update, or delete a gym/company based on the user's intent.",
-      gymSchema.shape,
-      async (input) => {
-        if (input.action === "delete") {
-          return jsonResponse(
-            await deleteGym({ id: requireValue(input.id, "id") }),
-          )
-        }
-        if (input.action === "create") {
-          return jsonResponse(
-            await createGym({
-              ...input,
-              name: requireValue(input.name, "name"),
-            }),
-          )
-        }
+  // `@lat`: [[architecture]]
+  server.tool(
+    "manage_gym",
+    "Create, update, or delete a gym/company based on the user's intent.",
+    gymSchema.shape,
+    async (input) => {
+      if (input.action === "delete") {
         return jsonResponse(
-          await updateGym({
+          await deleteGym({ id: requireValue(input.id, "id") }),
+        )
+      }
+      if (input.action === "create") {
+        return jsonResponse(
+          await createGym({
             ...input,
-            id: requireValue(input.id, "id"),
             name: requireValue(input.name, "name"),
           }),
         )
-      },
-    )
+      }
+      return jsonResponse(
+        await updateGym({
+          ...input,
+          id: requireValue(input.id, "id"),
+          name: requireValue(input.name, "name"),
+        }),
+      )
+    },
+  )
 
-    // `@lat`: [[architecture]]
-    this.server.tool(
-      "manage_contact",
-      "Create, update, or delete a contact based on the user's intent.",
-      contactSchema.shape,
-      async (input) => {
-        if (input.action === "delete") {
-          return jsonResponse(
-            await deleteContact({ id: requireValue(input.id, "id") }),
-          )
-        }
-        if (input.action === "create") {
-          return jsonResponse(
-            await createContact({
-              ...input,
-              fullName: requireValue(input.fullName, "fullName"),
-            }),
-          )
-        }
+  // `@lat`: [[architecture]]
+  server.tool(
+    "manage_contact",
+    "Create, update, or delete a contact based on the user's intent.",
+    contactSchema.shape,
+    async (input) => {
+      if (input.action === "delete") {
         return jsonResponse(
-          await updateContact({
+          await deleteContact({ id: requireValue(input.id, "id") }),
+        )
+      }
+      if (input.action === "create") {
+        return jsonResponse(
+          await createContact({
             ...input,
-            id: requireValue(input.id, "id"),
             fullName: requireValue(input.fullName, "fullName"),
           }),
         )
-      },
-    )
+      }
+      return jsonResponse(
+        await updateContact({
+          ...input,
+          id: requireValue(input.id, "id"),
+          fullName: requireValue(input.fullName, "fullName"),
+        }),
+      )
+    },
+  )
 
-    // `@lat`: [[architecture]]
-    this.server.tool(
-      "manage_interaction",
-      "Create, update, or delete a meeting/outreach interaction based on the user's intent.",
-      interactionSchema.shape,
-      async (input) => {
-        if (input.action === "delete") {
-          return jsonResponse(
-            await deleteInteraction({ id: requireValue(input.id, "id") }),
-          )
-        }
-        if (input.action === "create") {
-          const source = input.source ?? "Outreach"
-          return jsonResponse(
-            await createInteraction({
-              ...input,
-              source,
-              title: requireValue(input.title, "title"),
-            }),
-          )
-        }
+  // `@lat`: [[architecture]]
+  server.tool(
+    "manage_interaction",
+    "Create, update, or delete a meeting/outreach interaction based on the user's intent.",
+    interactionSchema.shape,
+    async (input) => {
+      if (input.action === "delete") {
         return jsonResponse(
-          await updateInteraction({
+          await deleteInteraction({ id: requireValue(input.id, "id") }),
+        )
+      }
+      if (input.action === "create") {
+        const source = input.source ?? "Outreach"
+        return jsonResponse(
+          await createInteraction({
             ...input,
-            id: requireValue(input.id, "id"),
-            source: requireValue(input.source, "source"),
+            source,
             title: requireValue(input.title, "title"),
           }),
         )
-      },
-    )
+      }
+      return jsonResponse(
+        await updateInteraction({
+          ...input,
+          id: requireValue(input.id, "id"),
+          source: requireValue(input.source, "source"),
+          title: requireValue(input.title, "title"),
+        }),
+      )
+    },
+  )
 
-    // `@lat`: [[crm-campaigns]]
-    this.server.tool(
-      "manage_campaign",
-      "Create, update, delete, assign audiences, and bulk create/update/delete campaign interactions based on the user's intent.",
-      campaignSchema.shape,
-      async (input) => {
-        if (input.action === "delete") {
-          return jsonResponse(
-            await deleteCampaign({ id: requireValue(input.id, "id") }),
-          )
-        }
+  // `@lat`: [[crm-campaigns]]
+  server.tool(
+    "manage_campaign",
+    "Create, update, delete, assign audiences, and bulk create/update/delete campaign interactions based on the user's intent.",
+    campaignSchema.shape,
+    async (input) => {
+      if (input.action === "delete") {
+        return jsonResponse(
+          await deleteCampaign({ id: requireValue(input.id, "id") }),
+        )
+      }
 
-        const shouldUpdateAudience =
-          input.action === "update_audience" ||
-          input.audienceGymIds !== undefined ||
-          input.audienceContactIds !== undefined
+      const shouldUpdateAudience =
+        input.action === "update_audience" ||
+        input.audienceGymIds !== undefined ||
+        input.audienceContactIds !== undefined
 
-        if (input.action === "create") {
-          const campaign = await createCampaign({
-            ...input,
-            name: requireValue(input.name, "name"),
+      if (input.action === "create") {
+        const campaign = await createCampaign({
+          ...input,
+          name: requireValue(input.name, "name"),
+          audienceGymIds: input.audienceGymIds ?? [],
+          audienceContactIds: input.audienceContactIds ?? [],
+        })
+        const interactions = await applyCampaignInteractionActions({
+          campaignId: campaign.id,
+          interactions: input.interactions ?? [],
+        })
+        return jsonResponse({ campaign, interactions })
+      }
+
+      const campaignId = requireValue(input.id, "id")
+      const campaign =
+        input.action === "update" || input.name !== undefined
+          ? await updateCampaign({
+              ...input,
+              id: campaignId,
+              name: requireValue(input.name, "name"),
+            })
+          : { id: campaignId }
+
+      const audience = shouldUpdateAudience
+        ? await updateCampaignAudience({
+            campaignId,
             audienceGymIds: input.audienceGymIds ?? [],
             audienceContactIds: input.audienceContactIds ?? [],
           })
-          const interactions = await applyCampaignInteractionActions({
-            campaignId: campaign.id,
-            interactions: input.interactions ?? [],
-          })
-          return jsonResponse({ campaign, interactions })
-        }
+        : undefined
 
-        const campaignId = requireValue(input.id, "id")
-        const campaign =
-          input.action === "update" || input.name !== undefined
-            ? await updateCampaign({
-                ...input,
-                id: campaignId,
-                name: requireValue(input.name, "name"),
-              })
-            : { id: campaignId }
+      const interactions = await applyCampaignInteractionActions({
+        campaignId,
+        interactions: input.interactions ?? [],
+      })
 
-        const audience = shouldUpdateAudience
-          ? await updateCampaignAudience({
-              campaignId,
-              audienceGymIds: input.audienceGymIds ?? [],
-              audienceContactIds: input.audienceContactIds ?? [],
-            })
-          : undefined
+      return jsonResponse({
+        campaign,
+        audience,
+        interactions,
+      })
+    },
+  )
 
-        const interactions = await applyCampaignInteractionActions({
-          campaignId,
-          interactions: input.interactions ?? [],
-        })
+  // `@lat`: [[crm-campaigns]]
+  server.tool(
+    "plan_campaign_touch",
+    "Add a planned outreach touch to a campaign, optionally tied to a gym/contact.",
+    {
+      campaignId: z.string().min(1),
+      title: z.string().min(1).max(255),
+      channel: optionalText(100),
+      owner: ownerSchema.optional(),
+      status: optionalStatus,
+      dueDate: optionalDate,
+      companyId: optionalId,
+      contactId: optionalId,
+      notes: optionalText(4000),
+      content: optionalText(10000),
+    },
+    async (input) => jsonResponse(await createCampaignTouch(input)),
+  )
 
-        return jsonResponse({
-          campaign,
-          audience,
-          interactions,
-        })
-      },
-    )
-
-    // `@lat`: [[crm-campaigns]]
-    this.server.tool(
-      "plan_campaign_touch",
-      "Add a planned outreach touch to a campaign, optionally tied to a gym/contact.",
-      {
-        campaignId: z.string().min(1),
-        title: z.string().min(1).max(255),
-        channel: optionalText(100),
-        owner: ownerSchema.optional(),
-        status: optionalStatus,
-        dueDate: optionalDate,
-        companyId: optionalId,
-        contactId: optionalId,
-        notes: optionalText(4000),
-        content: optionalText(10000),
-      },
-      async (input) => jsonResponse(await createCampaignTouch(input)),
-    )
-  }
+  return server
 }

--- a/apps/crm/src/mcp.ts
+++ b/apps/crm/src/mcp.ts
@@ -69,8 +69,12 @@ const interactionSchema = z.object({
   content: optionalText(10000),
 })
 
+const campaignInteractionSchema = interactionSchema.extend({
+  action: z.enum(["create", "update", "delete"]),
+})
+
 const campaignSchema = z.object({
-  action: z.enum(["create", "update", "delete", "update_audience"]),
+  action: z.enum(["create", "update", "delete", "update_audience", "manage"]),
   id: optionalId,
   name: optionalText(255),
   status: optionalStatus,
@@ -80,6 +84,7 @@ const campaignSchema = z.object({
   endDate: optionalDate,
   audienceGymIds: z.array(z.string().min(1)).optional(),
   audienceContactIds: z.array(z.string().min(1)).optional(),
+  interactions: z.array(campaignInteractionSchema).max(100).optional(),
 })
 
 function jsonResponse(value: unknown) {
@@ -144,6 +149,56 @@ function filterCrmData(
       ]),
     ),
   }
+}
+
+async function applyCampaignInteractionActions({
+  campaignId,
+  interactions,
+}: {
+  campaignId: string
+  interactions: z.infer<typeof campaignInteractionSchema>[]
+}) {
+  const results: Array<{
+    action: "create" | "update" | "delete"
+    id: string
+    deleted?: boolean
+  }> = []
+
+  for (const interaction of interactions) {
+    if (interaction.action === "delete") {
+      const result = await deleteInteraction({
+        id: requireValue(interaction.id, "interaction id"),
+      })
+      results.push({
+        action: "delete",
+        id: result.id,
+        deleted: result.deleted,
+      })
+      continue
+    }
+
+    if (interaction.action === "create") {
+      const result = await createInteraction({
+        ...interaction,
+        source: interaction.source ?? "Outreach",
+        title: requireValue(interaction.title, "interaction title"),
+        campaignId,
+      })
+      results.push({ action: "create", id: result.id })
+      continue
+    }
+
+    const result = await updateInteraction({
+      ...interaction,
+      id: requireValue(interaction.id, "interaction id"),
+      source: interaction.source ?? "Outreach",
+      title: requireValue(interaction.title, "interaction title"),
+      campaignId,
+    })
+    results.push({ action: "update", id: result.id })
+  }
+
+  return results
 }
 
 export class CrmMcp extends McpAgent {
@@ -278,7 +333,7 @@ export class CrmMcp extends McpAgent {
     // `@lat`: [[crm-campaigns]]
     this.server.tool(
       "manage_campaign",
-      "Create, update, delete, or change campaign audience based on the user's intent.",
+      "Create, update, delete, assign audiences, and bulk create/update/delete campaign interactions based on the user's intent.",
       campaignSchema.shape,
       async (input) => {
         if (input.action === "delete") {
@@ -286,32 +341,54 @@ export class CrmMcp extends McpAgent {
             await deleteCampaign({ id: requireValue(input.id, "id") }),
           )
         }
-        if (input.action === "update_audience") {
-          return jsonResponse(
-            await updateCampaignAudience({
-              campaignId: requireValue(input.id, "id"),
-              audienceGymIds: input.audienceGymIds ?? [],
-              audienceContactIds: input.audienceContactIds ?? [],
-            }),
-          )
-        }
+
+        const shouldUpdateAudience =
+          input.action === "update_audience" ||
+          input.audienceGymIds !== undefined ||
+          input.audienceContactIds !== undefined
+
         if (input.action === "create") {
-          return jsonResponse(
-            await createCampaign({
-              ...input,
-              name: requireValue(input.name, "name"),
+          const campaign = await createCampaign({
+            ...input,
+            name: requireValue(input.name, "name"),
+            audienceGymIds: input.audienceGymIds ?? [],
+            audienceContactIds: input.audienceContactIds ?? [],
+          })
+          const interactions = await applyCampaignInteractionActions({
+            campaignId: campaign.id,
+            interactions: input.interactions ?? [],
+          })
+          return jsonResponse({ campaign, interactions })
+        }
+
+        const campaignId = requireValue(input.id, "id")
+        const campaign =
+          input.action === "update" || input.name !== undefined
+            ? await updateCampaign({
+                ...input,
+                id: campaignId,
+                name: requireValue(input.name, "name"),
+              })
+            : { id: campaignId }
+
+        const audience = shouldUpdateAudience
+          ? await updateCampaignAudience({
+              campaignId,
               audienceGymIds: input.audienceGymIds ?? [],
               audienceContactIds: input.audienceContactIds ?? [],
-            }),
-          )
-        }
-        return jsonResponse(
-          await updateCampaign({
-            ...input,
-            id: requireValue(input.id, "id"),
-            name: requireValue(input.name, "name"),
-          }),
-        )
+            })
+          : undefined
+
+        const interactions = await applyCampaignInteractionActions({
+          campaignId,
+          interactions: input.interactions ?? [],
+        })
+
+        return jsonResponse({
+          campaign,
+          audience,
+          interactions,
+        })
       },
     )
 

--- a/apps/crm/src/mcp.ts
+++ b/apps/crm/src/mcp.ts
@@ -20,63 +20,66 @@ import {
 } from "@/server-fns/crm"
 
 const ownerSchema = z.enum(["Ian", "Zac"])
-const nullableString = z.string().optional()
+const optionalId = z.string().min(1).optional()
+const optionalText = (max: number) => z.string().max(max).optional()
+const optionalDate = optionalText(20)
+const optionalStatus = optionalText(100)
 
 const gymSchema = z.object({
   action: z.enum(["create", "update", "delete"]),
-  id: z.string().optional(),
-  name: nullableString,
-  location: nullableString,
-  website: nullableString,
-  crossfitPage: nullableString,
-  email: nullableString,
-  phone: nullableString,
-  instagram: nullableString,
-  ownerManager: nullableString,
-  status: nullableString,
-  priority: nullableString,
-  relationship: nullableString,
-  notes: nullableString,
+  id: optionalId,
+  name: optionalText(255),
+  location: optionalText(255),
+  website: optionalText(500),
+  crossfitPage: optionalText(500),
+  email: optionalText(255),
+  phone: optionalText(100),
+  instagram: optionalText(255),
+  ownerManager: optionalText(500),
+  status: optionalStatus,
+  priority: optionalText(50),
+  relationship: optionalText(255),
+  notes: optionalText(4000),
 })
 
 const contactSchema = z.object({
   action: z.enum(["create", "update", "delete"]),
-  id: z.string().optional(),
-  fullName: nullableString,
-  email: nullableString,
-  phone: nullableString,
-  status: nullableString,
-  companyId: nullableString,
-  notes: nullableString,
+  id: optionalId,
+  fullName: optionalText(255),
+  email: optionalText(255),
+  phone: optionalText(100),
+  status: optionalStatus,
+  companyId: optionalId,
+  notes: optionalText(4000),
 })
 
 const interactionSchema = z.object({
   action: z.enum(["create", "update", "delete"]),
-  id: z.string().optional(),
+  id: optionalId,
   source: z.enum(["Meeting", "Outreach"]).optional(),
-  title: nullableString,
-  date: nullableString,
-  channel: nullableString,
-  status: nullableString,
+  title: optionalText(255),
+  date: optionalDate,
+  channel: optionalText(100),
+  status: optionalStatus,
   owner: ownerSchema.optional(),
-  companyId: nullableString,
-  contactId: nullableString,
-  campaignId: nullableString,
-  notes: nullableString,
-  content: nullableString,
+  companyId: optionalId,
+  contactId: optionalId,
+  campaignId: optionalId,
+  notes: optionalText(4000),
+  content: optionalText(10000),
 })
 
 const campaignSchema = z.object({
   action: z.enum(["create", "update", "delete", "update_audience"]),
-  id: z.string().optional(),
-  name: nullableString,
-  status: nullableString,
+  id: optionalId,
+  name: optionalText(255),
+  status: optionalStatus,
   owner: ownerSchema.optional(),
-  goal: nullableString,
-  startDate: nullableString,
-  endDate: nullableString,
-  audienceGymIds: z.array(z.string()).optional(),
-  audienceContactIds: z.array(z.string()).optional(),
+  goal: optionalText(4000),
+  startDate: optionalDate,
+  endDate: optionalDate,
+  audienceGymIds: z.array(z.string().min(1)).optional(),
+  audienceContactIds: z.array(z.string().min(1)).optional(),
 })
 
 function jsonResponse(value: unknown) {
@@ -150,6 +153,7 @@ export class CrmMcp extends McpAgent {
   })
 
   async init() {
+    // `@lat`: [[architecture]]
     this.server.tool(
       "get_crm_context",
       "List CRM records and navigation targets. Use query to narrow results before updating records.",
@@ -181,6 +185,7 @@ export class CrmMcp extends McpAgent {
       },
     )
 
+    // `@lat`: [[architecture]]
     this.server.tool(
       "manage_gym",
       "Create, update, or delete a gym/company based on the user's intent.",
@@ -209,6 +214,7 @@ export class CrmMcp extends McpAgent {
       },
     )
 
+    // `@lat`: [[architecture]]
     this.server.tool(
       "manage_contact",
       "Create, update, or delete a contact based on the user's intent.",
@@ -237,6 +243,7 @@ export class CrmMcp extends McpAgent {
       },
     )
 
+    // `@lat`: [[architecture]]
     this.server.tool(
       "manage_interaction",
       "Create, update, or delete a meeting/outreach interaction based on the user's intent.",
@@ -248,9 +255,11 @@ export class CrmMcp extends McpAgent {
           )
         }
         if (input.action === "create") {
+          const source = input.source ?? "Outreach"
           return jsonResponse(
             await createInteraction({
               ...input,
+              source,
               title: requireValue(input.title, "title"),
             }),
           )
@@ -266,6 +275,7 @@ export class CrmMcp extends McpAgent {
       },
     )
 
+    // `@lat`: [[crm-campaigns]]
     this.server.tool(
       "manage_campaign",
       "Create, update, delete, or change campaign audience based on the user's intent.",
@@ -305,20 +315,21 @@ export class CrmMcp extends McpAgent {
       },
     )
 
+    // `@lat`: [[crm-campaigns]]
     this.server.tool(
       "plan_campaign_touch",
       "Add a planned outreach touch to a campaign, optionally tied to a gym/contact.",
       {
-        campaignId: z.string(),
-        title: z.string(),
-        channel: z.string().optional(),
+        campaignId: z.string().min(1),
+        title: z.string().min(1).max(255),
+        channel: optionalText(100),
         owner: ownerSchema.optional(),
-        status: z.string().optional(),
-        dueDate: z.string().optional(),
-        companyId: z.string().optional(),
-        contactId: z.string().optional(),
-        notes: z.string().optional(),
-        content: z.string().optional(),
+        status: optionalStatus,
+        dueDate: optionalDate,
+        companyId: optionalId,
+        contactId: optionalId,
+        notes: optionalText(4000),
+        content: optionalText(10000),
       },
       async (input) => jsonResponse(await createCampaignTouch(input)),
     )

--- a/apps/crm/src/routeTree.gen.ts
+++ b/apps/crm/src/routeTree.gen.ts
@@ -9,8 +9,10 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as McpRouteImport } from './routes/mcp'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as ApiMcpRouteImport } from './routes/api/mcp'
 import { Route as AuthenticatedInteractionsRouteImport } from './routes/_authenticated/interactions'
 import { Route as AuthenticatedGymsRouteImport } from './routes/_authenticated/gyms'
 import { Route as AuthenticatedDashboardRouteImport } from './routes/_authenticated/dashboard'
@@ -24,6 +26,11 @@ import { Route as AuthenticatedContactsContactIdRouteImport } from './routes/_au
 import { Route as AuthenticatedCampaignsCampaignIdRouteImport } from './routes/_authenticated/campaigns.$campaignId'
 import { Route as AuthenticatedCampaignsCampaignIdAudienceRouteImport } from './routes/_authenticated/campaigns.$campaignId.audience'
 
+const McpRoute = McpRouteImport.update({
+  id: '/mcp',
+  path: '/mcp',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
@@ -31,6 +38,11 @@ const AuthenticatedRoute = AuthenticatedRouteImport.update({
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiMcpRoute = ApiMcpRouteImport.update({
+  id: '/api/mcp',
+  path: '/api/mcp',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthenticatedInteractionsRoute =
@@ -101,11 +113,13 @@ const AuthenticatedCampaignsCampaignIdAudienceRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/mcp': typeof McpRoute
   '/campaigns': typeof AuthenticatedCampaignsRouteWithChildren
   '/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/gyms': typeof AuthenticatedGymsRouteWithChildren
   '/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/api/mcp': typeof ApiMcpRoute
   '/campaigns/$campaignId': typeof AuthenticatedCampaignsCampaignIdRouteWithChildren
   '/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
   '/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
@@ -116,11 +130,13 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/mcp': typeof McpRoute
   '/campaigns': typeof AuthenticatedCampaignsRouteWithChildren
   '/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/dashboard': typeof AuthenticatedDashboardRoute
   '/gyms': typeof AuthenticatedGymsRouteWithChildren
   '/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/api/mcp': typeof ApiMcpRoute
   '/campaigns/$campaignId': typeof AuthenticatedCampaignsCampaignIdRouteWithChildren
   '/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
   '/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
@@ -133,11 +149,13 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/mcp': typeof McpRoute
   '/_authenticated/campaigns': typeof AuthenticatedCampaignsRouteWithChildren
   '/_authenticated/contacts': typeof AuthenticatedContactsRouteWithChildren
   '/_authenticated/dashboard': typeof AuthenticatedDashboardRoute
   '/_authenticated/gyms': typeof AuthenticatedGymsRouteWithChildren
   '/_authenticated/interactions': typeof AuthenticatedInteractionsRouteWithChildren
+  '/api/mcp': typeof ApiMcpRoute
   '/_authenticated/campaigns/$campaignId': typeof AuthenticatedCampaignsCampaignIdRouteWithChildren
   '/_authenticated/contacts/$contactId': typeof AuthenticatedContactsContactIdRoute
   '/_authenticated/gyms/$gymId': typeof AuthenticatedGymsGymIdRoute
@@ -150,11 +168,13 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/mcp'
     | '/campaigns'
     | '/contacts'
     | '/dashboard'
     | '/gyms'
     | '/interactions'
+    | '/api/mcp'
     | '/campaigns/$campaignId'
     | '/contacts/$contactId'
     | '/gyms/$gymId'
@@ -165,11 +185,13 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/mcp'
     | '/campaigns'
     | '/contacts'
     | '/dashboard'
     | '/gyms'
     | '/interactions'
+    | '/api/mcp'
     | '/campaigns/$campaignId'
     | '/contacts/$contactId'
     | '/gyms/$gymId'
@@ -181,11 +203,13 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/_authenticated'
+    | '/mcp'
     | '/_authenticated/campaigns'
     | '/_authenticated/contacts'
     | '/_authenticated/dashboard'
     | '/_authenticated/gyms'
     | '/_authenticated/interactions'
+    | '/api/mcp'
     | '/_authenticated/campaigns/$campaignId'
     | '/_authenticated/contacts/$contactId'
     | '/_authenticated/gyms/$gymId'
@@ -198,12 +222,21 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  McpRoute: typeof McpRoute
+  ApiMcpRoute: typeof ApiMcpRoute
   ApiCrmAgentCapabilitiesRoute: typeof ApiCrmAgentCapabilitiesRoute
   ApiCrmDocumentsRoute: typeof ApiCrmDocumentsRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/mcp': {
+      id: '/mcp'
+      path: '/mcp'
+      fullPath: '/mcp'
+      preLoaderRoute: typeof McpRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
@@ -216,6 +249,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/mcp': {
+      id: '/api/mcp'
+      path: '/api/mcp'
+      fullPath: '/api/mcp'
+      preLoaderRoute: typeof ApiMcpRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_authenticated/interactions': {
@@ -397,6 +437,8 @@ const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
+  McpRoute: McpRoute,
+  ApiMcpRoute: ApiMcpRoute,
   ApiCrmAgentCapabilitiesRoute: ApiCrmAgentCapabilitiesRoute,
   ApiCrmDocumentsRoute: ApiCrmDocumentsRoute,
 }

--- a/apps/crm/src/routes/api/crm/documents.ts
+++ b/apps/crm/src/routes/api/crm/documents.ts
@@ -2,10 +2,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { json } from "@tanstack/react-start"
 import { z } from "zod"
 import { requireAuth } from "@/server-fns/auth"
-import {
-  documentUploadSchema,
-  uploadDocumentForEntry,
-} from "@/server-fns/crm"
+import { documentUploadSchema, uploadDocumentForEntry } from "@/server-fns/crm"
 
 export const Route = createFileRoute("/api/crm/documents")({
   server: {

--- a/apps/crm/src/routes/api/mcp.ts
+++ b/apps/crm/src/routes/api/mcp.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { handleMcpRequest } from "@/lib/mcp-handler"
+
+export const Route = createFileRoute("/api/mcp")({
+  server: {
+    handlers: {
+      GET: ({ request }) => handleMcpRequest(request),
+      POST: ({ request }) => handleMcpRequest(request),
+      DELETE: ({ request }) => handleMcpRequest(request),
+    },
+  },
+})

--- a/apps/crm/src/routes/mcp.ts
+++ b/apps/crm/src/routes/mcp.ts
@@ -1,0 +1,12 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { handleMcpRequest } from "@/lib/mcp-handler"
+
+export const Route = createFileRoute("/mcp")({
+  server: {
+    handlers: {
+      GET: ({ request }) => handleMcpRequest(request),
+      POST: ({ request }) => handleMcpRequest(request),
+      DELETE: ({ request }) => handleMcpRequest(request),
+    },
+  },
+})

--- a/apps/crm/src/server-fns/auth.ts
+++ b/apps/crm/src/server-fns/auth.ts
@@ -2,7 +2,7 @@ import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
 import { getAuthPassword, getSessionSecret, isSecureAppUrl } from "@/lib/env"
 
-const SESSION_COOKIE = "crm_session"
+export const SESSION_COOKIE = "crm_session"
 
 const MAX_LOGIN_ATTEMPTS = 5
 const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000 // 15 minutes
@@ -62,7 +62,7 @@ async function signToken(token: string): Promise<string> {
   return `${token}.${sigHex}`
 }
 
-async function verifyToken(cookie: string): Promise<boolean> {
+export async function verifySessionToken(cookie: string): Promise<boolean> {
   const dotIndex = cookie.lastIndexOf(".")
   if (dotIndex === -1) return false
 
@@ -77,14 +77,14 @@ export const checkAuthFn = createServerFn({ method: "GET" }).handler(
     const { getCookie } = await import("@tanstack/react-start/server")
     const cookie = await getCookie(SESSION_COOKIE)
     if (!cookie) return false
-    return verifyToken(cookie)
+    return verifySessionToken(cookie)
   },
 )
 
 export async function requireAuth() {
   const { getCookie } = await import("@tanstack/react-start/server")
   const cookie = await getCookie(SESSION_COOKIE)
-  if (!cookie || !(await verifyToken(cookie))) {
+  if (!cookie || !(await verifySessionToken(cookie))) {
     throw new Error("Unauthorized")
   }
 }

--- a/apps/crm/src/server-fns/auth.ts
+++ b/apps/crm/src/server-fns/auth.ts
@@ -74,6 +74,41 @@ export async function verifySessionToken(cookie: string): Promise<boolean> {
   return timingSafeEqual(cookie, expected)
 }
 
+function getCookieValue(request: Request, name: string) {
+  const cookie = request.headers.get("Cookie")
+  if (!cookie) return null
+
+  for (const part of cookie.split(";")) {
+    const [key, ...valueParts] = part.trim().split("=")
+    if (key !== name) continue
+
+    try {
+      return decodeURIComponent(valueParts.join("="))
+    } catch {
+      return null
+    }
+  }
+
+  return null
+}
+
+function getBearerToken(request: Request) {
+  const authorization = request.headers.get("Authorization")
+  const match = authorization?.match(/^Bearer\s+(.+)$/i)
+  return match?.[1] ?? null
+}
+
+// `@lat`: [[auth]]
+export async function isAuthenticatedRequest(request: Request) {
+  const bearerToken = getBearerToken(request)
+  if (bearerToken && (await verifySessionToken(bearerToken))) {
+    return true
+  }
+
+  const cookieToken = getCookieValue(request, SESSION_COOKIE)
+  return cookieToken ? verifySessionToken(cookieToken) : false
+}
+
 export const checkAuthFn = createServerFn({ method: "GET" }).handler(
   async () => {
     const { getCookie } = await import("@tanstack/react-start/server")

--- a/apps/crm/src/server-fns/auth.ts
+++ b/apps/crm/src/server-fns/auth.ts
@@ -2,6 +2,7 @@ import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
 import { getAuthPassword, getSessionSecret, isSecureAppUrl } from "@/lib/env"
 
+// `@lat`: [[auth]]
 export const SESSION_COOKIE = "crm_session"
 
 const MAX_LOGIN_ATTEMPTS = 5
@@ -62,6 +63,7 @@ async function signToken(token: string): Promise<string> {
   return `${token}.${sigHex}`
 }
 
+// `@lat`: [[auth]]
 export async function verifySessionToken(cookie: string): Promise<boolean> {
   const dotIndex = cookie.lastIndexOf(".")
   if (dotIndex === -1) return false

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -127,6 +127,7 @@ const contactUpdateSchema = contactInputSchema.extend({
 })
 
 const interactionInputSchema = z.object({
+  source: z.enum(["Meeting", "Outreach"]).optional(),
   title: z.string().min(1, "Subject is required").max(255),
   date: z.string().max(20).optional(),
   channel: z.string().max(100).optional(),
@@ -819,12 +820,16 @@ function requireField(
   return field
 }
 
+// `@lat`: [[architecture]]
 async function deleteEntryFromObject(entryId: string, objectName: string) {
   const db = getDb()
   const object = await getObject(objectName)
+  // `@lat`: [[architecture]]
   await assertEntryInObject(entryId, object.id)
+  // `@lat`: [[architecture]]
   await deleteDocumentsForEntries([entryId])
 
+  // `@lat`: [[architecture]]
   await db
     .delete(entriesTable)
     .where(
@@ -834,6 +839,7 @@ async function deleteEntryFromObject(entryId: string, objectName: string) {
   return { id: entryId, deleted: true }
 }
 
+// `@lat`: [[architecture]]
 async function deleteDocumentsForEntries(entryIds: string[]) {
   if (entryIds.length === 0) return
 
@@ -852,14 +858,14 @@ async function deleteDocumentsForEntries(entryIds: string[]) {
 
   if (documents.length === 0) return
 
-  await Promise.all(
-    documents.map((document) => getR2Bucket().delete(document.filePath)),
-  )
   await db.delete(documentsTable).where(
     inArray(
       documentsTable.id,
       documents.map((document) => document.documentId),
     ),
+  )
+  await Promise.allSettled(
+    documents.map((document) => getR2Bucket().delete(document.filePath)),
   )
 }
 
@@ -1203,18 +1209,32 @@ export const updateContactFn = createServerFn({ method: "POST" })
 export async function createInteraction(
   data: z.infer<typeof interactionInputSchema>,
 ) {
-  const { entryId, object } = await createEntry("Outreach")
+  const source = data.source ?? "Outreach"
+  const { entryId, object } = await createEntry(source)
   const fields = await getFieldsByName(object.id)
 
-  const updates: Array<[string, string | null]> = [
-    ["Subject", data.title],
-    ["Date Sent", clean(data.date) ?? new Date().toISOString().slice(0, 10)],
-    ["Channel", clean(data.channel) ?? "Email"],
-    ["Status", clean(data.status) ?? "Sent"],
-    ["Owner", clean(data.owner)],
-    ["Notes", clean(data.notes)],
-    ["Content", clean(data.content)],
-  ]
+  const updates: Array<[string, string | null]> =
+    source === "Meeting"
+      ? [
+          ["Title", data.title],
+          ["Date", clean(data.date) ?? new Date().toISOString().slice(0, 10)],
+          ["Type", clean(data.channel)],
+          ["Status", clean(data.status)],
+          ["Notes", clean(data.notes)],
+          ["Outcome", clean(data.content)],
+        ]
+      : [
+          ["Subject", data.title],
+          [
+            "Date Sent",
+            clean(data.date) ?? new Date().toISOString().slice(0, 10),
+          ],
+          ["Channel", clean(data.channel) ?? "Email"],
+          ["Status", clean(data.status) ?? "Sent"],
+          ["Owner", clean(data.owner)],
+          ["Notes", clean(data.notes)],
+          ["Content", clean(data.content)],
+        ]
 
   for (const [fieldName, value] of updates) {
     const field = fields.get(fieldName)
@@ -1226,8 +1246,10 @@ export async function createInteraction(
     await setRelation(entryId, companyField.id, clean(data.companyId))
   }
 
-  const personField = requireField(fields, "Person", "Outreach")
-  await setRelation(entryId, personField.id, clean(data.contactId))
+  const contactField = fields.get(source === "Meeting" ? "Contact" : "Person")
+  if (contactField) {
+    await setRelation(entryId, contactField.id, clean(data.contactId))
+  }
 
   const campaignField = fields.get("Campaign")
   if (campaignField) {

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -1487,7 +1487,10 @@ export async function deleteInteraction(
     .where(eq(entriesTable.id, data.id))
     .limit(1)
 
-  if (!entry || !["Meeting", "Outreach"].includes(entry.objectName)) {
+  if (
+    !entry ||
+    !["meeting", "outreach"].includes(entry.objectName.toLowerCase())
+  ) {
     throw new Error(`CRM interaction not found: ${data.id}`)
   }
 

--- a/apps/crm/src/server-fns/crm.ts
+++ b/apps/crm/src/server-fns/crm.ts
@@ -191,6 +191,10 @@ const campaignTouchInputSchema = z.object({
   content: z.string().max(10000).optional(),
 })
 
+const deleteCrmEntrySchema = z.object({
+  id: z.string().min(1, "Entry ID is required"),
+})
+
 export const documentUploadSchema = z.object({
   entryId: z.string().min(1, "Entry ID is required"),
   fileName: z.string().min(1, "File name is required"),
@@ -815,8 +819,51 @@ function requireField(
   return field
 }
 
-export async function getCrmData() {
-  await requireAuth()
+async function deleteEntryFromObject(entryId: string, objectName: string) {
+  const db = getDb()
+  const object = await getObject(objectName)
+  await assertEntryInObject(entryId, object.id)
+  await deleteDocumentsForEntries([entryId])
+
+  await db
+    .delete(entriesTable)
+    .where(
+      and(eq(entriesTable.id, entryId), eq(entriesTable.objectId, object.id)),
+    )
+
+  return { id: entryId, deleted: true }
+}
+
+async function deleteDocumentsForEntries(entryIds: string[]) {
+  if (entryIds.length === 0) return
+
+  const db = getDb()
+  const documents = await db
+    .select({
+      documentId: documentsTable.id,
+      filePath: documentsTable.filePath,
+    })
+    .from(documentEntriesTable)
+    .innerJoin(
+      documentsTable,
+      eq(documentEntriesTable.documentId, documentsTable.id),
+    )
+    .where(inArray(documentEntriesTable.entryId, entryIds))
+
+  if (documents.length === 0) return
+
+  await Promise.all(
+    documents.map((document) => getR2Bucket().delete(document.filePath)),
+  )
+  await db.delete(documentsTable).where(
+    inArray(
+      documentsTable.id,
+      documents.map((document) => document.documentId),
+    ),
+  )
+}
+
+export async function readCrmData() {
   await ensureCampaignSchema()
 
   const [gymsData, contactsData, outreachData, meetingsData, campaignsData] =
@@ -994,307 +1041,458 @@ export async function getCrmData() {
   return { gyms, contacts, interactions, campaigns, campaignTouches }
 }
 
+export async function getCrmData() {
+  await requireAuth()
+  return readCrmData()
+}
+
 export const getCrmDataFn = createServerFn({ method: "GET" }).handler(
   getCrmData,
 )
+
+export async function createGym(data: z.infer<typeof gymInputSchema>) {
+  const { entryId, object } = await createEntry("Company")
+  await ensureField({
+    objectId: object.id,
+    name: "CrossFit Page",
+    type: "url",
+    sortOrder: 70,
+  })
+  const fields = await getFieldsByName(object.id)
+
+  const updates: Array<[string, string | null]> = [
+    ["Company Name", data.name],
+    ["Industry", "Fitness"],
+    ["Type", "Prospect"],
+    ["Location", clean(data.location)],
+    ["Website", clean(data.website)],
+    ["CrossFit Page", clean(data.crossfitPage)],
+    ["Email Address", clean(data.email)],
+    ["Phone Number", clean(data.phone)],
+    ["Instagram", clean(data.instagram)],
+    ["Owner/Manager", clean(data.ownerManager)],
+    ["Wodsmith Status", clean(data.status) ?? "Prospect"],
+    ["Priority", clean(data.priority)],
+    ["Relationship", clean(data.relationship)],
+    ["Notes", clean(data.notes)],
+  ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(entryId, field.id, value)
+  }
+
+  return { id: entryId }
+}
+
+export async function updateGym(data: z.infer<typeof gymUpdateSchema>) {
+  const object = await getObject("Company")
+  await assertEntryInObject(data.id, object.id)
+  await ensureField({
+    objectId: object.id,
+    name: "CrossFit Page",
+    type: "url",
+    sortOrder: 70,
+  })
+  const fields = await getFieldsByName(object.id)
+
+  const updates: Array<[string, string | null]> = [
+    ["Company Name", data.name],
+    ["Location", clean(data.location)],
+    ["Website", clean(data.website)],
+    ["CrossFit Page", clean(data.crossfitPage)],
+    ["Email Address", clean(data.email)],
+    ["Phone Number", clean(data.phone)],
+    ["Instagram", clean(data.instagram)],
+    ["Owner/Manager", clean(data.ownerManager)],
+    ["Wodsmith Status", clean(data.status)],
+    ["Priority", clean(data.priority)],
+    ["Relationship", clean(data.relationship)],
+    ["Notes", clean(data.notes)],
+  ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(data.id, field.id, value)
+  }
+
+  await touchEntry(data.id)
+  return { id: data.id }
+}
 
 export const createGymFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => gymInputSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    const { entryId, object } = await createEntry("Company")
-    await ensureField({
-      objectId: object.id,
-      name: "CrossFit Page",
-      type: "url",
-      sortOrder: 70,
-    })
-    const fields = await getFieldsByName(object.id)
-
-    const updates: Array<[string, string | null]> = [
-      ["Company Name", data.name],
-      ["Industry", "Fitness"],
-      ["Type", "Prospect"],
-      ["Location", clean(data.location)],
-      ["Website", clean(data.website)],
-      ["CrossFit Page", clean(data.crossfitPage)],
-      ["Email Address", clean(data.email)],
-      ["Phone Number", clean(data.phone)],
-      ["Instagram", clean(data.instagram)],
-      ["Owner/Manager", clean(data.ownerManager)],
-      ["Wodsmith Status", clean(data.status) ?? "Prospect"],
-      ["Priority", clean(data.priority)],
-      ["Relationship", clean(data.relationship)],
-      ["Notes", clean(data.notes)],
-    ]
-
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(entryId, field.id, value)
-    }
-
-    return { id: entryId }
+    return createGym(data)
   })
 
 export const updateGymFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => gymUpdateSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    const object = await getObject("Company")
-    await assertEntryInObject(data.id, object.id)
-    await ensureField({
-      objectId: object.id,
-      name: "CrossFit Page",
-      type: "url",
-      sortOrder: 70,
-    })
-    const fields = await getFieldsByName(object.id)
-
-    const updates: Array<[string, string | null]> = [
-      ["Company Name", data.name],
-      ["Location", clean(data.location)],
-      ["Website", clean(data.website)],
-      ["CrossFit Page", clean(data.crossfitPage)],
-      ["Email Address", clean(data.email)],
-      ["Phone Number", clean(data.phone)],
-      ["Instagram", clean(data.instagram)],
-      ["Owner/Manager", clean(data.ownerManager)],
-      ["Wodsmith Status", clean(data.status)],
-      ["Priority", clean(data.priority)],
-      ["Relationship", clean(data.relationship)],
-      ["Notes", clean(data.notes)],
-    ]
-
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(data.id, field.id, value)
-    }
-
-    await touchEntry(data.id)
-    return { id: data.id }
+    return updateGym(data)
   })
+
+export async function createContact(data: z.infer<typeof contactInputSchema>) {
+  const { entryId, object } = await createEntry("People")
+  const fields = await getFieldsByName(object.id)
+
+  const updates: Array<[string, string | null]> = [
+    ["Full Name", data.fullName],
+    ["Email Address", clean(data.email)],
+    ["Phone Number", clean(data.phone)],
+    ["Status", clean(data.status) ?? "Lead"],
+    ["Notes", clean(data.notes)],
+  ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(entryId, field.id, value)
+  }
+
+  const companyField = fields.get("Company")
+  if (companyField) {
+    await setRelation(entryId, companyField.id, clean(data.companyId))
+  }
+
+  return { id: entryId }
+}
+
+export async function updateContact(data: z.infer<typeof contactUpdateSchema>) {
+  const object = await getObject("People")
+  await assertEntryInObject(data.id, object.id)
+  const fields = await getFieldsByName(object.id)
+
+  const updates: Array<[string, string | null]> = [
+    ["Full Name", data.fullName],
+    ["Email Address", clean(data.email)],
+    ["Phone Number", clean(data.phone)],
+    ["Status", clean(data.status)],
+    ["Notes", clean(data.notes)],
+  ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(data.id, field.id, value)
+  }
+
+  const companyField = fields.get("Company")
+  if (companyField) {
+    await setRelation(data.id, companyField.id, clean(data.companyId))
+  }
+
+  await touchEntry(data.id)
+  return { id: data.id }
+}
 
 export const createContactFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => contactInputSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    const { entryId, object } = await createEntry("People")
-    const fields = await getFieldsByName(object.id)
-
-    const updates: Array<[string, string | null]> = [
-      ["Full Name", data.fullName],
-      ["Email Address", clean(data.email)],
-      ["Phone Number", clean(data.phone)],
-      ["Status", clean(data.status) ?? "Lead"],
-      ["Notes", clean(data.notes)],
-    ]
-
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(entryId, field.id, value)
-    }
-
-    const companyField = fields.get("Company")
-    if (companyField) {
-      await setRelation(entryId, companyField.id, clean(data.companyId))
-    }
-
-    return { id: entryId }
+    return createContact(data)
   })
 
 export const updateContactFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => contactUpdateSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    const object = await getObject("People")
-    await assertEntryInObject(data.id, object.id)
-    const fields = await getFieldsByName(object.id)
-
-    const updates: Array<[string, string | null]> = [
-      ["Full Name", data.fullName],
-      ["Email Address", clean(data.email)],
-      ["Phone Number", clean(data.phone)],
-      ["Status", clean(data.status)],
-      ["Notes", clean(data.notes)],
-    ]
-
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(data.id, field.id, value)
-    }
-
-    const companyField = fields.get("Company")
-    if (companyField) {
-      await setRelation(data.id, companyField.id, clean(data.companyId))
-    }
-
-    await touchEntry(data.id)
-    return { id: data.id }
+    return updateContact(data)
   })
+
+export async function createInteraction(
+  data: z.infer<typeof interactionInputSchema>,
+) {
+  const { entryId, object } = await createEntry("Outreach")
+  const fields = await getFieldsByName(object.id)
+
+  const updates: Array<[string, string | null]> = [
+    ["Subject", data.title],
+    ["Date Sent", clean(data.date) ?? new Date().toISOString().slice(0, 10)],
+    ["Channel", clean(data.channel) ?? "Email"],
+    ["Status", clean(data.status) ?? "Sent"],
+    ["Owner", clean(data.owner)],
+    ["Notes", clean(data.notes)],
+    ["Content", clean(data.content)],
+  ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(entryId, field.id, value)
+  }
+
+  const companyField = fields.get("Company")
+  if (companyField) {
+    await setRelation(entryId, companyField.id, clean(data.companyId))
+  }
+
+  const personField = requireField(fields, "Person", "Outreach")
+  await setRelation(entryId, personField.id, clean(data.contactId))
+
+  const campaignField = fields.get("Campaign")
+  if (campaignField) {
+    const campaignId = clean(data.campaignId)
+    if (campaignId) await assertCampaignEntry(campaignId)
+    await setRelation(entryId, campaignField.id, campaignId)
+  }
+
+  return { id: entryId }
+}
+
+export async function updateInteraction(
+  data: z.infer<typeof interactionUpdateSchema>,
+) {
+  const objectName = data.source === "Meeting" ? "Meeting" : "Outreach"
+  const object = await getObject(objectName)
+  await assertEntryInObject(data.id, object.id)
+  const fields = await getFieldsByName(object.id)
+
+  const updates: Array<[string, string | null]> =
+    data.source === "Meeting"
+      ? [
+          ["Title", data.title],
+          ["Date", clean(data.date)],
+          ["Type", clean(data.channel)],
+          ["Status", clean(data.status)],
+          ["Notes", clean(data.notes)],
+          ["Outcome", clean(data.content)],
+        ]
+      : [
+          ["Subject", data.title],
+          ["Date Sent", clean(data.date)],
+          ["Channel", clean(data.channel)],
+          ["Status", clean(data.status)],
+          ["Owner", clean(data.owner)],
+          ["Notes", clean(data.notes)],
+          ["Content", clean(data.content)],
+        ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(data.id, field.id, value)
+  }
+
+  const companyField = fields.get("Company")
+  if (companyField) {
+    await setRelation(data.id, companyField.id, clean(data.companyId))
+  }
+
+  const contactField = fields.get(
+    data.source === "Meeting" ? "Contact" : "Person",
+  )
+  if (contactField) {
+    await setRelation(data.id, contactField.id, clean(data.contactId))
+  }
+
+  const campaignField = fields.get("Campaign")
+  if (campaignField) {
+    const campaignId = clean(data.campaignId)
+    if (campaignId) await assertCampaignEntry(campaignId)
+    await setRelation(data.id, campaignField.id, campaignId)
+  }
+
+  await touchEntry(data.id)
+  return { id: data.id }
+}
 
 export const createInteractionFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => interactionInputSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    const { entryId, object } = await createEntry("Outreach")
-    const fields = await getFieldsByName(object.id)
-
-    const updates: Array<[string, string | null]> = [
-      ["Subject", data.title],
-      ["Date Sent", clean(data.date) ?? new Date().toISOString().slice(0, 10)],
-      ["Channel", clean(data.channel) ?? "Email"],
-      ["Status", clean(data.status) ?? "Sent"],
-      ["Owner", clean(data.owner)],
-      ["Notes", clean(data.notes)],
-      ["Content", clean(data.content)],
-    ]
-
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(entryId, field.id, value)
-    }
-
-    const companyField = fields.get("Company")
-    if (companyField) {
-      await setRelation(entryId, companyField.id, clean(data.companyId))
-    }
-
-    const personField = requireField(fields, "Person", "Outreach")
-    await setRelation(entryId, personField.id, clean(data.contactId))
-
-    const campaignField = fields.get("Campaign")
-    if (campaignField) {
-      const campaignId = clean(data.campaignId)
-      if (campaignId) await assertCampaignEntry(campaignId)
-      await setRelation(entryId, campaignField.id, campaignId)
-    }
-
-    return { id: entryId }
+    return createInteraction(data)
   })
 
 export const updateInteractionFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => interactionUpdateSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    const objectName = data.source === "Meeting" ? "Meeting" : "Outreach"
-    const object = await getObject(objectName)
-    await assertEntryInObject(data.id, object.id)
-    const fields = await getFieldsByName(object.id)
-
-    const updates: Array<[string, string | null]> =
-      data.source === "Meeting"
-        ? [
-            ["Title", data.title],
-            ["Date", clean(data.date)],
-            ["Type", clean(data.channel)],
-            ["Status", clean(data.status)],
-            ["Notes", clean(data.notes)],
-            ["Outcome", clean(data.content)],
-          ]
-        : [
-            ["Subject", data.title],
-            ["Date Sent", clean(data.date)],
-            ["Channel", clean(data.channel)],
-            ["Status", clean(data.status)],
-            ["Owner", clean(data.owner)],
-            ["Notes", clean(data.notes)],
-            ["Content", clean(data.content)],
-          ]
-
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(data.id, field.id, value)
-    }
-
-    const companyField = fields.get("Company")
-    if (companyField) {
-      await setRelation(data.id, companyField.id, clean(data.companyId))
-    }
-
-    const contactField = fields.get(
-      data.source === "Meeting" ? "Contact" : "Person",
-    )
-    if (contactField) {
-      await setRelation(data.id, contactField.id, clean(data.contactId))
-    }
-
-    const campaignField = fields.get("Campaign")
-    if (campaignField) {
-      const campaignId = clean(data.campaignId)
-      if (campaignId) await assertCampaignEntry(campaignId)
-      await setRelation(data.id, campaignField.id, campaignId)
-    }
-
-    await touchEntry(data.id)
-    return { id: data.id }
+    return updateInteraction(data)
   })
+
+export async function createCampaign(
+  data: z.infer<typeof campaignInputSchema>,
+) {
+  await ensureCampaignSchema()
+  const { entryId, object } = await createEntry("Campaign")
+  const fields = await getFieldsByName(object.id)
+
+  const updates: Array<[string, string | null]> = [
+    ["Campaign Name", data.name],
+    ["Status", clean(data.status) ?? "Planning"],
+    ["Owner", clean(data.owner) ?? "Ian"],
+    ["Goal", clean(data.goal)],
+    ["Start Date", clean(data.startDate)],
+    ["End Date", clean(data.endDate)],
+  ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(entryId, field.id, value)
+  }
+
+  const audienceGymsField = requireField(fields, "Audience Gyms", "Campaign")
+  await setRelations(entryId, audienceGymsField.id, data.audienceGymIds)
+
+  const audienceContactsField = requireField(
+    fields,
+    "Audience Contacts",
+    "Campaign",
+  )
+  await setRelations(entryId, audienceContactsField.id, data.audienceContactIds)
+
+  return { id: entryId }
+}
+
+export async function updateCampaign(
+  data: z.infer<typeof campaignUpdateSchema>,
+) {
+  await ensureCampaignSchema()
+  await assertCampaignEntry(data.id)
+
+  const campaignObject = await getObject("Campaign")
+  const fields = await getFieldsByName(campaignObject.id)
+
+  const updates: Array<[string, string | null]> = [
+    ["Campaign Name", data.name],
+    ["Status", clean(data.status)],
+    ["Owner", clean(data.owner)],
+    ["Goal", clean(data.goal)],
+    ["Start Date", clean(data.startDate)],
+    ["End Date", clean(data.endDate)],
+  ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(data.id, field.id, value)
+  }
+
+  await touchEntry(data.id)
+  return { id: data.id }
+}
+
+export async function updateCampaignAudience(
+  data: z.infer<typeof campaignAudienceUpdateSchema>,
+) {
+  await ensureCampaignSchema()
+  await assertCampaignEntry(data.campaignId)
+  await assertEntriesInObject(data.audienceGymIds, "Company")
+  await assertEntriesInObject(data.audienceContactIds, "People")
+
+  const campaignObject = await getObject("Campaign")
+  const fields = await getFieldsByName(campaignObject.id)
+  const audienceGymsField = requireField(fields, "Audience Gyms", "Campaign")
+  const audienceContactsField = requireField(
+    fields,
+    "Audience Contacts",
+    "Campaign",
+  )
+
+  await setRelations(data.campaignId, audienceGymsField.id, data.audienceGymIds)
+  await setRelations(
+    data.campaignId,
+    audienceContactsField.id,
+    data.audienceContactIds,
+  )
+  await touchEntry(data.campaignId)
+
+  return { id: data.campaignId }
+}
+
+export async function createCampaignTouch(
+  data: z.infer<typeof campaignTouchInputSchema>,
+) {
+  await ensureCampaignSchema()
+  const { entryId, object } = await createEntry("Outreach")
+  const fields = await getFieldsByName(object.id)
+
+  const updates: Array<[string, string | null]> = [
+    ["Subject", data.title],
+    ["Date Sent", clean(data.dueDate)],
+    ["Channel", clean(data.channel) ?? "Email"],
+    ["Owner", clean(data.owner) ?? "Ian"],
+    ["Status", clean(data.status) ?? "Planned"],
+    ["Notes", clean(data.notes)],
+    ["Content", clean(data.content)],
+  ]
+
+  for (const [fieldName, value] of updates) {
+    const field = fields.get(fieldName)
+    if (field) await upsertFieldValue(entryId, field.id, value)
+  }
+
+  const campaignField = requireField(fields, "Campaign", "Outreach")
+  await assertCampaignEntry(data.campaignId)
+  await setRelation(entryId, campaignField.id, data.campaignId)
+
+  const companyField = fields.get("Company")
+  if (companyField) {
+    const companyId = clean(data.companyId)
+    if (companyId) await assertEntriesInObject([companyId], "Company")
+    await setRelation(entryId, companyField.id, companyId)
+  }
+
+  const personField = fields.get("Person")
+  if (personField) {
+    const contactId = clean(data.contactId)
+    if (contactId) await assertEntriesInObject([contactId], "People")
+    await setRelation(entryId, personField.id, contactId)
+  }
+
+  return { id: entryId }
+}
+
+export async function deleteGym(data: z.infer<typeof deleteCrmEntrySchema>) {
+  return deleteEntryFromObject(data.id, "Company")
+}
+
+export async function deleteContact(
+  data: z.infer<typeof deleteCrmEntrySchema>,
+) {
+  return deleteEntryFromObject(data.id, "People")
+}
+
+export async function deleteInteraction(
+  data: z.infer<typeof deleteCrmEntrySchema>,
+) {
+  const db = getDb()
+  const [entry] = await db
+    .select({
+      id: entriesTable.id,
+      objectName: objectsTable.name,
+    })
+    .from(entriesTable)
+    .innerJoin(objectsTable, eq(entriesTable.objectId, objectsTable.id))
+    .where(eq(entriesTable.id, data.id))
+    .limit(1)
+
+  if (!entry || !["Meeting", "Outreach"].includes(entry.objectName)) {
+    throw new Error(`CRM interaction not found: ${data.id}`)
+  }
+
+  await deleteDocumentsForEntries([data.id])
+  await db.delete(entriesTable).where(eq(entriesTable.id, data.id))
+  return { id: data.id, deleted: true }
+}
+
+export async function deleteCampaign(
+  data: z.infer<typeof deleteCrmEntrySchema>,
+) {
+  return deleteEntryFromObject(data.id, "Campaign")
+}
 
 // `@lat`: [[crm-campaigns]]
 export const createCampaignFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => campaignInputSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    await ensureCampaignSchema()
-    const { entryId, object } = await createEntry("Campaign")
-    const fields = await getFieldsByName(object.id)
-
-    const updates: Array<[string, string | null]> = [
-      ["Campaign Name", data.name],
-      ["Status", clean(data.status) ?? "Planning"],
-      ["Owner", clean(data.owner) ?? "Ian"],
-      ["Goal", clean(data.goal)],
-      ["Start Date", clean(data.startDate)],
-      ["End Date", clean(data.endDate)],
-    ]
-
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(entryId, field.id, value)
-    }
-
-    const audienceGymsField = requireField(fields, "Audience Gyms", "Campaign")
-    await setRelations(entryId, audienceGymsField.id, data.audienceGymIds)
-
-    const audienceContactsField = requireField(
-      fields,
-      "Audience Contacts",
-      "Campaign",
-    )
-    await setRelations(
-      entryId,
-      audienceContactsField.id,
-      data.audienceContactIds,
-    )
-
-    return { id: entryId }
+    return createCampaign(data)
   })
 
 export const updateCampaignFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => campaignUpdateSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    await ensureCampaignSchema()
-    await assertCampaignEntry(data.id)
-
-    const campaignObject = await getObject("Campaign")
-    const fields = await getFieldsByName(campaignObject.id)
-
-    const updates: Array<[string, string | null]> = [
-      ["Campaign Name", data.name],
-      ["Status", clean(data.status)],
-      ["Owner", clean(data.owner)],
-      ["Goal", clean(data.goal)],
-      ["Start Date", clean(data.startDate)],
-      ["End Date", clean(data.endDate)],
-    ]
-
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(data.id, field.id, value)
-    }
-
-    await touchEntry(data.id)
-    return { id: data.id }
+    return updateCampaign(data)
   })
 
 // `@lat`: [[crm-campaigns]]
@@ -1302,33 +1500,7 @@ export const updateCampaignAudienceFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => campaignAudienceUpdateSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    await ensureCampaignSchema()
-    await assertCampaignEntry(data.campaignId)
-    await assertEntriesInObject(data.audienceGymIds, "Company")
-    await assertEntriesInObject(data.audienceContactIds, "People")
-
-    const campaignObject = await getObject("Campaign")
-    const fields = await getFieldsByName(campaignObject.id)
-    const audienceGymsField = requireField(fields, "Audience Gyms", "Campaign")
-    const audienceContactsField = requireField(
-      fields,
-      "Audience Contacts",
-      "Campaign",
-    )
-
-    await setRelations(
-      data.campaignId,
-      audienceGymsField.id,
-      data.audienceGymIds,
-    )
-    await setRelations(
-      data.campaignId,
-      audienceContactsField.id,
-      data.audienceContactIds,
-    )
-    await touchEntry(data.campaignId)
-
-    return { id: data.campaignId }
+    return updateCampaignAudience(data)
   })
 
 // `@lat`: [[crm-campaigns]]
@@ -1336,44 +1508,35 @@ export const createCampaignTouchFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => campaignTouchInputSchema.parse(data))
   .handler(async ({ data }) => {
     await requireAuth()
-    await ensureCampaignSchema()
-    const { entryId, object } = await createEntry("Outreach")
-    const fields = await getFieldsByName(object.id)
+    return createCampaignTouch(data)
+  })
 
-    const updates: Array<[string, string | null]> = [
-      ["Subject", data.title],
-      ["Date Sent", clean(data.dueDate)],
-      ["Channel", clean(data.channel) ?? "Email"],
-      ["Owner", clean(data.owner) ?? "Ian"],
-      ["Status", clean(data.status) ?? "Planned"],
-      ["Notes", clean(data.notes)],
-      ["Content", clean(data.content)],
-    ]
+export const deleteGymFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => deleteCrmEntrySchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    return deleteGym(data)
+  })
 
-    for (const [fieldName, value] of updates) {
-      const field = fields.get(fieldName)
-      if (field) await upsertFieldValue(entryId, field.id, value)
-    }
+export const deleteContactFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => deleteCrmEntrySchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    return deleteContact(data)
+  })
 
-    const campaignField = requireField(fields, "Campaign", "Outreach")
-    await assertCampaignEntry(data.campaignId)
-    await setRelation(entryId, campaignField.id, data.campaignId)
+export const deleteInteractionFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => deleteCrmEntrySchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    return deleteInteraction(data)
+  })
 
-    const companyField = fields.get("Company")
-    if (companyField) {
-      const companyId = clean(data.companyId)
-      if (companyId) await assertEntriesInObject([companyId], "Company")
-      await setRelation(entryId, companyField.id, companyId)
-    }
-
-    const personField = fields.get("Person")
-    if (personField) {
-      const contactId = clean(data.contactId)
-      if (contactId) await assertEntriesInObject([contactId], "People")
-      await setRelation(entryId, personField.id, contactId)
-    }
-
-    return { id: entryId }
+export const deleteCampaignFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => deleteCrmEntrySchema.parse(data))
+  .handler(async ({ data }) => {
+    await requireAuth()
+    return deleteCampaign(data)
   })
 
 export const listDocumentsForEntryFn = createServerFn({ method: "GET" })

--- a/apps/crm/src/server.ts
+++ b/apps/crm/src/server.ts
@@ -1,45 +1,4 @@
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry"
-import { CrmMcp } from "@/mcp"
-import { SESSION_COOKIE, verifySessionToken } from "@/server-fns/auth"
-
-export { CrmMcp }
-
-// `@lat`: [[auth]]
-function getCookieValue(request: Request, name: string) {
-  const cookie = request.headers.get("Cookie")
-  if (!cookie) return null
-
-  for (const part of cookie.split(";")) {
-    const [key, ...valueParts] = part.trim().split("=")
-    if (key !== name) continue
-
-    try {
-      return decodeURIComponent(valueParts.join("="))
-    } catch {
-      return null
-    }
-  }
-
-  return null
-}
-
-// `@lat`: [[auth]]
-function getBearerToken(request: Request) {
-  const authorization = request.headers.get("Authorization")
-  const match = authorization?.match(/^Bearer\s+(.+)$/i)
-  return match?.[1] ?? null
-}
-
-// `@lat`: [[auth]]
-async function isMcpAuthenticated(request: Request) {
-  const bearerToken = getBearerToken(request)
-  if (bearerToken && (await verifySessionToken(bearerToken))) {
-    return true
-  }
-
-  const cookieToken = getCookieValue(request, SESSION_COOKIE)
-  return cookieToken ? verifySessionToken(cookieToken) : false
-}
 
 const startEntry = createServerEntry({
   fetch(request) {
@@ -48,21 +7,7 @@ const startEntry = createServerEntry({
 })
 
 export default {
-  async fetch(request: Request, env: Cloudflare.Env, ctx: ExecutionContext) {
-    const url = new URL(request.url)
-    if (url.pathname === "/mcp") {
-      // `@lat`: [[auth]]
-      if (!(await isMcpAuthenticated(request))) {
-        return new Response("Unauthorized", { status: 401 })
-      }
-
-      return CrmMcp.serve("/mcp", { binding: "CRM_MCP" }).fetch(
-        request,
-        env,
-        ctx,
-      )
-    }
-
+  fetch(request: Request) {
     return startEntry.fetch(request)
   },
 }

--- a/apps/crm/src/server.ts
+++ b/apps/crm/src/server.ts
@@ -4,28 +4,41 @@ import { SESSION_COOKIE, verifySessionToken } from "@/server-fns/auth"
 
 export { CrmMcp }
 
+// `@lat`: [[auth]]
 function getCookieValue(request: Request, name: string) {
   const cookie = request.headers.get("Cookie")
   if (!cookie) return null
 
   for (const part of cookie.split(";")) {
     const [key, ...valueParts] = part.trim().split("=")
-    if (key === name) return decodeURIComponent(valueParts.join("="))
+    if (key !== name) continue
+
+    try {
+      return decodeURIComponent(valueParts.join("="))
+    } catch {
+      return null
+    }
   }
 
   return null
 }
 
+// `@lat`: [[auth]]
 function getBearerToken(request: Request) {
   const authorization = request.headers.get("Authorization")
   const match = authorization?.match(/^Bearer\s+(.+)$/i)
   return match?.[1] ?? null
 }
 
+// `@lat`: [[auth]]
 async function isMcpAuthenticated(request: Request) {
-  const token =
-    getBearerToken(request) ?? getCookieValue(request, SESSION_COOKIE)
-  return token ? verifySessionToken(token) : false
+  const bearerToken = getBearerToken(request)
+  if (bearerToken && (await verifySessionToken(bearerToken))) {
+    return true
+  }
+
+  const cookieToken = getCookieValue(request, SESSION_COOKIE)
+  return cookieToken ? verifySessionToken(cookieToken) : false
 }
 
 const startEntry = createServerEntry({
@@ -38,6 +51,7 @@ export default {
   async fetch(request: Request, env: Cloudflare.Env, ctx: ExecutionContext) {
     const url = new URL(request.url)
     if (url.pathname === "/mcp") {
+      // `@lat`: [[auth]]
       if (!(await isMcpAuthenticated(request))) {
         return new Response("Unauthorized", { status: 401 })
       }

--- a/apps/crm/src/server.ts
+++ b/apps/crm/src/server.ts
@@ -1,4 +1,32 @@
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry"
+import { CrmMcp } from "@/mcp"
+import { SESSION_COOKIE, verifySessionToken } from "@/server-fns/auth"
+
+export { CrmMcp }
+
+function getCookieValue(request: Request, name: string) {
+  const cookie = request.headers.get("Cookie")
+  if (!cookie) return null
+
+  for (const part of cookie.split(";")) {
+    const [key, ...valueParts] = part.trim().split("=")
+    if (key === name) return decodeURIComponent(valueParts.join("="))
+  }
+
+  return null
+}
+
+function getBearerToken(request: Request) {
+  const authorization = request.headers.get("Authorization")
+  const match = authorization?.match(/^Bearer\s+(.+)$/i)
+  return match?.[1] ?? null
+}
+
+async function isMcpAuthenticated(request: Request) {
+  const token =
+    getBearerToken(request) ?? getCookieValue(request, SESSION_COOKIE)
+  return token ? verifySessionToken(token) : false
+}
 
 const startEntry = createServerEntry({
   fetch(request) {
@@ -7,5 +35,20 @@ const startEntry = createServerEntry({
 })
 
 export default {
-  fetch: startEntry.fetch,
+  async fetch(request: Request, env: Cloudflare.Env, ctx: ExecutionContext) {
+    const url = new URL(request.url)
+    if (url.pathname === "/mcp") {
+      if (!(await isMcpAuthenticated(request))) {
+        return new Response("Unauthorized", { status: 401 })
+      }
+
+      return CrmMcp.serve("/mcp", { binding: "CRM_MCP" }).fetch(
+        request,
+        env,
+        ctx,
+      )
+    }
+
+    return startEntry.fetch(request)
+  },
 }

--- a/apps/crm/wrangler.jsonc
+++ b/apps/crm/wrangler.jsonc
@@ -15,6 +15,22 @@
 	"placement": {
 		"mode": "smart"
 	},
+	"durable_objects": {
+		"bindings": [
+			{
+				"name": "CRM_MCP",
+				"class_name": "CrmMcp"
+			}
+		]
+	},
+	"migrations": [
+		{
+			"tag": "v1",
+			"new_sqlite_classes": [
+				"CrmMcp"
+			]
+		}
+	],
 	"vars": {
 		"APP_URL": "http://localhost:3001"
 	},

--- a/apps/crm/wrangler.jsonc
+++ b/apps/crm/wrangler.jsonc
@@ -2,7 +2,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"account_id": "317fb84f366ea1ab038ca90000953697",
 	"name": "crm",
-	"main": "src/server.ts",
+	"main": "@tanstack/react-start/server-entry",
 	"compatibility_date": "2025-09-02",
 	"compatibility_flags": [
 		"nodejs_compat",
@@ -15,22 +15,6 @@
 	"placement": {
 		"mode": "smart"
 	},
-	"durable_objects": {
-		"bindings": [
-			{
-				"name": "CRM_MCP",
-				"class_name": "CrmMcp"
-			}
-		]
-	},
-	"migrations": [
-		{
-			"tag": "v1",
-			"new_sqlite_classes": [
-				"CrmMcp"
-			]
-		}
-	],
 	"vars": {
 		"APP_URL": "http://localhost:3001"
 	},

--- a/apps/crm/wrangler.jsonc
+++ b/apps/crm/wrangler.jsonc
@@ -2,7 +2,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"account_id": "317fb84f366ea1ab038ca90000953697",
 	"name": "crm",
-	"main": "@tanstack/react-start/server-entry",
+	"main": "src/server.ts",
 	"compatibility_date": "2025-09-02",
 	"compatibility_flags": [
 		"nodejs_compat",

--- a/apps/wodsmith-code-mode-mcp/.dev.vars.example
+++ b/apps/wodsmith-code-mode-mcp/.dev.vars.example
@@ -1,0 +1,2 @@
+# Local development uses wrangler.jsonc bindings. No .dev.vars values are
+# required for the Code Mode MCP worker by default.

--- a/apps/wodsmith-code-mode-mcp/alchemy.run.ts
+++ b/apps/wodsmith-code-mode-mcp/alchemy.run.ts
@@ -1,0 +1,57 @@
+import alchemy from "alchemy"
+import {
+  KVNamespace,
+  Worker,
+  WorkerLoader,
+  WorkerRef,
+} from "alchemy/cloudflare"
+import { CloudflareStateStore } from "alchemy/state"
+import type { WodsmithOperationsService } from "./src/types"
+
+const stage = process.env.STAGE ?? "dev"
+
+const app = await alchemy("wodsmith-code-mode-mcp", {
+  stage,
+  phase: process.argv.includes("--destroy") ? "destroy" : "up",
+  stateStore: process.env.CI
+    ? (scope) => new CloudflareStateStore(scope)
+    : undefined,
+})
+
+const kvSession = await KVNamespace("wodsmith-sessions", {
+  title: `wodsmith-wodsmith-sessions-${stage}`,
+  adopt: true,
+  delete: false,
+})
+
+function getWodsmithServiceName(currentStage: string): string {
+  return process.env.WODSMITH_APP_WORKER ?? `wodsmith-app-${currentStage}`
+}
+
+function getDomains(currentStage: string): string[] | undefined {
+  if (currentStage === "prod") return ["mcp.wodsmith.com"]
+  if (currentStage === "demo") return ["mcp.demo.wodsmith.com"]
+  return undefined
+}
+
+const worker = await Worker("app", {
+  name: `wodsmith-code-mode-mcp-${stage}`,
+  entrypoint: "./src/index.ts",
+  compatibilityDate: "2025-12-17",
+  compatibilityFlags: ["nodejs_compat"],
+  bindings: {
+    KV_SESSION: kvSession,
+    MCP_CODE_LOADER: WorkerLoader(),
+    WODSMITH_APP: Worker.experimentalEntrypoint<WodsmithOperationsService>(
+      WorkerRef({ service: getWodsmithServiceName(stage) }),
+      "WodsmithMcpOperations",
+    ),
+  },
+  domains: getDomains(stage),
+  adopt: true,
+})
+
+export type Env = typeof worker.Env
+export default worker
+
+await app.finalize()

--- a/apps/wodsmith-code-mode-mcp/alchemy.run.ts
+++ b/apps/wodsmith-code-mode-mcp/alchemy.run.ts
@@ -34,6 +34,14 @@ function getDomains(currentStage: string): string[] | undefined {
   return undefined
 }
 
+function getAuthorizationServerUrl(currentStage: string): string {
+  if (process.env.WODSMITH_AUTHORIZATION_SERVER_URL) {
+    return process.env.WODSMITH_AUTHORIZATION_SERVER_URL
+  }
+  if (currentStage === "demo") return "https://demo.wodsmith.com"
+  return "https://wodsmith.com"
+}
+
 const worker = await Worker("app", {
   name: `wodsmith-code-mode-mcp-${stage}`,
   entrypoint: "./src/index.ts",
@@ -46,6 +54,7 @@ const worker = await Worker("app", {
       WorkerRef({ service: getWodsmithServiceName(stage) }),
       "WodsmithMcpOperations",
     ),
+    WODSMITH_AUTHORIZATION_SERVER_URL: getAuthorizationServerUrl(stage),
   },
   domains: getDomains(stage),
   adopt: true,

--- a/apps/wodsmith-code-mode-mcp/package.json
+++ b/apps/wodsmith-code-mode-mcp/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "wodsmith-code-mode-mcp",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev --config wrangler.jsonc --port 8788 --local --persist-to ../wodsmith-start/.alchemy/local/.wrangler/state",
+    "deploy": "bun alchemy.run.ts",
+    "deploy:staging": "STAGE=staging bun alchemy.run.ts",
+    "deploy:destroy": "bun alchemy.run.ts --destroy",
+    "test": "vitest run",
+    "type-check": "tsc --noEmit",
+    "cf-typegen": "wrangler types"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "agents": "^0.12.4",
+    "alchemy": "catalog:",
+    "zod": "^4.2.1"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "2.0.6",
+    "@cloudflare/workers-types": "^4.20250508.0",
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "^5.8.3",
+    "vitest": "^3.0.5",
+    "wrangler": "^4.56.0"
+  }
+}

--- a/apps/wodsmith-code-mode-mcp/src/auth.ts
+++ b/apps/wodsmith-code-mode-mcp/src/auth.ts
@@ -1,0 +1,140 @@
+import type {
+  AuthenticatedMcpSession,
+  KVSession,
+  SessionCredential,
+} from "./types"
+
+const SESSION_COOKIE_NAME = "session"
+const SESSION_PREFIX = "session:"
+
+type SessionTokenParts = {
+  userId: string
+  token: string
+}
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  )
+}
+
+async function generateSessionId(token: string): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(token),
+  )
+  return toHex(new Uint8Array(hashBuffer))
+}
+
+function getSessionKey(userId: string, sessionId: string): string {
+  return `${SESSION_PREFIX}${userId}:${sessionId}`
+}
+
+function decodeSessionToken(value: string): SessionTokenParts | null {
+  const colonIdx = value.indexOf(":")
+  if (colonIdx < 1) return null
+
+  const userId = value.slice(0, colonIdx)
+  const token = value.slice(colonIdx + 1)
+  if (!userId || !token) return null
+
+  return { userId, token }
+}
+
+function getCookieFromHeader(
+  cookieHeader: string | null,
+  name: string,
+): string | null {
+  if (!cookieHeader) return null
+
+  const prefix = `${name}=`
+  for (const part of cookieHeader.split(";")) {
+    const trimmed = part.trim()
+    if (!trimmed.startsWith(prefix)) continue
+    const value = trimmed.slice(prefix.length)
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  }
+
+  return null
+}
+
+async function validateSessionToken(
+  env: Env,
+  parts: SessionTokenParts,
+): Promise<{ sessionId: string; session: KVSession } | null> {
+  const sessionId = await generateSessionId(parts.token)
+  const sessionStr = await env.KV_SESSION.get(
+    getSessionKey(parts.userId, sessionId),
+  )
+  if (!sessionStr) return null
+
+  const session = JSON.parse(sessionStr) as KVSession
+  if (Date.now() >= session.expiresAt) {
+    await env.KV_SESSION.delete(getSessionKey(parts.userId, sessionId))
+    return null
+  }
+
+  if (session.userId !== parts.userId) return null
+
+  return { sessionId, session }
+}
+
+function getBearerCredential(request: Request): {
+  credential: SessionCredential
+  parts: SessionTokenParts
+} | null {
+  const authorization = request.headers.get("Authorization")
+  if (!authorization?.startsWith("Bearer ")) return null
+
+  const value = authorization.slice("Bearer ".length).trim()
+  const parts = decodeSessionToken(value)
+  if (!parts) return null
+
+  return {
+    credential: { kind: "bearer", authorization: `Bearer ${value}` },
+    parts,
+  }
+}
+
+function getCookieCredential(request: Request): {
+  credential: SessionCredential
+  parts: SessionTokenParts
+} | null {
+  const cookie = request.headers.get("Cookie")
+  const value = getCookieFromHeader(cookie, SESSION_COOKIE_NAME)
+  if (!cookie || !value) return null
+
+  const parts = decodeSessionToken(value)
+  if (!parts) return null
+
+  return {
+    credential: { kind: "cookie", cookie },
+    parts,
+  }
+}
+
+export async function authenticateMcpRequest(
+  request: Request,
+  env: Env,
+): Promise<AuthenticatedMcpSession | null> {
+  const candidate = getBearerCredential(request) ?? getCookieCredential(request)
+  if (!candidate) return null
+
+  const validated = await validateSessionToken(env, candidate.parts)
+  if (!validated) return null
+
+  return {
+    userId: candidate.parts.userId,
+    sessionId: validated.sessionId,
+    session: validated.session,
+    credential: candidate.credential,
+  }
+}
+
+export function unauthorizedResponse(): Response {
+  return Response.json({ error: "Unauthorized" }, { status: 401 })
+}

--- a/apps/wodsmith-code-mode-mcp/src/auth.ts
+++ b/apps/wodsmith-code-mode-mcp/src/auth.ts
@@ -136,5 +136,14 @@ export async function authenticateMcpRequest(
 }
 
 export function unauthorizedResponse(): Response {
-  return Response.json({ error: "Unauthorized" }, { status: 401 })
+  return Response.json(
+    { error: "Unauthorized" },
+    {
+      status: 401,
+      headers: {
+        "WWW-Authenticate":
+          'Bearer error="invalid_token", error_description="Missing or invalid OAuth access token"',
+      },
+    },
+  )
 }

--- a/apps/wodsmith-code-mode-mcp/src/env.d.ts
+++ b/apps/wodsmith-code-mode-mcp/src/env.d.ts
@@ -5,7 +5,6 @@ declare global {
     KV_SESSION: KVNamespace
     MCP_CODE_LOADER: WorkerLoader
     WODSMITH_APP: Service<WodsmithOperationsService>
+    WODSMITH_AUTHORIZATION_SERVER_URL?: string
   }
 }
-
-export {}

--- a/apps/wodsmith-code-mode-mcp/src/env.d.ts
+++ b/apps/wodsmith-code-mode-mcp/src/env.d.ts
@@ -1,0 +1,11 @@
+import type { WodsmithOperationsService } from "./types"
+
+declare global {
+  interface Env {
+    KV_SESSION: KVNamespace
+    MCP_CODE_LOADER: WorkerLoader
+    WODSMITH_APP: Service<WodsmithOperationsService>
+  }
+}
+
+export {}

--- a/apps/wodsmith-code-mode-mcp/src/index.ts
+++ b/apps/wodsmith-code-mode-mcp/src/index.ts
@@ -1,6 +1,7 @@
 import { WorkerEntrypoint } from "cloudflare:workers"
 import { handleMcpRequest } from "./mcp/handler"
 import { handleMcpOperationOutbound } from "./mcp/outbound"
+import { protectedResourceMetadata } from "./oauth-resource"
 import type { SessionCredential } from "./types"
 
 function isMcpPath(pathname: string): boolean {
@@ -27,6 +28,13 @@ export default {
     ctx: ExecutionContext,
   ): Promise<Response> {
     const url = new URL(request.url)
+    if (
+      url.pathname === "/.well-known/oauth-protected-resource" &&
+      request.method === "GET"
+    ) {
+      return protectedResourceMetadata(request, env)
+    }
+
     if (isMcpPath(url.pathname)) {
       return handleMcpRequest(request, env, ctx)
     }

--- a/apps/wodsmith-code-mode-mcp/src/index.ts
+++ b/apps/wodsmith-code-mode-mcp/src/index.ts
@@ -1,0 +1,42 @@
+import { WorkerEntrypoint } from "cloudflare:workers"
+import { handleMcpRequest } from "./mcp/handler"
+import { handleMcpOperationOutbound } from "./mcp/outbound"
+import type { SessionCredential } from "./types"
+
+function isMcpPath(pathname: string): boolean {
+  return pathname === "/mcp" || pathname === "/api/mcp"
+}
+
+export class WodsmithCodeModeOutbound extends WorkerEntrypoint<
+  Env,
+  { credential: SessionCredential }
+> {
+  async fetch(request: Request): Promise<Response> {
+    return handleMcpOperationOutbound(
+      request,
+      this.env,
+      this.ctx.props.credential,
+    )
+  }
+}
+
+export default {
+  async fetch(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext,
+  ): Promise<Response> {
+    const url = new URL(request.url)
+    if (isMcpPath(url.pathname)) {
+      return handleMcpRequest(request, env, ctx)
+    }
+
+    if (url.pathname === "/" && request.method === "GET") {
+      return new Response("WODsmith Code Mode MCP", {
+        headers: { "Content-Type": "text/plain" },
+      })
+    }
+
+    return new Response("Not Found", { status: 404 })
+  },
+} satisfies ExportedHandler<Env>

--- a/apps/wodsmith-code-mode-mcp/src/mcp/executor.ts
+++ b/apps/wodsmith-code-mode-mcp/src/mcp/executor.ts
@@ -1,0 +1,199 @@
+import type { CompetitionOperationSpec, SessionCredential } from "../types"
+
+interface ExecutorEntrypoint {
+  evaluate(): Promise<{ result: unknown; err?: string; stack?: string }>
+}
+
+type ExecutionContextWithMcpExports = ExecutionContext & {
+  exports?: {
+    WodsmithCodeModeOutbound?: (options: {
+      props: { credential: SessionCredential }
+    }) => Fetcher
+  }
+}
+
+const COMPATIBILITY_DATE = "2025-12-17"
+const INTERNAL_OPERATION_URL = "https://wodsmith-mcp.internal/operation"
+
+function getLoader(env: Env): WorkerLoader {
+  const loader = env.MCP_CODE_LOADER
+  if (!loader) {
+    throw new Error("MCP_CODE_LOADER binding is not configured")
+  }
+  return loader
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+const findOperationsSource = `
+function findOperations(query) {
+  const terms = String(query || "").toLowerCase().split(/\\s+/).filter(Boolean);
+  if (terms.length === 0) return operations;
+
+  return operations.filter((operation) => {
+    const haystack = [
+      operation.id,
+      operation.exportName,
+      operation.category,
+      operation.categoryTitle,
+      operation.mode,
+      operation.description,
+      operation.source,
+    ].join(" ").toLowerCase();
+
+    return terms.every((term) => haystack.includes(term));
+  });
+}
+`
+
+export function createSearchExecutor(
+  env: Env,
+  operationSpecs: CompetitionOperationSpec[],
+) {
+  return async (code: string): Promise<unknown> => {
+    const loader = getLoader(env)
+    const workerId = `wodsmith-mcp-search-${crypto.randomUUID()}`
+    const operationSpecJson = JSON.stringify(operationSpecs)
+
+    const worker = loader.get(workerId, () => ({
+      compatibilityDate: COMPATIBILITY_DATE,
+      globalOutbound: null,
+      mainModule: "worker.js",
+      modules: {
+        "worker.js": `
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+const operations = ${operationSpecJson};
+const categories = [...new Set(operations.map((operation) => operation.category))];
+const spec = { operations, categories };
+
+${findOperationsSource}
+
+export default class SearchExecutor extends WorkerEntrypoint {
+  async evaluate() {
+    try {
+      const result = await (${code})();
+      return { result, err: undefined };
+    } catch (err) {
+      return {
+        result: undefined,
+        err: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      };
+    }
+  }
+}
+        `,
+      },
+    }))
+
+    const entrypoint = worker.getEntrypoint() as unknown as ExecutorEntrypoint
+    const response = await entrypoint.evaluate()
+
+    if (response.err) {
+      throw new Error(response.err)
+    }
+
+    return response.result
+  }
+}
+
+export function createCodeExecutor(
+  env: Env,
+  ctx: ExecutionContext,
+  credential: SessionCredential,
+  operationSpecs: CompetitionOperationSpec[],
+) {
+  return async (code: string): Promise<unknown> => {
+    const loader = getLoader(env)
+    const workerId = `wodsmith-mcp-code-${crypto.randomUUID()}`
+    const operationSpecJson = JSON.stringify(operationSpecs)
+    const outbound = (
+      ctx as ExecutionContextWithMcpExports
+    ).exports?.WodsmithCodeModeOutbound?.({ props: { credential } })
+
+    if (!outbound) {
+      throw new Error("WodsmithCodeModeOutbound export is not available")
+    }
+
+    const worker = loader.get(workerId, () => ({
+      compatibilityDate: COMPATIBILITY_DATE,
+      globalOutbound: outbound,
+      mainModule: "worker.js",
+      modules: {
+        "worker.js": `
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+const operations = ${operationSpecJson};
+const categories = [...new Set(operations.map((operation) => operation.category))];
+const operationIds = new Set(operations.map((operation) => operation.id));
+
+${findOperationsSource}
+
+async function call(operation, input = {}) {
+  if (!operationIds.has(operation)) {
+    throw new Error("Unknown WODsmith operation: " + operation);
+  }
+
+  const response = await fetch(${JSON.stringify(INTERNAL_OPERATION_URL)}, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ operation, input }),
+  });
+
+  const text = await response.text();
+  let payload;
+  try {
+    payload = text ? JSON.parse(text) : {};
+  } catch {
+    payload = { error: text };
+  }
+
+  if (!response.ok) {
+    throw new Error(payload.error || "WODsmith operation failed with status " + response.status);
+  }
+
+  return payload.result;
+}
+
+const wodsmith = {
+  call,
+  operations,
+  categories,
+  findOperations,
+};
+
+export default class CodeExecutor extends WorkerEntrypoint {
+  async evaluate() {
+    try {
+      const result = await (${code})();
+      return { result, err: undefined };
+    } catch (err) {
+      return {
+        result: undefined,
+        err: err instanceof Error ? err.message : String(err),
+        stack: err instanceof Error ? err.stack : undefined,
+      };
+    }
+  }
+}
+        `,
+      },
+    }))
+
+    const entrypoint = worker.getEntrypoint() as unknown as ExecutorEntrypoint
+    const response = await entrypoint.evaluate()
+
+    if (response.err) {
+      throw new Error(response.err)
+    }
+
+    return response.result
+  }
+}
+
+export function toExecutorError(error: unknown): string {
+  return formatError(error)
+}

--- a/apps/wodsmith-code-mode-mcp/src/mcp/handler.ts
+++ b/apps/wodsmith-code-mode-mcp/src/mcp/handler.ts
@@ -1,0 +1,51 @@
+import { createMcpHandler } from "agents/mcp"
+import { authenticateMcpRequest, unauthorizedResponse } from "../auth"
+import type { CompetitionOperationSpec } from "../types"
+import { listCompetitionOperationSpecs } from "../wodsmith-service"
+import { createWodsmithMcpServer } from "./server"
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export async function handleMcpRequest(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const session = await authenticateMcpRequest(request, env)
+  if (!session) return unauthorizedResponse()
+
+  let operationSpecs: CompetitionOperationSpec[]
+  try {
+    operationSpecs = await listCompetitionOperationSpecs(env)
+  } catch (error) {
+    console.error("[MCP] Failed to load WODsmith operation catalog", error)
+    return Response.json(
+      {
+        error: `Failed to load WODsmith operation catalog: ${errorMessage(error)}`,
+      },
+      { status: 502 },
+    )
+  }
+
+  const server = createWodsmithMcpServer(env, ctx, session, operationSpecs)
+  const route = new URL(request.url).pathname
+  const handler = createMcpHandler(server, {
+    route,
+    sessionIdGenerator: undefined,
+    enableJsonResponse: true,
+    authContext: {
+      props: {
+        userId: session.userId,
+        sessionId: session.sessionId,
+      },
+    },
+  })
+
+  try {
+    return await handler(request, env, ctx)
+  } finally {
+    await server.close().catch(() => {})
+  }
+}

--- a/apps/wodsmith-code-mode-mcp/src/mcp/outbound.ts
+++ b/apps/wodsmith-code-mode-mcp/src/mcp/outbound.ts
@@ -1,0 +1,81 @@
+import type { SessionCredential } from "../types"
+import { callCompetitionOperation } from "../wodsmith-service"
+
+const INTERNAL_HOSTNAME = "wodsmith-mcp.internal"
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function json(value: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(value), {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  })
+}
+
+export async function handleMcpOperationOutbound(
+  request: Request,
+  env: Env,
+  credential: SessionCredential,
+): Promise<Response> {
+  const url = new URL(request.url)
+  if (url.hostname !== INTERNAL_HOSTNAME || url.pathname !== "/operation") {
+    return json(
+      { error: `Forbidden outbound request: ${url.hostname}${url.pathname}` },
+      { status: 403 },
+    )
+  }
+
+  if (request.method !== "POST") {
+    return json({ error: "Method not allowed" }, { status: 405 })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return json({ error: "Invalid JSON body" }, { status: 400 })
+  }
+
+  if (!body || typeof body !== "object") {
+    return json({ error: "Request body must be an object" }, { status: 400 })
+  }
+
+  const { operation, input } = body as {
+    operation?: unknown
+    input?: unknown
+  }
+
+  if (typeof operation !== "string" || operation.length === 0) {
+    return json(
+      { error: "operation must be a non-empty string" },
+      { status: 400 },
+    )
+  }
+
+  try {
+    const result = await callCompetitionOperation(
+      env,
+      credential,
+      operation,
+      input ?? {},
+    )
+    return json({ result })
+  } catch (error) {
+    console.error("[MCP] Operation failed", error)
+    const message = errorMessage(error)
+    const status = message.startsWith("Unknown competition operation")
+      ? 404
+      : 500
+    return json(
+      {
+        error: message,
+      },
+      { status },
+    )
+  }
+}

--- a/apps/wodsmith-code-mode-mcp/src/mcp/outbound.ts
+++ b/apps/wodsmith-code-mode-mcp/src/mcp/outbound.ts
@@ -17,6 +17,24 @@ function json(value: unknown, init?: ResponseInit): Response {
   })
 }
 
+function describeValue(value: unknown): Record<string, unknown> {
+  if (value === null) return { type: "null" }
+  if (value === undefined) return { type: "undefined" }
+  if (Array.isArray(value)) return { type: "array", length: value.length }
+  if (value instanceof Response) {
+    return {
+      type: "response",
+      status: value.status,
+      contentType: value.headers.get("Content-Type"),
+      serialized: value.headers.has("x-tss-serialized"),
+    }
+  }
+  if (typeof value === "object") {
+    return { type: "object", keys: Object.keys(value).slice(0, 20) }
+  }
+  return { type: typeof value }
+}
+
 export async function handleMcpOperationOutbound(
   request: Request,
   env: Env,
@@ -58,12 +76,21 @@ export async function handleMcpOperationOutbound(
   }
 
   try {
+    console.info("[MCP outbound] Calling WODsmith operation", {
+      operation,
+      input: describeValue(input ?? {}),
+      credentialKind: credential.kind,
+    })
     const result = await callCompetitionOperation(
       env,
       credential,
       operation,
       input ?? {},
     )
+    console.info("[MCP outbound] WODsmith operation returned", {
+      operation,
+      result: describeValue(result),
+    })
     return json({ result })
   } catch (error) {
     console.error("[MCP] Operation failed", error)

--- a/apps/wodsmith-code-mode-mcp/src/mcp/server.ts
+++ b/apps/wodsmith-code-mode-mcp/src/mcp/server.ts
@@ -1,0 +1,200 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { z } from "zod"
+import type {
+  AuthenticatedMcpSession,
+  CompetitionOperationSpec,
+} from "../types"
+import {
+  createCodeExecutor,
+  createSearchExecutor,
+  toExecutorError,
+} from "./executor"
+import { stringifyMcpResult, truncateMcpText } from "./truncate"
+
+const SERVER_INFO = {
+  name: "wodsmith-competition-code-mode",
+  version: "0.1.0",
+} as const
+
+const SEARCH_TYPES = `
+interface CompetitionOperation {
+  id: string;              // Pass this to wodsmith.call(operationId, input)
+  exportName: string;      // TanStack server function export
+  category: string;        // Functional area, e.g. "events", "schedule", "cohosts"
+  categoryTitle: string;
+  mode: "read" | "write";
+  source: string;          // Source file containing the server function
+  description: string;
+  input: string;
+}
+
+declare const operations: CompetitionOperation[];
+declare const categories: string[];
+declare const spec: { operations: CompetitionOperation[]; categories: string[] };
+declare function findOperations(query: string): CompetitionOperation[];
+`
+
+const EXECUTE_TYPES = `
+interface CompetitionOperation {
+  id: string;
+  exportName: string;
+  category: string;
+  categoryTitle: string;
+  mode: "read" | "write";
+  source: string;
+  description: string;
+  input: string;
+}
+
+declare const wodsmith: {
+  operations: CompetitionOperation[];
+  categories: string[];
+  findOperations(query: string): CompetitionOperation[];
+  call<T = unknown>(operationId: string, input?: unknown): Promise<T>;
+};
+`
+
+export function createWodsmithMcpServer(
+  env: Env,
+  ctx: ExecutionContext,
+  session: AuthenticatedMcpSession,
+  operationSpecs: CompetitionOperationSpec[],
+): McpServer {
+  const operationCount = operationSpecs.length
+  const categoryList = [
+    ...new Set(operationSpecs.map((operation) => operation.category)),
+  ]
+
+  const server = new McpServer(SERVER_INFO, {
+    instructions:
+      "Use Code Mode to manage WODsmith competitions. First call search to find operation ids, then call execute with JavaScript that uses wodsmith.call(operationId, input). Every call runs as the authenticated WODsmith user and is still gated by the app's organizer/cohost permissions.",
+  })
+
+  const executeSearch = createSearchExecutor(env, operationSpecs)
+  const executeCode = createCodeExecutor(
+    env,
+    ctx,
+    session.credential,
+    operationSpecs,
+  )
+
+  server.registerTool(
+    "search",
+    {
+      title: "Search WODsmith Competition Operations",
+      description: `Search the WODsmith competition operation catalog with JavaScript.
+
+The catalog currently exposes ${operationCount} operations across ${categoryList.length} categories:
+${categoryList.join(", ")}
+
+Available in your code:
+${SEARCH_TYPES}
+
+Your code must be an async arrow function that returns JSON-serializable data.
+
+Examples:
+
+// Find all heat scheduling operations
+async () => findOperations("heat schedule").map(({ id, mode, description }) => ({ id, mode, description }))
+
+// List write operations in the sponsors category
+async () => operations.filter((operation) => operation.category === "sponsors" && operation.mode === "write")
+
+// Inspect the source file for registration management operations
+async () => findOperations("manual registration transfer refund").map(({ id, source, exportName }) => ({ id, source, exportName }))`,
+      inputSchema: {
+        code: z
+          .string()
+          .min(1)
+          .describe("JavaScript async arrow function to search the catalog"),
+      },
+    },
+    async ({ code }) => {
+      try {
+        const result = await executeSearch(code)
+        return {
+          content: [
+            {
+              type: "text",
+              text: truncateMcpText(stringifyMcpResult(result)),
+            },
+          ],
+        }
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${toExecutorError(error)}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  server.registerTool(
+    "execute",
+    {
+      title: "Execute WODsmith Competition Code",
+      description: `Execute JavaScript against WODsmith competition management operations. Use search first to find operation ids and expected source modules.
+
+Available in your code:
+${EXECUTE_TYPES}
+
+Your code must be an async arrow function that returns JSON-serializable data.
+
+Examples:
+
+// Read the core competition setup context
+async () => {
+  const competition = await wodsmith.call("competitionDetails.getCompetitionById", {
+    competitionId: "comp_123"
+  });
+  const divisions = await wodsmith.call("divisions.getCompetitionDivisionsWithCounts", {
+    competitionId: "comp_123",
+    teamId: competition.competition.organizingTeamId
+  });
+  const events = await wodsmith.call("events.getCompetitionWorkouts", {
+    competitionId: "comp_123",
+    teamId: competition.competition.organizingTeamId
+  });
+  return { competition, divisions, events };
+}
+
+// Create a sponsor group, then list sponsors
+async () => {
+  await wodsmith.call("sponsors.createSponsorGroup", {
+    competitionId: "comp_123",
+    name: "Gold Sponsors",
+    sortOrder: 0
+  });
+  return wodsmith.call("sponsors.getCompetitionSponsors", {
+    competitionId: "comp_123"
+  });
+}`,
+      inputSchema: {
+        code: z
+          .string()
+          .min(1)
+          .describe("JavaScript async arrow function to execute"),
+      },
+    },
+    async ({ code }) => {
+      try {
+        const result = await executeCode(code)
+        return {
+          content: [
+            {
+              type: "text",
+              text: truncateMcpText(stringifyMcpResult(result)),
+            },
+          ],
+        }
+      } catch (error) {
+        return {
+          content: [{ type: "text", text: `Error: ${toExecutorError(error)}` }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  return server
+}

--- a/apps/wodsmith-code-mode-mcp/src/mcp/truncate.ts
+++ b/apps/wodsmith-code-mode-mcp/src/mcp/truncate.ts
@@ -1,0 +1,22 @@
+const DEFAULT_MAX_CHARS = 24_000
+
+export function stringifyMcpResult(value: unknown): string {
+  if (typeof value === "string") return value
+
+  return JSON.stringify(
+    value,
+    (_key, innerValue) =>
+      typeof innerValue === "bigint" ? innerValue.toString() : innerValue,
+    2,
+  )
+}
+
+export function truncateMcpText(
+  text: string,
+  maxChars = DEFAULT_MAX_CHARS,
+): string {
+  if (text.length <= maxChars) return text
+
+  const omitted = text.length - maxChars
+  return `${text.slice(0, maxChars)}\n\n[truncated ${omitted} characters; refine your search or return fewer fields]`
+}

--- a/apps/wodsmith-code-mode-mcp/src/oauth-resource.ts
+++ b/apps/wodsmith-code-mode-mcp/src/oauth-resource.ts
@@ -1,0 +1,30 @@
+export function getAuthorizationServerUrl(request: Request, env: Env): string {
+  if (env.WODSMITH_AUTHORIZATION_SERVER_URL) {
+    return env.WODSMITH_AUTHORIZATION_SERVER_URL.replace(/\/$/, "")
+  }
+
+  const url = new URL(request.url)
+  if (url.hostname === "localhost" || url.hostname === "127.0.0.1") {
+    return "http://localhost:3000"
+  }
+
+  return "https://wodsmith.com"
+}
+
+export function protectedResourceMetadata(
+  request: Request,
+  env: Env,
+): Response {
+  const resource = new URL(request.url).origin
+  return Response.json(
+    {
+      resource,
+      authorization_servers: [getAuthorizationServerUrl(request, env)],
+    },
+    {
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  )
+}

--- a/apps/wodsmith-code-mode-mcp/src/types.ts
+++ b/apps/wodsmith-code-mode-mcp/src/types.ts
@@ -1,0 +1,60 @@
+export type SessionCredential =
+  | {
+      kind: "bearer"
+      authorization: string
+    }
+  | {
+      kind: "cookie"
+      cookie: string
+    }
+
+export interface KVSession {
+  id: string
+  userId: string
+  expiresAt: number
+  createdAt: number
+  user?: {
+    id: string
+    email?: string
+    firstName?: string | null
+    lastName?: string | null
+    role?: string
+  }
+  teams?: Array<{
+    id: string
+    name: string
+    slug: string
+    permissions: string[]
+  }>
+  authenticationType?: "passkey" | "password" | "google-oauth"
+  version?: number
+}
+
+export interface AuthenticatedMcpSession {
+  userId: string
+  sessionId: string
+  session: KVSession
+  credential: SessionCredential
+}
+
+export type CompetitionOperationMode = "read" | "write"
+
+export interface CompetitionOperationSpec {
+  id: string
+  exportName: string
+  category: string
+  categoryTitle: string
+  mode: CompetitionOperationMode
+  source: string
+  description: string
+  input: string
+}
+
+export interface WodsmithOperationsService extends Rpc.WorkerEntrypointBranded {
+  listCompetitionOperationSpecs(): Promise<CompetitionOperationSpec[]>
+  callCompetitionOperation(request: {
+    credential: SessionCredential
+    operation: string
+    input: unknown
+  }): Promise<unknown>
+}

--- a/apps/wodsmith-code-mode-mcp/src/wodsmith-service.ts
+++ b/apps/wodsmith-code-mode-mcp/src/wodsmith-service.ts
@@ -1,0 +1,32 @@
+import type {
+  CompetitionOperationSpec,
+  SessionCredential,
+  WodsmithOperationsService,
+} from "./types"
+
+function getWodsmithApp(env: Env): WodsmithOperationsService {
+  const app = env.WODSMITH_APP
+  if (!app) {
+    throw new Error("WODSMITH_APP service binding is not configured")
+  }
+  return app
+}
+
+export async function listCompetitionOperationSpecs(
+  env: Env,
+): Promise<CompetitionOperationSpec[]> {
+  return getWodsmithApp(env).listCompetitionOperationSpecs()
+}
+
+export async function callCompetitionOperation(
+  env: Env,
+  credential: SessionCredential,
+  operation: string,
+  input: unknown,
+): Promise<unknown> {
+  return getWodsmithApp(env).callCompetitionOperation({
+    credential,
+    operation,
+    input,
+  })
+}

--- a/apps/wodsmith-code-mode-mcp/src/wodsmith-service.ts
+++ b/apps/wodsmith-code-mode-mcp/src/wodsmith-service.ts
@@ -12,6 +12,16 @@ function getWodsmithApp(env: Env): WodsmithOperationsService {
   return app
 }
 
+function describeValue(value: unknown): Record<string, unknown> {
+  if (value === null) return { type: "null" }
+  if (value === undefined) return { type: "undefined" }
+  if (Array.isArray(value)) return { type: "array", length: value.length }
+  if (typeof value === "object") {
+    return { type: "object", keys: Object.keys(value).slice(0, 20) }
+  }
+  return { type: typeof value }
+}
+
 export async function listCompetitionOperationSpecs(
   env: Env,
 ): Promise<CompetitionOperationSpec[]> {
@@ -24,9 +34,19 @@ export async function callCompetitionOperation(
   operation: string,
   input: unknown,
 ): Promise<unknown> {
-  return getWodsmithApp(env).callCompetitionOperation({
+  console.info("[MCP service] Forwarding operation to WODSMITH_APP", {
+    operation,
+    input: describeValue(input),
+    credentialKind: credential.kind,
+  })
+  const result = await getWodsmithApp(env).callCompetitionOperation({
     credential,
     operation,
     input,
   })
+  console.info("[MCP service] WODSMITH_APP operation returned", {
+    operation,
+    result: describeValue(result),
+  })
+  return result
 }

--- a/apps/wodsmith-code-mode-mcp/test/mcp/server-protocol.test.ts
+++ b/apps/wodsmith-code-mode-mcp/test/mcp/server-protocol.test.ts
@@ -1,0 +1,168 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type {
+  AuthenticatedMcpSession,
+  CompetitionOperationSpec,
+} from "../../src/types"
+
+const executeSearch = vi.fn(async () => [
+  {
+    id: "schedule.createHeat",
+    mode: "write",
+    description: "Create a heat for a competition schedule.",
+  },
+])
+
+const executeCode = vi.fn(async () => ({
+  ok: true,
+  operation: "schedule.createHeat",
+}))
+
+vi.mock("../../src/mcp/executor", () => ({
+  createSearchExecutor: () => executeSearch,
+  createCodeExecutor: () => executeCode,
+  toExecutorError: (error: unknown) =>
+    error instanceof Error ? error.message : String(error),
+}))
+
+const { createWodsmithMcpServer } = await import("../../src/mcp/server")
+
+const operationSpecs: CompetitionOperationSpec[] = [
+  {
+    id: "schedule.createHeat",
+    exportName: "createHeatFn",
+    category: "schedule",
+    categoryTitle: "Schedule",
+    mode: "write",
+    source: "src/server-fns/competition-heats-fns.ts",
+    description: "Create a heat for a competition schedule.",
+    input: "Pass the same data object this TanStack server function expects.",
+  },
+]
+
+const session: AuthenticatedMcpSession = {
+  userId: "user_test",
+  sessionId: "session_test",
+  session: {
+    id: "session_test",
+    userId: "user_test",
+    expiresAt: Date.now() + 60_000,
+    createdAt: Date.now(),
+  },
+  credential: {
+    kind: "bearer",
+    authorization: "Bearer user_test:token_test",
+  },
+}
+
+describe("WODsmith code mode MCP protocol server", () => {
+  afterEach(() => {
+    executeSearch.mockClear()
+    executeCode.mockClear()
+  })
+
+  it("initializes, lists tools, and calls the search tool", async () => {
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair()
+    const server = createWodsmithMcpServer(
+      {} as Env,
+      {} as ExecutionContext,
+      session,
+      operationSpecs,
+    )
+    const client = new Client({
+      name: "wodsmith-mcp-test-client",
+      version: "0.1.0",
+    })
+
+    await server.connect(serverTransport)
+    await client.connect(clientTransport)
+
+    expect(client.getServerVersion()).toMatchObject({
+      name: "wodsmith-competition-code-mode",
+      version: "0.1.0",
+    })
+    expect(client.getInstructions()).toContain("Use Code Mode")
+
+    const tools = await client.listTools()
+    expect(tools.tools.map((tool) => tool.name)).toEqual(["search", "execute"])
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: {
+        code: 'async () => findOperations("heat schedule")',
+      },
+    })
+
+    expect(executeSearch).toHaveBeenCalledWith(
+      'async () => findOperations("heat schedule")',
+    )
+    expect(result.isError).toBeFalsy()
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify(
+          [
+            {
+              id: "schedule.createHeat",
+              mode: "write",
+              description: "Create a heat for a competition schedule.",
+            },
+          ],
+          null,
+          2,
+        ),
+      },
+    ])
+
+    await client.close()
+    await server.close()
+  })
+
+  it("calls the execute tool through the code executor", async () => {
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair()
+    const server = createWodsmithMcpServer(
+      {} as Env,
+      {} as ExecutionContext,
+      session,
+      operationSpecs,
+    )
+    const client = new Client({
+      name: "wodsmith-mcp-test-client",
+      version: "0.1.0",
+    })
+
+    await server.connect(serverTransport)
+    await client.connect(clientTransport)
+
+    const result = await client.callTool({
+      name: "execute",
+      arguments: {
+        code: 'async () => wodsmith.call("schedule.createHeat", { competitionId: "comp_test" })',
+      },
+    })
+
+    expect(executeCode).toHaveBeenCalledWith(
+      'async () => wodsmith.call("schedule.createHeat", { competitionId: "comp_test" })',
+    )
+    expect(result.isError).toBeFalsy()
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            ok: true,
+            operation: "schedule.createHeat",
+          },
+          null,
+          2,
+        ),
+      },
+    ])
+
+    await client.close()
+    await server.close()
+  })
+})

--- a/apps/wodsmith-code-mode-mcp/test/mcp/server-protocol.test.ts
+++ b/apps/wodsmith-code-mode-mcp/test/mcp/server-protocol.test.ts
@@ -27,6 +27,7 @@ vi.mock("../../src/mcp/executor", () => ({
 }))
 
 const { createWodsmithMcpServer } = await import("../../src/mcp/server")
+const { protectedResourceMetadata } = await import("../../src/oauth-resource")
 
 const operationSpecs: CompetitionOperationSpec[] = [
   {
@@ -164,5 +165,22 @@ describe("WODsmith code mode MCP protocol server", () => {
 
     await client.close()
     await server.close()
+  })
+
+  it("advertises the WODsmith authorization server as its OAuth resource metadata", async () => {
+    const response = protectedResourceMetadata(
+      new Request(
+        "https://mcp.wodsmith.com/.well-known/oauth-protected-resource",
+      ),
+      {
+        WODSMITH_AUTHORIZATION_SERVER_URL: "https://wodsmith.com",
+      } as Env,
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      resource: "https://mcp.wodsmith.com",
+      authorization_servers: ["https://wodsmith.com"],
+    })
   })
 })

--- a/apps/wodsmith-code-mode-mcp/tsconfig.json
+++ b/apps/wodsmith-code-mode-mcp/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["@cloudflare/workers-types", "vitest/globals"],
+    "tsBuildInfoFile": ".tsbuildinfo"
+  },
+  "include": ["src", "test", "vitest.config.ts", "alchemy.run.ts"],
+  "exclude": ["node_modules", "dist", "build"]
+}

--- a/apps/wodsmith-code-mode-mcp/vitest.config.ts
+++ b/apps/wodsmith-code-mode-mcp/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+})

--- a/apps/wodsmith-code-mode-mcp/wrangler.jsonc
+++ b/apps/wodsmith-code-mode-mcp/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "account_id": "317fb84f366ea1ab038ca90000953697",
+  "name": "wodsmith-code-mode-mcp-dev",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-12-17",
+  "compatibility_flags": ["nodejs_compat"],
+  "kv_namespaces": [
+    {
+      "binding": "KV_SESSION",
+      "id": "e971afc3bbb149bd93cbd5a4f993869a",
+      "preview_id": "e971afc3bbb149bd93cbd5a4f993869a",
+      "remote": true
+    }
+  ],
+  "services": [
+    {
+      "binding": "WODSMITH_APP",
+      "service": "wodsmith-app-dev",
+      "entrypoint": "WodsmithMcpOperations"
+    }
+  ],
+  "worker_loaders": [
+    {
+      "binding": "MCP_CODE_LOADER"
+    }
+  ]
+}

--- a/apps/wodsmith-start/package.json
+++ b/apps/wodsmith-start/package.json
@@ -89,6 +89,7 @@
     "@tanstack/react-router-devtools": "^1.132.0",
     "@tanstack/react-router-ssr-query": "^1.131.7",
     "@tanstack/react-start": "^1.132.0",
+    "@tanstack/start-storage-context": "1.144.0",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/router-plugin": "^1.132.0",
     "@vimeo/player": "^2.30.3",

--- a/apps/wodsmith-start/src/mcp/competition-operations.ts
+++ b/apps/wodsmith-start/src/mcp/competition-operations.ts
@@ -645,6 +645,39 @@ const operationsById = new Map(
   operations.map((operation) => [operation.id, operation]),
 )
 
+function describeMcpValue(value: unknown): Record<string, unknown> {
+  if (value === null) return { type: "null" }
+  if (value === undefined) return { type: "undefined" }
+  if (Array.isArray(value)) return { type: "array", length: value.length }
+  if (value instanceof Response) {
+    return {
+      type: "response",
+      status: value.status,
+      ok: value.ok,
+      contentType: value.headers.get("Content-Type"),
+      serialized: value.headers.has("x-tss-serialized"),
+    }
+  }
+  if (typeof value === "object") {
+    return { type: "object", keys: Object.keys(value).slice(0, 20) }
+  }
+  return { type: typeof value }
+}
+
+function describeServerFnEnvelope(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || value instanceof Response) {
+    return describeMcpValue(value)
+  }
+
+  const envelope = value as Record<string, unknown>
+  return {
+    ...describeMcpValue(value),
+    result: describeMcpValue(envelope.result),
+    error: describeMcpValue(envelope.error),
+    context: describeMcpValue(envelope.context),
+  }
+}
+
 function createMcpStartContext(request?: Request) {
   return {
     getRouter: async () => {
@@ -670,7 +703,38 @@ async function callServerFunction(
   request?: Request,
 ): Promise<unknown> {
   const executeServer = handler.__executeServer
+  try {
+    console.info("[MCP operations] Executing direct server function handler", {
+      handler: handler.name || "<anonymous>",
+      input: describeMcpValue(input ?? {}),
+      hasRequest: Boolean(request),
+    })
+    const result = await runWithStartContext(
+      createMcpStartContext(request),
+      () => handler({ data: input ?? {} }),
+    )
+    console.info("[MCP operations] Direct server function handler returned", {
+      handler: handler.name || "<anonymous>",
+      result: describeMcpValue(result),
+    })
+    return result
+  } catch (error) {
+    if (typeof executeServer !== "function") {
+      throw error
+    }
+
+    console.info("[MCP operations] Direct handler failed; falling back to compiled server entrypoint", {
+      handler: handler.name || "<anonymous>",
+      error: describeMcpValue(error),
+    })
+  }
+
   if (typeof executeServer === "function") {
+    console.info("[MCP operations] Executing TanStack server function", {
+      handler: handler.name || "<anonymous>",
+      input: describeMcpValue(input ?? {}),
+      hasRequest: Boolean(request),
+    })
     const abortController = new AbortController()
     const response = await runWithStartContext(
       createMcpStartContext(request),
@@ -683,15 +747,27 @@ async function callServerFunction(
         }),
     )
 
-    return unwrapServerFunctionResponse(response)
+    console.info("[MCP operations] Server function raw response", {
+      handler: handler.name || "<anonymous>",
+      response: describeServerFnEnvelope(response),
+    })
+    const result = await unwrapServerFunctionResponse(response)
+    console.info("[MCP operations] Server function unwrapped result", {
+      handler: handler.name || "<anonymous>",
+      result: describeMcpValue(result),
+    })
+    return result
   }
 
-  return handler({ data: input ?? {} })
+  throw new Error("Server function has no executable handler")
 }
 
 async function unwrapServerFunctionResponse(
   response: ServerFnResult | Response | unknown,
 ): Promise<unknown> {
+  console.info("[MCP operations] Unwrapping server function response", {
+    response: describeServerFnEnvelope(response),
+  })
   if (response instanceof Response) {
     if (!response.ok) {
       throw new Error(`Server function failed with status ${response.status}`)
@@ -702,12 +778,19 @@ async function unwrapServerFunctionResponse(
 
     if (isSerialized && contentType.includes("application/json")) {
       const payload = await response.json()
+      console.info("[MCP operations] Decoding serialized server response", {
+        payload: describeMcpValue(payload),
+      })
       const unwrapped = fromSimpleCrossJson(payload as CrossJsonNode)
       return unwrapServerFunctionResponse(unwrapped)
     }
 
     if (contentType.includes("application/json")) {
-      return response.json()
+      const json = await response.json()
+      console.info("[MCP operations] Decoded JSON server response", {
+        json: describeMcpValue(json),
+      })
+      return json
     }
 
     return response
@@ -770,5 +853,18 @@ export async function callCompetitionOperation(
     throw new Error(`Unknown competition operation: ${operationId}`)
   }
 
-  return callServerFunction(operation.handler, input, request)
+  console.info("[MCP operations] Dispatching competition operation", {
+    operationId,
+    exportName: operation.exportName,
+    mode: operation.mode,
+    input: describeMcpValue(input ?? {}),
+    hasRequest: Boolean(request),
+  })
+  const result = await callServerFunction(operation.handler, input, request)
+  console.info("[MCP operations] Competition operation completed", {
+    operationId,
+    exportName: operation.exportName,
+    result: describeMcpValue(result),
+  })
+  return result
 }

--- a/apps/wodsmith-start/src/mcp/competition-operations.ts
+++ b/apps/wodsmith-start/src/mcp/competition-operations.ts
@@ -1,0 +1,774 @@
+import "server-only"
+
+import { runWithStartContext } from "@tanstack/start-storage-context"
+import * as addressFns from "@/server-fns/address-fns"
+import * as broadcastFns from "@/server-fns/broadcast-fns"
+import * as cohostCompetitionFns from "@/server-fns/cohost/cohost-competition-fns"
+import * as cohostCouponFns from "@/server-fns/cohost/cohost-coupon-fns"
+import * as cohostDivisionFns from "@/server-fns/cohost/cohost-division-fns"
+import * as cohostEventFns from "@/server-fns/cohost/cohost-event-fns"
+import * as cohostEventResourceFns from "@/server-fns/cohost/cohost-event-resources-fns"
+import * as cohostJudgeRotationFns from "@/server-fns/cohost/cohost-judge-rotation-fns"
+import * as cohostJudgingSheetFns from "@/server-fns/cohost/cohost-judging-sheet-fns"
+import * as cohostLocationFns from "@/server-fns/cohost/cohost-location-fns"
+import * as cohostPricingFns from "@/server-fns/cohost/cohost-pricing-fns"
+import * as cohostRegistrationFns from "@/server-fns/cohost/cohost-registration-fns"
+import * as cohostRegistrationQuestionFns from "@/server-fns/cohost/cohost-registration-questions-fns"
+import * as cohostResultsFns from "@/server-fns/cohost/cohost-results-fns"
+import * as cohostRevenueFns from "@/server-fns/cohost/cohost-revenue-fns"
+import * as cohostReviewNoteFns from "@/server-fns/cohost/cohost-review-note-fns"
+import * as cohostScheduleFns from "@/server-fns/cohost/cohost-schedule-fns"
+import * as cohostScoringFns from "@/server-fns/cohost/cohost-scoring-fns"
+import * as cohostSettingsFns from "@/server-fns/cohost/cohost-settings-fns"
+import * as cohostSponsorFns from "@/server-fns/cohost/cohost-sponsor-fns"
+import * as cohostSubmissionFns from "@/server-fns/cohost/cohost-submission-fns"
+import * as cohostVolunteerFns from "@/server-fns/cohost/cohost-volunteer-fns"
+import * as cohostWaiverFns from "@/server-fns/cohost/cohost-waiver-fns"
+import * as cohostWorkoutFns from "@/server-fns/cohost/cohost-workout-fns"
+import * as cohostFns from "@/server-fns/cohost-fns"
+import * as commerceFns from "@/server-fns/commerce-fns"
+import * as competitionDetailFns from "@/server-fns/competition-detail-fns"
+import * as competitionDivisionFns from "@/server-fns/competition-divisions-fns"
+import * as competitionEventFns from "@/server-fns/competition-event-fns"
+import * as competitionFns from "@/server-fns/competition-fns"
+import * as competitionHeatFns from "@/server-fns/competition-heats-fns"
+import * as competitionInviteFns from "@/server-fns/competition-invite-fns"
+import * as competitionScoreFns from "@/server-fns/competition-score-fns"
+import * as competitionWorkoutFns from "@/server-fns/competition-workouts-fns"
+import * as couponFns from "@/server-fns/coupon-fns"
+import * as divisionResultsFns from "@/server-fns/division-results-fns"
+import * as eventDivisionMappingFns from "@/server-fns/event-division-mapping-fns"
+import * as eventResourceFns from "@/server-fns/event-resources-fns"
+import * as judgeAssignmentFns from "@/server-fns/judge-assignment-fns"
+import * as judgeRotationFns from "@/server-fns/judge-rotation-fns"
+import * as judgeSchedulingFns from "@/server-fns/judge-scheduling-fns"
+import * as judgingSheetFns from "@/server-fns/judging-sheet-fns"
+import * as leaderboardFns from "@/server-fns/leaderboard-fns"
+import * as movementFns from "@/server-fns/movement-fns"
+import * as organizerAthleteFns from "@/server-fns/organizer-athlete-fns"
+import * as purchaseTransferFns from "@/server-fns/purchase-transfer-fns"
+import * as registrationFns from "@/server-fns/registration-fns"
+import * as registrationQuestionFns from "@/server-fns/registration-questions-fns"
+import * as reviewNoteFns from "@/server-fns/review-note-fns"
+import * as seriesCohostFns from "@/server-fns/series-cohost-fns"
+import * as seriesDivisionMappingFns from "@/server-fns/series-division-mapping-fns"
+import * as seriesEventTemplateFns from "@/server-fns/series-event-template-fns"
+import * as sponsorFns from "@/server-fns/sponsor-fns"
+import * as stripeConnectFns from "@/server-fns/stripe-connect-fns"
+import * as submissionVerificationFns from "@/server-fns/submission-verification-fns"
+import * as videoSubmissionFns from "@/server-fns/video-submission-fns"
+import * as videoValidationFns from "@/server-fns/video-validation-fns"
+import * as videoVoteFns from "@/server-fns/video-vote-fns"
+import * as volunteerFns from "@/server-fns/volunteer-fns"
+import * as volunteerScheduleFns from "@/server-fns/volunteer-schedule-fns"
+import * as volunteerShiftFns from "@/server-fns/volunteer-shift-fns"
+import * as waiverFns from "@/server-fns/waiver-fns"
+import * as workoutFns from "@/server-fns/workout-fns"
+
+type ServerFnResult = {
+  result?: unknown
+  error?: unknown
+}
+
+type CrossJsonNode =
+  | { t: 0; s: number }
+  | { t: 1; s: string }
+  | { t: 2; s: 0 | 1 | 2 | 3 }
+  | { t: 9; a: CrossJsonNode[] }
+  | { t: 10; p: { k: string[]; v: CrossJsonNode[] } }
+
+type CompiledServerFnHandler = {
+  __executeServer?: (opts: {
+    data: unknown
+    context: Record<string, unknown>
+    headers: HeadersInit
+    signal: AbortSignal
+  }) => Promise<ServerFnResult | unknown>
+}
+
+type ServerFnHandler = ((args: { data: unknown }) => Promise<unknown>) &
+  CompiledServerFnHandler
+type ServerFnModule = Record<string, unknown>
+
+export type CompetitionOperationMode = "read" | "write"
+
+export interface CompetitionOperationSpec {
+  id: string
+  exportName: string
+  category: string
+  categoryTitle: string
+  mode: CompetitionOperationMode
+  source: string
+  description: string
+  input: string
+}
+
+interface OperationModule {
+  category: string
+  title: string
+  source: string
+  description: string
+  module: ServerFnModule
+}
+
+interface CompetitionOperation extends CompetitionOperationSpec {
+  handler: ServerFnHandler
+}
+
+const operationModules: OperationModule[] = [
+  {
+    category: "competitions",
+    title: "Competitions",
+    source: "src/server-fns/competition-fns.ts",
+    description:
+      "Create, update, list, and delete competitions and competition series.",
+    module: competitionFns,
+  },
+  {
+    category: "competitionDetails",
+    title: "Competition Details",
+    source: "src/server-fns/competition-detail-fns.ts",
+    description:
+      "Read competition details, registration counts, organizer athletes, settings, and delete competitions.",
+    module: competitionDetailFns,
+  },
+  {
+    category: "divisions",
+    title: "Divisions",
+    source: "src/server-fns/competition-divisions-fns.ts",
+    description:
+      "Manage competition divisions, division ordering, capacities, and scaling templates.",
+    module: competitionDivisionFns,
+  },
+  {
+    category: "events",
+    title: "Events",
+    source: "src/server-fns/competition-workouts-fns.ts",
+    description:
+      "Create, edit, reorder, remove, and describe competition workouts/events.",
+    module: competitionWorkoutFns,
+  },
+  {
+    category: "submissionWindows",
+    title: "Submission Windows",
+    source: "src/server-fns/competition-event-fns.ts",
+    description:
+      "Manage online competition event records and submission windows.",
+    module: competitionEventFns,
+  },
+  {
+    category: "workoutLibrary",
+    title: "Workout Library",
+    source: "src/server-fns/workout-fns.ts",
+    description:
+      "Search and manage reusable workouts used when building competition events.",
+    module: workoutFns,
+  },
+  {
+    category: "movements",
+    title: "Movements",
+    source: "src/server-fns/movement-fns.ts",
+    description:
+      "Read and manage movement metadata used by workouts, review notes, and judging sheets.",
+    module: movementFns,
+  },
+  {
+    category: "eventDivisionMappings",
+    title: "Event-Division Mappings",
+    source: "src/server-fns/event-division-mapping-fns.ts",
+    description: "Control which divisions perform which competition events.",
+    module: eventDivisionMappingFns,
+  },
+  {
+    category: "schedule",
+    title: "Schedule, Heats, and Locations",
+    source: "src/server-fns/competition-heats-fns.ts",
+    description:
+      "Manage venues, heats, heat assignments, publishing, and schedule data.",
+    module: competitionHeatFns,
+  },
+  {
+    category: "addresses",
+    title: "Addresses",
+    source: "src/server-fns/address-fns.ts",
+    description: "Create, update, and read address records used by venues.",
+    module: addressFns,
+  },
+  {
+    category: "scores",
+    title: "Scores",
+    source: "src/server-fns/competition-score-fns.ts",
+    description: "Read score entry grids and create, update, or delete scores.",
+    module: competitionScoreFns,
+  },
+  {
+    category: "leaderboards",
+    title: "Leaderboards",
+    source: "src/server-fns/leaderboard-fns.ts",
+    description:
+      "Read public, organizer-preview, and event leaderboard data for results review.",
+    module: leaderboardFns,
+  },
+  {
+    category: "results",
+    title: "Results Publishing",
+    source: "src/server-fns/division-results-fns.ts",
+    description: "Read and publish per-event division result visibility.",
+    module: divisionResultsFns,
+  },
+  {
+    category: "registrations",
+    title: "Registrations",
+    source: "src/server-fns/registration-fns.ts",
+    description:
+      "Manage registration payment, manual registration, removal, division transfer, refunds, and team invites.",
+    module: registrationFns,
+  },
+  {
+    category: "purchaseTransfers",
+    title: "Purchase Transfers",
+    source: "src/server-fns/purchase-transfer-fns.ts",
+    description:
+      "Initiate, cancel, and list registration purchase transfers for organizer athlete management.",
+    module: purchaseTransferFns,
+  },
+  {
+    category: "organizerAthletes",
+    title: "Organizer Athlete Detail",
+    source: "src/server-fns/organizer-athlete-fns.ts",
+    description:
+      "Manage per-registration athlete details, roster slots, answers, affiliates, scores, and videos.",
+    module: organizerAthleteFns,
+  },
+  {
+    category: "invites",
+    title: "Competition Invites",
+    source: "src/server-fns/competition-invite-fns.ts",
+    description:
+      "Manage invite sources, allocations, rosters, active invites, bespoke invitees, and sending invites.",
+    module: competitionInviteFns,
+  },
+  {
+    category: "waivers",
+    title: "Waivers",
+    source: "src/server-fns/waiver-fns.ts",
+    description:
+      "Manage waiver templates, signatures, ordering, and athlete signing.",
+    module: waiverFns,
+  },
+  {
+    category: "volunteers",
+    title: "Volunteers",
+    source: "src/server-fns/volunteer-fns.ts",
+    description:
+      "Manage volunteer roster, invitations, role types, score access, and assignments.",
+    module: volunteerFns,
+  },
+  {
+    category: "volunteerShifts",
+    title: "Volunteer Shifts",
+    source: "src/server-fns/volunteer-shift-fns.ts",
+    description: "Create, edit, delete, and assign volunteers to shifts.",
+    module: volunteerShiftFns,
+  },
+  {
+    category: "volunteerSchedule",
+    title: "Volunteer Schedule",
+    source: "src/server-fns/volunteer-schedule-fns.ts",
+    description: "Read volunteer schedule and membership data.",
+    module: volunteerScheduleFns,
+  },
+  {
+    category: "judgeScheduling",
+    title: "Judge Scheduling",
+    source: "src/server-fns/judge-scheduling-fns.ts",
+    description:
+      "Assign judges to heats, inspect conflicts, and read judge schedule data.",
+    module: judgeSchedulingFns,
+  },
+  {
+    category: "broadcasts",
+    title: "Broadcasts",
+    source: "src/server-fns/broadcast-fns.ts",
+    description:
+      "Preview audiences, send broadcasts, list broadcasts, and inspect delivery.",
+    module: broadcastFns,
+  },
+  {
+    category: "pricingRevenue",
+    title: "Pricing and Revenue",
+    source: "src/server-fns/commerce-fns.ts",
+    description:
+      "Manage registration fee configuration, division fees, Stripe status, and revenue stats.",
+    module: commerceFns,
+  },
+  {
+    category: "stripeConnect",
+    title: "Stripe Connect",
+    source: "src/server-fns/stripe-connect-fns.ts",
+    description:
+      "Manage organizer payout onboarding, account status, dashboard links, and balances.",
+    module: stripeConnectFns,
+  },
+  {
+    category: "coupons",
+    title: "Coupons",
+    source: "src/server-fns/coupon-fns.ts",
+    description: "Create, list, validate, and deactivate competition coupons.",
+    module: couponFns,
+  },
+  {
+    category: "sponsors",
+    title: "Sponsors",
+    source: "src/server-fns/sponsor-fns.ts",
+    description:
+      "Manage sponsors, sponsor groups, sponsor ordering, and workout sponsor assignments.",
+    module: sponsorFns,
+  },
+  {
+    category: "cohosts",
+    title: "Cohosts",
+    source: "src/server-fns/cohost-fns.ts",
+    description:
+      "Manage cohost invites, active cohosts, permissions, and removal.",
+    module: cohostFns,
+  },
+  {
+    category: "eventResources",
+    title: "Event Resources",
+    source: "src/server-fns/event-resources-fns.ts",
+    description:
+      "Manage event resource links/files and their ordering for event detail pages.",
+    module: eventResourceFns,
+  },
+  {
+    category: "judgeAssignments",
+    title: "Judge Assignment Versions",
+    source: "src/server-fns/judge-assignment-fns.ts",
+    description:
+      "Read, publish, and roll back judge assignment versions for rotations.",
+    module: judgeAssignmentFns,
+  },
+  {
+    category: "judgeRotations",
+    title: "Judge Rotations",
+    source: "src/server-fns/judge-rotation-fns.ts",
+    description:
+      "Manage judge rotations, event defaults, batch edits, and occupied-lane adjustments.",
+    module: judgeRotationFns,
+  },
+  {
+    category: "judgingSheets",
+    title: "Judging Sheets",
+    source: "src/server-fns/judging-sheet-fns.ts",
+    description: "Manage judging sheets attached to competition events.",
+    module: judgingSheetFns,
+  },
+  {
+    category: "submissionVerification",
+    title: "Submission Verification",
+    source: "src/server-fns/submission-verification-fns.ts",
+    description:
+      "Verify online submissions, enter adjusted scores, and manage verification logs.",
+    module: submissionVerificationFns,
+  },
+  {
+    category: "videoSubmissions",
+    title: "Video Submissions",
+    source: "src/server-fns/video-submission-fns.ts",
+    description:
+      "Read and manage athlete video submissions, review state, sibling submissions, and organizer video URLs.",
+    module: videoSubmissionFns,
+  },
+  {
+    category: "reviewNotes",
+    title: "Review Notes",
+    source: "src/server-fns/review-note-fns.ts",
+    description:
+      "Create, edit, delete, and list video review notes for online submission judging.",
+    module: reviewNoteFns,
+  },
+  {
+    category: "videoVotes",
+    title: "Video Votes",
+    source: "src/server-fns/video-vote-fns.ts",
+    description:
+      "Read video vote details, flagged submissions, and cast video votes when permitted.",
+    module: videoVoteFns,
+  },
+  {
+    category: "videoValidation",
+    title: "Video Validation",
+    source: "src/server-fns/video-validation-fns.ts",
+    description:
+      "Validate single or batch video URLs before accepting online submissions.",
+    module: videoValidationFns,
+  },
+  {
+    category: "registrationQuestions",
+    title: "Registration Questions",
+    source: "src/server-fns/registration-questions-fns.ts",
+    description:
+      "Manage athlete/volunteer registration questions, answers, and series questions.",
+    module: registrationQuestionFns,
+  },
+  {
+    category: "seriesDivisions",
+    title: "Series Division Templates",
+    source: "src/server-fns/series-division-mapping-fns.ts",
+    description:
+      "Manage series division templates, mappings, preview sync, and sync to competitions.",
+    module: seriesDivisionMappingFns,
+  },
+  {
+    category: "seriesEvents",
+    title: "Series Event Templates",
+    source: "src/server-fns/series-event-template-fns.ts",
+    description:
+      "Manage series event templates, event mappings, resource/sheet sync, and competition sync previews.",
+    module: seriesEventTemplateFns,
+  },
+  {
+    category: "seriesCohosts",
+    title: "Series Cohosts",
+    source: "src/server-fns/series-cohost-fns.ts",
+    description:
+      "Invite, list, remove, and update cohost permissions across a competition series.",
+    module: seriesCohostFns,
+  },
+  {
+    category: "cohostCompetition",
+    title: "Cohost Competition",
+    source: "src/server-fns/cohost/cohost-competition-fns.ts",
+    description:
+      "Cohost-scoped competition reads and settings writes under granted permissions.",
+    module: cohostCompetitionFns,
+  },
+  {
+    category: "cohostDivisions",
+    title: "Cohost Divisions",
+    source: "src/server-fns/cohost/cohost-division-fns.ts",
+    description: "Cohost-scoped division and capacity management.",
+    module: cohostDivisionFns,
+  },
+  {
+    category: "cohostEvents",
+    title: "Cohost Events",
+    source: "src/server-fns/cohost/cohost-workout-fns.ts",
+    description: "Cohost-scoped event/workout management.",
+    module: cohostWorkoutFns,
+  },
+  {
+    category: "cohostSubmissionWindows",
+    title: "Cohost Submission Windows",
+    source: "src/server-fns/cohost/cohost-event-fns.ts",
+    description: "Cohost-scoped submission window management.",
+    module: cohostEventFns,
+  },
+  {
+    category: "cohostSchedule",
+    title: "Cohost Schedule",
+    source: "src/server-fns/cohost/cohost-schedule-fns.ts",
+    description: "Cohost-scoped heat scheduling and schedule publishing.",
+    module: cohostScheduleFns,
+  },
+  {
+    category: "cohostLocations",
+    title: "Cohost Locations",
+    source: "src/server-fns/cohost/cohost-location-fns.ts",
+    description: "Cohost-scoped venue/location management.",
+    module: cohostLocationFns,
+  },
+  {
+    category: "cohostScoring",
+    title: "Cohost Scoring",
+    source: "src/server-fns/cohost/cohost-scoring-fns.ts",
+    description: "Cohost-scoped score entry and score deletion.",
+    module: cohostScoringFns,
+  },
+  {
+    category: "cohostResults",
+    title: "Cohost Results",
+    source: "src/server-fns/cohost/cohost-results-fns.ts",
+    description: "Cohost-scoped result publishing.",
+    module: cohostResultsFns,
+  },
+  {
+    category: "cohostRegistrations",
+    title: "Cohost Registrations",
+    source: "src/server-fns/cohost/cohost-registration-fns.ts",
+    description:
+      "Cohost-scoped registration list, manual registration, removal, transfers, questions, and answers.",
+    module: cohostRegistrationFns,
+  },
+  {
+    category: "cohostRegistrationQuestions",
+    title: "Cohost Registration Questions",
+    source: "src/server-fns/cohost/cohost-registration-questions-fns.ts",
+    description: "Cohost-scoped registration question management.",
+    module: cohostRegistrationQuestionFns,
+  },
+  {
+    category: "cohostWaivers",
+    title: "Cohost Waivers",
+    source: "src/server-fns/cohost/cohost-waiver-fns.ts",
+    description: "Cohost-scoped waiver management.",
+    module: cohostWaiverFns,
+  },
+  {
+    category: "cohostVolunteers",
+    title: "Cohost Volunteers",
+    source: "src/server-fns/cohost/cohost-volunteer-fns.ts",
+    description: "Cohost-scoped volunteers, shifts, invitations, and roles.",
+    module: cohostVolunteerFns,
+  },
+  {
+    category: "cohostSponsors",
+    title: "Cohost Sponsors",
+    source: "src/server-fns/cohost/cohost-sponsor-fns.ts",
+    description: "Cohost-scoped sponsor and sponsor group management.",
+    module: cohostSponsorFns,
+  },
+  {
+    category: "cohostCoupons",
+    title: "Cohost Coupons",
+    source: "src/server-fns/cohost/cohost-coupon-fns.ts",
+    description: "Cohost-scoped coupon management.",
+    module: cohostCouponFns,
+  },
+  {
+    category: "cohostPricing",
+    title: "Cohost Pricing",
+    source: "src/server-fns/cohost/cohost-pricing-fns.ts",
+    description: "Cohost-scoped registration pricing management.",
+    module: cohostPricingFns,
+  },
+  {
+    category: "cohostRevenue",
+    title: "Cohost Revenue",
+    source: "src/server-fns/cohost/cohost-revenue-fns.ts",
+    description: "Cohost-scoped revenue statistics.",
+    module: cohostRevenueFns,
+  },
+  {
+    category: "cohostReviewNotes",
+    title: "Cohost Review Notes",
+    source: "src/server-fns/cohost/cohost-review-note-fns.ts",
+    description: "Cohost-scoped review notes and workout movement lookups.",
+    module: cohostReviewNoteFns,
+  },
+  {
+    category: "cohostSubmissions",
+    title: "Cohost Submissions",
+    source: "src/server-fns/cohost/cohost-submission-fns.ts",
+    description: "Cohost-scoped video submission review and verification.",
+    module: cohostSubmissionFns,
+  },
+  {
+    category: "cohostEventResources",
+    title: "Cohost Event Resources",
+    source: "src/server-fns/cohost/cohost-event-resources-fns.ts",
+    description: "Cohost-scoped event resource management.",
+    module: cohostEventResourceFns,
+  },
+  {
+    category: "cohostJudgeRotations",
+    title: "Cohost Judge Rotations",
+    source: "src/server-fns/cohost/cohost-judge-rotation-fns.ts",
+    description:
+      "Cohost-scoped judge rotations, publishing, rollback, and occupied-lane adjustments.",
+    module: cohostJudgeRotationFns,
+  },
+  {
+    category: "cohostJudgingSheets",
+    title: "Cohost Judging Sheets",
+    source: "src/server-fns/cohost/cohost-judging-sheet-fns.ts",
+    description: "Cohost-scoped judging sheet management.",
+    module: cohostJudgingSheetFns,
+  },
+  {
+    category: "cohostSettings",
+    title: "Cohost Settings",
+    source: "src/server-fns/cohost/cohost-settings-fns.ts",
+    description: "Cohost-scoped capacity, scoring, and rotation settings.",
+    module: cohostSettingsFns,
+  },
+]
+
+function isServerFunction(
+  exportName: string,
+  value: unknown,
+): value is ServerFnHandler {
+  return exportName.endsWith("Fn") && typeof value === "function"
+}
+
+function inferMode(exportName: string): CompetitionOperationMode {
+  return /^(get|list|check|can|preview|validate|export|cohostGet|cohostList|cohostCheck|cohostCan|cohostPreview|cohostValidate)/.test(
+    exportName,
+  )
+    ? "read"
+    : "write"
+}
+
+function describeOperation(
+  moduleInfo: OperationModule,
+  exportName: string,
+): string {
+  const base = exportName.replace(/Fn$/, "")
+  return `${moduleInfo.description} Calls ${exportName}; use operation id "${moduleInfo.category}.${base}".`
+}
+
+function buildOperations(): CompetitionOperation[] {
+  return operationModules.flatMap((moduleInfo) =>
+    Object.entries(moduleInfo.module)
+      .filter(([exportName, value]) => isServerFunction(exportName, value))
+      .map(([exportName, handler]) => {
+        const base = exportName.replace(/Fn$/, "")
+        return {
+          id: `${moduleInfo.category}.${base}`,
+          exportName,
+          category: moduleInfo.category,
+          categoryTitle: moduleInfo.title,
+          mode: inferMode(exportName),
+          source: moduleInfo.source,
+          description: describeOperation(moduleInfo, exportName),
+          input:
+            "Pass the same data object this TanStack server function expects. Do not wrap it in { data }; wodsmith.call does that for you.",
+          handler: handler as ServerFnHandler,
+        }
+      }),
+  )
+}
+
+const operations = buildOperations()
+const operationsById = new Map(
+  operations.map((operation) => [operation.id, operation]),
+)
+
+function createMcpStartContext(request?: Request) {
+  return {
+    getRouter: async () => {
+      throw new Error("Router is not available during MCP operation execution")
+    },
+    startOptions: {
+      functionMiddleware: [],
+      serializationAdapters: [],
+    },
+    contextAfterGlobalMiddlewares: {},
+    request:
+      request ??
+      new Request("https://wodsmith-mcp.internal/operation", {
+        method: "POST",
+      }),
+    executedRequestMiddlewares: new Set(),
+  }
+}
+
+async function callServerFunction(
+  handler: ServerFnHandler,
+  input: unknown,
+  request?: Request,
+): Promise<unknown> {
+  const executeServer = handler.__executeServer
+  if (typeof executeServer === "function") {
+    const abortController = new AbortController()
+    const response = await runWithStartContext(
+      createMcpStartContext(request),
+      () =>
+        executeServer({
+          data: input ?? {},
+          context: {},
+          headers: {},
+          signal: abortController.signal,
+        }),
+    )
+
+    return unwrapServerFunctionResponse(response)
+  }
+
+  return handler({ data: input ?? {} })
+}
+
+async function unwrapServerFunctionResponse(
+  response: ServerFnResult | Response | unknown,
+): Promise<unknown> {
+  if (response instanceof Response) {
+    if (!response.ok) {
+      throw new Error(`Server function failed with status ${response.status}`)
+    }
+
+    const contentType = response.headers.get("Content-Type") ?? ""
+    const isSerialized = response.headers.has("x-tss-serialized")
+
+    if (isSerialized && contentType.includes("application/json")) {
+      const payload = await response.json()
+      const unwrapped = fromSimpleCrossJson(payload as CrossJsonNode)
+      return unwrapServerFunctionResponse(unwrapped)
+    }
+
+    if (contentType.includes("application/json")) {
+      return response.json()
+    }
+
+    return response
+  }
+
+  if (
+    response &&
+    typeof response === "object" &&
+    "error" in response &&
+    response.error
+  ) {
+    throw response.error
+  }
+
+  if (response && typeof response === "object" && "result" in response) {
+    return response.result
+  }
+
+  return response
+}
+
+function fromSimpleCrossJson(node: CrossJsonNode): unknown {
+  switch (node.t) {
+    case 0:
+    case 1:
+      return node.s
+    case 2:
+      if (node.s === 0) return null
+      if (node.s === 1) return undefined
+      if (node.s === 2) return true
+      return false
+    case 9:
+      return node.a.map(fromSimpleCrossJson)
+    case 10:
+      return Object.fromEntries(
+        node.p.k.map((key, index) => [
+          key,
+          fromSimpleCrossJson(node.p.v[index] as CrossJsonNode),
+        ]),
+      )
+    default:
+      throw new Error("Unsupported serialized server function result")
+  }
+}
+
+export const competitionOperationSpecs: CompetitionOperationSpec[] =
+  operations.map(({ handler: _handler, ...spec }) => spec)
+
+export function listCompetitionOperationSpecs(): CompetitionOperationSpec[] {
+  return competitionOperationSpecs
+}
+
+export async function callCompetitionOperation(
+  operationId: string,
+  input: unknown,
+  request?: Request,
+): Promise<unknown> {
+  const operation = operationsById.get(operationId)
+  if (!operation) {
+    throw new Error(`Unknown competition operation: ${operationId}`)
+  }
+
+  return callServerFunction(operation.handler, input, request)
+}

--- a/apps/wodsmith-start/src/mcp/oauth.ts
+++ b/apps/wodsmith-start/src/mcp/oauth.ts
@@ -1,0 +1,241 @@
+import { env } from "cloudflare:workers"
+import {
+  createSession,
+  generateSessionToken,
+  getSessionFromRequestCookie,
+} from "@/utils/auth"
+import { encodeBearerToken } from "@/utils/bearer-auth"
+
+const OAUTH_CODE_PREFIX = "mcp_oauth_code:"
+const CODE_TTL_SECONDS = 300
+const ACCESS_TOKEN_TYPE = "Bearer"
+
+type OAuthCodeRecord = {
+  clientId: string
+  redirectUri: string
+  codeChallenge: string
+  codeChallengeMethod: "S256"
+  userId: string
+  createdAt: number
+}
+
+function json(data: unknown, init?: ResponseInit): Response {
+  const headers = new Headers(init?.headers)
+  headers.set("Content-Type", "application/json")
+  headers.set("Cache-Control", "no-store")
+  return new Response(JSON.stringify(data), { ...init, headers })
+}
+
+function baseUrl(request: Request): string {
+  const configured = (env as unknown as { APP_URL?: string }).APP_URL
+  return configured?.replace(/\/$/, "") ?? new URL(request.url).origin
+}
+
+function randomToken(byteLength = 32): string {
+  const bytes = new Uint8Array(byteLength)
+  crypto.getRandomValues(bytes)
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")
+}
+
+async function sha256Base64Url(value: string): Promise<string> {
+  const hash = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(value),
+  )
+  return btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")
+}
+
+function redirectWithParams(
+  redirectUri: string,
+  params: Record<string, string>,
+): Response {
+  const url = new URL(redirectUri)
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, value)
+  }
+  return Response.redirect(url.toString(), 302)
+}
+
+function authorizationServerMetadata(request: Request): Response {
+  const issuer = baseUrl(request)
+  return json({
+    issuer,
+    authorization_endpoint: `${issuer}/oauth/authorize`,
+    token_endpoint: `${issuer}/oauth/token`,
+    registration_endpoint: `${issuer}/oauth/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code"],
+    token_endpoint_auth_methods_supported: ["none"],
+    code_challenge_methods_supported: ["S256"],
+  })
+}
+
+function protectedResourceMetadata(request: Request): Response {
+  const issuer = baseUrl(request)
+  return json({
+    resource: issuer,
+    authorization_servers: [issuer],
+  })
+}
+
+async function registerClient(request: Request): Promise<Response> {
+  let body: Record<string, unknown> = {}
+  try {
+    body = (await request.json()) as Record<string, unknown>
+  } catch {
+    // Dynamic client registration permits sparse clients; invalid JSON still
+    // gets a useful default client for MCP clients that probe registration.
+  }
+
+  return json(
+    {
+      client_id: `mcp_${randomToken(18)}`,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      redirect_uris: Array.isArray(body.redirect_uris)
+        ? body.redirect_uris
+        : undefined,
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    },
+    { status: 201 },
+  )
+}
+
+async function authorize(request: Request): Promise<Response> {
+  const url = new URL(request.url)
+  const redirectUri = url.searchParams.get("redirect_uri")
+  const clientId = url.searchParams.get("client_id")
+  const responseType = url.searchParams.get("response_type")
+  const codeChallenge = url.searchParams.get("code_challenge")
+  const codeChallengeMethod = url.searchParams.get("code_challenge_method")
+  const state = url.searchParams.get("state")
+
+  if (
+    !redirectUri ||
+    !clientId ||
+    responseType !== "code" ||
+    !codeChallenge ||
+    codeChallengeMethod !== "S256"
+  ) {
+    return new Response("Invalid OAuth authorization request", { status: 400 })
+  }
+
+  const session = await getSessionFromRequestCookie(request)
+  if (!session?.userId) {
+    const signInUrl = new URL("/_auth/sign-in", baseUrl(request))
+    signInUrl.searchParams.set("redirect", `${url.pathname}${url.search}`)
+    return Response.redirect(signInUrl.toString(), 302)
+  }
+
+  const code = randomToken()
+  const record: OAuthCodeRecord = {
+    clientId,
+    redirectUri,
+    codeChallenge,
+    codeChallengeMethod,
+    userId: session.userId,
+    createdAt: Date.now(),
+  }
+  await env.KV_SESSION.put(
+    `${OAUTH_CODE_PREFIX}${code}`,
+    JSON.stringify(record),
+    {
+      expirationTtl: CODE_TTL_SECONDS,
+    },
+  )
+
+  return redirectWithParams(redirectUri, {
+    code,
+    ...(state ? { state } : {}),
+  })
+}
+
+async function token(request: Request): Promise<Response> {
+  const body = await request.formData().catch(() => null)
+  if (!body) {
+    return json({ error: "invalid_request" }, { status: 400 })
+  }
+
+  const grantType = String(body.get("grant_type") ?? "")
+  const code = String(body.get("code") ?? "")
+  const redirectUri = String(body.get("redirect_uri") ?? "")
+  const clientId = String(body.get("client_id") ?? "")
+  const codeVerifier = String(body.get("code_verifier") ?? "")
+
+  if (grantType !== "authorization_code" || !code || !codeVerifier) {
+    return json({ error: "unsupported_grant_type" }, { status: 400 })
+  }
+
+  const key = `${OAUTH_CODE_PREFIX}${code}`
+  const raw = await env.KV_SESSION.get(key)
+  if (!raw) {
+    return json({ error: "invalid_grant" }, { status: 400 })
+  }
+  await env.KV_SESSION.delete(key)
+
+  const record = JSON.parse(raw) as OAuthCodeRecord
+  const challenge = await sha256Base64Url(codeVerifier)
+  if (
+    record.clientId !== clientId ||
+    record.redirectUri !== redirectUri ||
+    record.codeChallenge !== challenge
+  ) {
+    return json({ error: "invalid_grant" }, { status: 400 })
+  }
+
+  const sessionToken = generateSessionToken()
+  const session = await createSession({
+    token: sessionToken,
+    userId: record.userId,
+  })
+  const accessToken = encodeBearerToken(record.userId, sessionToken).slice(
+    "Bearer ".length,
+  )
+
+  return json({
+    access_token: accessToken,
+    token_type: ACCESS_TOKEN_TYPE,
+    expires_in: Math.max(
+      0,
+      Math.floor((session.expiresAt - Date.now()) / 1000),
+    ),
+    scope: "mcp",
+  })
+}
+
+export function handleMcpOAuthRequest(
+  request: Request,
+): Promise<Response> | Response | null {
+  const url = new URL(request.url)
+
+  if (
+    request.method === "GET" &&
+    url.pathname === "/.well-known/oauth-authorization-server"
+  ) {
+    return authorizationServerMetadata(request)
+  }
+  if (
+    request.method === "GET" &&
+    url.pathname === "/.well-known/oauth-protected-resource"
+  ) {
+    return protectedResourceMetadata(request)
+  }
+  if (request.method === "POST" && url.pathname === "/oauth/register") {
+    return registerClient(request)
+  }
+  if (request.method === "GET" && url.pathname === "/oauth/authorize") {
+    return authorize(request)
+  }
+  if (request.method === "POST" && url.pathname === "/oauth/token") {
+    return token(request)
+  }
+
+  return null
+}

--- a/apps/wodsmith-start/src/mcp/rpc.ts
+++ b/apps/wodsmith-start/src/mcp/rpc.ts
@@ -1,0 +1,81 @@
+import "server-only"
+
+import { WorkerEntrypoint } from "cloudflare:workers"
+import type { SessionValidationResult } from "@/types"
+import { getSessionFromBearer } from "@/utils/bearer-auth"
+import { getSessionFromRequestCookie, withSessionOverride } from "@/utils/auth"
+import {
+  callCompetitionOperation,
+  listCompetitionOperationSpecs,
+} from "./competition-operations"
+
+type AuthenticatedSession = NonNullable<SessionValidationResult>
+
+type SessionCredential =
+  | {
+      kind: "bearer"
+      authorization: string
+    }
+  | {
+      kind: "cookie"
+      cookie: string
+    }
+
+export interface McpOperationCall {
+  credential: SessionCredential
+  operation: string
+  input?: unknown
+}
+
+export interface WodsmithMcpOperationsRpc extends Rpc.WorkerEntrypointBranded {
+  listCompetitionOperationSpecs(): Promise<
+    ReturnType<typeof listCompetitionOperationSpecs>
+  >
+  callCompetitionOperation(request: McpOperationCall): Promise<unknown>
+}
+
+function requestFromCredential(credential: SessionCredential): Request {
+  const headers = new Headers()
+
+  if (credential.kind === "bearer") {
+    headers.set("Authorization", credential.authorization)
+  } else {
+    headers.set("Cookie", credential.cookie)
+  }
+
+  return new Request("https://wodsmith-mcp.internal/rpc", { headers })
+}
+
+async function getAuthenticatedSession(
+  request: Request,
+): Promise<AuthenticatedSession | null> {
+  const bearerSession = await getSessionFromBearer(request)
+  if (bearerSession?.userId) return bearerSession
+
+  const cookieSession = await getSessionFromRequestCookie(request)
+  if (cookieSession?.userId) return cookieSession
+
+  return null
+}
+
+export class WodsmithMcpOperations extends WorkerEntrypoint<Env> {
+  async listCompetitionOperationSpecs() {
+    return listCompetitionOperationSpecs()
+  }
+
+  async callCompetitionOperation(request: McpOperationCall) {
+    const credentialRequest = requestFromCredential(request.credential)
+    const session = await getAuthenticatedSession(credentialRequest)
+    if (!session) {
+      throw new Error("Unauthorized")
+    }
+
+    return withSessionOverride(session, () =>
+      callCompetitionOperation(
+        request.operation,
+        request.input ?? {},
+        credentialRequest,
+      ),
+    )
+  }
+}

--- a/apps/wodsmith-start/src/mcp/rpc.ts
+++ b/apps/wodsmith-start/src/mcp/rpc.ts
@@ -46,6 +46,16 @@ function requestFromCredential(credential: SessionCredential): Request {
   return new Request("https://wodsmith-mcp.internal/rpc", { headers })
 }
 
+function describeValue(value: unknown): Record<string, unknown> {
+  if (value === null) return { type: "null" }
+  if (value === undefined) return { type: "undefined" }
+  if (Array.isArray(value)) return { type: "array", length: value.length }
+  if (typeof value === "object") {
+    return { type: "object", keys: Object.keys(value).slice(0, 20) }
+  }
+  return { type: typeof value }
+}
+
 async function getAuthenticatedSession(
   request: Request,
 ): Promise<AuthenticatedSession | null> {
@@ -65,17 +75,35 @@ export class WodsmithMcpOperations extends WorkerEntrypoint<Env> {
 
   async callCompetitionOperation(request: McpOperationCall) {
     const credentialRequest = requestFromCredential(request.credential)
+    console.info("[MCP RPC] Authenticating operation call", {
+      operation: request.operation,
+      input: describeValue(request.input ?? {}),
+      credentialKind: request.credential.kind,
+    })
     const session = await getAuthenticatedSession(credentialRequest)
     if (!session) {
+      console.warn("[MCP RPC] Operation call rejected as unauthorized", {
+        operation: request.operation,
+      })
       throw new Error("Unauthorized")
     }
 
-    return withSessionOverride(session, () =>
-      callCompetitionOperation(
+    console.info("[MCP RPC] Operation call authenticated", {
+      operation: request.operation,
+      userId: session.userId,
+    })
+
+    return withSessionOverride(session, async () => {
+      const result = await callCompetitionOperation(
         request.operation,
         request.input ?? {},
         credentialRequest,
-      ),
-    )
+      )
+      console.info("[MCP RPC] Operation call completed", {
+        operation: request.operation,
+        result: describeValue(result),
+      })
+      return result
+    })
   }
 }

--- a/apps/wodsmith-start/src/server.ts
+++ b/apps/wodsmith-start/src/server.ts
@@ -29,6 +29,7 @@ import {
   withRequestContext,
 } from "./lib/logging"
 import { getSentryOptions } from "./lib/sentry/server"
+import { handleMcpOAuthRequest } from "./mcp/oauth"
 import { getSessionFromRequestCookie, withSessionCache } from "./utils/auth"
 
 // Sensitive field names to redact as a safety net in the drain.
@@ -98,8 +99,8 @@ initWorkersLogger({
 
 // Workers runtime requires Durable Object classes to be exported from the entry point
 export { JudgeSchedulerAgent } from "./agents/judge-scheduler-agent"
-export { ManualRegistrationWorkflow } from "./workflows/manual-registration-workflow"
 export { WodsmithMcpOperations } from "./mcp/rpc"
+export { ManualRegistrationWorkflow } from "./workflows/manual-registration-workflow"
 // Workers runtime requires Workflow classes to be exported from the entry point
 export { StripeCheckoutWorkflow } from "./workflows/stripe-checkout-workflow"
 
@@ -109,6 +110,9 @@ const SLOW_REQUEST_THRESHOLD_MS = 2000
 // Create the base TanStack Start entry with default fetch handling
 const startEntry = createServerEntry({
   async fetch(request) {
+    const oauthResponse = handleMcpOAuthRequest(request)
+    if (oauthResponse) return oauthResponse
+
     // Route /agents/<namespace>/<name>/... to the matching Agent DO.
     // We resolve the stub via getAgentByName (which calls setName under the
     // hood and persists the name to DO storage) instead of routeAgentRequest

--- a/apps/wodsmith-start/src/server.ts
+++ b/apps/wodsmith-start/src/server.ts
@@ -99,6 +99,7 @@ initWorkersLogger({
 // Workers runtime requires Durable Object classes to be exported from the entry point
 export { JudgeSchedulerAgent } from "./agents/judge-scheduler-agent"
 export { ManualRegistrationWorkflow } from "./workflows/manual-registration-workflow"
+export { WodsmithMcpOperations } from "./mcp/rpc"
 // Workers runtime requires Workflow classes to be exported from the entry point
 export { StripeCheckoutWorkflow } from "./workflows/stripe-checkout-workflow"
 

--- a/apps/wodsmith-start/src/utils/auth.ts
+++ b/apps/wodsmith-start/src/utils/auth.ts
@@ -537,6 +537,13 @@ export function withSessionCache<T>(fn: () => T): T {
   return sessionCacheStorage.run({}, fn)
 }
 
+export function withSessionOverride<T>(
+  session: NonNullable<SessionValidationResult>,
+  fn: () => T,
+): T {
+  return sessionCacheStorage.run({ session: Promise.resolve(session) }, fn)
+}
+
 async function computeSessionFromCookie(): Promise<SessionValidationResult | null> {
   const sessionCookie = getCookie(SESSION_COOKIE_NAME)
 

--- a/apps/wodsmith-start/test/mcp/competition-operations.test.ts
+++ b/apps/wodsmith-start/test/mcp/competition-operations.test.ts
@@ -24,10 +24,13 @@ vi.mock("@tanstack/react-start", () => {
 
 vi.mock("@/server-fns/movement-fns", () => {
   const getAllMovementsFn = Object.assign(
-    async () => {
+    vi.fn(async ({ data }: { data: unknown }) => {
       movementFnState.directCalls += 1
-      throw new Error("compiled server function fetcher was called directly")
-    },
+      return {
+        ok: true,
+        data,
+      }
+    }),
     {
       __executeServer: async (opts: { data: unknown }) => {
         movementFnState.serverCalls += 1
@@ -85,6 +88,7 @@ import {
   callCompetitionOperation,
   competitionOperationSpecs,
 } from "@/mcp/competition-operations"
+import { getAllMovementsFn } from "@/server-fns/movement-fns"
 
 describe("competition MCP operation catalog", () => {
   beforeEach(() => {
@@ -135,7 +139,7 @@ describe("competition MCP operation catalog", () => {
     )
   })
 
-  it("executes compiled TanStack server functions through the server entrypoint", async () => {
+  it("executes imported server functions directly in the MCP server context", async () => {
     const input = { probe: true }
 
     await expect(
@@ -145,14 +149,18 @@ describe("competition MCP operation catalog", () => {
       data: input,
     })
 
-    expect(movementFnState.directCalls).toBe(0)
-    expect(movementFnState.serverCalls).toBe(1)
-    expect(movementFnState.serverData).toEqual([input])
+    expect(movementFnState.directCalls).toBe(1)
+    expect(movementFnState.serverCalls).toBe(0)
+    expect(movementFnState.serverData).toEqual([])
   })
 
-  it("unwraps serialized Response values from compiled TanStack server functions", async () => {
+  it("falls back to compiled TanStack server entrypoints when direct execution fails", async () => {
     const input = { serialized: true }
     movementFnState.responseMode = "serialized-response"
+    const directError = new Error("direct execution unavailable")
+    const directImplementation = vi
+      .mocked(getAllMovementsFn)
+      .mockRejectedValueOnce(directError)
 
     await expect(
       callCompetitionOperation("movements.getAllMovements", input),
@@ -161,7 +169,7 @@ describe("competition MCP operation catalog", () => {
       data: input,
     })
 
-    expect(movementFnState.directCalls).toBe(0)
+    expect(directImplementation).toHaveBeenCalledOnce()
     expect(movementFnState.serverCalls).toBe(1)
     expect(movementFnState.serverData).toEqual([input])
   })

--- a/apps/wodsmith-start/test/mcp/competition-operations.test.ts
+++ b/apps/wodsmith-start/test/mcp/competition-operations.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const movementFnState = vi.hoisted(() => ({
+  directCalls: 0,
+  serverCalls: 0,
+  serverData: [] as unknown[],
+  responseMode: "object" as "object" | "serialized-response",
+}))
+
+vi.mock("@tanstack/react-start", () => {
+  const createServerFn = () => ({
+    handler: (handler: unknown) => handler,
+    inputValidator: () => ({
+      handler: (handler: unknown) => handler,
+    }),
+  })
+
+  return {
+    createServerFn,
+    createServerOnlyFn: (handler: unknown) => handler,
+    json: (value: unknown, init?: ResponseInit) => Response.json(value, init),
+  }
+})
+
+vi.mock("@/server-fns/movement-fns", () => {
+  const getAllMovementsFn = Object.assign(
+    async () => {
+      movementFnState.directCalls += 1
+      throw new Error("compiled server function fetcher was called directly")
+    },
+    {
+      __executeServer: async (opts: { data: unknown }) => {
+        movementFnState.serverCalls += 1
+        movementFnState.serverData.push(opts.data)
+
+        if (movementFnState.responseMode === "serialized-response") {
+          return new Response(
+            JSON.stringify({
+              t: 10,
+              p: {
+                k: ["result"],
+                v: [
+                  {
+                    t: 10,
+                    p: {
+                      k: ["ok", "data"],
+                      v: [
+                        { t: 2, s: 2 },
+                        {
+                          t: 10,
+                          p: {
+                            k: ["serialized"],
+                            v: [{ t: 2, s: 2 }],
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            }),
+            {
+              headers: {
+                "Content-Type": "application/json",
+                "x-tss-serialized": "true",
+              },
+            },
+          )
+        }
+
+        return {
+          result: {
+            ok: true,
+            data: opts.data,
+          },
+        }
+      },
+    },
+  )
+
+  return { getAllMovementsFn }
+})
+
+import {
+  callCompetitionOperation,
+  competitionOperationSpecs,
+} from "@/mcp/competition-operations"
+
+describe("competition MCP operation catalog", () => {
+  beforeEach(() => {
+    movementFnState.directCalls = 0
+    movementFnState.serverCalls = 0
+    movementFnState.serverData = []
+    movementFnState.responseMode = "object"
+  })
+
+  it("generates stable unique ids for organizer and cohost competition functions", () => {
+    const ids = competitionOperationSpecs.map((operation) => operation.id)
+    expect(new Set(ids).size).toBe(ids.length)
+
+    expect(ids).toEqual(
+      expect.arrayContaining([
+        "competitions.createCompetition",
+        "competitionDetails.getCompetitionById",
+        "divisions.addCompetitionDivision",
+        "events.saveCompetitionEvent",
+        "eventDivisionMappings.saveEventDivisionMappings",
+        "workoutLibrary.getWorkouts",
+        "movements.getAllMovements",
+        "schedule.createHeat",
+        "addresses.createAddress",
+        "scores.saveCompetitionScore",
+        "leaderboards.getCompetitionLeaderboard",
+        "results.publishDivisionResults",
+        "registrations.createManualRegistration",
+        "purchaseTransfers.initiatePurchaseTransfer",
+        "invites.issueInvites",
+        "waivers.createWaiver",
+        "volunteers.inviteVolunteer",
+        "judgeScheduling.assignJudgeToHeat",
+        "broadcasts.sendBroadcast",
+        "pricingRevenue.updateCompetitionFeeConfig",
+        "stripeConnect.getStripeConnectionStatus",
+        "coupons.createCoupon",
+        "sponsors.createSponsor",
+        "cohosts.inviteCohost",
+        "submissionVerification.verifySubmissionScore",
+        "videoSubmissions.getOrganizerSubmissions",
+        "reviewNotes.createReviewNote",
+        "seriesDivisions.saveSeriesDivisionMappings",
+        "seriesEvents.addEventToSeriesTemplate",
+        "seriesCohosts.inviteSeriesCohost",
+        "cohostSchedule.cohostCreateHeat",
+      ]),
+    )
+  })
+
+  it("executes compiled TanStack server functions through the server entrypoint", async () => {
+    const input = { probe: true }
+
+    await expect(
+      callCompetitionOperation("movements.getAllMovements", input),
+    ).resolves.toEqual({
+      ok: true,
+      data: input,
+    })
+
+    expect(movementFnState.directCalls).toBe(0)
+    expect(movementFnState.serverCalls).toBe(1)
+    expect(movementFnState.serverData).toEqual([input])
+  })
+
+  it("unwraps serialized Response values from compiled TanStack server functions", async () => {
+    const input = { serialized: true }
+    movementFnState.responseMode = "serialized-response"
+
+    await expect(
+      callCompetitionOperation("movements.getAllMovements", input),
+    ).resolves.toEqual({
+      ok: true,
+      data: input,
+    })
+
+    expect(movementFnState.directCalls).toBe(0)
+    expect(movementFnState.serverCalls).toBe(1)
+    expect(movementFnState.serverData).toEqual([input])
+  })
+})

--- a/apps/wodsmith-start/vite.config.ts
+++ b/apps/wodsmith-start/vite.config.ts
@@ -17,6 +17,12 @@ const config = defineConfig({
       persistState: {
         path: "./.alchemy/local/.wrangler/state",
       },
+      remoteBindings: process.env.CLOUDFLARE_VITE_REMOTE_BINDINGS !== "false",
+      auxiliaryWorkers: [
+        {
+          configPath: "../wodsmith-code-mode-mcp/wrangler.jsonc",
+        },
+      ],
     }),
     // Transforms TC39 decorators (e.g. @callable() in src/agents/*) since
     // Oxc — Vite's default TS transformer — doesn't yet support them.

--- a/lat.md/lat.md
+++ b/lat.md/lat.md
@@ -6,6 +6,7 @@ This directory defines the high-level concepts, business logic, and architecture
 - [[commerce]] — Stripe payments, registration checkout, coupons, entitlements
 - [[registration]] — Registration flow, payment, capacity, team formation, workflows
 - [[organizer-dashboard]] — Competition organizer dashboard pages and features
+- [[mcp]] — Code Mode MCP server for organizer and cohost competition operations
 - [[series-event-templates]] — Series event templates: define once, sync to all competitions
 - [[competition-invites]] — Qualification sources, roster, and email-locked invite rounds (ADR-0011)
 - [[crm-crossfit-metadata]] — CRM gym CrossFit profile URLs and derived affiliate metadata

--- a/lat.md/mcp.md
+++ b/lat.md/mcp.md
@@ -36,9 +36,11 @@ Sandboxed code cannot import app modules directly; it calls a narrow MCP worker 
 
 [[apps/wodsmith-code-mode-mcp/src/index.ts]] exports `WodsmithCodeModeOutbound`, a Worker entrypoint used as the Worker Loader isolate's global outbound binding. [[apps/wodsmith-code-mode-mcp/src/mcp/outbound.ts]] accepts only `POST https://wodsmith-mcp.internal/operation`, validates the request shape, and forwards the call through [[apps/wodsmith-code-mode-mcp/src/wodsmith-service.ts]], which invokes the `WODSMITH_APP` service binding instead of HTTP.
 
-[[apps/wodsmith-start/src/mcp/competition-operations.ts#callCompetitionOperation]] invokes compiled TanStack server functions through `__executeServer` under a minimal Start context, so MCP calls stay on the server execution path outside normal `_serverFn` requests.
+[[apps/wodsmith-start/src/mcp/competition-operations.ts#callCompetitionOperation]] invokes the imported server function directly under a minimal Start context, so MCP calls stay on the server execution path outside normal `_serverFn` requests. If direct execution is unavailable for a compiled handler, the dispatcher falls back to `__executeServer`.
 
 Compiled TanStack server functions can return a Start-serialized JSON `Response` rather than a plain `{ result }` object. The MCP operation wrapper unwraps that response before it crosses the service-binding boundary so Code Mode receives the actual operation result instead of `undefined`.
+
+The operation path logs bounded diagnostics at every boundary so undefined-result bugs can be traced without exposing payload values. Logs identify the operation id, credential kind, input/result shape, response status, content type, and serialized-response flag across [[apps/wodsmith-code-mode-mcp/src/mcp/outbound.ts]], [[apps/wodsmith-code-mode-mcp/src/wodsmith-service.ts]], [[apps/wodsmith-start/src/mcp/rpc.ts]], and [[apps/wodsmith-start/src/mcp/competition-operations.ts]].
 
 This keeps the MCP surface broad but still routed through the same validation, database writes, audit behavior, and permission checks used by the organizer dashboard without an addressable internal HTTP endpoint.
 

--- a/lat.md/mcp.md
+++ b/lat.md/mcp.md
@@ -1,0 +1,49 @@
+# MCP
+
+WODsmith exposes a Code Mode MCP server so authenticated organizers and permitted cohosts can manage competitions through isolated JavaScript tools.
+
+## Code Mode Server
+
+The MCP protocol endpoint lives in a standalone Worker app.
+
+[[apps/wodsmith-code-mode-mcp/src/index.ts]] serves `/mcp` and `/api/mcp` without going through the TanStack Start router. [[apps/wodsmith-code-mode-mcp/src/auth.ts]] accepts WODsmith bearer session tokens or the normal WODsmith cookie, validates the shared `KV_SESSION` record, and keeps the original credential for downstream operation calls.
+
+The server registers two tools in [[apps/wodsmith-code-mode-mcp/src/mcp/server.ts]]:
+- `search` runs isolated JavaScript over the operation catalog only, for discovery and filtering.
+- `execute` runs isolated JavaScript with `wodsmith.call(operationId, input)`, so agents can sequence multiple organizer operations in one sandboxed script.
+
+[[apps/wodsmith-code-mode-mcp/alchemy.run.ts]] binds `MCP_CODE_LOADER` via Cloudflare `WorkerLoader()`, the shared WODsmith sessions KV namespace, and `WODSMITH_APP` as a named service binding to the WODsmith app. [[apps/wodsmith-code-mode-mcp/src/mcp/executor.ts]] uses Worker Loader to run user-supplied code in isolated Workers with a global outbound binding that can only call the MCP app's internal operation entrypoint.
+
+## Local Development
+
+The standalone MCP worker runs locally beside WODsmith Start.
+
+[[apps/wodsmith-start/vite.config.ts]] registers the MCP worker as a Cloudflare Vite auxiliary worker, so `pnpm --filter wodsmith-start dev` loads both workers in one Miniflare runtime. Set `CLOUDFLARE_VITE_REMOTE_BINDINGS=false` when local dev should avoid Wrangler's remote proxy. Codex still needs an addressable MCP URL, so `apps/wodsmith-code-mode-mcp/package.json` runs standalone Wrangler on port 8788 with `--local` and `--persist-to ../wodsmith-start/.alchemy/local/.wrangler/state`; that shares the Start session KV while `WODSMITH_APP` connects to the `WodsmithMcpOperations` service-binding entrypoint. Local testing no longer uses a shared bridge secret.
+
+## Operation Catalog
+
+The MCP operation catalog is derived from organizer and cohost TanStack server functions.
+
+[[apps/wodsmith-start/src/mcp/competition-operations.ts]] imports the relevant `server-fns` modules and exposes every exported `*Fn` as `{category}.{nameWithoutFn}`. Categories cover competition creation/editing, divisions, events, workout/movement lookup, locations/addresses, event-division mappings, scoring, leaderboard/results reads, online submission verification, registrations and transfers, invites, waivers, heat and judge scheduling, volunteers, broadcasts, pricing/revenue, Stripe Connect, coupons, sponsors, cohosts, series templates, judging assignments/rotations/sheets, registration questions, and cohost-scoped equivalents.
+
+Operations execute through the existing server functions instead of bypassing application services. [[apps/wodsmith-start/src/utils/auth.ts#withSessionOverride]] lets MCP reuse the authenticated session inside TanStack server-function code, so normal organizer, team, admin, and cohost permission checks still apply.
+
+[[apps/wodsmith-start/src/mcp/rpc.ts]] exports `WodsmithMcpOperations` as a named Worker entrypoint. The MCP app uses Cloudflare service-binding RPC to list the catalog and call operations; operation execution revalidates the WODsmith bearer token or cookie before calling the server function.
+
+## Internal Operation Dispatch
+
+Sandboxed code cannot import app modules directly; it calls a narrow MCP worker entrypoint.
+
+[[apps/wodsmith-code-mode-mcp/src/index.ts]] exports `WodsmithCodeModeOutbound`, a Worker entrypoint used as the Worker Loader isolate's global outbound binding. [[apps/wodsmith-code-mode-mcp/src/mcp/outbound.ts]] accepts only `POST https://wodsmith-mcp.internal/operation`, validates the request shape, and forwards the call through [[apps/wodsmith-code-mode-mcp/src/wodsmith-service.ts]], which invokes the `WODSMITH_APP` service binding instead of HTTP.
+
+[[apps/wodsmith-start/src/mcp/competition-operations.ts#callCompetitionOperation]] invokes compiled TanStack server functions through `__executeServer` under a minimal Start context, so MCP calls stay on the server execution path outside normal `_serverFn` requests.
+
+Compiled TanStack server functions can return a Start-serialized JSON `Response` rather than a plain `{ result }` object. The MCP operation wrapper unwraps that response before it crosses the service-binding boundary so Code Mode receives the actual operation result instead of `undefined`.
+
+This keeps the MCP surface broad but still routed through the same validation, database writes, audit behavior, and permission checks used by the organizer dashboard without an addressable internal HTTP endpoint.
+
+## Protocol Tests
+
+The MCP protocol contract is covered by focused tests in the standalone app.
+
+[[apps/wodsmith-code-mode-mcp/test/mcp/server-protocol.test.ts]] verifies initialization, tool discovery, and calls to the `search` and `execute` tools. [[apps/wodsmith-start/test/mcp/competition-operations.test.ts]] continues to cover operation id stability, server-function execution through `__executeServer`, and unwrapping serialized TanStack responses.

--- a/lat.md/mcp.md
+++ b/lat.md/mcp.md
@@ -8,6 +8,8 @@ The MCP protocol endpoint lives in a standalone Worker app.
 
 [[apps/wodsmith-code-mode-mcp/src/index.ts]] serves `/mcp` and `/api/mcp` without going through the TanStack Start router. [[apps/wodsmith-code-mode-mcp/src/auth.ts]] accepts WODsmith bearer session tokens or the normal WODsmith cookie, validates the shared `KV_SESSION` record, and keeps the original credential for downstream operation calls.
 
+[[apps/wodsmith-code-mode-mcp/src/oauth-resource.ts]] advertises the MCP worker as an OAuth protected resource. [[apps/wodsmith-start/src/mcp/oauth.ts]] makes WODsmith Start the OAuth authorization server with discovery metadata, dynamic client registration, authorization-code-with-PKCE issuance, and token exchange backed by the existing session KV store. The issued OAuth access token is the same opaque `{userId}:{sessionToken}` bearer format that the MCP worker and Start RPC already validate.
+
 The server registers two tools in [[apps/wodsmith-code-mode-mcp/src/mcp/server.ts]]:
 - `search` runs isolated JavaScript over the operation catalog only, for discovery and filtering.
 - `execute` runs isolated JavaScript with `wodsmith.call(operationId, input)`, so agents can sequence multiple organizer operations in one sandboxed script.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,9 +57,6 @@ importers:
       alchemy:
         specifier: 'catalog:'
         version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(stripe@17.7.0)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
-      agents:
-        specifier: ^0.12.4
-        version: 0.12.4(@babel/core@7.28.5)(@babel/runtime@7.27.6)(@cloudflare/workers-types@4.20251205.0)(ai@6.0.77(zod@4.2.1))(react@19.2.3)(rolldown@1.0.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(zod@4.2.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,40 @@ importers:
         specifier: ^4.16.1
         version: 4.56.0(@cloudflare/workers-types@4.20251205.0)
 
+  apps/wodsmith-code-mode-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
+      agents:
+        specifier: ^0.12.4
+        version: 0.12.4(@babel/core@7.28.5)(@babel/runtime@7.27.6)(@cloudflare/workers-types@4.20251205.0)(ai@6.0.77(zod@4.2.1))(react@19.2.4)(rolldown@1.0.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(zod@4.2.1)
+      alchemy:
+        specifier: 'catalog:'
+        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
+      zod:
+        specifier: ^4.2.1
+        version: 4.2.1
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 2.0.6
+        version: 2.0.6
+      '@cloudflare/workers-types':
+        specifier: ^4.20250508.0
+        version: 4.20251205.0
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.2.3(@types/debug@4.1.12)(@types/node@22.19.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
+      wrangler:
+        specifier: ^4.56.0
+        version: 4.56.0(@cloudflare/workers-types@4.20251205.0)
+
   apps/wodsmith-gameday:
     dependencies:
       '@capacitor/core':
@@ -561,6 +595,9 @@ importers:
       '@tanstack/router-plugin':
         specifier: ^1.132.0
         version: 1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)
+      '@tanstack/start-storage-context':
+        specifier: 1.144.0
+        version: 1.144.0
       '@vimeo/player':
         specifier: ^2.30.3
         version: 2.30.3
@@ -4474,16 +4511,6 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
-
-  '@modelcontextprotocol/sdk@1.26.0':
-    resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@cfworker/json-schema':
-        optional: true
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -8815,10 +8842,6 @@ packages:
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-
-  eventsource-parser@3.0.6:
-    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
-    engines: {node: '>=18.0.0'}
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
@@ -13414,7 +13437,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 4.2.1
 
   '@ai-sdk/provider-utils@4.0.27(zod@4.2.1)':
@@ -18505,7 +18528,7 @@ snapshots:
       '@isaacs/ttlcache': 2.1.4
       '@lukeed/uuid': 2.0.1
       '@mastra/schema-compat': 1.1.0(zod@4.2.1)
-      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
       '@sindresorhus/slugify': 2.2.1
       dotenv: 17.2.4
       gray-matter: 4.0.3
@@ -18572,30 +18595,6 @@ snapshots:
       '@types/react': 19.2.13
       react: 19.2.3
 
-  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)':
-    dependencies:
-      '@hono/node-server': 1.19.9(hono@4.11.9)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
-      content-type: 1.0.5
-      cors: 2.8.6
-      cross-spawn: 7.0.6
-      eventsource: 3.0.7
-      eventsource-parser: 3.0.6
-      express: 5.2.1
-      express-rate-limit: 8.2.1(express@5.2.1)
-      hono: 4.11.9
-      jose: 6.1.3
-      json-schema-typed: 8.0.2
-      pkce-challenge: 5.0.1
-      raw-body: 3.0.2
-      zod: 4.2.1
-      zod-to-json-schema: 3.25.1(zod@4.2.1)
-    optionalDependencies:
-      '@cfworker/json-schema': 4.1.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.9)
@@ -18605,7 +18604,7 @@ snapshots:
       cors: 2.8.6
       cross-spawn: 7.0.6
       eventsource: 3.0.7
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
       hono: 4.11.9
@@ -18779,6 +18778,56 @@ snapshots:
 
   '@oozcitak/util@10.0.0': {}
 
+  '@opennextjs/aws@3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+    dependencies:
+      '@ast-grep/napi': 0.40.0
+      '@aws-sdk/client-cloudfront': 3.398.0
+      '@aws-sdk/client-dynamodb': 3.808.0
+      '@aws-sdk/client-lambda': 3.808.0
+      '@aws-sdk/client-s3': 3.808.0
+      '@aws-sdk/client-sqs': 3.808.0
+      '@node-minify/core': 8.0.6
+      '@node-minify/terser': 8.0.6
+      '@tsconfig/node18': 1.0.3
+      aws4fetch: 1.0.20
+      chalk: 5.6.2
+      cookie: 1.1.1
+      esbuild: 0.25.4
+      express: 5.2.1
+      next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      path-to-regexp: 6.3.0
+      urlpattern-polyfill: 10.1.0
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - aws-crt
+      - supports-color
+    optional: true
+
+  '@opennextjs/aws@3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))':
+    dependencies:
+      '@ast-grep/napi': 0.40.0
+      '@aws-sdk/client-cloudfront': 3.398.0
+      '@aws-sdk/client-dynamodb': 3.808.0
+      '@aws-sdk/client-lambda': 3.808.0
+      '@aws-sdk/client-s3': 3.808.0
+      '@aws-sdk/client-sqs': 3.808.0
+      '@node-minify/core': 8.0.6
+      '@node-minify/terser': 8.0.6
+      '@tsconfig/node18': 1.0.3
+      aws4fetch: 1.0.20
+      chalk: 5.6.2
+      cookie: 1.1.1
+      esbuild: 0.25.4
+      express: 5.2.1
+      next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
+      path-to-regexp: 6.3.0
+      urlpattern-polyfill: 10.1.0
+      yaml: 2.8.2
+    transitivePeerDependencies:
+      - aws-crt
+      - supports-color
+    optional: true
+
   '@opennextjs/aws@3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@ast-grep/napi': 0.40.0
@@ -18808,11 +18857,29 @@ snapshots:
     dependencies:
       '@ast-grep/napi': 0.40.0
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@opennextjs/aws': 3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       cloudflare: 4.5.0
       enquirer: 2.4.1
       glob: 12.0.0
       next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      ts-tqdm: 0.8.6
+      wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
+      yargs: 18.0.0
+    transitivePeerDependencies:
+      - aws-crt
+      - encoding
+      - supports-color
+    optional: true
+
+  '@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))':
+    dependencies:
+      '@ast-grep/napi': 0.40.0
+      '@dotenvx/dotenvx': 1.31.0
+      '@opennextjs/aws': 3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))
+      cloudflare: 4.5.0
+      enquirer: 2.4.1
+      glob: 12.0.0
+      next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
       ts-tqdm: 0.8.6
       wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
       yargs: 18.0.0
@@ -21920,6 +21987,31 @@ snapshots:
       - rolldown
       - supports-color
 
+  agents@0.12.4(@babel/core@7.28.5)(@babel/runtime@7.27.6)(@cloudflare/workers-types@4.20251205.0)(ai@6.0.77(zod@4.2.1))(react@19.2.4)(rolldown@1.0.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(zod@4.2.1):
+    dependencies:
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.28.5)
+      '@cfworker/json-schema': 4.1.1
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.28.5)(@babel/runtime@7.27.6)(rolldown@1.0.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))
+      ai: 6.0.77(zod@4.2.1)
+      cron-schedule: 6.0.0
+      mimetext: 3.0.28
+      nanoid: 5.1.11
+      partyserver: 0.5.6(@cloudflare/workers-types@4.20251205.0)
+      partysocket: 1.1.19(react@19.2.4)
+      react: 19.2.4
+      yargs: 18.0.0
+      zod: 4.2.1
+    optionalDependencies:
+      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@babel/plugin-transform-runtime'
+      - '@babel/runtime'
+      - '@cloudflare/workers-types'
+      - rolldown
+      - supports-color
+
   aggregate-error@3.1.0:
     dependencies:
       clean-stack: 2.2.0
@@ -22041,6 +22133,80 @@ snapshots:
       '@cloudflare/vite-plugin': 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
       '@opennextjs/cloudflare': 1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
       stripe: 17.7.0
+      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@aws-sdk/client-rds-data'
+      - '@electric-sql/pglite'
+      - '@libsql/client-wasm'
+      - '@neondatabase/serverless'
+      - '@op-engineering/op-sqlite'
+      - '@opentelemetry/api'
+      - '@planetscale/database'
+      - '@prisma/client'
+      - '@tidbcloud/serverless'
+      - '@types/better-sqlite3'
+      - '@types/pg'
+      - '@types/sql.js'
+      - '@upstash/redis'
+      - '@vercel/postgres'
+      - '@xata.io/client'
+      - aws-crt
+      - better-sqlite3
+      - bufferutil
+      - bun-types
+      - expo-sqlite
+      - gel
+      - knex
+      - kysely
+      - mysql2
+      - pg
+      - postgres
+      - prisma
+      - sql.js
+      - sqlite3
+      - utf-8-validate
+      - workerd
+
+  alchemy@0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)):
+    dependencies:
+      '@aws-sdk/credential-providers': 3.958.0
+      '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20251217.0)
+      '@cloudflare/workers-types': 4.20251205.0
+      '@iarna/toml': 2.2.5
+      '@octokit/rest': 21.1.1
+      '@smithy/node-config-provider': 4.3.7
+      '@smithy/types': 4.11.0
+      aws4fetch: 1.0.20
+      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20251205.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)
+      env-paths: 3.0.0
+      esbuild: 0.25.10
+      execa: 9.6.1
+      fast-json-patch: 3.1.1
+      fast-xml-parser: 5.3.3
+      find-process: 2.0.0
+      glob: 10.5.0
+      jszip: 3.10.1
+      libsodium-wrappers: 0.7.15
+      miniflare: 4.20251217.0
+      neverthrow: 8.2.0
+      open: 10.2.0
+      openapi-types: 12.1.3
+      pathe: 2.0.3
+      picocolors: 1.1.1
+      proper-lockfile: 4.1.2
+      signal-exit: 4.1.0
+      unenv: 2.0.0-rc.21
+      wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
+      ws: 8.18.3
+      yaml: 2.8.2
+    optionalDependencies:
+      '@aws-sdk/client-dynamodb': 3.808.0
+      '@aws-sdk/client-lambda': 3.808.0
+      '@aws-sdk/client-s3': 3.808.0
+      '@aws-sdk/client-sqs': 3.808.0
+      '@aws-sdk/client-sts': 3.398.0
+      '@cloudflare/vite-plugin': 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
+      '@opennextjs/cloudflare': 1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
       vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -23686,8 +23852,6 @@ snapshots:
   eventemitter3@4.0.7: {}
 
   events@3.3.0: {}
-
-  eventsource-parser@3.0.6: {}
 
   eventsource-parser@3.0.8: {}
 
@@ -25838,6 +26002,32 @@ snapshots:
       - babel-plugin-macros
     optional: true
 
+  next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 15.5.7
+      '@swc/helpers': 0.5.15
+      caniuse-lite: 1.0.30001762
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.3(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 15.5.7
+      '@next/swc-darwin-x64': 15.5.7
+      '@next/swc-linux-arm64-gnu': 15.5.7
+      '@next/swc-linux-arm64-musl': 15.5.7
+      '@next/swc-linux-x64-gnu': 15.5.7
+      '@next/swc-linux-x64-musl': 15.5.7
+      '@next/swc-win32-arm64-msvc': 15.5.7
+      '@next/swc-win32-x64-msvc': 15.5.7
+      '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.57.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    optional: true
+
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
@@ -26092,6 +26282,12 @@ snapshots:
       event-target-polyfill: 0.0.4
     optionalDependencies:
       react: 19.2.3
+
+  partysocket@1.1.19(react@19.2.4):
+    dependencies:
+      event-target-polyfill: 0.0.4
+    optionalDependencies:
+      react: 19.2.4
 
   pascal-case@3.1.2:
     dependencies:
@@ -27737,6 +27933,14 @@ snapshots:
     dependencies:
       client-only: 0.0.1
       react: 19.2.3
+    optionalDependencies:
+      '@babel/core': 7.28.5
+    optional: true
+
+  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.4):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.4
     optionalDependencies:
       '@babel/core': 7.28.5
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@cloudflare/vite-plugin':
         specifier: ^1.19.0
         version: 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.2.1)
       '@tailwindcss/vite':
         specifier: ^4.0.6
         version: 4.1.18(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))
@@ -54,6 +57,9 @@ importers:
       alchemy:
         specifier: 'catalog:'
         version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(stripe@17.7.0)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
+      agents:
+        specifier: ^0.12.4
+        version: 0.12.4(@babel/core@7.28.5)(@babel/runtime@7.27.6)(@cloudflare/workers-types@4.20251205.0)(ai@6.0.77(zod@4.2.1))(react@19.2.3)(rolldown@1.0.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(zod@4.2.1)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1


### PR DESCRIPTION
## Summary
- Adds the WODsmith Code Mode MCP worker and Start-side service-binding operation catalog.
- Fixes MCP operation execution so compiled TanStack server-function responses are unwrapped when they return Start-serialized JSON Responses instead of plain { result } objects.
- Adds regression coverage for the serialized-response shape that produced undefined results in Code Mode.

## Verification
- PASS: PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter wodsmith-start test test/mcp/competition-operations.test.ts
- PASS: PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter wodsmith-start type-check
- PASS: PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter wodsmith-start exec biome check src/mcp/competition-operations.ts test/mcp/competition-operations.test.ts
- PASS: PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH lat check

## Live MCP check
- Before this branch is deployed, the currently connected mcp__wodsmith_code_mode__ tool still returns undefined for competitions.getOrganizerCompetitions. That matches the bug being fixed here and should be retested against a deployment of this branch.

## Notes
- GitNexus impact/change detection could not complete: sandboxed run failed DNS for registry.npmjs.org, and approved network run crashed in gitnexus@1.6.5 with Cannot destructure property 'package' of 'node.target' as it is null.
- lat search also could not complete under sandbox DNS restrictions; lat expand and lat check did run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes undefined Code Mode MCP results by unwrapping Start-serialized responses, and adds an OAuth-backed MCP stack for searching and executing WODsmith competition and CRM operations.

- **New Features**
  - Implemented OAuth for MCP: Start acts as the authorization server (auth code + PKCE), the MCP worker advertises protected resource metadata, and accepts bearer or session cookie auth.
  - Added `apps/wodsmith-code-mode-mcp` Worker exposing `/mcp` and `/api/mcp`; registers `search` and `execute` tools; proxies to Start via a service binding.
  - Exposed MCP endpoints in CRM (`/mcp`, `/api/mcp`) behind existing auth using `@modelcontextprotocol/sdk`.
  - Implemented operation catalog and execution RPC in `wodsmith-start` with `@tanstack/start-storage-context`.

- **Bug Fixes**
  - Unwrap compiled TanStack server-function results when they return Start-serialized JSON `Response`, fixing undefined results in Code Mode; added regression tests for the response shape and MCP server protocol.

<sup>Written for commit 8daf756faa594624a36aaf086acaea007fc5331e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP support for CRM and competition operations with sandboxed code execution (search + execute)
  * New /mcp and /api/mcp endpoints and OAuth protected-resource metadata
  * Authentication now accepts Authorization: Bearer or session cookie for MCP flows
  * Operation catalog and remote operation invocation support

* **Documentation**
  * Added MCP server docs covering setup, operation catalog, and usage

* **Chores**
  * Added Code Mode MCP worker, project configs, and npm scripts

* **Tests**
  * Added protocol and catalog tests for MCP behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->