### PR TITLE
Enable Stripe Checkout promotion codes

### DIFF
--- a/apps/wodsmith-start/src/server-fns/registration-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/registration-fns.ts
@@ -906,6 +906,7 @@ export const initiateRegistrationPaymentFn = createServerFn({ method: "POST" })
       cancel_url: `${appUrl}/compete/${competition.slug}/register?canceled=true`,
       expires_at: Math.floor(Date.now() / 1000) + 30 * 60,
       customer_email: session.user.email ?? undefined,
+      allow_promotion_codes: true,
     }
 
     // Add transfer_data if organizer has verified Stripe connection
@@ -937,6 +938,10 @@ export const initiateRegistrationPaymentFn = createServerFn({ method: "POST" })
         max_redemptions: 1,
         metadata: { couponId: validatedCoupon.id, purchaseId: purchaseIds[0] },
       })
+      // Stripe Checkout only supports one discount path per session. If WODsmith
+      // pre-applies an app coupon, hide the promo-code entry box to avoid users
+      // stacking a second Stripe-hosted promotion code.
+      sessionParams.allow_promotion_codes = false
       sessionParams.discounts = [{ coupon: stripeCouponId }]
       sessionParams.metadata = {
         ...sessionParams.metadata,

--- a/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
@@ -902,6 +902,7 @@ describe('registration-fns', () => {
         expect(mockStripeCheckoutCreate).toHaveBeenCalledTimes(1)
         const stripeArgs = mockStripeCheckoutCreate.mock.calls[0]?.[0] as any
         expect(stripeArgs.line_items).toHaveLength(2)
+        expect(stripeArgs.allow_promotion_codes).toBe(true)
         expect(stripeArgs.metadata.multiDivision).toBe('true')
         expect(stripeArgs.metadata.purchaseIds).toContain(',')
 

--- a/lat.md/commerce.md
+++ b/lat.md/commerce.md
@@ -14,6 +14,8 @@ Athletes pay registration fees via Stripe Checkout, handled by `src/workflows/st
 
 Competitions set a `defaultRegistrationFeeCents` (default $0 = free). Division-specific fees can override the default. The checkout flow creates a Stripe session, redirects the athlete, and a webhook confirms payment.
 
+Stripe Checkout sessions allow Stripe promotion codes by default so athletes can enter hosted promo codes at payment time. If a WODsmith coupon is pre-applied, the session disables promotion-code entry and attaches that discount directly.
+
 ## Coupons
 
 Discount codes that reduce registration fees, defined in `src/db/schemas/coupons.ts`.


### PR DESCRIPTION
## Summary
- enable Stripe Checkout promotion code entry for registration checkout sessions
- disable hosted promotion-code entry when a WODsmith coupon is already pre-applied to avoid stacking discounts
- document the Checkout promo-code behavior in lat.md

## Tests
- pnpm --filter wodsmith-start test -- registration-fns.test.ts
- pre-push: pnpm lint
- pre-push: pnpm type-check
- lat_check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Stripe Checkout promotion codes for registration. If a WODsmith coupon is pre-applied, the promo-code field is hidden to prevent stacking discounts.

- New Features
  - Set `allow_promotion_codes: true` for Checkout; disable it when applying a WODsmith coupon.
  - Added a test asserting default `allow_promotion_codes` behavior.
  - Documented the behavior in `lat.md/commerce.md`.

<sup>Written for commit 6cc6e3cb676b96c9aef6630c91783daa74d7e9a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promotion codes can now be entered during competition registration checkout

* **Bug Fixes**
  * Fixed discount stacking by preventing promotion code entry when coupons are pre-applied

* **Documentation**
  * Updated registration checkout documentation to clarify promotion code behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->