### PR TITLE
Align organizer primary action placement

### DIFF
--- a/apps/wodsmith-start/src/components/organizer/schedule/venue-manager.tsx
+++ b/apps/wodsmith-start/src/components/organizer/schedule/venue-manager.tsx
@@ -16,7 +16,6 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog"
 import {
   Form,
@@ -353,6 +352,24 @@ export function VenueManager({
 
   return (
     <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight">Venues</h2>
+          <p className="text-sm text-muted-foreground">
+            Add and manage the locations where heats are scheduled.
+          </p>
+        </div>
+        {displayVenues.length > 0 ? (
+          <Button
+            onClick={() => setIsCreateOpen(true)}
+            className="w-full sm:w-auto"
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Add venue
+          </Button>
+        ) : null}
+      </div>
+
       {/* Venue List */}
       {displayVenues.length === 0 ? (
         <OrganizerEmptyState
@@ -395,6 +412,7 @@ export function VenueManager({
                       size="icon"
                       onClick={() => handleDelete(venue)}
                       disabled={isDeleting}
+                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                     >
                       <Trash2 className="h-4 w-4" />
                     </Button>
@@ -419,14 +437,6 @@ export function VenueManager({
           }
         }}
       >
-        {displayVenues.length > 0 ? (
-          <DialogTrigger asChild>
-            <Button variant="outline" size="sm">
-              <Plus className="h-4 w-4 mr-2" />
-              Add Venue
-            </Button>
-          </DialogTrigger>
-        ) : null}
         <DialogContent className="max-h-[90vh] overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Create venue</DialogTitle>

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/publish-rotations-button.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/publish-rotations-button.tsx
@@ -96,10 +96,7 @@ export function PublishRotationsButton({
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>
-        <Button
-          disabled={disabled || rotationsCount === 0}
-          className="bg-orange-500 text-white hover:bg-orange-600 dark:bg-orange-500 dark:text-white dark:hover:bg-orange-600"
-        >
+        <Button disabled={disabled || rotationsCount === 0}>
           <Send className="mr-2 h-4 w-4" />
           Publish rotations
         </Button>

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/scoring-settings-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/scoring-settings-form.tsx
@@ -94,7 +94,7 @@ export function ScoringSettingsForm({
   }
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6 pb-24">
       <ScoringConfigForm
         value={config}
         onChange={setConfig}
@@ -102,20 +102,22 @@ export function ScoringSettingsForm({
         disabled={isSaving}
       />
 
-      <div className="flex justify-end">
-        <Button onClick={handleSave} disabled={isSaving}>
-          {isSaving ? (
-            <>
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              Saving...
-            </>
-          ) : (
-            <>
-              <Save className="mr-2 h-4 w-4" />
-              Save scoring settings
-            </>
-          )}
-        </Button>
+      <div className="sticky bottom-0 z-10 -mx-4 border-t bg-background/95 px-4 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:-mx-6 sm:px-6">
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={isSaving}>
+            {isSaving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              <>
+                <Save className="mr-2 h-4 w-4" />
+                Save scoring settings
+              </>
+            )}
+          </Button>
+        </div>
       </div>
     </div>
   )

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/shifts/shift-list.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/shifts/shift-list.tsx
@@ -267,7 +267,22 @@ export function ShiftList({
   // Empty state
   if (shifts.length === 0) {
     return (
-      <>
+      <div className="space-y-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <h2 className="text-2xl font-bold tracking-tight">
+              Volunteer shifts
+            </h2>
+            <p className="text-muted-foreground">
+              Manage time-based volunteer shifts for non-judge roles
+            </p>
+          </div>
+          <Button onClick={handleOpenCreateDialog} className="w-full sm:w-auto">
+            <Plus className="mr-2 h-4 w-4" />
+            Add shift
+          </Button>
+        </div>
+
         <OrganizerEmptyState
           icon={CalendarDays}
           title="No volunteer shifts yet"
@@ -285,7 +300,7 @@ export function ShiftList({
           onCreateShift={onCreateShift}
           onUpdateShift={onUpdateShift}
         />
-      </>
+      </div>
     )
   }
 
@@ -295,7 +310,7 @@ export function ShiftList({
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h2 className="text-2xl font-bold tracking-tight">
-            Volunteer Shifts
+            Volunteer shifts
           </h2>
           <p className="text-muted-foreground">
             Manage time-based volunteer shifts for non-judge roles


### PR DESCRIPTION
## Summary
- move venue creation into the section header while keeping the empty-state CTA
- keep the volunteer shift page-level CTA visible even when the list is empty
- make scoring settings save persistently available in a sticky bottom save bar
- use standard primary styling for publishing rotations and destructive styling for venue delete actions

## Validation
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/ianjones/.nix-profile/bin:/Users/ianjones/.codex/tmp/arg0/codex-arg0Njckwz:/Users/ianjones/.local/bin:/Users/ianjones/.bun/bin:/Users/ianjones/Library/pnpm:/Users/ianjones/.cabal/bin:/Users/ianjones/.ghcup/bin:/Users/ianjones/.rbenv/shims:/Users/ianjones/.rbenv/bin:/Users/ianjones/.nvm/versions/node/v24.14.1/bin:/opt/local/bin:/opt/local/sbin:/Users/ianjones/.cargo/bin:/Users/ianjones/clojure-lsp:/Users/ianjones/.emacs.d/bin:/Users/ianjones/.simple/bin:/Users/ianjones/go/bin:/Applications/Codex.app/Contents/Resources pnpm exec biome check src/components/organizer/schedule/venue-manager.tsx 'src/routes/compete/organizer/$competitionId/-components/shifts/shift-list.tsx' 'src/routes/compete/organizer/$competitionId/-components/scoring-settings-form.tsx' 'src/routes/compete/organizer/$competitionId/-components/judges/publish-rotations-button.tsx'
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/ianjones/.nix-profile/bin:/Users/ianjones/.codex/tmp/arg0/codex-arg0Njckwz:/Users/ianjones/.local/bin:/Users/ianjones/.bun/bin:/Users/ianjones/Library/pnpm:/Users/ianjones/.cabal/bin:/Users/ianjones/.ghcup/bin:/Users/ianjones/.rbenv/shims:/Users/ianjones/.rbenv/bin:/Users/ianjones/.nvm/versions/node/v24.14.1/bin:/opt/local/bin:/opt/local/sbin:/Users/ianjones/.cargo/bin:/Users/ianjones/clojure-lsp:/Users/ianjones/.emacs.d/bin:/Users/ianjones/.simple/bin:/Users/ianjones/go/bin:/Applications/Codex.app/Contents/Resources pnpm type-check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns primary action placement and button styling across organizer screens for consistent, clearer CTAs. Adds a sticky save bar for scoring settings.

- **Refactors**
  - Venues: Moved “Add venue” to the section header; kept empty-state CTA; delete button now uses destructive styling.
  - Volunteer shifts: Header and “Add shift” button stay visible even when empty; normalized title casing.
  - Scoring settings: Added sticky bottom save bar; padded content to avoid overlap.
  - Judges rotations: “Publish rotations” now uses standard primary button styling.

<sup>Written for commit 51539dd929a0458e76523b16d7be19a08eee4585. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Add shift" button to empty shift state

* **Style**
  * Updated venue delete button with destructive styling
  * Removed hardcoded orange styling from rotations button

* **UI Improvements**
  * Moved "Add venue" button to venues header
  * Implemented sticky bottom bar for scoring settings save button
  * Enhanced shift list with "Volunteer shifts" heading

<!-- end of auto-generated comment: release notes by coderabbit.ai -->