### PR TITLE
Fix registration coupon entry before Stripe checkout

### DIFF
--- a/apps/wodsmith-start/src/components/registration/registration-form.tsx
+++ b/apps/wodsmith-start/src/components/registration/registration-form.tsx
@@ -17,6 +17,7 @@ import {
   CapacityBanners,
   ClosedRegistrationBanner,
   CompetitionDetailsCard,
+  CouponCodeSection,
   DivisionPickerSection,
   FeeSummarySection,
   PageHeader,
@@ -136,6 +137,15 @@ export function PublicRegistrationForm(props: PublicProps) {
           answers={r.answers}
           onAnswerChange={r.updateAnswer}
           disabled={fieldsDisabled}
+        />
+        <CouponCodeSection
+          value={r.couponCodeInput}
+          activeCoupon={r.activeCoupon}
+          onChange={r.setCouponCodeInput}
+          onApply={r.handleApplyCoupon}
+          onRemove={r.handleRemoveCoupon}
+          disabled={fieldsDisabled}
+          isApplying={r.isApplyingCoupon}
         />
         <FeeSummarySection
           competitionId={props.competition.id}
@@ -263,6 +273,15 @@ export function InviteRegistrationForm(props: InviteProps) {
           answers={r.answers}
           onAnswerChange={r.updateAnswer}
           disabled={fieldsDisabled}
+        />
+        <CouponCodeSection
+          value={r.couponCodeInput}
+          activeCoupon={r.activeCoupon}
+          onChange={r.setCouponCodeInput}
+          onApply={r.handleApplyCoupon}
+          onRemove={r.handleRemoveCoupon}
+          disabled={fieldsDisabled}
+          isApplying={r.isApplyingCoupon}
         />
         <FeeSummarySection
           competitionId={props.competition.id}

--- a/apps/wodsmith-start/src/components/registration/registration-sections.tsx
+++ b/apps/wodsmith-start/src/components/registration/registration-sections.tsx
@@ -645,6 +645,81 @@ export function RegistrationQuestionsSection({
   )
 }
 
+export function CouponCodeSection({
+  value,
+  activeCoupon,
+  onChange,
+  onApply,
+  onRemove,
+  disabled,
+  isApplying,
+}: {
+  value: string
+  activeCoupon: { code: string; amountOffCents: number } | null
+  onChange: (value: string) => void
+  onApply: () => void
+  onRemove: () => void
+  disabled?: boolean
+  isApplying: boolean
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Coupon Code</CardTitle>
+        <CardDescription>
+          Have a WODsmith coupon code? Apply it before checkout.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {activeCoupon ? (
+          <div className="flex items-center justify-between gap-3 rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-300">
+            <span className="flex items-center gap-2">
+              <Tag className="h-4 w-4" />
+              <span>
+                <span className="font-semibold">{activeCoupon.code}</span>{" "}
+                applied (${(activeCoupon.amountOffCents / 100).toFixed(2)} off)
+              </span>
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onRemove}
+              disabled={disabled}
+            >
+              Remove
+            </Button>
+          </div>
+        ) : (
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <Label htmlFor="registration-coupon-code" className="sr-only">
+                Coupon code
+              </Label>
+              <Input
+                id="registration-coupon-code"
+                value={value}
+                onChange={(event) => onChange(event.target.value)}
+                placeholder="Enter coupon code"
+                disabled={disabled || isApplying}
+                autoCapitalize="characters"
+              />
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onApply}
+              disabled={disabled || isApplying || !value.trim()}
+            >
+              {isApplying ? "Applying..." : "Apply"}
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
 export function FeeSummarySection({
   competitionId,
   selectedDivisionIds,

--- a/apps/wodsmith-start/src/components/registration/use-registration-form.ts
+++ b/apps/wodsmith-start/src/components/registration/use-registration-form.ts
@@ -11,10 +11,15 @@ import type {
 } from "@/db/schema"
 import { trackEvent } from "@/lib/posthog"
 import type { PublicCompetitionDivision } from "@/server-fns/competition-divisions-fns"
+import { validateCouponForCheckoutFn } from "@/server-fns/coupon-fns"
 import { initiateRegistrationPaymentFn } from "@/server-fns/registration-fns"
 import type { RegistrationQuestion } from "@/server-fns/registration-questions-fns"
 import { signWaiverFn } from "@/server-fns/waiver-fns"
-import { clearCouponSession, getCouponSession } from "@/utils/coupon-cookie"
+import {
+  clearCouponSession,
+  getCouponSession,
+  setCouponSession,
+} from "@/utils/coupon-cookie"
 
 export interface Teammate {
   email: string
@@ -84,10 +89,13 @@ export function useRegistrationForm(input: UseRegistrationFormInput) {
 
   const navigate = useNavigate()
   const signWaiver = useServerFn(signWaiverFn)
+  const validateCouponForCheckout = useServerFn(validateCouponForCheckoutFn)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isApplyingCoupon, setIsApplyingCoupon] = useState(false)
+  const [couponCodeInput, setCouponCodeInput] = useState("")
 
-  // Active coupon from sessionStorage
-  const [activeCoupon] = useState(() => {
+  // Active coupon from sessionStorage or manual entry.
+  const [activeCoupon, setActiveCoupon] = useState(() => {
     const coupon = getCouponSession()
     return coupon?.competitionSlug === competition.slug ? coupon : null
   })
@@ -308,6 +316,46 @@ export function useRegistrationForm(input: UseRegistrationFormInput) {
     )
   }
 
+  const handleApplyCoupon = async () => {
+    const code = couponCodeInput.trim()
+    if (!code) {
+      toast.error("Enter a coupon code")
+      return
+    }
+
+    setIsApplyingCoupon(true)
+    try {
+      const result = await validateCouponForCheckout({
+        data: { code, competitionId: competition.id },
+      })
+
+      if (!result.valid || !result.coupon) {
+        toast.error("Invalid or expired coupon code")
+        return
+      }
+
+      const couponSession = {
+        code: result.coupon.code,
+        competitionSlug: competition.slug,
+        competitionName: competition.name,
+        amountOffCents: result.amountOffCents,
+      }
+      setCouponSession(couponSession)
+      setActiveCoupon(couponSession)
+      setCouponCodeInput("")
+      toast.success("Coupon applied")
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to apply coupon")
+    } finally {
+      setIsApplyingCoupon(false)
+    }
+  }
+
+  const handleRemoveCoupon = () => {
+    clearCouponSession()
+    setActiveCoupon(null)
+  }
+
   const buildRegistrationItems = () =>
     selectedDivisionIds.map((divisionId) => {
       const division = getDivision(divisionId)
@@ -474,13 +522,16 @@ export function useRegistrationForm(input: UseRegistrationFormInput) {
 
     // state
     isSubmitting,
+    isApplyingCoupon,
     activeCoupon,
+    couponCodeInput,
     invitedDivision,
     selectedDivisionIds,
     selectedTeamDivisions,
     hasSelectedDivisions,
     affiliateName,
     setAffiliateName,
+    setCouponCodeInput,
     teamEntries,
     divisionFees,
     answers,
@@ -494,6 +545,8 @@ export function useRegistrationForm(input: UseRegistrationFormInput) {
     getDivision,
     handleDivisionToggle,
     handleFeesLoaded,
+    handleApplyCoupon,
+    handleRemoveCoupon,
     updateTeamEntry,
     updateTeammate,
     handleWaiverCheckChange,

--- a/apps/wodsmith-start/src/server-fns/registration-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/registration-fns.ts
@@ -906,7 +906,6 @@ export const initiateRegistrationPaymentFn = createServerFn({ method: "POST" })
       cancel_url: `${appUrl}/compete/${competition.slug}/register?canceled=true`,
       expires_at: Math.floor(Date.now() / 1000) + 30 * 60,
       customer_email: session.user.email ?? undefined,
-      allow_promotion_codes: true,
     }
 
     // Add transfer_data if organizer has verified Stripe connection
@@ -938,10 +937,6 @@ export const initiateRegistrationPaymentFn = createServerFn({ method: "POST" })
         max_redemptions: 1,
         metadata: { couponId: validatedCoupon.id, purchaseId: purchaseIds[0] },
       })
-      // Stripe Checkout only supports one discount path per session. If WODsmith
-      // pre-applies an app coupon, hide the promo-code entry box to avoid users
-      // stacking a second Stripe-hosted promotion code.
-      sessionParams.allow_promotion_codes = false
       sessionParams.discounts = [{ coupon: stripeCouponId }]
       sessionParams.metadata = {
         ...sessionParams.metadata,

--- a/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/registration-fns.test.ts
@@ -902,7 +902,7 @@ describe('registration-fns', () => {
         expect(mockStripeCheckoutCreate).toHaveBeenCalledTimes(1)
         const stripeArgs = mockStripeCheckoutCreate.mock.calls[0]?.[0] as any
         expect(stripeArgs.line_items).toHaveLength(2)
-        expect(stripeArgs.allow_promotion_codes).toBe(true)
+        expect(stripeArgs.allow_promotion_codes).toBeUndefined()
         expect(stripeArgs.metadata.multiDivision).toBe('true')
         expect(stripeArgs.metadata.purchaseIds).toContain(',')
 

--- a/lat.md/commerce.md
+++ b/lat.md/commerce.md
@@ -22,6 +22,12 @@ Discount codes that reduce registration fees, defined in `src/db/schemas/coupons
 
 Organizers create coupons per competition with percentage or fixed-amount discounts, usage limits, and expiration dates. Athletes can apply a coupon link or manually enter the code on registration before checkout.
 
+### Registration coupon entry
+
+Athletes enter WODsmith coupon codes before leaving for Stripe Checkout.
+
+[[apps/wodsmith-start/src/components/registration/registration-sections.tsx#CouponCodeSection]] renders the manual entry field on public and invite registration forms. It calls [[apps/wodsmith-start/src/server-fns/coupon-fns.ts#validateCouponForCheckoutFn]] through the registration form hook, stores the same session coupon payload used by coupon links, and passes the validated code to [[apps/wodsmith-start/src/server-fns/registration-fns.ts#initiateRegistrationPaymentFn]]. This keeps link-based and manual coupon application on the same server-side discount path.
+
 ## Purchase Transfers
 
 Registered athletes can transfer their registration to another person.

--- a/lat.md/commerce.md
+++ b/lat.md/commerce.md
@@ -14,13 +14,13 @@ Athletes pay registration fees via Stripe Checkout, handled by `src/workflows/st
 
 Competitions set a `defaultRegistrationFeeCents` (default $0 = free). Division-specific fees can override the default. The checkout flow creates a Stripe session, redirects the athlete, and a webhook confirms payment.
 
-Stripe Checkout sessions allow Stripe promotion codes by default so athletes can enter hosted promo codes at payment time. If a WODsmith coupon is pre-applied, the session disables promotion-code entry and attaches that discount directly.
+Stripe Checkout sessions do not enable Stripe-hosted promotion-code entry. WODsmith coupons are collected before checkout and, when applied, are attached to the session as a transient Stripe coupon discount.
 
 ## Coupons
 
 Discount codes that reduce registration fees, defined in `src/db/schemas/coupons.ts`.
 
-Organizers create coupons per competition with percentage or fixed-amount discounts, usage limits, and expiration dates. Applied during checkout.
+Organizers create coupons per competition with percentage or fixed-amount discounts, usage limits, and expiration dates. Athletes can apply a coupon link or manually enter the code on registration before checkout.
 
 ## Purchase Transfers
 

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -23,6 +23,8 @@ For **free** competitions (or fully discounted by coupon): calls `registerForCom
 
 For **paid** competitions: creates `commercePurchaseTable` records (one per division), builds Stripe Checkout line items with fee breakdown, creates a Stripe Checkout Session, and redirects the athlete. Registration is finalized asynchronously by the [[registration#Stripe Checkout Workflow]].
 
+Coupon codes are resolved before redirecting to Stripe; see [[commerce#Coupons#Registration coupon entry]] for the shared link/manual entry behavior.
+
 ### Organizer Manual Registration
 
 Organizers register athletes from the dashboard via `createManualRegistrationFn`, bypassing the registration window.

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -17,7 +17,7 @@ The flow validates in order:
 4. Competition-wide capacity not exceeded
 5. Required registration questions answered
 6. Fee calculated per division (division-specific fee overrides competition default)
-7. Coupon applied if provided
+7. Coupon applied if provided by link session data or manual entry
 
 For **free** competitions (or fully discounted by coupon): calls `registerForCompetition` directly and returns immediately.
 


### PR DESCRIPTION
## Summary
- remove Stripe Checkout hosted promotion-code entry from registration sessions
- add a WODsmith coupon-code field to public and invite registration forms
- validate manual coupon codes through existing checkout coupon validation and apply them through the same session data path used by coupon links
- update lat.md commerce/registration docs and registration test expectation

## Validation
- pnpm -C apps/wodsmith-start type-check
- pnpm -C apps/wodsmith-start test -- --run test/server-fns/registration-fns.test.ts test/server-fns/coupon-fns.test.ts
- pnpm -C apps/wodsmith-start exec biome check src/components/registration/use-registration-form.ts src/components/registration/registration-form.tsx src/components/registration/registration-sections.tsx test/server-fns/registration-fns.test.ts
- lat_check
- gitnexus_detect_changes: low risk

## Notes
- Full app-wide `pnpm -C apps/wodsmith-start check` still reports pre-existing Biome diagnostics outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved coupon entry into the registration flow and disabled Stripe’s promo-code box. Athletes can enter WODsmith coupons before checkout; valid codes are attached to the Stripe session via the shared link/manual path.

- **New Features**
  - Added `CouponCodeSection` to public and invite forms with input, apply, and remove states.
  - Validates codes via `validateCouponForCheckoutFn`, stores with `setCouponSession`, and carries the discount into checkout.

- **Bug Fixes**
  - Removed Stripe Checkout `allow_promotion_codes` to avoid stacking codes and ensure consistent discounts; tests updated.
  - Docs updated (`lat.md/commerce.md`, `lat.md/registration.md`) to clarify pre-checkout coupon entry and shared link/manual behavior.

<sup>Written for commit 03963e2346b06d150524102fd4e9bc5c9b2327e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

