### PR TITLE
Show pending competition invites on competition page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ The second example is invalid because `Bad Section` has no leading paragraph. `l
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **thewodapp** (30097 symbols, 50474 relationships, 293 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **thewodapp** (30101 symbols, 50502 relationships, 293 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,7 +279,7 @@ skills:
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **thewodapp** (30097 symbols, 50474 relationships, 293 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **thewodapp** (30101 symbols, 50502 relationships, 293 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/apps/wodsmith-start/src/components/registration-sidebar.tsx
+++ b/apps/wodsmith-start/src/components/registration-sidebar.tsx
@@ -128,6 +128,13 @@ interface PendingTeamInviteEntry {
   token: string
 }
 
+interface PendingCompetitionInviteEntry {
+  id: string
+  token: string
+  divisionLabel: string
+  expiresAt: Date | string | number | null
+}
+
 interface RegistrationSidebarProps {
   competition: Competition & {
     organizingTeam: Team | null
@@ -143,6 +150,7 @@ interface RegistrationSidebarProps {
   isVolunteer?: boolean
   userRegistrations?: UserRegistrationEntry[]
   pendingTeamInvites?: PendingTeamInviteEntry[]
+  pendingCompetitionInvites?: PendingCompetitionInviteEntry[]
   session?: { userId: string } | null
   competitionCapacity?: {
     spotsAvailable: number | null
@@ -181,6 +189,7 @@ export function RegistrationSidebar({
   isVolunteer = false,
   userRegistrations = [],
   pendingTeamInvites = [],
+  pendingCompetitionInvites = [],
   session,
   competitionCapacity,
 }: RegistrationSidebarProps) {
@@ -198,6 +207,7 @@ export function RegistrationSidebar({
     regOpensAt && !hasDateStartedInTimezone(regOpensAt, competitionTimezone)
 
   const hasMultipleRegistrations = userRegistrations.length > 1
+  const hasPendingCompetitionInvites = pendingCompetitionInvites.length > 0
 
   return (
     <div className="space-y-4">
@@ -229,6 +239,42 @@ export function RegistrationSidebar({
         </Card>
       )}
 
+      {hasPendingCompetitionInvites && (
+        <Card className="border-2 border-emerald-200 bg-card shadow-lg shadow-slate-950/10 dark:border-green-500/20 dark:bg-white/5 dark:backdrop-blur-md dark:shadow-none">
+          <CardContent className="p-4 space-y-3">
+            <div className="flex items-center gap-2 text-emerald-700 dark:text-green-600">
+              <UserPlus className="h-5 w-5" />
+              <span className="font-semibold">Competition invite waiting</span>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              You've been invited to register for this competition.
+            </p>
+            <div className="space-y-2">
+              {pendingCompetitionInvites.map((invite, index) => (
+                <div key={invite.id} className="space-y-1.5">
+                  <Button asChild size="lg" className="w-full">
+                    <Link
+                      to="/compete/$slug/claim/$token"
+                      params={{ slug: competition.slug, token: invite.token }}
+                    >
+                      {pendingCompetitionInvites.length > 1
+                        ? `Accept Invite ${index + 1}`
+                        : "Accept Invite"}
+                    </Link>
+                  </Button>
+                  <p className="text-xs text-muted-foreground text-center">
+                    {invite.divisionLabel}
+                    {invite.expiresAt
+                      ? ` · Respond by ${formatDeadlineDate(invite.expiresAt)}`
+                      : ""}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Volunteer Dashboard Button */}
       {isVolunteer && (
         <Card className="border-2 border-blue-500/20 bg-white/5 backdrop-blur-md">
@@ -244,7 +290,7 @@ export function RegistrationSidebar({
       )}
 
       {/* Registration CTA Card - shown when NOT registered at all */}
-      {!isRegistered && registrationOpen && (
+      {!hasPendingCompetitionInvites && !isRegistered && registrationOpen && (
         <Card
           className={`backdrop-blur-md ${
             urgency?.urgencyLevel === "critical"
@@ -337,7 +383,8 @@ export function RegistrationSidebar({
       )}
 
       {/* Registration Not Yet Open */}
-      {!isRegistered &&
+      {!hasPendingCompetitionInvites &&
+        !isRegistered &&
         !registrationOpen &&
         registrationNotYetOpen &&
         regOpensAt && (
@@ -357,7 +404,8 @@ export function RegistrationSidebar({
         )}
 
       {/* Registration Closed */}
-      {!isRegistered &&
+      {!hasPendingCompetitionInvites &&
+        !isRegistered &&
         !registrationOpen &&
         !registrationNotYetOpen &&
         regClosesAt && (

--- a/apps/wodsmith-start/src/routes/compete/$slug.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/server-fns/competition-detail-fns"
 import { getPublicCompetitionDivisionsFn } from "@/server-fns/competition-divisions-fns"
 import { getCompetitionBySlugFn } from "@/server-fns/competition-fns"
+import { listMyPendingCompetitionInvitesFn } from "@/server-fns/competition-invite-fns"
 import { getCouponByCodeFn } from "@/server-fns/coupon-fns"
 import { hasJudgesScheduleFn } from "@/server-fns/judge-scheduling-fns"
 import { getCompetitionSponsorsFn } from "@/server-fns/sponsor-fns"
@@ -92,6 +93,7 @@ export const Route = createFileRoute("/compete/$slug")({
       organizerContactEmail,
       userRegsResult,
       pendingTeamInvitesResult,
+      pendingCompetitionInvitesResult,
       judgesScheduleResult,
       cohostPermissions,
     ] = await Promise.all([
@@ -119,6 +121,13 @@ export const Route = createFileRoute("/compete/$slug")({
             },
           })
         : Promise.resolve({ invitations: [] }),
+      session
+        ? listMyPendingCompetitionInvitesFn({
+            data: {
+              championshipCompetitionId: competition.id,
+            },
+          })
+        : Promise.resolve({ invites: [] }),
       hasJudgesScheduleFn({
         data: { competitionId: competition.id },
       }),
@@ -169,6 +178,7 @@ export const Route = createFileRoute("/compete/$slug")({
       competitionCapacity,
       sponsors,
       pendingTeamInvites: pendingTeamInvitesResult.invitations,
+      pendingCompetitionInvites: pendingCompetitionInvitesResult.invites,
       userDivision,
       userDivisions,
       maxSpots: undefined as number | undefined,

--- a/apps/wodsmith-start/src/routes/compete/$slug/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/index.tsx
@@ -116,6 +116,7 @@ function CompetitionOverviewPage() {
     competitionCapacity,
     sponsors,
     pendingTeamInvites,
+    pendingCompetitionInvites,
     userDivision,
     userDivisions,
     maxSpots,
@@ -285,6 +286,7 @@ function CompetitionOverviewPage() {
           isVolunteer={isVolunteer}
           userRegistrations={userDivisions}
           pendingTeamInvites={pendingTeamInvites}
+          pendingCompetitionInvites={pendingCompetitionInvites}
           session={session}
           competitionCapacity={competitionCapacity}
         />

--- a/apps/wodsmith-start/src/server-fns/competition-invite-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-invite-fns.ts
@@ -18,7 +18,7 @@
 import { env } from "cloudflare:workers"
 import { render } from "@react-email/render"
 import { createServerFn } from "@tanstack/react-start"
-import { and, eq, inArray, ne, sql } from "drizzle-orm"
+import { and, eq, inArray, isNotNull, ne, or, sql } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import {
@@ -221,6 +221,10 @@ const listBespokeInvitesInputSchema = z.object({
    *  picked a target championship division yet — the choice is deferred to
    *  send time). */
   championshipDivisionId: z.string().min(1).optional(),
+})
+
+const listMyPendingCompetitionInvitesInputSchema = z.object({
+  championshipCompetitionId: z.string().min(1),
 })
 
 const bespokeBulkInviteInputSchema = z.object({
@@ -1441,6 +1445,14 @@ export const createBespokeInvitesBulkFn = createServerFn({ method: "POST" })
  * uses this to distinguish drafts from sent invites without exposing
  * raw token columns.
  */
+export interface MyPendingCompetitionInviteSummary {
+  id: string
+  token: string
+  championshipDivisionId: string
+  divisionLabel: string
+  expiresAt: Date | null
+}
+
 export interface ActiveInviteSummary {
   id: string
   email: string
@@ -1511,6 +1523,76 @@ export interface AuditInviteSummary extends ActiveInviteSummary {
  * regardless of origin so the UI can classify. Returns a minimal DTO so
  * the raw token columns never reach the client.
  */
+export const listMyPendingCompetitionInvitesFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) =>
+    listMyPendingCompetitionInvitesInputSchema.parse(data),
+  )
+  .handler(
+    async ({
+      data,
+    }): Promise<{ invites: MyPendingCompetitionInviteSummary[] }> => {
+      const session = await getSessionFromCookie()
+      if (!session?.userId) return { invites: [] }
+
+      const db = getDb()
+      const normalizedEmail = session.user.email
+        ? normalizeInviteEmail(session.user.email)
+        : null
+      const identityPredicate = normalizedEmail
+        ? or(
+            eq(competitionInvitesTable.userId, session.userId),
+            eq(competitionInvitesTable.email, normalizedEmail),
+          )
+        : eq(competitionInvitesTable.userId, session.userId)
+
+      const rows = await db
+        .select({
+          id: competitionInvitesTable.id,
+          token: competitionInvitesTable.claimToken,
+          championshipDivisionId:
+            competitionInvitesTable.championshipDivisionId,
+          divisionLabel: scalingLevelsTable.label,
+          expiresAt: competitionInvitesTable.expiresAt,
+        })
+        .from(competitionInvitesTable)
+        .leftJoin(
+          scalingLevelsTable,
+          eq(
+            scalingLevelsTable.id,
+            competitionInvitesTable.championshipDivisionId,
+          ),
+        )
+        .where(
+          and(
+            eq(
+              competitionInvitesTable.championshipCompetitionId,
+              data.championshipCompetitionId,
+            ),
+            identityPredicate,
+            eq(
+              competitionInvitesTable.status,
+              COMPETITION_INVITE_STATUS.PENDING,
+            ),
+            eq(
+              competitionInvitesTable.activeMarker,
+              COMPETITION_INVITE_ACTIVE_MARKER,
+            ),
+            isNotNull(competitionInvitesTable.claimToken),
+          ),
+        )
+
+      return {
+        invites: rows.map((row) => ({
+          ...row,
+          token: row.token ?? "",
+          divisionLabel: row.divisionLabel ?? "Invited division",
+        })),
+      }
+    },
+  )
+
 export const listActiveInvitesFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => listBespokeInvitesInputSchema.parse(data))
   .handler(async ({ data }): Promise<{ invites: ActiveInviteSummary[] }> => {

--- a/apps/wodsmith-start/src/server-fns/competition-invite-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-invite-fns.ts
@@ -18,7 +18,17 @@
 import { env } from "cloudflare:workers"
 import { render } from "@react-email/render"
 import { createServerFn } from "@tanstack/react-start"
-import { and, eq, inArray, isNotNull, ne, or, sql } from "drizzle-orm"
+import {
+  and,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  isNull,
+  ne,
+  or,
+  sql,
+} from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import {
@@ -1517,12 +1527,11 @@ export interface AuditInviteSummary extends ActiveInviteSummary {
 }
 
 /**
- * List all active invites for a championship+division. Used by the
- * organizer invites route to render the bespoke section + invite state
- * overlays on source roster rows. Phase 2: returns every active row
- * regardless of origin so the UI can classify. Returns a minimal DTO so
- * the raw token columns never reach the client.
+ * List claimable pending competition invites for the signed-in athlete on
+ * the public competition page. Mirrors the claim guard's expiry semantics so
+ * a still-pending row stops producing a sidebar CTA once its deadline passes.
  */
+// @lat: [[competition-invites#Competition page invite card]]
 export const listMyPendingCompetitionInvitesFn = createServerFn({
   method: "GET",
 })
@@ -1546,6 +1555,7 @@ export const listMyPendingCompetitionInvitesFn = createServerFn({
             eq(competitionInvitesTable.email, normalizedEmail),
           )
         : eq(competitionInvitesTable.userId, session.userId)
+      const now = new Date()
 
       const rows = await db
         .select({
@@ -1580,6 +1590,10 @@ export const listMyPendingCompetitionInvitesFn = createServerFn({
               COMPETITION_INVITE_ACTIVE_MARKER,
             ),
             isNotNull(competitionInvitesTable.claimToken),
+            or(
+              isNull(competitionInvitesTable.expiresAt),
+              gt(competitionInvitesTable.expiresAt, now),
+            ),
           ),
         )
 

--- a/apps/wodsmith-start/test/components/registration-sidebar.test.tsx
+++ b/apps/wodsmith-start/test/components/registration-sidebar.test.tsx
@@ -14,11 +14,9 @@ vi.mock("@tanstack/react-router", () => ({
     to: string
     params?: Record<string, string>
   }) => {
-    const href = params?.token
-      ? to.replace("$token", params.token)
-      : params?.slug
-        ? to.replace("$slug", params.slug)
-        : to
+    let href = to
+    if (params?.slug) href = href.replace("$slug", params.slug)
+    if (params?.token) href = href.replace("$token", params.token)
     return (
       <a href={href} {...rest}>
         {children}
@@ -71,6 +69,53 @@ function renderSidebar(
     />,
   )
 }
+
+describe("RegistrationSidebar pending competition invites", () => {
+  it("shows an accept invite CTA in place of the public registration CTA", () => {
+    renderSidebar({
+      registrationOpen: true,
+      pendingCompetitionInvites: [
+        {
+          id: "comp_invite_1",
+          token: "claim_token_abc",
+          divisionLabel: "Individual RX",
+          expiresAt: "2026-05-15",
+        },
+      ],
+    })
+
+    const link = screen.getByRole("link", { name: "Accept Invite" })
+    expect(screen.getByText("Competition invite waiting")).toBeInTheDocument()
+    expect(screen.getByText(/Individual RX/)).toBeInTheDocument()
+    expect(link).toHaveAttribute(
+      "href",
+      "/compete/test-comp/claim/claim_token_abc",
+    )
+    expect(
+      screen.queryByRole("link", { name: "Register Now" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows the invite CTA even when public registration is closed", () => {
+    renderSidebar({
+      registrationOpen: false,
+      pendingCompetitionInvites: [
+        {
+          id: "comp_invite_1",
+          token: "claim_token_abc",
+          divisionLabel: "Individual RX",
+          expiresAt: null,
+        },
+      ],
+    })
+
+    expect(screen.getByRole("link", { name: "Accept Invite" })).toHaveAttribute(
+      "href",
+      "/compete/test-comp/claim/claim_token_abc",
+    )
+    expect(screen.queryByText("Registration closed")).not.toBeInTheDocument()
+  })
+})
 
 describe("RegistrationSidebar pending team invites", () => {
   it("shows an accept team invite CTA when a pending invite exists", () => {

--- a/apps/wodsmith-start/test/server-fns/competition-invite-fns.lists.test.ts
+++ b/apps/wodsmith-start/test/server-fns/competition-invite-fns.lists.test.ts
@@ -31,12 +31,16 @@ vi.mock("@tanstack/react-start", () => ({
 }))
 
 const lookupQueue: Array<unknown[]> = []
+const whereCalls: unknown[] = []
 vi.mock("@/db", () => ({
   getDb: () => {
     const chain = {
       select: vi.fn(() => chain),
       from: vi.fn(() => chain),
-      where: vi.fn(() => chain),
+      where: vi.fn((condition: unknown) => {
+        whereCalls.push(condition)
+        return chain
+      }),
       orderBy: vi.fn(() => chain),
       groupBy: vi.fn(() => chain),
       innerJoin: vi.fn(() => chain),
@@ -103,6 +107,65 @@ async function getMocks() {
 
 beforeEach(() => {
   lookupQueue.length = 0
+  whereCalls.length = 0
+})
+
+function collectSqlFragments(value: unknown, fragments: string[] = []): string[] {
+  if (!value || typeof value !== "object") return fragments
+
+  const node = value as {
+    name?: unknown
+    queryChunks?: unknown[]
+    value?: unknown
+  }
+
+  if (typeof node.name === "string") fragments.push(node.name)
+  if (Array.isArray(node.value)) {
+    for (const chunk of node.value) {
+      if (typeof chunk === "string") fragments.push(chunk)
+    }
+  }
+  if (Array.isArray(node.queryChunks)) {
+    for (const chunk of node.queryChunks) {
+      collectSqlFragments(chunk, fragments)
+    }
+  }
+
+  return fragments
+}
+
+// ============================================================================
+// listMyPendingCompetitionInvitesFn
+// ============================================================================
+
+describe("listMyPendingCompetitionInvitesFn", () => {
+  it("only returns pending invite cards that are still claimable by expiry", async () => {
+    const { auth } = await getMocks()
+    vi.mocked(auth.getSessionFromCookie).mockResolvedValue(
+      sessionStub as unknown as Awaited<
+        ReturnType<typeof auth.getSessionFromCookie>
+      >,
+    )
+    lookupQueue.push([])
+
+    const { listMyPendingCompetitionInvitesFn } = await import(
+      "@/server-fns/competition-invite-fns"
+    )
+
+    await (
+      listMyPendingCompetitionInvitesFn as unknown as (ctx: {
+        data: unknown
+      }) => Promise<unknown>
+    )({
+      data: { championshipCompetitionId: "comp_champ" },
+    })
+
+    expect(whereCalls).toHaveLength(1)
+    const whereSql = collectSqlFragments(whereCalls[0]).join(" ")
+    expect(whereSql).toContain("expiresAt")
+    expect(whereSql).toContain(" is null")
+    expect(whereSql).toContain(" > ")
+  })
 })
 
 // ============================================================================

--- a/lat.md/competition-invites.md
+++ b/lat.md/competition-invites.md
@@ -223,7 +223,7 @@ The claim landing page also surfaces a secondary "Decline this invite" link dire
 
 Signed-in athletes with a live pending invite see an accept-invite card on the public competition page sidebar.
 
-The parent `/compete/$slug` loader calls [[apps/wodsmith-start/src/server-fns/competition-invite-fns.ts#listMyPendingCompetitionInvitesFn]] for the current session and passes matching pending invite tokens into [[apps/wodsmith-start/src/components/registration-sidebar.tsx#RegistrationSidebar]]. Matches are scoped to the championship and the signed-in identity (`userId` or normalized email), require `status = pending`, `activeMarker = active`, and a non-null claim token.
+The parent `/compete/$slug` loader calls [[apps/wodsmith-start/src/server-fns/competition-invite-fns.ts#listMyPendingCompetitionInvitesFn]] for the current session and passes matching pending invite tokens into [[apps/wodsmith-start/src/components/registration-sidebar.tsx#RegistrationSidebar]]. Matches are scoped to the championship and the signed-in identity (`userId` or normalized email), require `status = pending`, `activeMarker = active`, a non-null claim token, and either no `expiresAt` value or an `expiresAt` later than the lookup time. Expired-but-still-pending rows are hidden even before [[apps/wodsmith-start/src/server/competition-invites/expiry.ts#sweepExpiredInvites]] transitions them.
 
 [[apps/wodsmith-start/src/routes/compete/$slug.tsx]] owns the signed-in lookup so every public child tab receives the same pending-invite state from the parent route. [[apps/wodsmith-start/src/routes/compete/$slug/index.tsx#CompetitionOverviewPage]] threads that state into the sidebar on the overview page.
 

--- a/lat.md/competition-invites.md
+++ b/lat.md/competition-invites.md
@@ -219,6 +219,18 @@ The claim landing page also surfaces a secondary "Decline this invite" link dire
 
 `invite-pending.tsx` is a fallback landing for visitors who arrive without a token (e.g. a stale bookmark) — it tells them to re-open the email rather than guessing a URL. The claim route's `wrong_account` branch no longer routes through it; the post-logout redirect goes straight to `/sign-in` with the original claim URL pinned as `redirect`.
 
+## Competition page invite card
+
+Signed-in athletes with a live pending invite see an accept-invite card on the public competition page sidebar.
+
+The parent `/compete/$slug` loader calls [[apps/wodsmith-start/src/server-fns/competition-invite-fns.ts#listMyPendingCompetitionInvitesFn]] for the current session and passes matching pending invite tokens into [[apps/wodsmith-start/src/components/registration-sidebar.tsx#RegistrationSidebar]]. Matches are scoped to the championship and the signed-in identity (`userId` or normalized email), require `status = pending`, `activeMarker = active`, and a non-null claim token.
+
+[[apps/wodsmith-start/src/routes/compete/$slug.tsx]] owns the signed-in lookup so every public child tab receives the same pending-invite state from the parent route. [[apps/wodsmith-start/src/routes/compete/$slug/index.tsx#CompetitionOverviewPage]] threads that state into the sidebar on the overview page.
+
+The sidebar renders an "Accept Invite" CTA to `/compete/$slug/claim/$token` with the invited division label and RSVP deadline. When this card is present it suppresses the public Register Now / Registration closed / Registration opens soon card because the invite route is the athlete's registration authority and can bypass the public window.
+
+The card stays opaque in light mode (`bg-card` with a soft emerald border/shadow) so dark competition banners cannot bleed through the sidebar. Dark mode keeps the existing translucent glass treatment.
+
 ## Email delivery
 
 Invite emails ride the existing broadcast queue binding (`BROADCAST_EMAIL_QUEUE`) with a discriminator.


### PR DESCRIPTION
## Summary
- Show a pending competition invite card on the public competition overview sidebar for signed-in invitees
- Add a user-scoped pending invite lookup and route the CTA to the existing claim flow
- Keep the card opaque in light mode so dark competition banners do not bleed through
- Document the behavior in lat.md

## Tests
- pnpm --filter wodsmith-start test test/components/registration-sidebar.test.tsx
- pnpm --filter wodsmith-start type-check
- lat_check
- gitnexus_detect_changes (medium risk, expected public competition loader/sidebar flow)

## Notes
- Pre-push also ran monorepo lint and type-check. Lint completed with existing warnings only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show pending competition invite card(s) on the competition overview sidebar for signed-in athletes. Expired invites are hidden; each invite links to the claim flow and replaces public registration CTAs.

- New Features
  - Added `listMyPendingCompetitionInvitesFn` to return user-scoped, claimable invites (matches by `userId` or normalized email; requires `status=pending`, active marker, non-null claim token, and `expiresAt` is null or in the future).
  - The `/compete/$slug` loader fetches invites and passes them to children; `RegistrationSidebar` renders one “Accept Invite” button per invite to `/compete/$slug/claim/$token` with division label and RSVP deadline, and hides Register/Open/Closed cards when invites exist.
  - Sidebar card stays opaque in light mode to prevent banner bleed; tests cover expiry filtering and CTA suppression across open/closed states, and docs were updated.

<sup>Written for commit 696ff3cecd5a0d2bf29997dc167bfe635fd75689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

