### PR TITLE
Support volunteer-required waivers

### DIFF
--- a/apps/wodsmith-start/src/components/registration/fee-breakdown.tsx
+++ b/apps/wodsmith-start/src/components/registration/fee-breakdown.tsx
@@ -64,9 +64,16 @@ export function FeeBreakdown({
 
   if (!divisionId) {
     return (
-      <p className="text-muted-foreground text-sm">
-        Select a division to see pricing
-      </p>
+      <div className="space-y-2 text-sm text-muted-foreground">
+        <div className="flex justify-between">
+          <span>Registration Fee</span>
+          <span className="font-medium">—</span>
+        </div>
+        <div className="flex justify-between font-medium pt-2 border-t">
+          <span>Total</span>
+          <span className="text-lg">—</span>
+        </div>
+      </div>
     )
   }
 

--- a/apps/wodsmith-start/src/components/registration/registration-form.tsx
+++ b/apps/wodsmith-start/src/components/registration/registration-form.tsx
@@ -82,6 +82,7 @@ interface InviteProps extends RegistrationFormProps {
 export function PublicRegistrationForm(props: PublicProps) {
   const r = useRegistrationForm(props)
   const navigate = useNavigate()
+  const athleteWaivers = props.waivers.filter((waiver) => waiver.required)
   const competitionFull = props.competitionCapacity?.isFull ?? false
   const submitDisabled =
     r.isSubmitting ||
@@ -89,7 +90,7 @@ export function PublicRegistrationForm(props: PublicProps) {
     competitionFull ||
     !r.hasSelectedDivisions ||
     !r.affiliateName.trim() ||
-    (props.waivers.length > 0 && !r.allRequiredWaiversAgreed)
+    (athleteWaivers.length > 0 && !r.allRequiredWaiversAgreed)
 
   const fieldsDisabled = r.isSubmitting || !props.registrationOpen
 
@@ -166,7 +167,7 @@ export function PublicRegistrationForm(props: PublicProps) {
           disabled={fieldsDisabled}
         />
         <WaiversSection
-          waivers={props.waivers}
+          waivers={athleteWaivers}
           agreedWaivers={r.agreedWaivers}
           onWaiverToggle={r.handleWaiverCheckChange}
           disabled={fieldsDisabled}
@@ -184,7 +185,7 @@ export function PublicRegistrationForm(props: PublicProps) {
               "Competition Full"
             ) : !r.hasSelectedDivisions ? (
               "Select a Division"
-            ) : props.waivers.length > 0 && !r.allRequiredWaiversAgreed ? (
+            ) : athleteWaivers.length > 0 && !r.allRequiredWaiversAgreed ? (
               "Agree to Waivers to Continue"
             ) : r.selectedDivisionIds.length > 1 ? (
               `Register for ${r.selectedDivisionIds.length} Divisions`
@@ -217,6 +218,7 @@ export function PublicRegistrationForm(props: PublicProps) {
 export function InviteRegistrationForm(props: InviteProps) {
   const r = useRegistrationForm(props)
   const navigate = useNavigate()
+  const athleteWaivers = props.waivers.filter((waiver) => waiver.required)
 
   // If the URL pointed at a division that's no longer eligible (full,
   // already registered, removed), fall back to the public flow so the
@@ -242,7 +244,7 @@ export function InviteRegistrationForm(props: InviteProps) {
   const submitDisabled =
     r.isSubmitting ||
     !r.affiliateName.trim() ||
-    (props.waivers.length > 0 && !r.allRequiredWaiversAgreed)
+    (athleteWaivers.length > 0 && !r.allRequiredWaiversAgreed)
   const fieldsDisabled = r.isSubmitting
 
   return (
@@ -302,7 +304,7 @@ export function InviteRegistrationForm(props: InviteProps) {
           disabled={fieldsDisabled}
         />
         <WaiversSection
-          waivers={props.waivers}
+          waivers={athleteWaivers}
           agreedWaivers={r.agreedWaivers}
           onWaiverToggle={r.handleWaiverCheckChange}
           disabled={fieldsDisabled}
@@ -314,7 +316,7 @@ export function InviteRegistrationForm(props: InviteProps) {
                 <Loader2 className="w-4 h-4 mr-2 animate-spin" />
                 Processing...
               </>
-            ) : props.waivers.length > 0 && !r.allRequiredWaiversAgreed ? (
+            ) : athleteWaivers.length > 0 && !r.allRequiredWaiversAgreed ? (
               "Agree to Waivers to Continue"
             ) : r.selectedTeamDivisions.length > 0 ? (
               "Confirm Team Spot"

--- a/apps/wodsmith-start/src/components/registration/registration-sections.tsx
+++ b/apps/wodsmith-start/src/components/registration/registration-sections.tsx
@@ -740,6 +740,12 @@ export function FeeSummarySection({
 }) {
   const isMulti = selectedDivisionIds.length > 1
   const hasSelectedDivisions = selectedDivisionIds.length > 0
+  const selectedFeeValues = selectedDivisionIds
+    .map((divisionId) => divisionFees.get(divisionId))
+    .filter((fee): fee is number => fee !== undefined)
+  const hasLoadedSelectedFees =
+    selectedFeeValues.length === selectedDivisionIds.length
+
   return (
     <Card>
       <CardHeader>
@@ -772,12 +778,9 @@ export function FeeSummarySection({
             </div>
           )
         })}
-        {divisionFees.size > 0
+        {hasSelectedDivisions && hasLoadedSelectedFees
           ? (() => {
-              const subtotal = Array.from(divisionFees.values()).reduce(
-                (sum, c) => sum + c,
-                0,
-              )
+              const subtotal = selectedFeeValues.reduce((sum, c) => sum + c, 0)
               if (!activeCoupon) {
                 if (!isMulti) return null
                 return (

--- a/apps/wodsmith-start/src/components/registration/registration-sections.tsx
+++ b/apps/wodsmith-start/src/components/registration/registration-sections.tsx
@@ -738,14 +738,21 @@ export function FeeSummarySection({
   ) => void
   activeCoupon: { code: string; amountOffCents: number } | null
 }) {
-  if (selectedDivisionIds.length === 0) return null
   const isMulti = selectedDivisionIds.length > 1
+  const hasSelectedDivisions = selectedDivisionIds.length > 0
   return (
     <Card>
       <CardHeader>
         <CardTitle>Registration Fee{isMulti ? "s" : ""}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
+        {!hasSelectedDivisions ? (
+          <FeeBreakdown
+            competitionId={competitionId}
+            divisionId={null}
+            onFeesLoaded={onFeesLoaded}
+          />
+        ) : null}
         {selectedDivisionIds.map((divisionId) => {
           const division = getDivision(divisionId)
           const hideDivTotal = isMulti || !!activeCoupon

--- a/apps/wodsmith-start/src/db/schemas/waivers.ts
+++ b/apps/wodsmith-start/src/db/schemas/waivers.ts
@@ -2,13 +2,13 @@ import { createId } from "@paralleldrive/cuid2"
 import type { InferSelectModel } from "drizzle-orm"
 import { relations } from "drizzle-orm"
 import {
+  boolean,
+  datetime,
   index,
   int,
-  varchar,
-  datetime,
-  boolean,
   mysqlTable,
   text,
+  varchar,
 } from "drizzle-orm/mysql-core"
 import { commonColumns } from "./common"
 import {
@@ -40,8 +40,12 @@ export const waiversTable = mysqlTable(
     title: varchar({ length: 255 }).notNull(),
     // Rich text content stored as Lexical JSON
     content: text().notNull(),
-    // Whether this waiver is required for registration
+    // Whether this waiver is required for athlete registration
     required: boolean().default(true).notNull(),
+    // Whether this waiver is required for volunteer signup/invite acceptance
+    requiredForVolunteers: boolean("required_for_volunteers")
+      .default(false)
+      .notNull(),
     // Display order (for showing multiple waivers in sequence)
     position: int().default(0).notNull(),
   },
@@ -53,7 +57,7 @@ export const waiversTable = mysqlTable(
 
 /**
  * Waiver Signatures Table
- * Tracks when athletes sign waivers during registration or invite acceptance.
+ * Tracks when athletes and volunteers sign waivers during registration or invite acceptance.
  */
 export const waiverSignaturesTable = mysqlTable(
   "waiver_signatures",

--- a/apps/wodsmith-start/src/lib/series-template-asset-sync.ts
+++ b/apps/wodsmith-start/src/lib/series-template-asset-sync.ts
@@ -1,4 +1,4 @@
-type TitledAsset = {
+interface TitledAsset {
   title: string
 }
 
@@ -6,6 +6,14 @@ function normalizeAssetTitle(title: string): string {
   return title.toLowerCase().trim()
 }
 
+/**
+ * Selects template assets whose normalized titles are absent from existing assets.
+ * It also deduplicates template assets by normalized title, keeping the first match.
+ *
+ * @param templateAssets - Assets from the template to compare.
+ * @param existingAssets - Assets already present in the competition.
+ * @returns Missing template assets, deduplicated by normalized title.
+ */
 export function selectTemplateAssetsMissingByTitle<T extends TitledAsset>(
   templateAssets: T[],
   existingAssets: TitledAsset[],

--- a/apps/wodsmith-start/src/lib/series-template-asset-sync.ts
+++ b/apps/wodsmith-start/src/lib/series-template-asset-sync.ts
@@ -1,0 +1,28 @@
+type TitledAsset = {
+  title: string
+}
+
+function normalizeAssetTitle(title: string): string {
+  return title.toLowerCase().trim()
+}
+
+export function selectTemplateAssetsMissingByTitle<T extends TitledAsset>(
+  templateAssets: T[],
+  existingAssets: TitledAsset[],
+): T[] {
+  const existingTitles = new Set(
+    existingAssets.map((asset) => normalizeAssetTitle(asset.title)),
+  )
+
+  const missingAssets: T[] = []
+
+  for (const asset of templateAssets) {
+    const normalizedTitle = normalizeAssetTitle(asset.title)
+    if (existingTitles.has(normalizedTitle)) continue
+
+    missingAssets.push(asset)
+    existingTitles.add(normalizedTitle)
+  }
+
+  return missingAssets
+}

--- a/apps/wodsmith-start/src/lib/volunteer-waiver-agreements.ts
+++ b/apps/wodsmith-start/src/lib/volunteer-waiver-agreements.ts
@@ -1,0 +1,22 @@
+import type { Waiver } from "@/db/schemas/waivers"
+
+export function haveAllVolunteerWaiversBeenAgreed(
+  waivers: Waiver[],
+  agreedWaiverIds: Set<string>,
+): boolean {
+  return waivers.every((waiver) => agreedWaiverIds.has(waiver.id))
+}
+
+export function toggleVolunteerWaiverAgreement(
+  agreedWaiverIds: Set<string>,
+  waiverId: string,
+  checked: boolean,
+): Set<string> {
+  const next = new Set(agreedWaiverIds)
+  if (checked) {
+    next.add(waiverId)
+  } else {
+    next.delete(waiverId)
+  }
+  return next
+}

--- a/apps/wodsmith-start/src/routes/compete/$slug/-components/volunteer-signup-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/-components/volunteer-signup-form.tsx
@@ -1,8 +1,9 @@
 "use client"
 
+import { useServerFn } from "@tanstack/react-start"
 import { CheckCircle2, Loader2 } from "lucide-react"
 import { useState } from "react"
-import { useServerFn } from "@tanstack/react-start"
+import { WaiverViewer } from "@/components/compete/waiver-viewer"
 import { Button } from "@/components/ui/button"
 import {
   Card,
@@ -11,6 +12,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -22,6 +24,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { VOLUNTEER_AVAILABILITY } from "@/db/schemas/volunteers"
+import type { Waiver } from "@/db/schemas/waivers"
 import type { RegistrationQuestion } from "@/server-fns/registration-questions-fns"
 import {
   createAccountAndApplyAsVolunteerFn,
@@ -36,6 +39,7 @@ interface VolunteerSignupFormProps {
   }
   competitionTeamId: string
   questions?: RegistrationQuestion[]
+  waivers?: Waiver[]
   currentUser: { name: string; email: string } | null
 }
 
@@ -49,12 +53,14 @@ export function VolunteerSignupForm({
   competition,
   competitionTeamId,
   questions = [],
+  waivers = [],
   currentUser,
 }: VolunteerSignupFormProps) {
   const [submitted, setSubmitted] = useState(false)
   const [isPending, setIsPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [agreedWaivers, setAgreedWaivers] = useState<Set<string>>(new Set())
 
   const submitVolunteerSignup = useServerFn(submitVolunteerSignupFn)
   const createAccountAndApply = useServerFn(createAccountAndApplyAsVolunteerFn)
@@ -76,6 +82,15 @@ export function VolunteerSignupForm({
         setIsPending(false)
         return
       }
+    }
+
+    const allVolunteerWaiversAgreed = waivers.every((waiver) =>
+      agreedWaivers.has(waiver.id),
+    )
+    if (!allVolunteerWaiversAgreed) {
+      setError("Please agree to all required waivers before volunteering")
+      setIsPending(false)
+      return
     }
 
     const answersArray = Object.entries(answers)
@@ -101,6 +116,7 @@ export function VolunteerSignupForm({
         (formData.get("availabilityNotes") as string) || undefined,
       website: (formData.get("website") as string) || undefined,
       answers: answersArray.length > 0 ? answersArray : undefined,
+      waiverIds: Array.from(agreedWaivers),
     }
 
     try {
@@ -337,6 +353,49 @@ export function VolunteerSignupForm({
               disabled={isPending}
             />
           </div>
+
+          {/* Volunteer Waivers */}
+          {waivers.length > 0 && (
+            <div className="space-y-4 border-t pt-4">
+              <p className="text-sm font-medium">Required Waivers</p>
+              {waivers.map((waiver) => (
+                <div
+                  key={waiver.id}
+                  className="space-y-3 rounded-lg border p-4"
+                >
+                  <h3 className="font-medium">{waiver.title}</h3>
+                  <div className="max-h-64 overflow-y-auto rounded-lg border bg-muted/10 p-4">
+                    <WaiverViewer
+                      content={waiver.content}
+                      className="prose prose-sm max-w-none dark:prose-invert"
+                    />
+                  </div>
+                  <div className="flex items-start gap-3 rounded-lg bg-muted/20 p-4">
+                    <Checkbox
+                      id={`waiver-${waiver.id}`}
+                      checked={agreedWaivers.has(waiver.id)}
+                      onCheckedChange={(checked) => {
+                        setAgreedWaivers((prev) => {
+                          const next = new Set(prev)
+                          if (checked === true) next.add(waiver.id)
+                          else next.delete(waiver.id)
+                          return next
+                        })
+                      }}
+                      disabled={isPending}
+                    />
+                    <Label
+                      htmlFor={`waiver-${waiver.id}`}
+                      className="cursor-pointer text-sm font-medium leading-none"
+                    >
+                      I have read and agree to this waiver
+                      <span className="text-destructive ml-1">*</span>
+                    </Label>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
 
           {/* Volunteer Registration Questions */}
           {questions.length > 0 && (

--- a/apps/wodsmith-start/src/routes/compete/$slug/-components/volunteer-signup-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/-components/volunteer-signup-form.tsx
@@ -25,6 +25,10 @@ import {
 import { Textarea } from "@/components/ui/textarea"
 import { VOLUNTEER_AVAILABILITY } from "@/db/schemas/volunteers"
 import type { Waiver } from "@/db/schemas/waivers"
+import {
+  haveAllVolunteerWaiversBeenAgreed,
+  toggleVolunteerWaiverAgreement,
+} from "@/lib/volunteer-waiver-agreements"
 import type { RegistrationQuestion } from "@/server-fns/registration-questions-fns"
 import {
   createAccountAndApplyAsVolunteerFn,
@@ -84,10 +88,7 @@ export function VolunteerSignupForm({
       }
     }
 
-    const allVolunteerWaiversAgreed = waivers.every((waiver) =>
-      agreedWaivers.has(waiver.id),
-    )
-    if (!allVolunteerWaiversAgreed) {
+    if (!haveAllVolunteerWaiversBeenAgreed(waivers, agreedWaivers)) {
       setError("Please agree to all required waivers before volunteering")
       setIsPending(false)
       return
@@ -375,12 +376,13 @@ export function VolunteerSignupForm({
                       id={`waiver-${waiver.id}`}
                       checked={agreedWaivers.has(waiver.id)}
                       onCheckedChange={(checked) => {
-                        setAgreedWaivers((prev) => {
-                          const next = new Set(prev)
-                          if (checked === true) next.add(waiver.id)
-                          else next.delete(waiver.id)
-                          return next
-                        })
+                        setAgreedWaivers((prev) =>
+                          toggleVolunteerWaiverAgreement(
+                            prev,
+                            waiver.id,
+                            checked === true,
+                          ),
+                        )
                       }}
                       disabled={isPending}
                     />

--- a/apps/wodsmith-start/src/routes/compete/$slug/register/-components/waiver-signing-step.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/register/-components/waiver-signing-step.tsx
@@ -53,14 +53,16 @@ export function WaiverSigningStep({
   // Use useServerFn for TanStack Start pattern
   const signWaiver = useServerFn(signWaiverFn)
 
-  // If no waivers, don't render anything
-  if (waivers.length === 0) {
+  const athleteWaivers = waivers.filter((w) => w.required)
+
+  // If no athlete-required waivers, don't render anything
+  if (athleteWaivers.length === 0) {
     return null
   }
 
-  const allRequiredWaiversSigned = waivers
-    .filter((w) => w.required)
-    .every((w) => checkedWaivers.has(w.id))
+  const allRequiredWaiversSigned = athleteWaivers.every((w) =>
+    checkedWaivers.has(w.id),
+  )
 
   const handleCheckboxChange = (waiverId: string, checked: boolean) => {
     if (checked) {
@@ -83,7 +85,7 @@ export function WaiverSigningStep({
 
     try {
       // Sign all checked waivers that haven't been signed yet
-      const unsignedWaivers = waivers.filter(
+      const unsignedWaivers = athleteWaivers.filter(
         (w) => checkedWaivers.has(w.id) && !signedWaiverIds.has(w.id),
       )
 
@@ -124,7 +126,7 @@ export function WaiverSigningStep({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-6">
-          {waivers.map((waiver) => (
+          {athleteWaivers.map((waiver) => (
             <Card key={waiver.id} className="border-2">
               <CardHeader>
                 <CardTitle className="text-lg">

--- a/apps/wodsmith-start/src/routes/compete/$slug/volunteer.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/volunteer.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { getVolunteerQuestionsFn } from "@/server-fns/registration-questions-fns"
+import { getCompetitionWaiversFn } from "@/server-fns/waiver-fns"
 import { VolunteerSignupForm } from "./-components/volunteer-signup-form"
 
 export const Route = createFileRoute("/compete/$slug/volunteer")({
@@ -12,21 +13,28 @@ export const Route = createFileRoute("/compete/$slug/volunteer")({
       throw new Error("Competition not found")
     }
 
-    const volunteerQuestionsResult = await getVolunteerQuestionsFn({
-      data: { competitionId: competition.id },
-    })
+    const [volunteerQuestionsResult, waiversResult] = await Promise.all([
+      getVolunteerQuestionsFn({
+        data: { competitionId: competition.id },
+      }),
+      getCompetitionWaiversFn({
+        data: { competitionId: competition.id },
+      }),
+    ])
 
-    const currentUser =
-      session?.user.email
-        ? {
-            name: `${session.user.firstName || ""} ${session.user.lastName || ""}`.trim(),
-            email: session.user.email,
-          }
-        : null
+    const currentUser = session?.user.email
+      ? {
+          name: `${session.user.firstName || ""} ${session.user.lastName || ""}`.trim(),
+          email: session.user.email,
+        }
+      : null
 
     return {
       competition,
       volunteerQuestions: volunteerQuestionsResult.questions,
+      volunteerWaivers: waiversResult.waivers.filter(
+        (waiver) => waiver.requiredForVolunteers,
+      ),
       currentUser,
     }
   },
@@ -51,7 +59,8 @@ export const Route = createFileRoute("/compete/$slug/volunteer")({
 })
 
 function VolunteerSignupPage() {
-  const { competition, volunteerQuestions, currentUser } = Route.useLoaderData()
+  const { competition, volunteerQuestions, volunteerWaivers, currentUser } =
+    Route.useLoaderData()
 
   // Check if competition has a team (required for volunteer signups)
   if (!competition.competitionTeamId) {
@@ -79,6 +88,7 @@ function VolunteerSignupPage() {
         }}
         competitionTeamId={competition.competitionTeamId}
         questions={volunteerQuestions}
+        waivers={volunteerWaivers}
         currentUser={currentUser}
       />
     </div>

--- a/apps/wodsmith-start/src/routes/compete/cohost/$competitionId/waivers.tsx
+++ b/apps/wodsmith-start/src/routes/compete/cohost/$competitionId/waivers.tsx
@@ -6,8 +6,8 @@
  * Passes override callbacks to WaiverList so mutations use cohost auth.
  */
 
-import { useMemo } from "react"
 import { createFileRoute, getRouteApi } from "@tanstack/react-router"
+import { useMemo } from "react"
 import {
   cohostCreateWaiverFn,
   cohostDeleteWaiverFn,
@@ -21,9 +21,7 @@ import { WaiverList } from "../../organizer/$competitionId/-components/waiver-li
 // Get parent route API to access its loader data
 const parentRoute = getRouteApi("/compete/cohost/$competitionId")
 
-export const Route = createFileRoute(
-  "/compete/cohost/$competitionId/waivers",
-)({
+export const Route = createFileRoute("/compete/cohost/$competitionId/waivers")({
   staleTime: 10_000,
   loader: async ({ params, parentMatchPromise }) => {
     const parentMatch = await parentMatchPromise
@@ -60,6 +58,7 @@ function CohostWaiversPage() {
             title: opts.data.title,
             content: opts.data.content,
             required: opts.data.required,
+            requiredForVolunteers: opts.data.requiredForVolunteers,
           },
         }),
       updateWaiver: async (opts) =>
@@ -71,6 +70,7 @@ function CohostWaiversPage() {
             title: opts.data.title,
             content: opts.data.content,
             required: opts.data.required,
+            requiredForVolunteers: opts.data.requiredForVolunteers,
           },
         }),
       deleteWaiver: async (opts) =>

--- a/apps/wodsmith-start/src/routes/compete/invite/$token.tsx
+++ b/apps/wodsmith-start/src/routes/compete/invite/$token.tsx
@@ -37,6 +37,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
+import type { Waiver } from "@/db/schemas/waivers"
 import {
   checkEmailExistsFn,
   getPendingInviteDataFn,
@@ -52,7 +53,6 @@ import {
   type RegistrationQuestion,
 } from "@/server-fns/registration-questions-fns"
 import { getCompetitionWaiversFn } from "@/server-fns/waiver-fns"
-import type { Waiver } from "@/db/schemas/waivers"
 import { AcceptInviteButton } from "./-components/accept-invite-button"
 import { AcceptVolunteerInviteForm } from "./-components/accept-volunteer-invite-form"
 import { GuestInviteForm } from "./-components/guest-invite-form"
@@ -101,9 +101,11 @@ export const Route = createFileRoute("/compete/invite/$token")({
     }
 
     let waivers: Waiver[] = []
-    if (teammateInvite?.competition?.id) {
+    const waiverCompetitionId =
+      teammateInvite?.competition?.id ?? volunteerInvite?.competition?.id
+    if (waiverCompetitionId) {
       const waiversResult = await getCompetitionWaiversFn({
-        data: { competitionId: teammateInvite.competition.id },
+        data: { competitionId: waiverCompetitionId },
       })
       waivers = waiversResult.waivers
     }
@@ -200,6 +202,9 @@ function InvitePage() {
         token={token}
         emailHasAccount={emailHasAccount}
         volunteerQuestions={volunteerQuestions}
+        volunteerWaivers={waivers.filter(
+          (waiver) => waiver.requiredForVolunteers,
+        )}
       />
     )
   }
@@ -274,6 +279,8 @@ function InvitePage() {
     )
   }
 
+  const athleteWaivers = waivers.filter((waiver) => waiver.required)
+
   // Note: Pending data transfer now happens automatically in acceptTeamInvitationFn
   // when the user accepts the invite - no need for separate transfer logic
 
@@ -299,11 +306,11 @@ function InvitePage() {
             <InviteDetails invite={invite} />
 
             {/* Registration Questions & Waivers - only show if no pending data (guest already filled them) */}
-            {(teammateQuestions.length > 0 || waivers.length > 0) &&
+            {(teammateQuestions.length > 0 || athleteWaivers.length > 0) &&
               !hasPendingData && (
                 <TeammateRequirementsForm
                   questions={teammateQuestions}
-                  waivers={waivers}
+                  waivers={athleteWaivers}
                   token={token}
                   competitionSlug={invite.competition?.slug}
                   competitionId={invite.competition?.id}
@@ -312,7 +319,7 @@ function InvitePage() {
               )}
 
             {/* Simple accept button if no requirements OR if pending data exists (will be transferred on accept) */}
-            {(teammateQuestions.length === 0 && waivers.length === 0) ||
+            {(teammateQuestions.length === 0 && athleteWaivers.length === 0) ||
             hasPendingData ? (
               <>
                 {hasPendingData && (
@@ -358,11 +365,11 @@ function InvitePage() {
             </div>
 
             {/* Show requirements form if questions or waivers exist */}
-            {(teammateQuestions.length > 0 || waivers.length > 0) &&
+            {(teammateQuestions.length > 0 || athleteWaivers.length > 0) &&
             !hasPendingData ? (
               <TeammateRequirementsForm
                 questions={teammateQuestions}
-                waivers={waivers}
+                waivers={athleteWaivers}
                 token={token}
                 competitionSlug={invite.competition?.slug}
                 competitionId={invite.competition?.id}
@@ -415,13 +422,13 @@ function InvitePage() {
               inviteToken={token}
               emailHasAccount={emailHasAccount}
             />
-          ) : teammateQuestions.length > 0 || waivers.length > 0 ? (
+          ) : teammateQuestions.length > 0 || athleteWaivers.length > 0 ? (
             <>
               <InviteDetails invite={invite} />
               <GuestInviteForm
                 token={token}
                 questions={teammateQuestions}
-                waivers={waivers}
+                waivers={athleteWaivers}
                 teamName={invite.team.name}
                 competitionName={invite.competition?.name || "Competition"}
                 onSuccess={() => setGuestSubmitComplete(true)}
@@ -641,12 +648,14 @@ function DirectVolunteerInvite({
   token,
   emailHasAccount,
   volunteerQuestions,
+  volunteerWaivers,
 }: {
   invite: VolunteerInvite
   session: { userId: string; email: string | null } | null
   token: string
   emailHasAccount: boolean
   volunteerQuestions: RegistrationQuestion[]
+  volunteerWaivers: Waiver[]
 }) {
   // Check if already accepted
   if (invite.acceptedAt) {
@@ -722,6 +731,7 @@ function DirectVolunteerInvite({
               competitionId={invite.competition?.id}
               competitionName={invite.competition?.name}
               questions={volunteerQuestions}
+              waivers={volunteerWaivers}
             />
           </CardContent>
         </Card>
@@ -759,6 +769,7 @@ function DirectVolunteerInvite({
               competitionId={invite.competition?.id}
               competitionName={invite.competition?.name}
               questions={volunteerQuestions}
+              waivers={volunteerWaivers}
             />
 
             <div className="flex justify-center">
@@ -887,8 +898,8 @@ function TeammateRequirementsForm({
   )
 
   // Check if all required waivers are signed
-  const requiredWaivers = waivers.filter((w) => w.required)
-  const allRequiredWaiversSigned = requiredWaivers.every(
+  const athleteWaivers = waivers.filter((w) => w.required)
+  const allRequiredWaiversSigned = athleteWaivers.every(
     (w) =>
       (signatures[w.id]?.signatureName?.trim() ?? "") !== "" &&
       signatures[w.id]?.agreed === true,
@@ -988,7 +999,7 @@ function TeammateRequirementsForm({
       )}
 
       {/* Waivers Section */}
-      {waivers.length > 0 && (
+      {athleteWaivers.length > 0 && (
         <Card>
           <CardHeader>
             <CardTitle>Waivers</CardTitle>
@@ -997,7 +1008,7 @@ function TeammateRequirementsForm({
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            {waivers.map((waiver) => (
+            {athleteWaivers.map((waiver) => (
               <Card key={waiver.id} className="border-2">
                 <Collapsible>
                   <CardHeader>

--- a/apps/wodsmith-start/src/routes/compete/invite/-components/accept-volunteer-invite-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/invite/-components/accept-volunteer-invite-form.tsx
@@ -5,7 +5,9 @@ import { useServerFn } from "@tanstack/react-start"
 import { CheckCircle, Loader2 } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
+import { WaiverViewer } from "@/components/compete/waiver-viewer"
 import { Button } from "@/components/ui/button"
+import { Checkbox } from "@/components/ui/checkbox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -17,6 +19,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { VOLUNTEER_AVAILABILITY } from "@/db/schemas/volunteers"
+import type { Waiver } from "@/db/schemas/waivers"
 import { useTrackEvent } from "@/lib/posthog/hooks"
 import { acceptVolunteerInviteFn } from "@/server-fns/invite-fns"
 import type { RegistrationQuestion } from "@/server-fns/registration-questions-fns"
@@ -27,6 +30,7 @@ interface AcceptVolunteerInviteFormProps {
   competitionName?: string
   competitionId?: string
   questions?: RegistrationQuestion[]
+  waivers?: Waiver[]
 }
 
 /**
@@ -39,11 +43,13 @@ export function AcceptVolunteerInviteForm({
   competitionName,
   competitionId,
   questions = [],
+  waivers = [],
 }: AcceptVolunteerInviteFormProps) {
   const navigate = useNavigate()
   const [isPending, setIsPending] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [agreedWaivers, setAgreedWaivers] = useState<Set<string>>(new Set())
   const acceptInvite = useServerFn(acceptVolunteerInviteFn)
   const trackEvent = useTrackEvent()
 
@@ -66,6 +72,15 @@ export function AcceptVolunteerInviteForm({
       }
     }
 
+    const allVolunteerWaiversAgreed = waivers.every((waiver) =>
+      agreedWaivers.has(waiver.id),
+    )
+    if (!allVolunteerWaiversAgreed) {
+      setError("Please agree to all required waivers before accepting")
+      setIsPending(false)
+      return
+    }
+
     const answersArray = Object.entries(answers)
       .filter(([_, value]) => value && value.trim() !== "")
       .map(([questionId, answer]) => ({ questionId, answer }))
@@ -83,6 +98,7 @@ export function AcceptVolunteerInviteForm({
           credentials: (formData.get("credentials") as string) || undefined,
           signupPhone: (formData.get("phone") as string) || undefined,
           answers: answersArray.length > 0 ? answersArray : undefined,
+          waiverIds: Array.from(agreedWaivers),
         },
       })
 
@@ -212,6 +228,46 @@ export function AcceptVolunteerInviteForm({
           disabled={isPending}
         />
       </div>
+
+      {/* Volunteer Waivers */}
+      {waivers.length > 0 && (
+        <div className="space-y-4 border-t pt-4">
+          <p className="text-sm font-medium">Required Waivers</p>
+          {waivers.map((waiver) => (
+            <div key={waiver.id} className="space-y-3 rounded-lg border p-4">
+              <h3 className="font-medium">{waiver.title}</h3>
+              <div className="max-h-64 overflow-y-auto rounded-lg border bg-muted/10 p-4">
+                <WaiverViewer
+                  content={waiver.content}
+                  className="prose prose-sm max-w-none dark:prose-invert"
+                />
+              </div>
+              <div className="flex items-start gap-3 rounded-lg bg-muted/20 p-4">
+                <Checkbox
+                  id={`volunteer-waiver-${waiver.id}`}
+                  checked={agreedWaivers.has(waiver.id)}
+                  onCheckedChange={(checked) => {
+                    setAgreedWaivers((prev) => {
+                      const next = new Set(prev)
+                      if (checked === true) next.add(waiver.id)
+                      else next.delete(waiver.id)
+                      return next
+                    })
+                  }}
+                  disabled={isPending}
+                />
+                <Label
+                  htmlFor={`volunteer-waiver-${waiver.id}`}
+                  className="cursor-pointer text-sm font-medium leading-none"
+                >
+                  I have read and agree to this waiver
+                  <span className="text-destructive ml-1">*</span>
+                </Label>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Volunteer Registration Questions */}
       {questions.length > 0 && (

--- a/apps/wodsmith-start/src/routes/compete/invite/-components/accept-volunteer-invite-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/invite/-components/accept-volunteer-invite-form.tsx
@@ -21,6 +21,10 @@ import { Textarea } from "@/components/ui/textarea"
 import { VOLUNTEER_AVAILABILITY } from "@/db/schemas/volunteers"
 import type { Waiver } from "@/db/schemas/waivers"
 import { useTrackEvent } from "@/lib/posthog/hooks"
+import {
+  haveAllVolunteerWaiversBeenAgreed,
+  toggleVolunteerWaiverAgreement,
+} from "@/lib/volunteer-waiver-agreements"
 import { acceptVolunteerInviteFn } from "@/server-fns/invite-fns"
 import type { RegistrationQuestion } from "@/server-fns/registration-questions-fns"
 
@@ -72,10 +76,7 @@ export function AcceptVolunteerInviteForm({
       }
     }
 
-    const allVolunteerWaiversAgreed = waivers.every((waiver) =>
-      agreedWaivers.has(waiver.id),
-    )
-    if (!allVolunteerWaiversAgreed) {
+    if (!haveAllVolunteerWaiversBeenAgreed(waivers, agreedWaivers)) {
       setError("Please agree to all required waivers before accepting")
       setIsPending(false)
       return
@@ -247,12 +248,13 @@ export function AcceptVolunteerInviteForm({
                   id={`volunteer-waiver-${waiver.id}`}
                   checked={agreedWaivers.has(waiver.id)}
                   onCheckedChange={(checked) => {
-                    setAgreedWaivers((prev) => {
-                      const next = new Set(prev)
-                      if (checked === true) next.add(waiver.id)
-                      else next.delete(waiver.id)
-                      return next
-                    })
+                    setAgreedWaivers((prev) =>
+                      toggleVolunteerWaiverAgreement(
+                        prev,
+                        waiver.id,
+                        checked === true,
+                      ),
+                    )
                   }}
                   disabled={isPending}
                 />

--- a/apps/wodsmith-start/src/routes/compete/invite/-components/guest-invite-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/invite/-components/guest-invite-form.tsx
@@ -91,8 +91,8 @@ export function GuestInviteForm({
     (q) => answers[q.id] && answers[q.id].trim() !== "",
   )
 
-  const requiredWaivers = waivers.filter((w) => w.required)
-  const allRequiredWaiversSigned = requiredWaivers.every(
+  const athleteWaivers = waivers.filter((w) => w.required)
+  const allRequiredWaiversSigned = athleteWaivers.every(
     (w) =>
       signatures[w.id]?.signatureName?.trim() !== "" &&
       signatures[w.id]?.agreed === true,
@@ -147,7 +147,7 @@ export function GuestInviteForm({
   }
 
   const hasQuestions = questions.length > 0
-  const hasWaivers = waivers.length > 0
+  const hasWaivers = athleteWaivers.length > 0
 
   return (
     <div className="space-y-6">
@@ -233,7 +233,7 @@ export function GuestInviteForm({
             </CardDescription>
           </CardHeader>
           <CardContent className="space-y-4">
-            {waivers.map((waiver) => (
+            {athleteWaivers.map((waiver) => (
               <Card key={waiver.id} className="border-2">
                 <Collapsible>
                   <CardHeader>

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/volunteer-row.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/volunteer-row.tsx
@@ -241,14 +241,14 @@ function VolunteerWaiverStatusBadge({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Badge
-          variant="secondary"
-          className="w-fit max-w-full cursor-pointer bg-amber-100 text-xs text-amber-900 hover:bg-amber-200"
+        <button
+          type="button"
+          className="inline-flex w-fit max-w-full items-center rounded-md bg-amber-100 px-2.5 py-0.5 text-xs font-semibold text-amber-900 transition-colors hover:bg-amber-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
         >
           <AlertCircle className="mr-1 h-3 w-3" />
           {showTitle && <span className="mr-1 truncate">{status.title}:</span>}
           Missing
-        </Badge>
+        </button>
       </PopoverTrigger>
       <PopoverContent className="w-72" align="start">
         <div className="space-y-2">

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/volunteer-row.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/volunteer-row.tsx
@@ -1,8 +1,14 @@
 "use client"
 
 import { useRouter } from "@tanstack/react-router"
-import { useSession } from "@/utils/auth-client"
-import { Calendar, Check, ClipboardList, X } from "lucide-react"
+import {
+  AlertCircle,
+  Calendar,
+  Check,
+  CheckCircle2,
+  ClipboardList,
+  X,
+} from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
@@ -44,6 +50,7 @@ import {
   revokeScoreAccessFn,
   updateVolunteerMetadataFn,
 } from "@/server-fns/volunteer-fns"
+import { useSession } from "@/utils/auth-client"
 
 interface VolunteerWithAccess {
   id: string
@@ -72,6 +79,8 @@ interface VolunteerRowProps {
   onToggleSelect?: (shiftKey: boolean) => void
   answers: Array<{ id: string; questionId: string; answer: string }>
   questions: RegistrationQuestion[]
+  showWaiverStatus?: boolean
+  waiverStatuses?: VolunteerWaiverStatus[]
   variant?: "row" | "card"
   assignments: {
     shifts: Array<{
@@ -95,15 +104,42 @@ interface VolunteerRowProps {
     }>
   }
   /** Optional callback to add a role type. Defaults to organizer server fn. */
-  onAddRoleType?: (params: { membershipId: string; competitionId: string; roleType: string }) => Promise<{ success: boolean }>
+  onAddRoleType?: (params: {
+    membershipId: string
+    competitionId: string
+    roleType: string
+  }) => Promise<{ success: boolean }>
   /** Optional callback to remove a role type. Defaults to organizer server fn. */
-  onRemoveRoleType?: (params: { membershipId: string; competitionId: string; roleType: string }) => Promise<{ success: boolean }>
+  onRemoveRoleType?: (params: {
+    membershipId: string
+    competitionId: string
+    roleType: string
+  }) => Promise<{ success: boolean }>
   /** Optional callback to update volunteer metadata. Defaults to organizer server fn. */
-  onUpdateMetadata?: (params: { membershipId: string; competitionId: string; metadata: Record<string, unknown> }) => Promise<{ success: boolean }>
+  onUpdateMetadata?: (params: {
+    membershipId: string
+    competitionId: string
+    metadata: Record<string, unknown>
+  }) => Promise<{ success: boolean }>
   /** Optional callback to grant score access. Defaults to organizer server fn. */
-  onGrantScoreAccess?: (params: { volunteerId: string; competitionTeamId: string; competitionId: string; grantedBy: string }) => Promise<{ success: boolean }>
+  onGrantScoreAccess?: (params: {
+    volunteerId: string
+    competitionTeamId: string
+    competitionId: string
+    grantedBy: string
+  }) => Promise<{ success: boolean }>
   /** Optional callback to revoke score access. Defaults to organizer server fn. */
-  onRevokeScoreAccess?: (params: { userId: string; competitionTeamId: string; competitionId: string }) => Promise<{ success: boolean }>
+  onRevokeScoreAccess?: (params: {
+    userId: string
+    competitionTeamId: string
+    competitionId: string
+  }) => Promise<{ success: boolean }>
+}
+
+type VolunteerWaiverStatus = {
+  id: string
+  title: string
+  signed: boolean
 }
 
 function getAvailabilityLabel(availability?: string): string | null {
@@ -185,6 +221,50 @@ function formatShiftTimeCompact(startTime: Date, endTime: Date): string {
   return `${startStr} - ${endStr}`
 }
 
+function VolunteerWaiverStatusBadge({
+  status,
+  showTitle = false,
+}: {
+  status: VolunteerWaiverStatus
+  showTitle?: boolean
+}) {
+  if (status.signed) {
+    return (
+      <Badge className="w-fit max-w-full bg-green-600 text-xs hover:bg-green-700">
+        <CheckCircle2 className="mr-1 h-3 w-3" />
+        {showTitle && <span className="mr-1 truncate">{status.title}:</span>}
+        Signed
+      </Badge>
+    )
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Badge
+          variant="secondary"
+          className="w-fit max-w-full cursor-pointer bg-amber-100 text-xs text-amber-900 hover:bg-amber-200"
+        >
+          <AlertCircle className="mr-1 h-3 w-3" />
+          {showTitle && <span className="mr-1 truncate">{status.title}:</span>}
+          Missing
+        </Badge>
+      </PopoverTrigger>
+      <PopoverContent className="w-72" align="start">
+        <div className="space-y-2">
+          <p className="text-sm font-semibold">Missing volunteer waivers</p>
+          <ul className="space-y-1 text-sm text-muted-foreground">
+            <li className="flex items-start gap-2">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+              <span>{status.title}</span>
+            </li>
+          </ul>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 export function VolunteerRow({
   volunteer,
   competitionId,
@@ -195,6 +275,8 @@ export function VolunteerRow({
   assignments,
   answers,
   questions,
+  showWaiverStatus = false,
+  waiverStatuses = [],
   variant = "row",
   onAddRoleType,
   onRemoveRoleType,
@@ -496,6 +578,14 @@ export function VolunteerRow({
               {availabilityLabel}
             </Badge>
           )}
+          {showWaiverStatus &&
+            waiverStatuses.map((status) => (
+              <VolunteerWaiverStatusBadge
+                key={status.id}
+                status={status}
+                showTitle
+              />
+            ))}
           {Array.from(selectedRoles).map((roleType) => (
             <Badge key={roleType} variant="outline" className="text-xs">
               {VOLUNTEER_ROLE_LABELS[roleType]}
@@ -678,6 +768,12 @@ export function VolunteerRow({
           )}
         </div>
       </TableCell>
+      {showWaiverStatus &&
+        waiverStatuses.map((status) => (
+          <TableCell key={status.id}>
+            <VolunteerWaiverStatusBadge status={status} />
+          </TableCell>
+        ))}
       <TableCell>
         {assignments.shifts.length === 0 &&
         assignments.judgeHeats.length === 0 ? (

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/volunteers-list.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/volunteers-list.tsx
@@ -43,7 +43,10 @@ import {
   type VolunteerRoleType,
 } from "@/db/schemas/volunteers"
 import type { RegistrationQuestion } from "@/server-fns/registration-questions-fns"
-import { bulkAssignVolunteerRoleFn } from "@/server-fns/volunteer-fns"
+import {
+  bulkAssignVolunteerRoleFn,
+  type VolunteerWaiverStatusResult,
+} from "@/server-fns/volunteer-fns"
 import { InviteVolunteerDialog } from "./invite-volunteer-dialog"
 import { VolunteerRow } from "./volunteer-row"
 
@@ -77,6 +80,7 @@ interface VolunteersListProps {
   volunteerQuestions: RegistrationQuestion[]
   answersByInvitation: Record<string, VolunteerAnswer[]>
   emailToInvitationId: Record<string, string>
+  volunteerWaiverStatus?: VolunteerWaiverStatusResult
   volunteerAssignments: Record<
     string,
     {
@@ -102,19 +106,50 @@ interface VolunteersListProps {
     }
   >
   /** Optional callback for bulk role assignment. Defaults to organizer server fn. */
-  onBulkAssignRole?: (params: { membershipIds: string[]; competitionId: string; roleType: string }) => Promise<{ succeeded: number; failed: number }>
+  onBulkAssignRole?: (params: {
+    membershipIds: string[]
+    competitionId: string
+    roleType: string
+  }) => Promise<{ succeeded: number; failed: number }>
   /** Optional callback to invite a volunteer. Passed through to InviteVolunteerDialog. */
-  onInviteVolunteer?: (params: { name?: string; email: string; competitionTeamId: string; competitionId: string; roleTypes: string[] }) => Promise<{ success: boolean }>
+  onInviteVolunteer?: (params: {
+    name?: string
+    email: string
+    competitionTeamId: string
+    competitionId: string
+    roleTypes: string[]
+  }) => Promise<{ success: boolean }>
   /** Optional callback to add a role type. Passed through to VolunteerRow. */
-  onAddRoleType?: (params: { membershipId: string; competitionId: string; roleType: string }) => Promise<{ success: boolean }>
+  onAddRoleType?: (params: {
+    membershipId: string
+    competitionId: string
+    roleType: string
+  }) => Promise<{ success: boolean }>
   /** Optional callback to remove a role type. Passed through to VolunteerRow. */
-  onRemoveRoleType?: (params: { membershipId: string; competitionId: string; roleType: string }) => Promise<{ success: boolean }>
+  onRemoveRoleType?: (params: {
+    membershipId: string
+    competitionId: string
+    roleType: string
+  }) => Promise<{ success: boolean }>
   /** Optional callback to update volunteer metadata. Passed through to VolunteerRow. */
-  onUpdateMetadata?: (params: { membershipId: string; competitionId: string; metadata: Record<string, unknown> }) => Promise<{ success: boolean }>
+  onUpdateMetadata?: (params: {
+    membershipId: string
+    competitionId: string
+    metadata: Record<string, unknown>
+  }) => Promise<{ success: boolean }>
   /** Optional callback to grant score access. Passed through to VolunteerRow. */
-  onGrantScoreAccess?: (params: { volunteerId: string; competitionTeamId: string; competitionId: string; grantedBy: string }) => Promise<{ success: boolean }>
+  onGrantScoreAccess?: (params: {
+    volunteerId: string
+    competitionTeamId: string
+    competitionId: string
+    grantedBy: string
+  }) => Promise<{ success: boolean }>
   /** Optional callback to revoke score access. Passed through to VolunteerRow. */
-  onRevokeScoreAccess?: (params: { userId: string; competitionTeamId: string; competitionId: string }) => Promise<{ success: boolean }>
+  onRevokeScoreAccess?: (params: {
+    userId: string
+    competitionTeamId: string
+    competitionId: string
+  }) => Promise<{ success: boolean }>
 }
 
 /**
@@ -132,6 +167,7 @@ export function VolunteersList({
   volunteerQuestions,
   answersByInvitation,
   emailToInvitationId,
+  volunteerWaiverStatus,
   onBulkAssignRole,
   onInviteVolunteer,
   onAddRoleType,
@@ -152,6 +188,41 @@ export function VolunteersList({
     }
     return invitationId ? (answersByInvitation[invitationId] ?? []) : []
   }
+
+  function getEmailForVolunteer(volunteer: VolunteerWithAccess): string | null {
+    if (volunteer.user?.email) return volunteer.user.email
+
+    try {
+      const parsed = JSON.parse(volunteer.metadata || "{}") as {
+        signupEmail?: string
+        inviteEmail?: string
+      }
+      return parsed.signupEmail ?? parsed.inviteEmail ?? null
+    } catch {
+      return null
+    }
+  }
+
+  function getWaiverStatusesForVolunteer(volunteer: VolunteerWithAccess) {
+    if (!volunteerWaiverStatus) return []
+
+    const email = getEmailForVolunteer(volunteer)
+    const userId =
+      volunteer.user?.id ??
+      (email ? volunteerWaiverStatus.userIdByEmail[email.toLowerCase()] : null)
+    const signedWaiverIds = new Set(
+      userId
+        ? (volunteerWaiverStatus.signedWaiverIdsByUserId[userId] ?? [])
+        : [],
+    )
+
+    return volunteerWaiverStatus.requiredWaivers.map((waiver) => ({
+      id: waiver.id,
+      title: waiver.title,
+      signed: signedWaiverIds.has(waiver.id),
+    }))
+  }
+
   const router = useRouter()
   const [inviteDialogOpen, setInviteDialogOpen] = useState(false)
   const [filter, setFilter] = useState<"all" | "pending" | "approved">("all")
@@ -363,6 +434,8 @@ export function VolunteersList({
   const allSelected =
     filteredIds.length > 0 && filteredIds.every((id) => selectedIds.has(id))
   const someSelected = selectedIds.size > 0
+  const waiverColumns = volunteerWaiverStatus?.requiredWaivers ?? []
+  const showWaiverStatus = waiverColumns.length > 0
 
   /**
    * Export all visible volunteers to CSV, including registration question answers
@@ -701,6 +774,10 @@ export function VolunteersList({
                     }
                     answers={getAnswersForVolunteer(volunteerItem)}
                     questions={volunteerQuestions}
+                    showWaiverStatus={showWaiverStatus}
+                    waiverStatuses={getWaiverStatusesForVolunteer(
+                      volunteerItem,
+                    )}
                     variant="card"
                     onAddRoleType={onAddRoleType}
                     onRemoveRoleType={onRemoveRoleType}
@@ -731,6 +808,8 @@ export function VolunteersList({
                   }
                   answers={getAnswersForVolunteer(volunteer)}
                   questions={volunteerQuestions}
+                  showWaiverStatus={showWaiverStatus}
+                  waiverStatuses={getWaiverStatusesForVolunteer(volunteer)}
                   variant="card"
                   onAddRoleType={onAddRoleType}
                   onRemoveRoleType={onRemoveRoleType}
@@ -759,6 +838,9 @@ export function VolunteersList({
                       <TableHead>Name</TableHead>
                       <TableHead>Email</TableHead>
                       <TableHead>Role Types</TableHead>
+                      {waiverColumns.map((waiver) => (
+                        <TableHead key={waiver.id}>{waiver.title}</TableHead>
+                      ))}
                       <TableHead>Assignments</TableHead>
                       <TableHead>Score Access</TableHead>
                       <TableHead className="text-right">Actions</TableHead>
@@ -819,6 +901,10 @@ export function VolunteersList({
                             }
                             answers={getAnswersForVolunteer(volunteerItem)}
                             questions={volunteerQuestions}
+                            showWaiverStatus={showWaiverStatus}
+                            waiverStatuses={getWaiverStatusesForVolunteer(
+                              volunteerItem,
+                            )}
                             onAddRoleType={onAddRoleType}
                             onRemoveRoleType={onRemoveRoleType}
                             onUpdateMetadata={onUpdateMetadata}
@@ -848,6 +934,10 @@ export function VolunteersList({
                           }
                           answers={getAnswersForVolunteer(volunteer)}
                           questions={volunteerQuestions}
+                          showWaiverStatus={showWaiverStatus}
+                          waiverStatuses={getWaiverStatusesForVolunteer(
+                            volunteer,
+                          )}
                           onAddRoleType={onAddRoleType}
                           onRemoveRoleType={onRemoveRoleType}
                           onUpdateMetadata={onUpdateMetadata}

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/waiver-form-dialog.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/waiver-form-dialog.tsx
@@ -28,6 +28,7 @@ export interface WaiverFormDialogOverrides {
       title: string
       content: string
       required: boolean
+      requiredForVolunteers: boolean
     }
   }) => Promise<{ success: true; waiver: Waiver }>
   updateWaiver?: (opts: {
@@ -38,6 +39,7 @@ export interface WaiverFormDialogOverrides {
       title?: string
       content?: string
       required?: boolean
+      requiredForVolunteers?: boolean
     }
   }) => Promise<{ success: true; waiver: Waiver }>
 }
@@ -66,6 +68,9 @@ export function WaiverFormDialog({
     waiver?.content ? JSON.parse(waiver.content) : undefined,
   )
   const [required, setRequired] = useState(waiver?.required ?? true)
+  const [requiredForVolunteers, setRequiredForVolunteers] = useState(
+    waiver?.requiredForVolunteers ?? false,
+  )
   const [isPending, setIsPending] = useState(false)
 
   // Use overrides if provided, otherwise default organizer server fns via useServerFn
@@ -102,6 +107,7 @@ export function WaiverFormDialog({
             title,
             content: contentString,
             required,
+            requiredForVolunteers,
           },
         })
 
@@ -117,6 +123,7 @@ export function WaiverFormDialog({
             title,
             content: contentString,
             required,
+            requiredForVolunteers,
           },
         })
 
@@ -142,7 +149,7 @@ export function WaiverFormDialog({
           <DialogDescription>
             {isEditing
               ? "Update waiver details and content"
-              : "Create a new waiver for athletes to sign"}
+              : "Create a new waiver for athletes or volunteers to sign"}
           </DialogDescription>
         </DialogHeader>
 
@@ -179,7 +186,24 @@ export function WaiverFormDialog({
               htmlFor="required"
               className="cursor-pointer text-sm font-normal"
             >
-              Required (athletes must sign to register)
+              Required for athletes
+            </Label>
+          </div>
+
+          <div className="flex items-center space-x-2">
+            <Checkbox
+              id="requiredForVolunteers"
+              checked={requiredForVolunteers}
+              onCheckedChange={(checked) =>
+                setRequiredForVolunteers(checked === true)
+              }
+              disabled={isPending}
+            />
+            <Label
+              htmlFor="requiredForVolunteers"
+              className="cursor-pointer text-sm font-normal"
+            >
+              Required for volunteers
             </Label>
           </div>
 

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/waiver-list.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/waiver-list.tsx
@@ -199,12 +199,18 @@ function WaiverItem({
                 {waiver.required ? (
                   <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/30 dark:text-red-400">
                     <AlertTriangle className="h-3 w-3" />
-                    Required
+                    Athlete required
                   </span>
                 ) : (
                   <span className="inline-flex items-center gap-1 rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700 dark:bg-slate-800 dark:text-slate-300">
                     <CheckCircle2 className="h-3 w-3" />
-                    Optional
+                    Athlete optional
+                  </span>
+                )}
+                {waiver.requiredForVolunteers && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+                    <AlertTriangle className="h-3 w-3" />
+                    Volunteer required
                   </span>
                 )}
               </div>
@@ -379,7 +385,14 @@ export function WaiverList({
         competitionId={competitionId}
         teamId={teamId}
         onSuccess={handleWaiverCreated}
-        overrides={overrides ? { createWaiver: overrides.createWaiver, updateWaiver: overrides.updateWaiver } : undefined}
+        overrides={
+          overrides
+            ? {
+                createWaiver: overrides.createWaiver,
+                updateWaiver: overrides.updateWaiver,
+              }
+            : undefined
+        }
       />
 
       {/* Edit Dialog */}
@@ -391,7 +404,14 @@ export function WaiverList({
           teamId={teamId}
           waiver={editingWaiver}
           onSuccess={handleWaiverUpdated}
-          overrides={overrides ? { createWaiver: overrides.createWaiver, updateWaiver: overrides.updateWaiver } : undefined}
+          overrides={
+            overrides
+              ? {
+                  createWaiver: overrides.createWaiver,
+                  updateWaiver: overrides.updateWaiver,
+                }
+              : undefined
+          }
         />
       )}
 

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/volunteers.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/volunteers.tsx
@@ -1,8 +1,6 @@
-import { useEffect } from "react"
 import { createFileRoute, useNavigate, useRouter } from "@tanstack/react-router"
+import { useEffect } from "react"
 import { z } from "zod"
-import type { JudgeAssignmentVersion } from "@/db/schema"
-import type { LaneShiftPattern } from "@/db/schemas/volunteers"
 import { RegistrationQuestionsEditor } from "@/components/competition-settings/registration-questions-editor"
 import {
   Select,
@@ -12,6 +10,8 @@ import {
   SelectValue,
 } from "@/components/ui/select"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import type { JudgeAssignmentVersion } from "@/db/schema"
+import type { LaneShiftPattern } from "@/db/schemas/volunteers"
 import { getHeatsForCompetitionFn } from "@/server-fns/competition-heats-fns"
 import { getCompetitionWorkoutsFn } from "@/server-fns/competition-workouts-fns"
 import {
@@ -33,6 +33,7 @@ import {
   getDirectVolunteerInvitesFn,
   getPendingVolunteerInvitationsFn,
   getVolunteerAssignmentsFn,
+  getVolunteerWaiverStatusesFn,
 } from "@/server-fns/volunteer-fns"
 import { getCompetitionShiftsFn } from "@/server-fns/volunteer-shift-fns"
 import { InvitedVolunteersList } from "./-components/invited-volunteers-list"
@@ -64,7 +65,11 @@ export const Route = createFileRoute(
   validateSearch: searchParamsSchema,
   loader: async ({ parentMatchPromise }) => {
     const parentMatch = await parentMatchPromise
-    const { competition } = parentMatch.loaderData!
+    const competition = parentMatch.loaderData?.competition
+
+    if (!competition) {
+      throw new Error("Competition not found")
+    }
 
     if (!competition.competitionTeamId) {
       throw new Error("Competition team not found")
@@ -83,6 +88,7 @@ export const Route = createFileRoute(
       volunteerAssignments,
       volunteerQuestionsResult,
       volunteerAnswersResult,
+      volunteerWaiverStatus,
     ] = await Promise.all([
       getPendingVolunteerInvitationsFn({
         data: { competitionTeamId },
@@ -113,6 +119,13 @@ export const Route = createFileRoute(
       }),
       getVolunteerAnswersFn({
         data: {
+          competitionTeamId,
+          organizingTeamId: competition.organizingTeamId,
+        },
+      }),
+      getVolunteerWaiverStatusesFn({
+        data: {
+          competitionId: competition.id,
           competitionTeamId,
           organizingTeamId: competition.organizingTeamId,
         },
@@ -230,6 +243,7 @@ export const Route = createFileRoute(
       volunteerQuestions,
       answersByInvitation,
       emailToInvitationId,
+      volunteerWaiverStatus,
     }
   },
   component: VolunteersPage,
@@ -255,6 +269,7 @@ function VolunteersPage() {
     volunteerQuestions,
     answersByInvitation,
     emailToInvitationId,
+    volunteerWaiverStatus,
   } = Route.useLoaderData()
 
   const { tab, event: eventFromUrl } = Route.useSearch()
@@ -382,6 +397,7 @@ function VolunteersPage() {
             volunteerQuestions={volunteerQuestions}
             answersByInvitation={answersByInvitation}
             emailToInvitationId={emailToInvitationId}
+            volunteerWaiverStatus={volunteerWaiverStatus}
           />
         </section>
       </TabsContent>
@@ -433,7 +449,6 @@ function VolunteersPage() {
           questionTarget="volunteer"
         />
       </TabsContent>
-
     </Tabs>
   )
 }

--- a/apps/wodsmith-start/src/server-fns/cohost/cohost-waiver-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/cohost/cohost-waiver-fns.ts
@@ -37,6 +37,7 @@ const createWaiverInputSchema = z.object({
     .min(1, "Content is required")
     .max(50000, "Content is too long"),
   required: z.boolean().default(true),
+  requiredForVolunteers: z.boolean().default(false),
 })
 
 const updateWaiverInputSchema = z.object({
@@ -54,6 +55,7 @@ const updateWaiverInputSchema = z.object({
     .max(50000, "Content is too long")
     .optional(),
   required: z.boolean().optional(),
+  requiredForVolunteers: z.boolean().optional(),
 })
 
 const deleteWaiverInputSchema = z.object({
@@ -204,6 +206,7 @@ export const cohostCreateWaiverFn = createServerFn({ method: "POST" })
       title: data.title,
       content: data.content,
       required: data.required,
+      requiredForVolunteers: data.requiredForVolunteers,
       position: maxPosition + 1,
     })
 
@@ -251,6 +254,9 @@ export const cohostUpdateWaiverFn = createServerFn({ method: "POST" })
     if (data.title !== undefined) updateData.title = data.title
     if (data.content !== undefined) updateData.content = data.content
     if (data.required !== undefined) updateData.required = data.required
+    if (data.requiredForVolunteers !== undefined) {
+      updateData.requiredForVolunteers = data.requiredForVolunteers
+    }
 
     await db
       .update(waiversTable)

--- a/apps/wodsmith-start/src/server-fns/invite-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/invite-fns.ts
@@ -34,7 +34,11 @@ import type {
 } from "@/db/schemas/teams"
 import type { VolunteerMembershipMetadata } from "@/db/schemas/volunteers"
 import { VOLUNTEER_AVAILABILITY } from "@/db/schemas/volunteers"
-import { waiverSignaturesTable, waiversTable } from "@/db/schemas/waivers"
+import {
+  createWaiverSignatureId,
+  waiverSignaturesTable,
+  waiversTable,
+} from "@/db/schemas/waivers"
 import { getSessionFromCookie } from "@/utils/auth"
 import { updateAllSessionsOfUser } from "@/utils/kv-session"
 
@@ -143,6 +147,7 @@ const acceptVolunteerInviteSchema = z.object({
       }),
     )
     .optional(),
+  waiverIds: z.array(z.string().startsWith("waiv_")).optional(),
 })
 
 const submitPendingInviteDataSchema = z.object({
@@ -1054,6 +1059,55 @@ export const acceptTeamInvitationFn = createServerFn({ method: "POST" })
     }
   })
 
+async function signVolunteerInviteWaivers({
+  userId,
+  competitionTeamId,
+  waiverIds = [],
+}: {
+  userId: string
+  competitionTeamId: string
+  waiverIds?: string[]
+}) {
+  const db = getDb()
+  const competition = await db.query.competitionsTable.findFirst({
+    where: eq(competitionsTable.competitionTeamId, competitionTeamId),
+  })
+
+  if (!competition) return
+
+  const requiredWaivers = await db.query.waiversTable.findMany({
+    where: and(
+      eq(waiversTable.competitionId, competition.id),
+      eq(waiversTable.requiredForVolunteers, true),
+    ),
+  })
+  const signedIds = new Set(waiverIds)
+
+  for (const waiver of requiredWaivers) {
+    if (!signedIds.has(waiver.id)) {
+      throw new Error("Please agree to all required waivers before accepting")
+    }
+  }
+
+  for (const waiver of requiredWaivers) {
+    const existingSignature = await db.query.waiverSignaturesTable.findFirst({
+      where: and(
+        eq(waiverSignaturesTable.waiverId, waiver.id),
+        eq(waiverSignaturesTable.userId, userId),
+      ),
+    })
+    if (existingSignature) continue
+
+    await db.insert(waiverSignaturesTable).values({
+      id: createWaiverSignatureId(),
+      waiverId: waiver.id,
+      userId,
+      registrationId: null,
+      signedAt: new Date(),
+    })
+  }
+}
+
 /**
  * Accept a direct volunteer invitation with additional volunteer data
  */
@@ -1161,6 +1215,12 @@ export const acceptVolunteerInviteFn = createServerFn({ method: "POST" })
       // Mark as approved since user is accepting a direct invite
       status: "approved",
     }
+
+    await signVolunteerInviteWaivers({
+      userId: session.userId,
+      competitionTeamId: invitation.teamId,
+      waiverIds: data.waiverIds,
+    })
 
     // Add user to the team with merged metadata
     await db.insert(teamMembershipTable).values({

--- a/apps/wodsmith-start/src/server-fns/invite-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/invite-fns.ts
@@ -34,11 +34,8 @@ import type {
 } from "@/db/schemas/teams"
 import type { VolunteerMembershipMetadata } from "@/db/schemas/volunteers"
 import { VOLUNTEER_AVAILABILITY } from "@/db/schemas/volunteers"
-import {
-  createWaiverSignatureId,
-  waiverSignaturesTable,
-  waiversTable,
-} from "@/db/schemas/waivers"
+import { waiverSignaturesTable, waiversTable } from "@/db/schemas/waivers"
+import { signRequiredVolunteerWaivers } from "@/server/volunteer-waivers"
 import { getSessionFromCookie } from "@/utils/auth"
 import { updateAllSessionsOfUser } from "@/utils/kv-session"
 
@@ -1059,55 +1056,6 @@ export const acceptTeamInvitationFn = createServerFn({ method: "POST" })
     }
   })
 
-async function signVolunteerInviteWaivers({
-  userId,
-  competitionTeamId,
-  waiverIds = [],
-}: {
-  userId: string
-  competitionTeamId: string
-  waiverIds?: string[]
-}) {
-  const db = getDb()
-  const competition = await db.query.competitionsTable.findFirst({
-    where: eq(competitionsTable.competitionTeamId, competitionTeamId),
-  })
-
-  if (!competition) return
-
-  const requiredWaivers = await db.query.waiversTable.findMany({
-    where: and(
-      eq(waiversTable.competitionId, competition.id),
-      eq(waiversTable.requiredForVolunteers, true),
-    ),
-  })
-  const signedIds = new Set(waiverIds)
-
-  for (const waiver of requiredWaivers) {
-    if (!signedIds.has(waiver.id)) {
-      throw new Error("Please agree to all required waivers before accepting")
-    }
-  }
-
-  for (const waiver of requiredWaivers) {
-    const existingSignature = await db.query.waiverSignaturesTable.findFirst({
-      where: and(
-        eq(waiverSignaturesTable.waiverId, waiver.id),
-        eq(waiverSignaturesTable.userId, userId),
-      ),
-    })
-    if (existingSignature) continue
-
-    await db.insert(waiverSignaturesTable).values({
-      id: createWaiverSignatureId(),
-      waiverId: waiver.id,
-      userId,
-      registrationId: null,
-      signedAt: new Date(),
-    })
-  }
-}
-
 /**
  * Accept a direct volunteer invitation with additional volunteer data
  */
@@ -1216,51 +1164,56 @@ export const acceptVolunteerInviteFn = createServerFn({ method: "POST" })
       status: "approved",
     }
 
-    await signVolunteerInviteWaivers({
-      userId: session.userId,
-      competitionTeamId: invitation.teamId,
-      waiverIds: data.waiverIds,
-    })
-
-    // Add user to the team with merged metadata
-    await db.insert(teamMembershipTable).values({
-      teamId: invitation.teamId,
-      userId: session.userId,
-      roleId: invitation.roleId,
-      isSystemRole: invitation.isSystemRole,
-      invitedBy: invitation.invitedBy ?? undefined,
-      invitedAt: invitation.createdAt
-        ? new Date(invitation.createdAt)
-        : new Date(),
-      joinedAt: new Date(),
-      isActive: true,
-      metadata: JSON.stringify(mergedMetadata),
-    })
-
-    // Mark invitation as accepted (with account)
-    await db
-      .update(teamInvitationTable)
-      .set({
-        acceptedAt: new Date(),
-        acceptedBy: session.userId,
-        status: INVITATION_STATUS.ACCEPTED,
-        updatedAt: new Date(),
+    await db.transaction(async (tx) => {
+      await signRequiredVolunteerWaivers({
+        db: tx,
+        userId: session.userId,
+        competitionTeamId: invitation.teamId,
+        waiverIds: data.waiverIds,
+        missingWaiverMessage:
+          "Please agree to all required waivers before accepting",
       })
-      .where(eq(teamInvitationTable.id, invitation.id))
 
-    // Save registration question answers if provided
-    if (data.answers && data.answers.length > 0) {
-      for (const { questionId, answer } of data.answers) {
-        await db
-          .insert(volunteerRegistrationAnswersTable)
-          .values({
-            questionId,
-            invitationId: invitation.id,
-            answer,
-          })
-          .onDuplicateKeyUpdate({ set: { answer } })
+      // Add user to the team with merged metadata
+      await tx.insert(teamMembershipTable).values({
+        teamId: invitation.teamId,
+        userId: session.userId,
+        roleId: invitation.roleId,
+        isSystemRole: invitation.isSystemRole,
+        invitedBy: invitation.invitedBy ?? undefined,
+        invitedAt: invitation.createdAt
+          ? new Date(invitation.createdAt)
+          : new Date(),
+        joinedAt: new Date(),
+        isActive: true,
+        metadata: JSON.stringify(mergedMetadata),
+      })
+
+      // Mark invitation as accepted (with account)
+      await tx
+        .update(teamInvitationTable)
+        .set({
+          acceptedAt: new Date(),
+          acceptedBy: session.userId,
+          status: INVITATION_STATUS.ACCEPTED,
+          updatedAt: new Date(),
+        })
+        .where(eq(teamInvitationTable.id, invitation.id))
+
+      // Save registration question answers if provided
+      if (data.answers && data.answers.length > 0) {
+        for (const { questionId, answer } of data.answers) {
+          await tx
+            .insert(volunteerRegistrationAnswersTable)
+            .values({
+              questionId,
+              invitationId: invitation.id,
+              answer,
+            })
+            .onDuplicateKeyUpdate({ set: { answer } })
+        }
       }
-    }
+    })
 
     // Update the user's session to include this team
     await updateAllSessionsOfUser(session.userId)

--- a/apps/wodsmith-start/src/server-fns/volunteer-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/volunteer-fns.ts
@@ -34,9 +34,13 @@ import { volunteerRegistrationAnswersTable } from "@/db/schemas/competitions"
 import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
 import type { VolunteerMembershipMetadata } from "@/db/schemas/volunteers"
 import { VOLUNTEER_AVAILABILITY } from "@/db/schemas/volunteers"
+import {
+  createWaiverSignatureId,
+  waiverSignaturesTable,
+  waiversTable,
+} from "@/db/schemas/waivers"
 import { createEntitlement } from "@/server/entitlements"
 import { inviteUserToTeam } from "@/server/team-members"
-import { sendVolunteerDirectInviteEmail } from "@/utils/email"
 import {
   calculateInviteStatus,
   isDirectInvite,
@@ -47,6 +51,7 @@ import {
   createAndStoreSession,
   getSessionFromCookie,
 } from "@/utils/auth"
+import { sendVolunteerDirectInviteEmail } from "@/utils/email"
 import { hashPassword } from "@/utils/password-hasher"
 
 import { requireTeamPermission } from "@/utils/team-auth"
@@ -78,6 +83,12 @@ export type DirectVolunteerInvite = {
   createdAt: Date
   expiresAt: Date | null
   acceptedAt: Date | null
+}
+
+export type VolunteerWaiverStatusResult = {
+  requiredWaivers: Array<{ id: string; title: string }>
+  signedWaiverIdsByUserId: Record<string, string[]>
+  userIdByEmail: Record<string, string>
 }
 
 // ============================================================================
@@ -155,6 +166,144 @@ export const getCompetitionVolunteersFn = createServerFn({ method: "GET" })
         user: true,
       },
     }) as unknown as Promise<TeamMembershipWithUser[]>
+  })
+
+/**
+ * Get volunteer-required waiver signature status for the volunteer roster.
+ */
+export const getVolunteerWaiverStatusesFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    z
+      .object({
+        competitionId: z.string().startsWith("comp_", "Invalid competition ID"),
+        competitionTeamId: competitionTeamIdSchema,
+        organizingTeamId: competitionTeamIdSchema,
+      })
+      .parse(data),
+  )
+  .handler(async ({ data }): Promise<VolunteerWaiverStatusResult> => {
+    await requireTeamPermission(
+      data.organizingTeamId,
+      TEAM_PERMISSIONS.MANAGE_COMPETITIONS,
+    )
+
+    const db = getDb()
+    const competition = await db.query.competitionsTable.findFirst({
+      where: eq(competitionsTable.id, data.competitionId),
+      columns: { competitionTeamId: true, organizingTeamId: true },
+    })
+
+    if (!competition) {
+      throw new Error("Competition not found")
+    }
+
+    if (
+      competition.competitionTeamId !== data.competitionTeamId ||
+      competition.organizingTeamId !== data.organizingTeamId
+    ) {
+      throw new Error("Competition does not match this team")
+    }
+
+    const requiredWaivers = await db.query.waiversTable.findMany({
+      where: and(
+        eq(waiversTable.competitionId, data.competitionId),
+        eq(waiversTable.requiredForVolunteers, true),
+      ),
+      columns: {
+        id: true,
+        title: true,
+      },
+      orderBy: (table, { asc }) => [asc(table.position)],
+    })
+
+    if (requiredWaivers.length === 0) {
+      return {
+        requiredWaivers: [],
+        signedWaiverIdsByUserId: {},
+        userIdByEmail: {},
+      }
+    }
+
+    const volunteerMemberships = await db.query.teamMembershipTable.findMany({
+      where: and(
+        eq(teamMembershipTable.teamId, data.competitionTeamId),
+        eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamMembershipTable.isSystemRole, true),
+      ),
+      columns: {
+        userId: true,
+      },
+    })
+    const volunteerInvitations = await db.query.teamInvitationTable.findMany({
+      where: and(
+        eq(teamInvitationTable.teamId, data.competitionTeamId),
+        eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamInvitationTable.isSystemRole, true),
+      ),
+      columns: {
+        email: true,
+      },
+    })
+
+    const invitationEmails = [
+      ...new Set(
+        volunteerInvitations
+          .map((invitation) => invitation.email?.toLowerCase())
+          .filter((email): email is string => Boolean(email)),
+      ),
+    ]
+    const invitationUsers =
+      invitationEmails.length > 0
+        ? await db.query.userTable.findMany({
+            where: inArray(userTable.email, invitationEmails),
+            columns: {
+              id: true,
+              email: true,
+            },
+          })
+        : []
+
+    const userIdSet = new Set(volunteerMemberships.map((m) => m.userId))
+    const userIdByEmail: Record<string, string> = {}
+
+    for (const user of invitationUsers) {
+      if (!user.email) continue
+      userIdSet.add(user.id)
+      userIdByEmail[user.email.toLowerCase()] = user.id
+    }
+
+    const userIds = [...userIdSet]
+    if (userIds.length === 0) {
+      return {
+        requiredWaivers,
+        signedWaiverIdsByUserId: {},
+        userIdByEmail,
+      }
+    }
+
+    const waiverIds = requiredWaivers.map((waiver) => waiver.id)
+    const signatures = await db.query.waiverSignaturesTable.findMany({
+      where: and(
+        inArray(waiverSignaturesTable.waiverId, waiverIds),
+        inArray(waiverSignaturesTable.userId, userIds),
+      ),
+      columns: {
+        userId: true,
+        waiverId: true,
+      },
+    })
+
+    const signedWaiverIdsByUserId: Record<string, string[]> = {}
+    for (const signature of signatures) {
+      signedWaiverIdsByUserId[signature.userId] ??= []
+      signedWaiverIdsByUserId[signature.userId]?.push(signature.waiverId)
+    }
+
+    return {
+      requiredWaivers,
+      signedWaiverIdsByUserId,
+      userIdByEmail,
+    }
   })
 
 /**
@@ -281,9 +430,66 @@ const volunteerApplicationSchema = z.object({
       }),
     )
     .optional(),
+  waiverIds: z.array(z.string().startsWith("waiv_")).optional(),
 })
 
 type VolunteerApplicationInput = z.infer<typeof volunteerApplicationSchema>
+
+async function signVolunteerWaivers({
+  userId,
+  competitionTeamId,
+  waiverIds = [],
+}: {
+  userId: string
+  competitionTeamId: string
+  waiverIds?: string[]
+}) {
+  const db = getDb()
+  const competition = await db.query.competitionsTable.findFirst({
+    where: eq(competitionsTable.competitionTeamId, competitionTeamId),
+  })
+
+  if (!competition) {
+    throw new Error("Competition not found")
+  }
+
+  const requiredWaivers = await db.query.waiversTable.findMany({
+    where: and(
+      eq(waiversTable.competitionId, competition.id),
+      eq(waiversTable.requiredForVolunteers, true),
+    ),
+  })
+  const requiredIds = new Set(requiredWaivers.map((waiver) => waiver.id))
+  const signedIds = new Set(waiverIds)
+
+  for (const waiver of requiredWaivers) {
+    if (!signedIds.has(waiver.id)) {
+      throw new Error(
+        "Please agree to all required waivers before volunteering",
+      )
+    }
+  }
+
+  for (const waiverId of signedIds) {
+    if (!requiredIds.has(waiverId)) continue
+
+    const existingSignature = await db.query.waiverSignaturesTable.findFirst({
+      where: and(
+        eq(waiverSignaturesTable.waiverId, waiverId),
+        eq(waiverSignaturesTable.userId, userId),
+      ),
+    })
+    if (existingSignature) continue
+
+    await db.insert(waiverSignaturesTable).values({
+      id: createWaiverSignatureId(),
+      waiverId,
+      userId,
+      registrationId: null,
+      signedAt: new Date(),
+    })
+  }
+}
 
 /**
  * Creates a volunteer application (team invitation) and saves any question answers.
@@ -395,6 +601,16 @@ export const submitVolunteerSignupFn = createServerFn({ method: "POST" })
       return { success: true }
     }
     const { membershipId } = await createVolunteerApplication(data)
+    const session = await getSessionFromCookie()
+    if (session) {
+      await signVolunteerWaivers({
+        userId: session.userId,
+        competitionTeamId: data.competitionTeamId,
+        waiverIds: data.waiverIds,
+      })
+    } else if (data.waiverIds && data.waiverIds.length > 0) {
+      throw new Error("NOT_AUTHORIZED: You must be logged in to sign waivers")
+    }
     return { success: true, membershipId }
   })
 
@@ -501,6 +717,11 @@ export const createAccountAndApplyAsVolunteerFn = createServerFn({
     // Submit the volunteer application first — if this fails, no session is
     // created and the user can safely retry without hitting "account exists"
     const { membershipId } = await createVolunteerApplication(data)
+    await signVolunteerWaivers({
+      userId,
+      competitionTeamId: data.competitionTeamId,
+      waiverIds: data.waiverIds,
+    })
 
     // Log user in only after the application is successfully persisted
     await createAndStoreSession(userId, "password")

--- a/apps/wodsmith-start/src/server-fns/volunteer-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/volunteer-fns.ts
@@ -6,7 +6,7 @@
 import { createServerFn } from "@tanstack/react-start"
 import { and, eq, gt, inArray, isNull, or } from "drizzle-orm"
 import { z } from "zod"
-import { getDb } from "@/db"
+import { type Database, getDb } from "@/db"
 import type { TeamMembership, User } from "@/db/schema"
 import {
   competitionHeatsTable,
@@ -34,13 +34,10 @@ import { volunteerRegistrationAnswersTable } from "@/db/schemas/competitions"
 import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
 import type { VolunteerMembershipMetadata } from "@/db/schemas/volunteers"
 import { VOLUNTEER_AVAILABILITY } from "@/db/schemas/volunteers"
-import {
-  createWaiverSignatureId,
-  waiverSignaturesTable,
-  waiversTable,
-} from "@/db/schemas/waivers"
+import { waiverSignaturesTable, waiversTable } from "@/db/schemas/waivers"
 import { createEntitlement } from "@/server/entitlements"
 import { inviteUserToTeam } from "@/server/team-members"
+import { signRequiredVolunteerWaivers } from "@/server/volunteer-waivers"
 import {
   calculateInviteStatus,
   isDirectInvite,
@@ -434,62 +431,7 @@ const volunteerApplicationSchema = z.object({
 })
 
 type VolunteerApplicationInput = z.infer<typeof volunteerApplicationSchema>
-
-async function signVolunteerWaivers({
-  userId,
-  competitionTeamId,
-  waiverIds = [],
-}: {
-  userId: string
-  competitionTeamId: string
-  waiverIds?: string[]
-}) {
-  const db = getDb()
-  const competition = await db.query.competitionsTable.findFirst({
-    where: eq(competitionsTable.competitionTeamId, competitionTeamId),
-  })
-
-  if (!competition) {
-    throw new Error("Competition not found")
-  }
-
-  const requiredWaivers = await db.query.waiversTable.findMany({
-    where: and(
-      eq(waiversTable.competitionId, competition.id),
-      eq(waiversTable.requiredForVolunteers, true),
-    ),
-  })
-  const requiredIds = new Set(requiredWaivers.map((waiver) => waiver.id))
-  const signedIds = new Set(waiverIds)
-
-  for (const waiver of requiredWaivers) {
-    if (!signedIds.has(waiver.id)) {
-      throw new Error(
-        "Please agree to all required waivers before volunteering",
-      )
-    }
-  }
-
-  for (const waiverId of signedIds) {
-    if (!requiredIds.has(waiverId)) continue
-
-    const existingSignature = await db.query.waiverSignaturesTable.findFirst({
-      where: and(
-        eq(waiverSignaturesTable.waiverId, waiverId),
-        eq(waiverSignaturesTable.userId, userId),
-      ),
-    })
-    if (existingSignature) continue
-
-    await db.insert(waiverSignaturesTable).values({
-      id: createWaiverSignatureId(),
-      waiverId,
-      userId,
-      registrationId: null,
-      signedAt: new Date(),
-    })
-  }
-}
+type VolunteerDb = Pick<Database, "insert" | "query" | "update">
 
 /**
  * Creates a volunteer application (team invitation) and saves any question answers.
@@ -497,9 +439,8 @@ async function signVolunteerWaivers({
  */
 async function createVolunteerApplication(
   data: VolunteerApplicationInput,
+  db: VolunteerDb = getDb(),
 ): Promise<{ membershipId: string }> {
-  const db = getDb()
-
   // Check for duplicate email sign-up
   const existingInvitations = await db.query.teamInvitationTable.findMany({
     where: and(
@@ -600,17 +541,22 @@ export const submitVolunteerSignupFn = createServerFn({ method: "POST" })
     if (data.website && data.website.trim() !== "") {
       return { success: true }
     }
-    const { membershipId } = await createVolunteerApplication(data)
     const session = await getSessionFromCookie()
-    if (session) {
-      await signVolunteerWaivers({
+    if (!session) {
+      throw new Error("NOT_AUTHORIZED: You must be logged in to volunteer")
+    }
+
+    const db = getDb()
+    const { membershipId } = await db.transaction(async (tx) => {
+      await signRequiredVolunteerWaivers({
+        db: tx,
         userId: session.userId,
         competitionTeamId: data.competitionTeamId,
         waiverIds: data.waiverIds,
       })
-    } else if (data.waiverIds && data.waiverIds.length > 0) {
-      throw new Error("NOT_AUTHORIZED: You must be logged in to sign waivers")
-    }
+      return createVolunteerApplication(data, tx)
+    })
+
     return { success: true, membershipId }
   })
 
@@ -658,69 +604,72 @@ export const createAccountAndApplyAsVolunteerFn = createServerFn({
 
     const hashedPassword = await hashPassword({ password: data.password })
 
-    let userId: string
+    const { userId, membershipId } = await db.transaction(async (tx) => {
+      let userId: string
 
-    if (existingUser) {
-      // Fully verified account — ask them to sign in instead
-      if (existingUser.emailVerified && existingUser.passwordHash) {
-        throw new Error(
-          "An account with this email already exists. Please sign in to apply as a volunteer.",
-        )
-      }
-      // Placeholder or unverified — upgrade with password and auto-verify
-      userId = existingUser.id
-      await db
-        .update(userTable)
-        .set({
-          passwordHash: hashedPassword,
+      if (existingUser) {
+        // Fully verified account — ask them to sign in instead
+        if (existingUser.emailVerified && existingUser.passwordHash) {
+          throw new Error(
+            "An account with this email already exists. Please sign in to apply as a volunteer.",
+          )
+        }
+        // Placeholder or unverified — upgrade with password and auto-verify
+        userId = existingUser.id
+        await tx
+          .update(userTable)
+          .set({
+            passwordHash: hashedPassword,
+            firstName: data.firstName,
+            lastName: data.lastName,
+            emailVerified: new Date(),
+          })
+          .where(eq(userTable.id, existingUser.id))
+      } else {
+        // Brand-new user
+        const newUserId = createUserId()
+        const teamId = createTeamId()
+        userId = newUserId
+
+        await tx.insert(userTable).values({
+          id: newUserId,
+          email: data.signupEmail,
           firstName: data.firstName,
           lastName: data.lastName,
+          passwordHash: hashedPassword,
           emailVerified: new Date(),
         })
-        .where(eq(userTable.id, existingUser.id))
-    } else {
-      // Brand-new user
-      const newUserId = createUserId()
-      const teamId = createTeamId()
-      userId = newUserId
 
-      await db.insert(userTable).values({
-        id: newUserId,
-        email: data.signupEmail,
-        firstName: data.firstName,
-        lastName: data.lastName,
-        passwordHash: hashedPassword,
-        emailVerified: new Date(),
+        // Create personal team
+        await tx.insert(teamTable).values({
+          id: teamId,
+          name: `${data.firstName}'s Team (personal)`,
+          slug: `${data.firstName.toLowerCase()}-${newUserId.slice(-6)}`,
+          description:
+            "Personal team for individual programming track subscriptions",
+          isPersonalTeam: true,
+          personalTeamOwnerId: newUserId,
+        })
+
+        await tx.insert(teamMembershipTable).values({
+          teamId,
+          userId: newUserId,
+          roleId: "owner",
+          isSystemRole: true,
+          joinedAt: new Date(),
+          isActive: true,
+        })
+      }
+
+      await signRequiredVolunteerWaivers({
+        db: tx,
+        userId,
+        competitionTeamId: data.competitionTeamId,
+        waiverIds: data.waiverIds,
       })
+      const { membershipId } = await createVolunteerApplication(data, tx)
 
-      // Create personal team
-      await db.insert(teamTable).values({
-        id: teamId,
-        name: `${data.firstName}'s Team (personal)`,
-        slug: `${data.firstName.toLowerCase()}-${newUserId.slice(-6)}`,
-        description:
-          "Personal team for individual programming track subscriptions",
-        isPersonalTeam: true,
-        personalTeamOwnerId: newUserId,
-      })
-
-      await db.insert(teamMembershipTable).values({
-        teamId,
-        userId: newUserId,
-        roleId: "owner",
-        isSystemRole: true,
-        joinedAt: new Date(),
-        isActive: true,
-      })
-    }
-
-    // Submit the volunteer application first — if this fails, no session is
-    // created and the user can safely retry without hitting "account exists"
-    const { membershipId } = await createVolunteerApplication(data)
-    await signVolunteerWaivers({
-      userId,
-      competitionTeamId: data.competitionTeamId,
-      waiverIds: data.waiverIds,
+      return { userId, membershipId }
     })
 
     // Log user in only after the application is successfully persisted

--- a/apps/wodsmith-start/src/server-fns/waiver-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/waiver-fns.ts
@@ -49,6 +49,7 @@ const createWaiverInputSchema = z.object({
     .min(1, "Content is required")
     .max(50000, "Content is too long"),
   required: z.boolean().default(true),
+  requiredForVolunteers: z.boolean().default(false),
 })
 
 const updateWaiverInputSchema = z.object({
@@ -66,6 +67,7 @@ const updateWaiverInputSchema = z.object({
     .max(50000, "Content is too long")
     .optional(),
   required: z.boolean().optional(),
+  requiredForVolunteers: z.boolean().optional(),
 })
 
 const deleteWaiverInputSchema = z.object({
@@ -345,6 +347,7 @@ export const createWaiverFn = createServerFn({ method: "POST" })
       title: data.title,
       content: data.content,
       required: data.required,
+      requiredForVolunteers: data.requiredForVolunteers,
       position: maxPosition + 1,
     })
 
@@ -406,6 +409,9 @@ export const updateWaiverFn = createServerFn({ method: "POST" })
     if (data.title !== undefined) updateData.title = data.title
     if (data.content !== undefined) updateData.content = data.content
     if (data.required !== undefined) updateData.required = data.required
+    if (data.requiredForVolunteers !== undefined) {
+      updateData.requiredForVolunteers = data.requiredForVolunteers
+    }
 
     // Update waiver with compound where clause
     await db

--- a/apps/wodsmith-start/src/server/volunteer-waivers.ts
+++ b/apps/wodsmith-start/src/server/volunteer-waivers.ts
@@ -1,0 +1,67 @@
+import { and, eq } from "drizzle-orm"
+import type { Database } from "@/db"
+import { competitionsTable } from "@/db/schema"
+import {
+  createWaiverSignatureId,
+  waiverSignaturesTable,
+  waiversTable,
+} from "@/db/schemas/waivers"
+
+type VolunteerWaiverDb = Pick<Database, "insert" | "query">
+
+export async function signRequiredVolunteerWaivers({
+  db,
+  userId,
+  competitionTeamId,
+  waiverIds = [],
+  missingWaiverMessage = "Please agree to all required waivers before volunteering",
+}: {
+  db: VolunteerWaiverDb
+  userId: string
+  competitionTeamId: string
+  waiverIds?: string[]
+  missingWaiverMessage?: string
+}) {
+  const competition = await db.query.competitionsTable.findFirst({
+    where: eq(competitionsTable.competitionTeamId, competitionTeamId),
+  })
+
+  if (!competition) {
+    throw new Error("Competition not found")
+  }
+
+  const requiredWaivers = await db.query.waiversTable.findMany({
+    where: and(
+      eq(waiversTable.competitionId, competition.id),
+      eq(waiversTable.requiredForVolunteers, true),
+    ),
+  })
+  const requiredIds = new Set(requiredWaivers.map((waiver) => waiver.id))
+  const signedIds = new Set(waiverIds)
+
+  for (const waiver of requiredWaivers) {
+    if (!signedIds.has(waiver.id)) {
+      throw new Error(missingWaiverMessage)
+    }
+  }
+
+  for (const waiverId of signedIds) {
+    if (!requiredIds.has(waiverId)) continue
+
+    const existingSignature = await db.query.waiverSignaturesTable.findFirst({
+      where: and(
+        eq(waiverSignaturesTable.waiverId, waiverId),
+        eq(waiverSignaturesTable.userId, userId),
+      ),
+    })
+    if (existingSignature) continue
+
+    await db.insert(waiverSignaturesTable).values({
+      id: createWaiverSignatureId(),
+      waiverId,
+      userId,
+      registrationId: null,
+      signedAt: new Date(),
+    })
+  }
+}

--- a/apps/wodsmith-start/test/lib/series-template-asset-sync.test.ts
+++ b/apps/wodsmith-start/test/lib/series-template-asset-sync.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+import { selectTemplateAssetsMissingByTitle } from "@/lib/series-template-asset-sync"
+
+describe("selectTemplateAssetsMissingByTitle", () => {
+	it("selects quick links and judging sheets that are newly added before resync", () => {
+		const templateAssets = [
+			{ id: "template-existing", title: "Movement Standards" },
+			{ id: "template-new", title: "Heat Flow" },
+		]
+		const existingCompetitionAssets = [
+			{ title: "movement standards" },
+		]
+
+		expect(
+			selectTemplateAssetsMissingByTitle(
+				templateAssets,
+				existingCompetitionAssets,
+			),
+		).toEqual([{ id: "template-new", title: "Heat Flow" }])
+	})
+
+	it("deduplicates by trimmed case-insensitive title during initial sync", () => {
+		const templateAssets = [
+			{ id: "template-first", title: "Scorecard" },
+			{ id: "template-duplicate", title: " scorecard " },
+		]
+
+		expect(selectTemplateAssetsMissingByTitle(templateAssets, [])).toEqual([
+			{ id: "template-first", title: "Scorecard" },
+		])
+	})
+})

--- a/apps/wodsmith-start/test/lib/series-template-asset-sync.test.ts
+++ b/apps/wodsmith-start/test/lib/series-template-asset-sync.test.ts
@@ -29,4 +29,50 @@ describe("selectTemplateAssetsMissingByTitle", () => {
 			{ id: "template-first", title: "Scorecard" },
 		])
 	})
+
+	it("returns an empty array when there are no template assets", () => {
+		expect(
+			selectTemplateAssetsMissingByTitle([], [{ title: "Movement Standards" }]),
+		).toEqual([])
+	})
+
+	it("returns an empty array when all template assets already exist", () => {
+		const templateAssets = [{ id: "template-existing", title: "Scorecard" }]
+		const existingCompetitionAssets = [{ title: "scorecard" }]
+
+		expect(
+			selectTemplateAssetsMissingByTitle(
+				templateAssets,
+				existingCompetitionAssets,
+			),
+		).toEqual([])
+	})
+
+	it("deduplicates empty and whitespace-only titles consistently", () => {
+		const templateAssets = [
+			{ id: "template-empty", title: "" },
+			{ id: "template-spaces", title: "   " },
+			{ id: "template-tabs", title: "\t\n" },
+			{ id: "template-valid", title: "Volunteer Briefing" },
+		]
+
+		expect(selectTemplateAssetsMissingByTitle(templateAssets, [])).toEqual([
+			{ id: "template-empty", title: "" },
+			{ id: "template-valid", title: "Volunteer Briefing" },
+		])
+	})
+
+	it("deduplicates multiple duplicates with varying case and whitespace", () => {
+		const templateAssets = [
+			{ id: "template-first", title: " Scorecard " },
+			{ id: "template-second", title: "scorecard" },
+			{ id: "template-third", title: "SCORECARD" },
+			{ id: "template-standards", title: "Movement Standards" },
+		]
+
+		expect(selectTemplateAssetsMissingByTitle(templateAssets, [])).toEqual([
+			{ id: "template-first", title: " Scorecard " },
+			{ id: "template-standards", title: "Movement Standards" },
+		])
+	})
 })

--- a/apps/wodsmith-start/test/server-fns/volunteer-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/volunteer-fns.test.ts
@@ -177,6 +177,14 @@ const createMockMembership = (overrides?: Partial<{
   updateCounter: null,
 })
 
+const mockCompetitionWithoutRequiredVolunteerWaivers = () => {
+  mockDb.query.competitionsTable.findFirst.mockResolvedValueOnce({
+    id: 'comp_test123',
+    competitionTeamId: 'team_comp123',
+  })
+  mockDb.query.waiversTable.findMany.mockResolvedValueOnce([])
+}
+
 describe('Volunteer Server Functions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -192,6 +200,8 @@ describe('Volunteer Server Functions', () => {
     mockDb.registerTable('competitionHeatsTable')
     mockDb.registerTable('judgeHeatAssignmentsTable')
     mockDb.registerTable('teamTable')
+    mockDb.registerTable('waiversTable')
+    mockDb.registerTable('waiverSignaturesTable')
     setMockSession(mockOrganizerSession)
   })
 
@@ -324,6 +334,7 @@ describe('Volunteer Server Functions', () => {
   // ============================================================================
   describe('submitVolunteerSignupFn', () => {
     it('should create a volunteer signup invitation', async () => {
+      mockCompetitionWithoutRequiredVolunteerWaivers()
       // findMany must return [] for duplicate check
       mockDb.query.teamInvitationTable.findMany.mockResolvedValueOnce([])
       mockDb.setMockSingleValue(null) // No existing user
@@ -359,6 +370,7 @@ describe('Volunteer Server Functions', () => {
     })
 
     it('should reject duplicate email signups', async () => {
+      mockCompetitionWithoutRequiredVolunteerWaivers()
       // Return existing invitation with same email
       mockDb.setMockReturnValue([
         createMockInvitation({email: 'duplicate@example.com'}),
@@ -376,6 +388,7 @@ describe('Volunteer Server Functions', () => {
     })
 
     it('should reject when user already has volunteer membership', async () => {
+      mockCompetitionWithoutRequiredVolunteerWaivers()
       // No existing invitations with matching email
       mockDb.setMockReturnValue([])
       // User exists
@@ -933,6 +946,7 @@ describe('Volunteer Server Functions', () => {
     })
 
     it('should create a new user account and volunteer application', async () => {
+      mockCompetitionWithoutRequiredVolunteerWaivers()
       // No existing user in account creation check
       mockDb.query.userTable.findFirst.mockResolvedValueOnce(null)
       // No duplicate invitations in createVolunteerApplication
@@ -954,6 +968,7 @@ describe('Volunteer Server Functions', () => {
     })
 
     it('should upgrade an existing placeholder user and create volunteer application', async () => {
+      mockCompetitionWithoutRequiredVolunteerWaivers()
       const placeholderUser = {
         id: 'user_placeholder123',
         email: 'jane@example.com',

--- a/lat.md/domain.md
+++ b/lat.md/domain.md
@@ -174,9 +174,11 @@ Each scaling group contains ordered scaling levels. Workouts and scores can refe
 
 ## Waivers
 
-Legal documents that athletes must sign before competing.
+Legal documents that athletes and volunteers must sign before participating.
 
-Organizers create waiver templates per competition. Athletes sign waivers during registration. Signature and acceptance timestamps are recorded.
+Organizers create waiver templates per competition. Waivers can be required for athletes, volunteers, or both. Only athlete-required waivers appear in athlete registration and invite flows. Volunteers sign volunteer-required waivers during public signup or direct invite acceptance. Signature and acceptance timestamps are recorded.
+
+The waiver schema stores the athlete requirement as `required` and volunteer requirement as `requiredForVolunteers` / `required_for_volunteers` on [[apps/wodsmith-start/src/db/schemas/waivers.ts#waiversTable]].
 
 ## Video Submissions
 

--- a/lat.md/organizer-dashboard.md
+++ b/lat.md/organizer-dashboard.md
@@ -150,6 +150,8 @@ Lists confirmed volunteers with their roles and capabilities (e.g., can input sc
 
 Uses `getCompetitionVolunteersFn` and `getDirectVolunteerInvitesFn`. Features invite dialog, role management, and activation/deactivation. Also shows `InvitedVolunteersList` for pending invitations.
 
+The roster displays one status column per volunteer-required waiver, with each column titled from the waiver. Status data comes from [[apps/wodsmith-start/src/server-fns/volunteer-fns.ts#getVolunteerWaiverStatusesFn]]. Pending applications resolve signatures by invite email when a user account exists; approved volunteers resolve by membership user id.
+
 ### Volunteer Shifts
 
 Time-based work assignments for volunteers independent of heats.
@@ -174,15 +176,17 @@ Gated by the `ai_judge_scheduling` feature (see [[apps/wodsmith-start/src/config
 
 ### Volunteer Registration Rules
 
-Custom registration questions targeted at volunteers (separate from athlete registration questions).
+Custom registration questions and waivers targeted at volunteers (separate from athlete registration requirements).
 
-Uses `RegistrationQuestionsEditor` with `questionTarget: "volunteer"`.
+Uses `RegistrationQuestionsEditor` with `questionTarget: "volunteer"`. Waivers marked required for volunteers are shown on the public volunteer signup page and during direct volunteer invite acceptance through [[apps/wodsmith-start/src/routes/compete/$slug/-components/volunteer-signup-form.tsx#VolunteerSignupForm]] and [[apps/wodsmith-start/src/routes/compete/invite/-components/accept-volunteer-invite-form.tsx#AcceptVolunteerInviteForm]].
 
 ## Waivers
 
-Manages legal waiver documents that athletes must sign before competing.
+Manages legal waiver documents that athletes or volunteers must sign before participating.
 
-Uses `getCompetitionWaiversFn`. `WaiverList` and `WaiverFormDialog` handle CRUD with reordering. Each waiver has a title, content (rich text), and required/optional flag.
+Uses `getCompetitionWaiversFn`. `WaiverList` and `WaiverFormDialog` handle CRUD with reordering. Each waiver has a title, content (rich text), a required-for-athletes flag, and a required-for-volunteers flag.
+
+[[apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/waiver-form-dialog.tsx#WaiverFormDialog]] labels the existing athlete checkbox "Required for athletes" and adds a separate "Required for volunteers" checkbox. Organizer and cohost waiver mutations persist both flags. Unchecked athlete-required waivers remain manageable in the dashboard but are hidden from athlete registration pages.
 
 ## Pricing
 

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -81,6 +81,8 @@ The public volunteer route loads competition waivers marked `requiredForVoluntee
 
 Volunteer waiver signing is centralized in [[apps/wodsmith-start/src/server/volunteer-waivers.ts#signRequiredVolunteerWaivers]]. Signup/application writes and direct invite acceptance writes call it inside the same database transaction as their invitation, membership, and answer writes so a waiver failure rolls back the whole volunteer action.
 
+Volunteer application unit tests in [[apps/wodsmith-start/test/server-fns/volunteer-fns.test.ts]] mock a competition with no volunteer-required waivers when asserting legacy duplicate, membership, and application persistence paths so the centralized waiver gate does not mask those behaviors.
+
 ## Capacity Management
 
 Both division-level and competition-wide capacity are enforced at registration time and again at payment completion.

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -25,7 +25,7 @@ For **paid** competitions: creates `commercePurchaseTable` records (one per divi
 
 Coupon codes are resolved before redirecting to Stripe; see [[commerce#Coupons#Registration coupon entry]] for the shared link/manual entry behavior.
 
-The registration form always shows the fee summary card. Before a division is selected, fee and total amounts render as dashes so the pricing area remains stable without implying a charge.
+The registration form always shows the fee summary card. Before a division is selected, fee and total amounts render as dashes so the pricing area remains stable without implying a charge. Aggregate totals only use currently selected divisions so stale fee loads from a previous selection cannot briefly appear.
 
 ### Organizer Manual Registration
 
@@ -75,9 +75,11 @@ Volunteer-required waivers are collected before volunteer signup or direct invit
 
 Athlete registration and teammate invite flows only display waivers where the athlete-required flag (`required`) is selected. Waivers that are only volunteer-required or fully optional do not appear on athlete registration pages.
 
-The public volunteer route loads competition waivers marked `requiredForVolunteers` and requires agreement before submitting an application. Direct volunteer invite acceptance loads the same waiver set and stores signatures before accepting the team invitation.
+The public volunteer route loads competition waivers marked `requiredForVolunteers` and requires agreement before submitting an application. Direct volunteer invite acceptance loads the same waiver set and stores signatures before accepting the team invitation. Both client forms share waiver agreement helpers in [[apps/wodsmith-start/src/lib/volunteer-waiver-agreements.ts#haveAllVolunteerWaiversBeenAgreed]].
 
 [[apps/wodsmith-start/src/server-fns/volunteer-fns.ts#submitVolunteerSignupFn]] validates that signed-in volunteer applicants have agreed to all volunteer-required waivers before persisting signatures. [[apps/wodsmith-start/src/server-fns/invite-fns.ts#acceptVolunteerInviteFn]] performs the same required-waiver check before accepting a direct volunteer team invitation.
+
+Volunteer waiver signing is centralized in [[apps/wodsmith-start/src/server/volunteer-waivers.ts#signRequiredVolunteerWaivers]]. Signup/application writes and direct invite acceptance writes call it inside the same database transaction as their invitation, membership, and answer writes so a waiver failure rolls back the whole volunteer action.
 
 ## Capacity Management
 

--- a/lat.md/registration.md
+++ b/lat.md/registration.md
@@ -25,6 +25,8 @@ For **paid** competitions: creates `commercePurchaseTable` records (one per divi
 
 Coupon codes are resolved before redirecting to Stripe; see [[commerce#Coupons#Registration coupon entry]] for the shared link/manual entry behavior.
 
+The registration form always shows the fee summary card. Before a division is selected, fee and total amounts render as dashes so the pricing area remains stable without implying a charge.
+
 ### Organizer Manual Registration
 
 Organizers register athletes from the dashboard via `createManualRegistrationFn`, bypassing the registration window.
@@ -66,6 +68,16 @@ The public competition page surfaces unclaimed teammate invites for the signed-i
 Tests cover both halves of this recovery path: the server lookup requires a signed-in email and returns invite rows only after resolving competition athlete teams, while the sidebar renders the CTA even when the athlete is already registered elsewhere.
 
 Organizers manage roster composition from the [[organizer-dashboard#Registrations (Athletes)#Athlete Detail Page]] without captaincy: [[apps/wodsmith-start/src/server-fns/organizer-athlete-fns.ts#addTeammateToRegistrationFn]] creates a pending invite directly (bypasses the captain-only `INVITE_MEMBERS` check by inlining the invite insert + email send), [[apps/wodsmith-start/src/server-fns/organizer-athlete-fns.ts#removeTeammateFromRegistrationFn]] deactivates a single athlete-team membership (and the matching event-team membership) without touching the captain, [[apps/wodsmith-start/src/server-fns/organizer-athlete-fns.ts#cancelPendingTeamInviteFn]] sets a pending invite to `CANCELLED`, and [[apps/wodsmith-start/src/server-fns/organizer-athlete-fns.ts#resendTeamInviteAsOrganizerFn]] resends any pending invite regardless of expiry (vs. the captain-only fn which only permits *expired* refreshes).
+
+## Volunteer Waiver Collection
+
+Volunteer-required waivers are collected before volunteer signup or direct invite acceptance completes.
+
+Athlete registration and teammate invite flows only display waivers where the athlete-required flag (`required`) is selected. Waivers that are only volunteer-required or fully optional do not appear on athlete registration pages.
+
+The public volunteer route loads competition waivers marked `requiredForVolunteers` and requires agreement before submitting an application. Direct volunteer invite acceptance loads the same waiver set and stores signatures before accepting the team invitation.
+
+[[apps/wodsmith-start/src/server-fns/volunteer-fns.ts#submitVolunteerSignupFn]] validates that signed-in volunteer applicants have agreed to all volunteer-required waivers before persisting signatures. [[apps/wodsmith-start/src/server-fns/invite-fns.ts#acceptVolunteerInviteFn]] performs the same required-waiver check before accepting a direct volunteer team invitation.
 
 ## Capacity Management
 

--- a/lat.md/series-event-templates.md
+++ b/lat.md/series-event-templates.md
@@ -45,6 +45,8 @@ Sync behavior by data type:
 - **Resources** — Additive only, deduplicated by title match (case-insensitive)
 - **Judging sheets** — Additive only, deduplicated by title match (case-insensitive)
 
+Template asset selection uses [[apps/wodsmith-start/src/lib/series-template-asset-sync.ts#selectTemplateAssetsMissingByTitle]] for both resources and judging sheets. The helper filters titles already present in the competition and deduplicates repeated template titles after trim/case normalization, including empty or whitespace-only titles.
+
 ### Selective Sync
 
 The `templateEventIds` optional parameter filters which template events to sync. When provided, only those events are synced. If a child event is selected without its parent, the parent is auto-included to maintain the hierarchy.


### PR DESCRIPTION
## Summary

- add volunteer-required waiver support across waiver management, public volunteer signup, and direct volunteer invite acceptance
- show volunteer waiver signature status on the organizer volunteer roster with one titled column per required volunteer waiver
- keep athlete registration and teammate invite flows scoped to athlete-required waivers
- stabilize the registration fee summary empty state
- add a helper and tests for selecting missing series template assets by title

## Verification

- pnpm type-check (wodsmith-start)
- pnpm exec biome check on touched wodsmith-start files
- pnpm test test/lib/series-template-asset-sync.test.ts
- lat check
- git diff --check
- pre-push: pnpm lint completed with existing warnings; pnpm type-check passed

## Notes

- GitNexus detect-changes reported HIGH before committing because the full working tree spanned 23 files and 12 affected flows.
- GitHub warned that lat.md/.cache/vectors.db is larger than the recommended 50 MB file size.

<!-- This is an auto-generated description by cubic. -->

***

## Summary by cubic

Adds volunteer-required waivers across management, signup, and direct invite flows. Volunteers must agree to required waivers before proceeding; athlete flows only show athlete-required waivers and the fee summary stays stable.

- **New Features**
  - Added `requiredForVolunteers` on waivers; organizer/cohost CRUD and UI manage both athlete and volunteer flags.
  - Public volunteer signup and direct invite acceptance display volunteer-required waivers, require agreement, and persist signatures transactionally via `signRequiredVolunteerWaivers`.
  - Organizer volunteer roster shows one column per volunteer-required waiver with Signed/Missing status, resolving by user ID or invite email through `getVolunteerWaiverStatusesFn`.
  - Athlete registration and teammate invite flows now filter to athlete-required waivers only.
  - Added `selectTemplateAssetsMissingByTitle` helper with tests.

- **Bug Fixes**
  - Registration fee summary uses a stable dash placeholder before selection and totals only reflect selected divisions.

<sup>Written for commit 11331d43e53dfcb3b224160a31c9f97da210ff74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Volunteers can be required to sign waivers during signup or invite acceptance.
  - Organizers can mark waivers separately for athletes vs. volunteers.
  - Volunteer waiver signing and per-volunteer waiver status are surfaced in roster views and signup flows.

- **Improvements**
  - Fee summary shows a stable placeholder before a division is selected; totals reflect only selected divisions.
  - Registration and invite flows now require agreement to all applicable waivers before submission.

- **Documentation**
  - Docs updated to describe athlete vs. volunteer waiver behavior and roster waiver status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- **Support volunteer-required waivers** :point\_left: <!-- branch-stack -->
  - \#496
