### PR TITLE
ci: skip drizzle-kit push to prod on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,7 +191,11 @@ jobs:
           echo "DATABASE_URL=$database_url" >> $GITHUB_ENV
           echo "::add-mask::$database_url"
 
+      # Prod schema changes are applied out-of-band via PlanetScale deploy
+      # requests, so never push drizzle schema changes to the prod (main)
+      # branch on deploy. Non-prod stages (demo/staging/dev) still push.
       - name: Push schema to PlanetScale branch
+        if: ${{ inputs.stage != 'prod' }}
         run: pnpm --filter wodsmith-start exec drizzle-kit push
         working-directory: .
         env:

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -33,6 +33,14 @@ The primary web application containing all user-facing functionality.
 - `src/workflows/` — Multi-step business processes (registration, checkout)
 - `src/agents/` — Cloudflare Agents (Durable Object classes) for AI-augmented features
 
+#### Deploy pipeline
+
+The main app deploys to Cloudflare Workers via `.github/workflows/deploy.yml` using Alchemy IaC, with database schema handled differently per stage.
+
+A push to `main` auto-deploys the demo environment; production and other stages deploy via manual `workflow_dispatch` (prod requires GitHub environment approval and must run from `main`).
+
+Non-prod stages (demo, staging, dev) run `drizzle-kit push` against their PlanetScale branch during deploy, matching the push-based local dev workflow. Production schema changes are **not** pushed on deploy — they are applied out-of-band via PlanetScale deploy requests — so the prod deploy skips the schema-push step. This avoids `drizzle-kit push` hitting an interactive data-loss prompt (e.g. on leftover Vitess `_vt_*` artifact tables) that would hang the non-interactive CI job.
+
 ### apps/crm
 
 The CRM app is a separate TanStack Start application shell for future customer relationship workflows.


### PR DESCRIPTION
Prod schema changes are applied out-of-band via PlanetScale deploy requests, so the deploy workflow should no longer run `drizzle-kit push` against the prod (main) branch. The schema-push step now runs only for non-prod stages (demo/staging/dev), where push-based sync is intended.

This also fixes prod deploys stalling on drizzle-kit's interactive data-loss prompt (e.g. on leftover Vitess _vt_* artifact tables): the prompt has no stdin in CI and hangs until the run is cancelled.


Claude-Session: https://claude.ai/code/session_01QZfCCuwPAc1Mdybp2gCuZa

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip running `drizzle-kit push` on production deploys; run it only for demo/staging/dev. This prevents CI hangs from interactive data-loss prompts and aligns prod schema changes with PlanetScale deploy requests; architecture docs updated to explain the pipeline.

<sup>Written for commit 4e61667c2310f1e702b5d654b3c4d1f9922e3a09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation with deploy pipeline details, including deployment workflows, environment-specific processes, and schema management strategies.

* **Chores**
  * Enhanced production deployment workflow with clarified schema handling and conditional execution for different deployment stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->