### PR TITLE
[codex] fix ledger date rendering

### DIFF
--- a/apps/ledger/src/components/document-table.tsx
+++ b/apps/ledger/src/components/document-table.tsx
@@ -27,7 +27,19 @@ function formatCurrency(cents: number | null, currency: string): string {
 
 function formatDate(dateStr: string | null): string {
 	if (!dateStr) return "-"
-	return new Date(dateStr).toLocaleDateString("en-US", {
+
+	const dateOnlyMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr)
+	const date = dateOnlyMatch
+		? new Date(
+				Number(dateOnlyMatch[1]),
+				Number(dateOnlyMatch[2]) - 1,
+				Number(dateOnlyMatch[3]),
+			)
+		: new Date(dateStr)
+
+	if (Number.isNaN(date.getTime())) return "-"
+
+	return date.toLocaleDateString("en-US", {
 		month: "short",
 		day: "numeric",
 		year: "numeric",


### PR DESCRIPTION
## Summary
- Fix ledger document invoice date rendering for date-only values
- Parse `YYYY-MM-DD` as a local calendar date before formatting
- Keep invalid or missing dates rendering as `-`

## Root Cause
The documents table used `new Date(dateStr)` for invoice dates stored as `YYYY-MM-DD`. JavaScript parses that shape as UTC midnight, so viewers in US timezones could see the previous calendar day on `https://ledger.wodsmith.com/documents`.

## Validation
- `pnpm --filter ledger type-check`
- `pnpm --filter ledger exec biome lint src/components/document-table.tsx`
- Manual Boise timezone check: `2026-06-01` renders as `Jun 1, 2026`

## Note
A full `pnpm --filter ledger check` is still blocked by preexisting Biome formatting/import diagnostics elsewhere in `apps/ledger`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix invoice date rendering in the `ledger` documents table by parsing `YYYY-MM-DD` as a local date to prevent timezone shifts that showed the previous day. Invalid or missing dates still render as "-".

<sup>Written for commit afa9106ddd05cd79d90800f8833b4f8bba8f62ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

