### PR TITLE
Fix published judge schedule edits

### DIFF
--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-heat-card.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-heat-card.tsx
@@ -15,7 +15,6 @@ import {
   Loader2,
   MapPin,
   Plus,
-  Trash2,
   X,
 } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
@@ -287,7 +286,6 @@ interface JudgeHeatCardProps {
   unassignedVolunteers: JudgeVolunteerInfo[]
   judgeAssignments: JudgeHeatAssignment[]
   maxLanes: number
-  onDelete: () => void
   onAssignmentChange: (assignments: JudgeHeatAssignment[]) => void
   onMoveAssignment?: (
     assignmentId: string,
@@ -300,6 +298,7 @@ interface JudgeHeatCardProps {
   onClearSelection?: () => void
   filterEmptyLanes?: boolean
   athleteOccupiedLanes?: Set<number>
+  onScheduleRevisionPublished?: () => Promise<void> | void
 }
 
 /**
@@ -314,13 +313,13 @@ export function JudgeHeatCard({
   unassignedVolunteers,
   judgeAssignments,
   maxLanes,
-  onDelete,
   onAssignmentChange,
   onMoveAssignment,
   selectedJudgeIds,
   onClearSelection,
   filterEmptyLanes,
   athleteOccupiedLanes,
+  onScheduleRevisionPublished,
 }: JudgeHeatCardProps) {
   const [isAssignOpen, setIsAssignOpen] = useState(false)
   const [selectedMembershipId, setSelectedMembershipId] = useState<string>("")
@@ -380,6 +379,7 @@ export function JudgeHeatCard({
           }
           onAssignmentChange([...heatAssignments, newAssignment])
         }
+        await onScheduleRevisionPublished?.()
         setIsAssignOpen(false)
         setSelectedMembershipId("")
         // Auto-select next available lane
@@ -406,6 +406,7 @@ export function JudgeHeatCard({
       })
 
       onAssignmentChange(heatAssignments.filter((a) => a.id !== assignmentId))
+      await onScheduleRevisionPublished?.()
     } catch (err) {
       console.error("Failed to remove judge:", err)
     } finally {
@@ -469,6 +470,7 @@ export function JudgeHeatCard({
             onAssignmentChange([...heatAssignments, newAssignment])
           }
         }
+        await onScheduleRevisionPublished?.()
       } catch (err) {
         console.error("Failed to assign judge:", err)
       } finally {
@@ -504,6 +506,7 @@ export function JudgeHeatCard({
 
           onAssignmentChange([...heatAssignments, ...newAssignments])
         }
+        await onScheduleRevisionPublished?.()
       } catch (err) {
         console.error("Failed to bulk assign judges:", err)
       } finally {
@@ -548,6 +551,7 @@ export function JudgeHeatCard({
             a.id === assignmentId ? { ...a, laneNumber: targetLane } : a,
           ),
         )
+        await onScheduleRevisionPublished?.()
       } else {
         // Cross-heat move
         await moveJudgeAssignmentFn({
@@ -570,6 +574,7 @@ export function JudgeHeatCard({
             assignment,
           )
         }
+        await onScheduleRevisionPublished?.()
       }
     } catch (err) {
       console.error("Failed to move judge:", err)
@@ -643,14 +648,9 @@ export function JudgeHeatCard({
               {heatAssignments.length}/{maxLanes}
             </Badge>
           </div>
-          <div className="flex items-center gap-2">
-            {heat.division && (
-              <Badge variant="secondary">{heat.division.label}</Badge>
-            )}
-            <Button variant="ghost" size="icon" onClick={onDelete}>
-              <Trash2 className="h-4 w-4" />
-            </Button>
-          </div>
+          {heat.division && (
+            <Badge variant="secondary">{heat.division.label}</Badge>
+          )}
         </div>
         <div className="flex items-center gap-4 text-sm text-muted-foreground">
           {heat.scheduledTime && (

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-scheduling-container.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-scheduling-container.tsx
@@ -28,7 +28,6 @@ import type {
 } from "@/db/schema"
 import type { LaneShiftPattern } from "@/db/schemas/volunteers"
 import { calculateCoverage } from "@/lib/judge-rotation-utils"
-import { formatTrackOrder } from "@/utils/format-track-order"
 import type { HeatWithAssignments } from "@/server-fns/competition-heats-fns"
 import type { CompetitionWorkout } from "@/server-fns/competition-workouts-fns"
 import {
@@ -41,6 +40,7 @@ import {
   type JudgeHeatAssignment,
   type JudgeVolunteerInfo,
 } from "@/server-fns/judge-scheduling-fns"
+import { formatTrackOrder } from "@/utils/format-track-order"
 
 import { DraggableJudge } from "./draggable-judge"
 import { EventDefaultsEditor } from "./event-defaults-editor"
@@ -573,8 +573,7 @@ export function JudgeSchedulingContainer({
             <SelectContent>
               {events.map((event) => (
                 <SelectItem key={event.id} value={event.id}>
-                  {formatTrackOrder(event.trackOrder)} -{" "}
-                  {event.workout.name}
+                  {formatTrackOrder(event.trackOrder)} - {event.workout.name}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -638,128 +637,119 @@ export function JudgeSchedulingContainer({
             </Card>
           )}
 
-          <>
-            {/* Overview */}
-            <JudgeOverview
-              events={events}
-                heats={heats}
-                judgeAssignments={assignments}
-                filterEmptyLanes={filterEmptyLanes}
-                onFilterEmptyLanesChange={setFilterEmptyLanes}
-              />
+          {/* Overview */}
+          <JudgeOverview
+            events={events}
+            heats={heats}
+            judgeAssignments={assignments}
+            filterEmptyLanes={filterEmptyLanes}
+            onFilterEmptyLanesChange={setFilterEmptyLanes}
+          />
 
-              {/* Main content: judges panel + heats */}
-              <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
-                {/* Available Judges Panel */}
-                <Card className="lg:sticky lg:top-4 lg:self-start">
-                  <CardContent className="p-4">
-                    <div className="mb-3 flex items-center justify-between">
-                      <h4 className="text-sm font-medium">Available Judges</h4>
-                      {selectedJudgeIds.size > 0 && (
-                        <button
-                          type="button"
-                          onClick={clearSelection}
-                          className="text-xs text-muted-foreground hover:text-foreground"
-                        >
-                          Clear ({selectedJudgeIds.size})
-                        </button>
-                      )}
-                    </div>
-                    {judges.length === 0 ? (
-                      <p className="py-4 text-center text-sm text-muted-foreground">
-                        No judges have been added yet. Add volunteers with the
-                        Judge role type in the Volunteers section above.
-                      </p>
-                    ) : (
-                      <>
-                        {/* Search Input */}
-                        <div className="relative mb-3">
-                          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-                          <Input
-                            type="text"
-                            placeholder="Search judges..."
-                            value={availableJudgeSearch}
-                            onChange={(e) =>
-                              setAvailableJudgeSearch(e.target.value)
-                            }
-                            className="h-8 pl-8 text-sm"
-                          />
-                        </div>
-                        <div className="max-h-[55vh] space-y-1.5 overflow-y-auto">
-                          {filteredJudgesByAssignmentCount.map((judge) => (
-                            <DraggableJudge
-                              key={judge.membershipId}
-                              volunteer={judge}
-                              isSelected={selectedJudgeIds.has(
-                                judge.membershipId,
-                              )}
-                              onToggleSelect={handleToggleSelect}
-                              selectedIds={selectedJudgeIds}
-                              assignmentCount={judge.assignmentCount}
-                              isAssignedToCurrentEvent={assignedJudgeIds.has(
-                                judge.membershipId,
-                              )}
-                            />
-                          ))}
-                          {filteredJudgesByAssignmentCount.length === 0 &&
-                            availableJudgeSearch && (
-                              <p className="py-4 text-center text-sm text-muted-foreground">
-                                No judges match "{availableJudgeSearch}"
-                              </p>
-                            )}
-                        </div>
-                      </>
-                    )}
-                  </CardContent>
-                </Card>
-
-                {/* Heats Grid */}
-                <div className="space-y-4">
-                  {eventHeats.length === 0 ? (
-                    <Card>
-                      <CardContent className="py-8 text-center">
-                        <p className="text-muted-foreground">
-                          No heats scheduled for this event yet.
-                        </p>
-                        <p className="mt-2 text-sm text-muted-foreground">
-                          Create heats in the Schedule section first.
-                        </p>
-                      </CardContent>
-                    </Card>
-                  ) : (
-                    eventHeats.map((heat) => (
-                      <JudgeHeatCard
-                        key={heat.id}
-                        heat={heat}
-                        competitionId={competitionId}
-                        organizingTeamId={organizingTeamId}
-                        unassignedVolunteers={unassignedJudges}
-                        judgeAssignments={assignments.filter(
-                          (a) => a.heatId === heat.id,
-                        )}
-                        maxLanes={maxLanes}
-                        onDelete={() => {
-                          // No-op: Heat deletion should be done in Schedule section
-                          console.debug(
-                            "Heat deletion is handled in Schedule section",
-                          )
-                        }}
-                        onAssignmentChange={(newAssignments) =>
-                          handleAssignmentChange(heat.id, newAssignments)
-                        }
-                        onMoveAssignment={handleMoveAssignment}
-                        selectedJudgeIds={selectedJudgeIds}
-                        onClearSelection={clearSelection}
-                        filterEmptyLanes={filterEmptyLanes}
-                        athleteOccupiedLanes={occupiedLanesByHeat.get(
-                          heat.heatNumber,
-                        )}
-                      />
-                    ))
+          {/* Main content: judges panel + heats */}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-[280px_1fr]">
+            {/* Available Judges Panel */}
+            <Card className="lg:sticky lg:top-4 lg:self-start">
+              <CardContent className="p-4">
+                <div className="mb-3 flex items-center justify-between">
+                  <h4 className="text-sm font-medium">Available Judges</h4>
+                  {selectedJudgeIds.size > 0 && (
+                    <button
+                      type="button"
+                      onClick={clearSelection}
+                      className="text-xs text-muted-foreground hover:text-foreground"
+                    >
+                      Clear ({selectedJudgeIds.size})
+                    </button>
                   )}
                 </div>
-              </div>
-          </>
+                {judges.length === 0 ? (
+                  <p className="py-4 text-center text-sm text-muted-foreground">
+                    No judges have been added yet. Add volunteers with the Judge
+                    role type in the Volunteers section above.
+                  </p>
+                ) : (
+                  <>
+                    {/* Search Input */}
+                    <div className="relative mb-3">
+                      <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                      <Input
+                        type="text"
+                        placeholder="Search judges..."
+                        value={availableJudgeSearch}
+                        onChange={(e) =>
+                          setAvailableJudgeSearch(e.target.value)
+                        }
+                        className="h-8 pl-8 text-sm"
+                      />
+                    </div>
+                    <div className="max-h-[55vh] space-y-1.5 overflow-y-auto">
+                      {filteredJudgesByAssignmentCount.map((judge) => (
+                        <DraggableJudge
+                          key={judge.membershipId}
+                          volunteer={judge}
+                          isSelected={selectedJudgeIds.has(judge.membershipId)}
+                          onToggleSelect={handleToggleSelect}
+                          selectedIds={selectedJudgeIds}
+                          assignmentCount={judge.assignmentCount}
+                          isAssignedToCurrentEvent={assignedJudgeIds.has(
+                            judge.membershipId,
+                          )}
+                        />
+                      ))}
+                      {filteredJudgesByAssignmentCount.length === 0 &&
+                        availableJudgeSearch && (
+                          <p className="py-4 text-center text-sm text-muted-foreground">
+                            No judges match "{availableJudgeSearch}"
+                          </p>
+                        )}
+                    </div>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+
+            {/* Heats Grid */}
+            <div className="space-y-4">
+              {eventHeats.length === 0 ? (
+                <Card>
+                  <CardContent className="py-8 text-center">
+                    <p className="text-muted-foreground">
+                      No heats scheduled for this event yet.
+                    </p>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Create heats in the Schedule section first.
+                    </p>
+                  </CardContent>
+                </Card>
+              ) : (
+                eventHeats.map((heat) => (
+                  <JudgeHeatCard
+                    key={heat.id}
+                    heat={heat}
+                    competitionId={competitionId}
+                    organizingTeamId={organizingTeamId}
+                    unassignedVolunteers={unassignedJudges}
+                    judgeAssignments={assignments.filter(
+                      (a) => a.heatId === heat.id,
+                    )}
+                    maxLanes={maxLanes}
+                    onAssignmentChange={(newAssignments) =>
+                      handleAssignmentChange(heat.id, newAssignments)
+                    }
+                    onMoveAssignment={handleMoveAssignment}
+                    selectedJudgeIds={selectedJudgeIds}
+                    onClearSelection={clearSelection}
+                    filterEmptyLanes={filterEmptyLanes}
+                    athleteOccupiedLanes={occupiedLanesByHeat.get(
+                      heat.heatNumber,
+                    )}
+                    onScheduleRevisionPublished={refreshVersionData}
+                  />
+                ))
+              )}
+            </div>
+          </div>
         </section>
       )}
 
@@ -866,8 +856,12 @@ export function JudgeSchedulingContainer({
               onBatchCreateRotations={overrides?.batchCreateRotations}
               onBatchDeleteRotations={overrides?.batchDeleteRotations}
               onDeleteJudgeRotation={overrides?.deleteJudgeRotation}
-              onBatchUpdateVolunteerRotations={overrides?.batchUpdateVolunteerRotations}
-              onAdjustRotationsForOccupiedLanes={overrides?.adjustRotationsForOccupiedLanes}
+              onBatchUpdateVolunteerRotations={
+                overrides?.batchUpdateVolunteerRotations
+              }
+              onAdjustRotationsForOccupiedLanes={
+                overrides?.adjustRotationsForOccupiedLanes
+              }
             />
           ) : (
             <Card>

--- a/apps/wodsmith-start/src/server-fns/judge-scheduling-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/judge-scheduling-fns.ts
@@ -5,7 +5,7 @@
  */
 
 import { createServerFn } from "@tanstack/react-start"
-import { and, eq, inArray } from "drizzle-orm"
+import { and, desc, eq, inArray } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import {
@@ -25,7 +25,10 @@ import {
   VOLUNTEER_ROLE_TYPES,
   workouts,
 } from "@/db/schema"
-import { createHeatVolunteerId } from "@/db/schemas/common"
+import {
+  createHeatVolunteerId,
+  createJudgeAssignmentVersionId,
+} from "@/db/schemas/common"
 import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
 import type {
   VolunteerAvailability,
@@ -84,11 +87,9 @@ const membershipIdSchema = z
   .string()
   .startsWith("tmem_", "Invalid membership ID")
 
-const heatIdSchema = z.string().startsWith("cheat_", "Invalid heat ID")
+const heatIdSchema = z.string().min(1, "Heat ID is required")
 
-const assignmentIdSchema = z
-  .string()
-  .startsWith("chvol_", "Invalid assignment ID")
+const assignmentIdSchema = z.string().min(1, "Assignment ID is required")
 
 const volunteerRoleTypeSchema = z.enum([
   VOLUNTEER_ROLE_TYPES.JUDGE,
@@ -132,6 +133,114 @@ function isJudge(metadata: string | null): boolean {
     meta.volunteerRoleTypes.includes(VOLUNTEER_ROLE_TYPES.JUDGE) ||
     meta.volunteerRoleTypes.includes(VOLUNTEER_ROLE_TYPES.HEAD_JUDGE)
   )
+}
+
+async function getTrackWorkoutIdForHeat(heatId: string): Promise<string> {
+  const db = getDb()
+  const heat = await db
+    .select({ trackWorkoutId: competitionHeatsTable.trackWorkoutId })
+    .from(competitionHeatsTable)
+    .where(eq(competitionHeatsTable.id, heatId))
+    .then((rows) => rows[0] ?? null)
+
+  if (!heat) {
+    throw new Error("Heat not found")
+  }
+
+  return heat.trackWorkoutId
+}
+
+type JudgeAssignmentSnapshot = typeof judgeHeatAssignmentsTable.$inferInsert
+type JudgeAssignmentRow = typeof judgeHeatAssignmentsTable.$inferSelect
+
+async function createPublishedJudgeScheduleRevision(
+  trackWorkoutId: string,
+  editAssignments: (
+    assignments: JudgeAssignmentSnapshot[],
+  ) => JudgeAssignmentSnapshot[],
+): Promise<{ assignments: JudgeAssignmentRow[]; versionId: string }> {
+  const db = getDb()
+
+  const heats = await db
+    .select({ id: competitionHeatsTable.id })
+    .from(competitionHeatsTable)
+    .where(eq(competitionHeatsTable.trackWorkoutId, trackWorkoutId))
+
+  if (heats.length === 0) {
+    throw new Error("No heats found for event")
+  }
+
+  const heatIds = heats.map((h) => h.id)
+  const versions = await db.query.judgeAssignmentVersionsTable.findMany({
+    where: eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
+    orderBy: desc(judgeAssignmentVersionsTable.version),
+  })
+  const activeVersion = versions.find((version) => version.isActive) ?? null
+  const nextVersion = versions.length > 0 ? (versions[0]?.version ?? 0) + 1 : 1
+  const sourceAssignments = activeVersion
+    ? await db
+        .select()
+        .from(judgeHeatAssignmentsTable)
+        .where(
+          and(
+            inArray(judgeHeatAssignmentsTable.heatId, heatIds),
+            eq(judgeHeatAssignmentsTable.versionId, activeVersion.id),
+          ),
+        )
+    : []
+  const sourceAssignmentIds = new Set(sourceAssignments.map((a) => a.id))
+
+  const newVersionId = createJudgeAssignmentVersionId()
+  const editedAssignments = editAssignments(
+    sourceAssignments.map((assignment) => ({
+      id: assignment.id,
+      heatId: assignment.heatId,
+      membershipId: assignment.membershipId,
+      rotationId: assignment.rotationId,
+      laneNumber: assignment.laneNumber,
+      position: assignment.position,
+      instructions: assignment.instructions,
+      isManualOverride: assignment.isManualOverride,
+    })),
+  ).map((assignment) => ({
+    ...assignment,
+    id:
+      assignment.id && !sourceAssignmentIds.has(assignment.id)
+        ? assignment.id
+        : createHeatVolunteerId(),
+    versionId: newVersionId,
+  }))
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(judgeAssignmentVersionsTable)
+      .set({ isActive: false, updatedAt: new Date() })
+      .where(eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId))
+
+    await tx.insert(judgeAssignmentVersionsTable).values({
+      id: newVersionId,
+      trackWorkoutId,
+      version: nextVersion,
+      notes: activeVersion
+        ? `Edited published schedule v${activeVersion.version}`
+        : "Edited published schedule",
+      isActive: true,
+    })
+
+    if (editedAssignments.length > 0) {
+      await tx.insert(judgeHeatAssignmentsTable).values(editedAssignments)
+    }
+  })
+
+  const assignments =
+    editedAssignments.length > 0
+      ? await db
+          .select()
+          .from(judgeHeatAssignmentsTable)
+          .where(eq(judgeHeatAssignmentsTable.versionId, newVersionId))
+      : []
+
+  return { assignments, versionId: newVersionId }
 }
 
 // ============================================================================
@@ -377,9 +486,7 @@ export const getJudgeSchedulingDataForEventsFn = createServerFn({
   method: "GET",
 })
   .inputValidator((data: unknown) =>
-    z
-      .object({ trackWorkoutIds: z.array(z.string().min(1)) })
-      .parse(data),
+    z.object({ trackWorkoutIds: z.array(z.string().min(1)) }).parse(data),
   )
   .handler(async ({ data }) => {
     const { trackWorkoutIds } = data
@@ -480,9 +587,7 @@ export const getJudgeSchedulingDataForEventsFn = createServerFn({
     // Assignments only exist under a published (active) version; a version
     // belongs to exactly one event, so filtering by active version ids is
     // sufficient to scope assignments to their events.
-    const activeVersionIds = versions
-      .filter((v) => v.isActive)
-      .map((v) => v.id)
+    const activeVersionIds = versions.filter((v) => v.isActive).map((v) => v.id)
 
     if (activeVersionIds.length > 0) {
       const assignments = await db
@@ -701,23 +806,25 @@ export const assignJudgeToHeatFn = createServerFn({ method: "POST" })
       TEAM_PERMISSIONS.MANAGE_COMPETITIONS,
     )
 
-    const db = getDb()
     const assignmentId = createHeatVolunteerId()
-    await db.insert(judgeHeatAssignmentsTable).values({
-      id: assignmentId,
-      heatId: data.heatId,
-      membershipId: data.membershipId,
-      laneNumber: data.laneNumber,
-      position: data.position ?? null,
-      instructions: data.instructions ?? null,
-    })
+    const trackWorkoutId = await getTrackWorkoutIdForHeat(data.heatId)
+    const { assignments } = await createPublishedJudgeScheduleRevision(
+      trackWorkoutId,
+      (currentAssignments) => [
+        ...currentAssignments,
+        {
+          id: assignmentId,
+          heatId: data.heatId,
+          membershipId: data.membershipId,
+          laneNumber: data.laneNumber,
+          position: data.position ?? null,
+          instructions: data.instructions ?? null,
+          isManualOverride: true,
+        },
+      ],
+    )
 
-    // Select back the created record
-    const [assignment] = await db
-      .select()
-      .from(judgeHeatAssignmentsTable)
-      .where(eq(judgeHeatAssignmentsTable.id, assignmentId))
-
+    const assignment = assignments.find((a) => a.id === assignmentId)
     if (!assignment) {
       throw new Error("Failed to assign judge to heat")
     }
@@ -756,9 +863,7 @@ export const bulkAssignJudgesToHeatFn = createServerFn({ method: "POST" })
       return { success: true, data: [] }
     }
 
-    const db = getDb()
-
-    // Insert all assignments in a single query (MySQL has no param limit)
+    const trackWorkoutId = await getTrackWorkoutIdForHeat(data.heatId)
     const insertedIds: string[] = []
     const values = data.assignments.map((a) => {
       const id = createHeatVolunteerId()
@@ -770,16 +875,16 @@ export const bulkAssignJudgesToHeatFn = createServerFn({ method: "POST" })
         laneNumber: a.laneNumber,
         position: a.position ?? null,
         instructions: a.instructions ?? null,
+        isManualOverride: true,
       }
     })
-
-    await db.insert(judgeHeatAssignmentsTable).values(values)
-
-    // Select back the created records
-    const results = await db
-      .select()
-      .from(judgeHeatAssignmentsTable)
-      .where(inArray(judgeHeatAssignmentsTable.id, insertedIds))
+    const { assignments } = await createPublishedJudgeScheduleRevision(
+      trackWorkoutId,
+      (currentAssignments) => [...currentAssignments, ...values],
+    )
+    const results = assignments.filter((assignment) =>
+      insertedIds.includes(assignment.id ?? ""),
+    )
 
     return { success: true, data: results }
   })
@@ -804,9 +909,24 @@ export const removeJudgeFromHeatFn = createServerFn({ method: "POST" })
     )
 
     const db = getDb()
-    await db
-      .delete(judgeHeatAssignmentsTable)
+    const assignment = await db
+      .select({
+        heatId: judgeHeatAssignmentsTable.heatId,
+      })
+      .from(judgeHeatAssignmentsTable)
       .where(eq(judgeHeatAssignmentsTable.id, data.assignmentId))
+      .then((rows) => rows[0] ?? null)
+
+    if (!assignment) {
+      return { success: true }
+    }
+
+    const trackWorkoutId = await getTrackWorkoutIdForHeat(assignment.heatId)
+    await createPublishedJudgeScheduleRevision(
+      trackWorkoutId,
+      (currentAssignments) =>
+        currentAssignments.filter((a) => a.id !== data.assignmentId),
+    )
 
     return { success: true }
   })
@@ -832,15 +952,21 @@ export const moveJudgeAssignmentFn = createServerFn({ method: "POST" })
       TEAM_PERMISSIONS.MANAGE_COMPETITIONS,
     )
 
-    const db = getDb()
-    await db
-      .update(judgeHeatAssignmentsTable)
-      .set({
-        heatId: data.targetHeatId,
-        laneNumber: data.targetLaneNumber,
-        updatedAt: new Date(),
-      })
-      .where(eq(judgeHeatAssignmentsTable.id, data.assignmentId))
+    const trackWorkoutId = await getTrackWorkoutIdForHeat(data.targetHeatId)
+    await createPublishedJudgeScheduleRevision(
+      trackWorkoutId,
+      (currentAssignments) =>
+        currentAssignments.map((assignment) =>
+          assignment.id === data.assignmentId
+            ? {
+                ...assignment,
+                heatId: data.targetHeatId,
+                laneNumber: data.targetLaneNumber,
+                isManualOverride: true,
+              }
+            : assignment,
+        ),
+    )
 
     return { success: true }
   })


### PR DESCRIPTION
## Summary
- allow judge schedule mutations to accept existing demo heat/assignment IDs instead of generated-only prefixes
- edit published judge assignments by cloning the active version, applying the change, and activating the new published version
- remove the heat delete button from judge scheduling cards and refresh version data after assignment edits

## Verification
- queried PlanetScale `wodsmith-db` demo branch for `tw_winter_event1_fran` heat/version/assignment ID shapes
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/ianjones/.nix-profile/bin:/Users/ianjones/.codex/tmp/arg0/codex-arg0Njckwz:/Users/ianjones/.local/bin:/Users/ianjones/.bun/bin:/Users/ianjones/Library/pnpm:/Users/ianjones/.cabal/bin:/Users/ianjones/.ghcup/bin:/Users/ianjones/.rbenv/shims:/Users/ianjones/.rbenv/bin:/Users/ianjones/.nvm/versions/node/v24.14.1/bin:/opt/local/bin:/opt/local/sbin:/Users/ianjones/.cargo/bin:/Users/ianjones/clojure-lsp:/Users/ianjones/.emacs.d/bin:/Users/ianjones/.simple/bin:/Users/ianjones/go/bin:/Applications/Codex.app/Contents/Resources pnpm -C apps/wodsmith-start exec biome check --write 'src/server-fns/judge-scheduling-fns.ts' 'src/routes/compete/organizer/$competitionId/-components/judges/judge-heat-card.tsx' 'src/routes/compete/organizer/$competitionId/-components/judges/judge-scheduling-container.tsx'`
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/local/sbin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/X11/bin:/Library/Apple/usr/bin:/Library/TeX/texbin:/Users/ianjones/.nix-profile/bin:/Users/ianjones/.codex/tmp/arg0/codex-arg0Njckwz:/Users/ianjones/.local/bin:/Users/ianjones/.bun/bin:/Users/ianjones/Library/pnpm:/Users/ianjones/.cabal/bin:/Users/ianjones/.ghcup/bin:/Users/ianjones/.rbenv/shims:/Users/ianjones/.rbenv/bin:/Users/ianjones/.nvm/versions/node/v24.14.1/bin:/opt/local/bin:/opt/local/sbin:/Users/ianjones/.cargo/bin:/Users/ianjones/clojure-lsp:/Users/ianjones/.emacs.d/bin:/Users/ianjones/.simple/bin:/Users/ianjones/go/bin:/Applications/Codex.app/Contents/Resources pnpm -C apps/wodsmith-start type-check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes judge scheduling so edits to published schedules are applied by creating a new active version and the UI refreshes immediately. Also removes the heat delete button and relaxes ID validation to support existing data.

- **Bug Fixes**
  - Assign, move, remove, and bulk-assign now clone the active judge schedule, apply the change, and activate the new version.
  - Mark manual edits with `isManualOverride`.
  - Refresh version data after each change via `onScheduleRevisionPublished`.
  - Relax heat/assignment ID validation to accept existing IDs (no prefix required).
  - Remove the heat delete action from judge cards.

- **Refactors**
  - Added helpers to get an event from a heat and to apply versioned edits.
  - Removed the unused `onDelete` prop from `JudgeHeatCard` and simplified the container.

<sup>Written for commit 11c148887c13d84bb9f6ecd8b4e36731d20edbcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

