### PR TITLE
feat: organizer file-drop import agent (volunteers/judges MVP)

### DIFF
--- a/apps/wodsmith-start/alchemy.run.ts
+++ b/apps/wodsmith-start/alchemy.run.ts
@@ -536,6 +536,7 @@ const judgeSchedulerAgent = DurableObjectNamespace("judge-scheduler-agent", {
  *
  * @see src/agents/organizer-file-import-agent.ts
  */
+// @lat: [[architecture#AI Agents#Organizer file-drop import]]
 const organizerFileImportAgent = DurableObjectNamespace(
   "organizer-file-import-agent",
   {
@@ -676,6 +677,7 @@ const website = await TanStackStart("app", {
     /** Durable Object namespace for the AI judge-scheduling agent */
     JUDGE_SCHEDULER_AGENT: judgeSchedulerAgent,
     /** Durable Object namespace for the organizer file-drop import agent */
+    // @lat: [[architecture#AI Agents#Organizer file-drop import]]
     ORGANIZER_FILE_IMPORT_AGENT: organizerFileImportAgent,
     /** Cloudflare Workers AI binding for LLM inference */
     AI: aiBinding,

--- a/apps/wodsmith-start/alchemy.run.ts
+++ b/apps/wodsmith-start/alchemy.run.ts
@@ -528,6 +528,23 @@ const judgeSchedulerAgent = DurableObjectNamespace("judge-scheduler-agent", {
 })
 
 /**
+ * Durable Object namespace for the organizer file-drop import agent.
+ *
+ * Each dropped file is an isolated session keyed by `${importRunId}__${userId}`
+ * (a fresh ULID per drop) so concurrent imports never collide and a
+ * reconnecting organizer reattaches to the same in-flight proposal stream.
+ *
+ * @see src/agents/organizer-file-import-agent.ts
+ */
+const organizerFileImportAgent = DurableObjectNamespace(
+  "organizer-file-import-agent",
+  {
+    className: "OrganizerFileImportAgent",
+    sqlite: true,
+  },
+)
+
+/**
  * Cloudflare Workers AI binding for built-in LLM inference.
  *
  * Currently used by the judge-scheduling agent to call
@@ -658,6 +675,8 @@ const website = await TanStackStart("app", {
     BROADCAST_EMAIL_QUEUE: broadcastEmailQueue,
     /** Durable Object namespace for the AI judge-scheduling agent */
     JUDGE_SCHEDULER_AGENT: judgeSchedulerAgent,
+    /** Durable Object namespace for the organizer file-drop import agent */
+    ORGANIZER_FILE_IMPORT_AGENT: organizerFileImportAgent,
     /** Cloudflare Workers AI binding for LLM inference */
     AI: aiBinding,
     /**

--- a/apps/wodsmith-start/package.json
+++ b/apps/wodsmith-start/package.json
@@ -127,7 +127,7 @@
     "ua-parser-js": "^2.0.3",
     "ulid": "^3.0.2",
     "workers-ai-provider": "^3.1.14",
-    "xlsx": "^0.18.5",
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
     "zod": "^4.2.1",
     "zustand": "^5.0.5"
   },

--- a/apps/wodsmith-start/package.json
+++ b/apps/wodsmith-start/package.json
@@ -108,6 +108,7 @@
     "lucide-react": "^0.544.0",
     "ms": "^2.1.3",
     "mysql2": "^3.16.2",
+    "papaparse": "^5.5.3",
     "posthog-js": "^1.310.1",
     "posthog-node": "^5.18.0",
     "react": "^19.2.3",
@@ -126,6 +127,7 @@
     "ua-parser-js": "^2.0.3",
     "ulid": "^3.0.2",
     "workers-ai-provider": "^3.1.14",
+    "xlsx": "^0.18.5",
     "zod": "^4.2.1",
     "zustand": "^5.0.5"
   },
@@ -140,6 +142,7 @@
     "@testing-library/react": "^16.2.0",
     "@types/ms": "^0.7.34",
     "@types/node": "^22.19.3",
+    "@types/papaparse": "^5.5.2",
     "@types/react": "^19.2.0",
     "@types/react-dom": "^19.2.0",
     "@types/ua-parser-js": "^0.7.39",

--- a/apps/wodsmith-start/src/agents/organizer-file-import-agent.ts
+++ b/apps/wodsmith-start/src/agents/organizer-file-import-agent.ts
@@ -25,7 +25,10 @@ import {
 	classifyVolunteer,
 	type ExistingVolunteer,
 } from "@/lib/organizer-file-import/validate"
-import { requireFileImportAgentAccess } from "@/server/organizer-file-import/access"
+import {
+	type FileImportScope,
+	requireFileImportAgentAccess,
+} from "@/server/organizer-file-import/access"
 import {
 	type FileImportPageContext,
 	loadExistingVolunteers,
@@ -40,6 +43,8 @@ import type { ParsedTable } from "@/lib/organizer-file-import/parse"
  */
 const MODEL_ID = "workers-ai/@cf/moonshotai/kimi-k2.6"
 const MAX_STEPS = 32
+const AGENT_NAME_PATTERN =
+	/^(aimp_[0-9A-HJKMNP-TV-Z]{26})__([a-z0-9_-]{1,128})$/i
 
 const SYSTEM_PROMPT = `You are an assistant that imports volunteers and judges into a Functional Fitness competition from a file an organizer dropped onto a page. You read the file's already-parsed rows, map columns, and DRAFT proposals.
 
@@ -60,7 +65,7 @@ Workflow:
 - Do not propose the same person (same email) twice.`
 
 interface ImportRunContext {
-	scope: { competitionTeamId: string | null }
+	scope: FileImportScope
 	pageContext: FileImportPageContext
 	table: ParsedTable
 	truncated: boolean
@@ -129,7 +134,12 @@ export class OrganizerFileImportAgent extends Agent<Env, AgentState> {
 			})
 			this.logActivity("thinking", "Reading the dropped file…")
 
-			const ctx = await this.#loadContext(input.importRunId, scope, input)
+			const ctx = await this.#loadContext(
+				input.importRunId,
+				scope,
+				input,
+				userId,
+			)
 			if (ctx.table.warnings.length > 0) {
 				this.setState({ ...this.state, parseWarnings: ctx.table.warnings })
 			}
@@ -182,15 +192,21 @@ export class OrganizerFileImportAgent extends Agent<Env, AgentState> {
 				status: "thinking",
 				summary: null,
 				errorMessage: null,
+				clarification: null,
 				completedAt: null,
 			})
 			this.logActivity("thinking", `Refining draft: "${instruction}"`)
 
-			const ctx = await this.#loadContext(this.state.importRunId, scope, {
-				competitionId: this.state.competitionId,
-				routeKind: this.state.routeKind,
-				eventId: this.state.eventId ?? undefined,
-			})
+			const ctx = await this.#loadContext(
+				this.state.importRunId,
+				scope,
+				{
+					competitionId: this.state.competitionId,
+					routeKind: this.state.routeKind,
+					eventId: this.state.eventId ?? undefined,
+				},
+				userId,
+			)
 
 			await this.#generate(
 				ctx,
@@ -212,11 +228,14 @@ export class OrganizerFileImportAgent extends Agent<Env, AgentState> {
 			return { ok: false, running: false }
 		}
 		this.#abortController.abort()
+		this.#abortController = null
 		return { ok: true, running: true }
 	}
 
 	@callable()
 	reset(): { ok: true } {
+		this.#abortController?.abort()
+		this.#abortController = null
 		this.setState(initialAgentState)
 		return { ok: true }
 	}
@@ -249,12 +268,13 @@ export class OrganizerFileImportAgent extends Agent<Env, AgentState> {
 
 	async #loadContext(
 		importRunId: string,
-		scope: { competitionTeamId: string | null },
+		scope: FileImportScope,
 		page: { competitionId: string; routeKind: string; eventId?: string | null },
+		userId: string,
 	): Promise<ImportRunContext> {
 		const [{ table, truncated }, pageContext, existingVolunteers] =
 			await Promise.all([
-				readImportFile(importRunId),
+				readImportFile(importRunId, scope, userId),
 				loadPageContext({
 					competitionId: page.competitionId,
 					routeKind: page.routeKind,
@@ -358,11 +378,11 @@ export class OrganizerFileImportAgent extends Agent<Env, AgentState> {
 }
 
 function getUserIdFromAgentName(name: string): string {
-	const match = /^[a-z0-9_-]{1,128}__([a-z0-9_-]{1,128})$/i.exec(name)
-	if (!match?.[1]) {
+	const match = AGENT_NAME_PATTERN.exec(name)
+	if (!match?.[2]) {
 		throw new Error("Invalid agent name")
 	}
-	return match[1]
+	return match[2]
 }
 
 function buildKickoffPrompt(ctx: ImportRunContext): string {
@@ -445,11 +465,24 @@ function buildTools(
 				"Draft ONE volunteer/judge to import. The organizer sees it stream in immediately. Duplicate detection and no-email warnings are attached automatically.",
 			inputSchema: proposeVolunteerInputSchema,
 			execute: async (input) => {
+				const normalizedEmail = input.email?.trim().toLowerCase() ?? null
+				const isDuplicateProposal = normalizedEmail
+					? agent.state.volunteerProposals.some(
+							(p) =>
+								p.proposalId !== input.proposalId &&
+								p.email?.trim().toLowerCase() === normalizedEmail,
+						)
+					: false
 				const classification = classifyVolunteer(
 					{ email: input.email, name: input.name },
 					existingVolunteers,
 				)
 				const warnings = [...classification.warnings]
+				if (isDuplicateProposal) {
+					warnings.push(
+						"Duplicate email in this import — only the first row will be applied.",
+					)
+				}
 				if (classification.matchKind === "existing_member") {
 					warnings.push("Already a volunteer — will be skipped.")
 				} else if (classification.matchKind === "existing_invite") {
@@ -458,6 +491,7 @@ function buildTools(
 
 				const merged: VolunteerProposal = {
 					...input,
+					action: isDuplicateProposal ? "skip" : input.action,
 					matchKind: classification.matchKind,
 					matchedMembershipId: classification.matchedMembershipId,
 					warnings: dedupeStrings(warnings).slice(0, 10),

--- a/apps/wodsmith-start/src/agents/organizer-file-import-agent.ts
+++ b/apps/wodsmith-start/src/agents/organizer-file-import-agent.ts
@@ -1,0 +1,559 @@
+import "server-only"
+
+import { createId } from "@paralleldrive/cuid2"
+import { Agent, callable } from "agents"
+import { generateText, stepCountIs, type Tool, tool } from "ai"
+import { createAiGateway } from "ai-gateway-provider"
+import { createUnified } from "ai-gateway-provider/providers/unified"
+import { z } from "zod"
+import { logError, logInfo } from "@/lib/logging"
+import {
+	type ActivityEntry,
+	type AgentState,
+	askClarificationInputSchema,
+	initialAgentState,
+	MAX_THINKING_LOG_ENTRIES,
+	markCompleteInputSchema,
+	markImportAppliedInputSchema,
+	proposeVolunteerInputSchema,
+	refineInputSchema,
+	revokeProposalInputSchema,
+	startImportInputSchema,
+	type VolunteerProposal,
+} from "@/lib/organizer-file-import/schemas"
+import {
+	classifyVolunteer,
+	type ExistingVolunteer,
+} from "@/lib/organizer-file-import/validate"
+import { requireFileImportAgentAccess } from "@/server/organizer-file-import/access"
+import {
+	type FileImportPageContext,
+	loadExistingVolunteers,
+	loadPageContext,
+	readImportFile,
+} from "@/server/organizer-file-import/context"
+import type { ParsedTable } from "@/lib/organizer-file-import/parse"
+
+/**
+ * Workers AI model id addressed via the AI Gateway's unified adapter — same
+ * model the judge-scheduling agent uses.
+ */
+const MODEL_ID = "workers-ai/@cf/moonshotai/kimi-k2.6"
+const MAX_STEPS = 32
+
+const SYSTEM_PROMPT = `You are an assistant that imports volunteers and judges into a Functional Fitness competition from a file an organizer dropped onto a page. You read the file's already-parsed rows, map columns, and DRAFT proposals.
+
+CRITICAL — you may classify, extract, validate, and PROPOSE only. You NEVER write anything, never send invitations, and must never imply that anyone has been added. A human organizer reviews your draft and confirms once; only then does anything happen.
+
+Workflow:
+- Always start by calling get_page_context and get_import_table exactly once each.
+- The page tells you the intent: 'volunteers' / 'judges' = import people as volunteers; 'judges' means default roleTypes to ["judge"].
+- For EACH person row in the table, call propose_volunteer exactly once. Generate a fresh proposalId per row (e.g. "v1", "v2") and set rowKey to a stable identifier from the row (the email if present, else the row's name).
+- Map columns intelligently: Name/Full Name → name; Email/E-mail → email; Phone/Mobile → phone; Role/Position/Job → roleTypes; Credentials/Certifications/Cert → credentials; Shirt/Size → shirtSize; Availability → availability.
+- roleTypes MUST come from this set only: judge, head_judge, equipment, medical, check_in, staff, scorekeeper, emcee, floor_manager, media, general, athlete_control, equipment_team. Map free text (e.g. "head judge" → head_judge, "coach" → judge, "EMT" → medical). If unsure, use ["general"], or ["judge"] on the judges page.
+- action: use "create" for a new person to invite. If a row has no usable email, use "needs_input" (the system also flags this — an invitation can't be sent without an email).
+- availability must be one of: morning, afternoon, all_day, or omit it.
+- Set confidence (high/medium/low) by how cleanly the row mapped. Keep rationale under 240 chars, concrete (e.g. "Mapped Name+Email; role from 'Head Judge'").
+- Duplicate detection against existing volunteers happens automatically server-side — still propose the row; it will be marked as a match and excluded by default.
+- INTENT CHECK: if the file clearly is NOT a roster of people (e.g. it lists workouts/events, scores, or schedule rows), do NOT invent volunteers. Call ask_clarification asking whether they meant a different page, and stop.
+- When every person row has been proposed once, call mark_complete with a 1-2 sentence summary. Do not invent extra rows.
+- Do not propose the same person (same email) twice.`
+
+interface ImportRunContext {
+	scope: { competitionTeamId: string | null }
+	pageContext: FileImportPageContext
+	table: ParsedTable
+	truncated: boolean
+	existingVolunteers: ExistingVolunteer[]
+}
+
+/**
+ * Durable-Object-backed agent that drafts volunteer/judge imports from a
+ * dropped file. `state.volunteerProposals` is the UI-watched source of truth;
+ * every setState is broadcast to connected clients over WebSocket. The agent
+ * proposes only — all writes happen later in applyOrganizerImportFn after the
+ * organizer confirms. Mirrors JudgeSchedulerAgent.
+ */
+export class OrganizerFileImportAgent extends Agent<Env, AgentState> {
+	initialState: AgentState = initialAgentState
+
+	#abortController: AbortController | null = null
+
+	logActivity(kind: ActivityEntry["kind"], message: string): void {
+		const entry: ActivityEntry = {
+			id: createId(),
+			timestamp: Date.now(),
+			kind,
+			message,
+		}
+		const next = [...this.state.thinkingLog, entry]
+		const trimmed =
+			next.length > MAX_THINKING_LOG_ENTRIES
+				? next.slice(next.length - MAX_THINKING_LOG_ENTRIES)
+				: next
+		this.setState({ ...this.state, thinkingLog: trimmed })
+	}
+
+	@callable()
+	async start(rawInput: unknown): Promise<{ ok: boolean; error?: string }> {
+		const runStartedAt = Date.now()
+		try {
+			const input = startImportInputSchema.parse(rawInput)
+			logInfo({
+				message: "[ImportAgent] start invoked",
+				attributes: {
+					importRunId: input.importRunId,
+					competitionId: input.competitionId,
+					routeKind: input.routeKind,
+				},
+			})
+
+			const userId = getUserIdFromAgentName(this.name)
+			const scope = await requireFileImportAgentAccess(
+				{
+					competitionId: input.competitionId,
+					routeKind: input.routeKind,
+					eventId: input.eventId ?? null,
+				},
+				userId,
+			)
+
+			this.setState({
+				...initialAgentState,
+				importRunId: input.importRunId,
+				competitionId: input.competitionId,
+				eventId: input.eventId ?? null,
+				routeKind: input.routeKind,
+				status: "parsing",
+				startedAt: Date.now(),
+			})
+			this.logActivity("thinking", "Reading the dropped file…")
+
+			const ctx = await this.#loadContext(input.importRunId, scope, input)
+			if (ctx.table.warnings.length > 0) {
+				this.setState({ ...this.state, parseWarnings: ctx.table.warnings })
+			}
+			this.logActivity(
+				"thinking",
+				`Parsed ${ctx.table.rows.length} row${
+					ctx.table.rows.length === 1 ? "" : "s"
+				} with columns: ${ctx.table.headers.join(", ") || "(none detected)"}.`,
+			)
+
+			await this.#generate(
+				ctx,
+				buildKickoffPrompt(ctx),
+				runStartedAt,
+				input.importRunId,
+			)
+			return { ok: true }
+		} catch (err) {
+			return this.#handleRunError(err, runStartedAt)
+		} finally {
+			this.#abortController = null
+		}
+	}
+
+	@callable()
+	async refine(rawInput: unknown): Promise<{ ok: boolean; error?: string }> {
+		const runStartedAt = Date.now()
+		try {
+			const { instruction } = refineInputSchema.parse(rawInput)
+			if (
+				!this.state.importRunId ||
+				!this.state.competitionId ||
+				!this.state.routeKind
+			) {
+				throw new Error("Nothing to refine yet — run an import first.")
+			}
+
+			const userId = getUserIdFromAgentName(this.name)
+			const scope = await requireFileImportAgentAccess(
+				{
+					competitionId: this.state.competitionId,
+					routeKind: this.state.routeKind,
+					eventId: this.state.eventId ?? undefined,
+				},
+				userId,
+			)
+
+			this.setState({
+				...this.state,
+				status: "thinking",
+				summary: null,
+				errorMessage: null,
+				completedAt: null,
+			})
+			this.logActivity("thinking", `Refining draft: "${instruction}"`)
+
+			const ctx = await this.#loadContext(this.state.importRunId, scope, {
+				competitionId: this.state.competitionId,
+				routeKind: this.state.routeKind,
+				eventId: this.state.eventId ?? undefined,
+			})
+
+			await this.#generate(
+				ctx,
+				buildRefinePrompt(this.state.volunteerProposals, instruction),
+				runStartedAt,
+				this.state.importRunId,
+			)
+			return { ok: true }
+		} catch (err) {
+			return this.#handleRunError(err, runStartedAt)
+		} finally {
+			this.#abortController = null
+		}
+	}
+
+	@callable()
+	stop(): { ok: boolean; running: boolean } {
+		if (!this.#abortController) {
+			return { ok: false, running: false }
+		}
+		this.#abortController.abort()
+		return { ok: true, running: true }
+	}
+
+	@callable()
+	reset(): { ok: true } {
+		this.setState(initialAgentState)
+		return { ok: true }
+	}
+
+	/**
+	 * Flip the given proposalIds to accepted and drop them from the review
+	 * list. Called by the UI after applyOrganizerImportFn persists them, so a
+	 * subsequent refine won't re-surface already-applied rows.
+	 */
+	@callable()
+	markApplied(rawInput: unknown): { ok: true; appliedCount: number } {
+		const input = markImportAppliedInputSchema.parse(rawInput)
+		const appliedSet = new Set(input.proposalIds)
+		const remaining = this.state.volunteerProposals.filter(
+			(p) => !appliedSet.has(p.proposalId),
+		)
+		this.setState({
+			...this.state,
+			volunteerProposals: remaining,
+			status: remaining.length === 0 ? "idle" : this.state.status,
+		})
+		this.logActivity(
+			"done",
+			`Organizer applied ${input.proposalIds.length} import${
+				input.proposalIds.length === 1 ? "" : "s"
+			}.`,
+		)
+		return { ok: true, appliedCount: input.proposalIds.length }
+	}
+
+	async #loadContext(
+		importRunId: string,
+		scope: { competitionTeamId: string | null },
+		page: { competitionId: string; routeKind: string; eventId?: string | null },
+	): Promise<ImportRunContext> {
+		const [{ table, truncated }, pageContext, existingVolunteers] =
+			await Promise.all([
+				readImportFile(importRunId),
+				loadPageContext({
+					competitionId: page.competitionId,
+					routeKind: page.routeKind,
+					eventId: page.eventId ?? null,
+				}),
+				loadExistingVolunteers(scope.competitionTeamId),
+			])
+		return { scope, pageContext, table, truncated, existingVolunteers }
+	}
+
+	async #generate(
+		ctx: ImportRunContext,
+		prompt: string,
+		runStartedAt: number,
+		importRunId: string,
+	): Promise<void> {
+		this.setState({ ...this.state, status: "thinking" })
+
+		const gatewayBinding = this.env.AI.gateway(this.env.CF_AIG_GATEWAY)
+		const aiGateway = createAiGateway({
+			binding: {
+				run: (data) =>
+					gatewayBinding.run(data as Parameters<typeof gatewayBinding.run>[0]),
+			},
+		})
+		const unified = createUnified()
+		this.#abortController = new AbortController()
+
+		const result = await generateText({
+			model: aiGateway(unified(MODEL_ID)),
+			system: SYSTEM_PROMPT,
+			prompt,
+			tools: buildTools(this, ctx),
+			stopWhen: stepCountIs(MAX_STEPS),
+			abortSignal: this.#abortController.signal,
+		})
+
+		logInfo({
+			message: "[ImportAgent] generateText finished",
+			attributes: {
+				importRunId,
+				durationMs: Date.now() - runStartedAt,
+				proposalCount: this.state.volunteerProposals.length,
+				stepCount: result.steps?.length ?? 0,
+				finishReason: result.finishReason,
+				status: this.state.status,
+			},
+		})
+
+		if (this.state.status !== "proposals_ready") {
+			this.setState({
+				...this.state,
+				status: "proposals_ready",
+				summary: result.text || this.state.summary || "Draft ready for review.",
+				completedAt: Date.now(),
+			})
+			this.logActivity(
+				"done",
+				result.text || this.state.summary || "Draft ready for review.",
+			)
+		}
+	}
+
+	#handleRunError(
+		err: unknown,
+		runStartedAt: number,
+	): { ok: boolean; error?: string } {
+		const message = err instanceof Error ? err.message : String(err)
+		const isAbort =
+			err instanceof Error &&
+			(err.name === "AbortError" || message.toLowerCase().includes("abort"))
+		if (isAbort) {
+			this.logActivity("thinking", "Run stopped by organizer.")
+			this.setState({
+				...this.state,
+				status:
+					this.state.volunteerProposals.length > 0 ? "proposals_ready" : "idle",
+				summary: null,
+				errorMessage: null,
+				completedAt: Date.now(),
+			})
+			return { ok: true }
+		}
+		this.logActivity("error", `Run failed: ${message}`)
+		logError({
+			message: "[ImportAgent] run failed",
+			error: err,
+			attributes: {
+				durationMs: Date.now() - runStartedAt,
+				proposalCount: this.state.volunteerProposals.length,
+			},
+		})
+		this.setState({
+			...this.state,
+			status: "error",
+			errorMessage: message,
+			completedAt: Date.now(),
+		})
+		return { ok: false, error: message }
+	}
+}
+
+function getUserIdFromAgentName(name: string): string {
+	const match = /^[a-z0-9_-]{1,128}__([a-z0-9_-]{1,128})$/i.exec(name)
+	if (!match?.[1]) {
+		throw new Error("Invalid agent name")
+	}
+	return match[1]
+}
+
+function buildKickoffPrompt(ctx: ImportRunContext): string {
+	const { pageContext, table, truncated, existingVolunteers } = ctx
+	const lines = [
+		`Import volunteers for "${pageContext.competitionName}" (page: ${pageContext.routeKind}).`,
+		`The dropped file parsed to ${table.rows.length} data row${
+			table.rows.length === 1 ? "" : "s"
+		}${truncated ? " (showing the first 200)" : ""} with columns: ${
+			table.headers.join(", ") || "(none detected)"
+		}.`,
+		`There ${existingVolunteers.length === 1 ? "is" : "are"} ${existingVolunteers.length} existing volunteer${
+			existingVolunteers.length === 1 ? "" : "s"
+		}; duplicates are detected automatically.`,
+		"Call get_page_context and get_import_table first, then propose one volunteer per person row, and finish with mark_complete.",
+	]
+	return lines.join("\n")
+}
+
+function buildRefinePrompt(
+	current: VolunteerProposal[],
+	instruction: string,
+): string {
+	const summary = current.map((p) => ({
+		proposalId: p.proposalId,
+		name: p.name,
+		email: p.email,
+		roleTypes: p.roleTypes,
+		action: p.action,
+	}))
+	return [
+		`You previously drafted ${current.length} volunteer proposal${
+			current.length === 1 ? "" : "s"
+		}. The organizer wants to refine the draft:`,
+		`"${instruction}"`,
+		`Current proposals (JSON): ${JSON.stringify(summary)}`,
+		"Apply the instruction by editing the draft in place: call revoke_proposal for any to remove, and propose_volunteer (reuse the SAME proposalId to replace one) for changes. Call get_import_table if you need the original rows. Finish with mark_complete.",
+	].join("\n")
+}
+
+function buildTools(
+	agent: OrganizerFileImportAgent,
+	ctx: ImportRunContext,
+): Record<string, Tool> {
+	const { pageContext, table, truncated, existingVolunteers } = ctx
+
+	return {
+		get_page_context: tool({
+			description:
+				"Return the competition name, the page the file was dropped on (routeKind), and any event id. Call once per run.",
+			inputSchema: z.object({}),
+			execute: async () => {
+				agent.logActivity("tool", "Checked which page the file was dropped on.")
+				return pageContext
+			},
+		}),
+
+		get_import_table: tool({
+			description:
+				"Return the parsed file: detected headers and up to the first 200 data rows. Call once per run, then map each row to a volunteer.",
+			inputSchema: z.object({}),
+			execute: async () => {
+				agent.logActivity(
+					"tool",
+					`Read the file — ${table.rows.length} row${
+						table.rows.length === 1 ? "" : "s"
+					}, ${table.headers.length} column${table.headers.length === 1 ? "" : "s"}.`,
+				)
+				return {
+					headers: table.headers,
+					rows: table.rows,
+					rowCount: table.rows.length,
+					truncated,
+				}
+			},
+		}),
+
+		propose_volunteer: tool({
+			description:
+				"Draft ONE volunteer/judge to import. The organizer sees it stream in immediately. Duplicate detection and no-email warnings are attached automatically.",
+			inputSchema: proposeVolunteerInputSchema,
+			execute: async (input) => {
+				const classification = classifyVolunteer(
+					{ email: input.email, name: input.name },
+					existingVolunteers,
+				)
+				const warnings = [...classification.warnings]
+				if (classification.matchKind === "existing_member") {
+					warnings.push("Already a volunteer — will be skipped.")
+				} else if (classification.matchKind === "existing_invite") {
+					warnings.push("Already invited — will be skipped.")
+				}
+
+				const merged: VolunteerProposal = {
+					...input,
+					matchKind: classification.matchKind,
+					matchedMembershipId: classification.matchedMembershipId,
+					warnings: dedupeStrings(warnings).slice(0, 10),
+					status: "pending",
+				}
+
+				const next = agent.state.volunteerProposals.filter(
+					(p) => p.proposalId !== merged.proposalId,
+				)
+				next.push(merged)
+				agent.setState({ ...agent.state, volunteerProposals: next })
+
+				const label = merged.name || merged.email || merged.rowKey
+				if (merged.matchKind === "new") {
+					agent.logActivity(
+						"proposed",
+						`Proposed ${label}${
+							merged.warnings.length > 0
+								? ` (${merged.warnings.length} warning${merged.warnings.length === 1 ? "" : "s"})`
+								: ""
+						}.`,
+					)
+				} else {
+					agent.logActivity(
+						"skipped",
+						`${label} ${
+							merged.matchKind === "existing_member"
+								? "is already a volunteer"
+								: "was already invited"
+						} — flagged as a duplicate.`,
+					)
+				}
+				return {
+					status: "recorded" as const,
+					matchKind: merged.matchKind,
+					warnings: merged.warnings,
+				}
+			},
+		}),
+
+		revoke_proposal: tool({
+			description:
+				"Withdraw a previously drafted volunteer by proposalId. Use when reconsidering or replacing.",
+			inputSchema: revokeProposalInputSchema,
+			execute: async (input) => {
+				const before = agent.state.volunteerProposals.length
+				const next = agent.state.volunteerProposals.filter(
+					(p) => p.proposalId !== input.proposalId,
+				)
+				agent.setState({ ...agent.state, volunteerProposals: next })
+				agent.logActivity(
+					"thinking",
+					`Withdrew ${input.proposalId} — ${input.reason}`,
+				)
+				return {
+					status: "revoked" as const,
+					removed: before - next.length,
+				}
+			},
+		}),
+
+		ask_clarification: tool({
+			description:
+				"Ask the organizer a question when the file doesn't match the page (e.g. a roster dropped on Events). Sets a banner and stops proposing.",
+			inputSchema: askClarificationInputSchema,
+			execute: async (input) => {
+				agent.setState({
+					...agent.state,
+					clarification: {
+						question: input.question,
+						suggestedRouteKind: input.suggestedRouteKind,
+					},
+				})
+				agent.logActivity("thinking", `Asked: ${input.question}`)
+				return { status: "asked" as const }
+			},
+		}),
+
+		mark_complete: tool({
+			description:
+				"Mark the draft finished with a 1-2 sentence summary for the organizer.",
+			inputSchema: markCompleteInputSchema,
+			execute: async (input) => {
+				agent.setState({
+					...agent.state,
+					status: "proposals_ready",
+					summary: input.summary,
+					completedAt: Date.now(),
+				})
+				agent.logActivity("done", input.summary)
+				return { status: "complete" as const }
+			},
+		}),
+	}
+}
+
+function dedupeStrings(input: string[]): string[] {
+	return Array.from(new Set(input))
+}

--- a/apps/wodsmith-start/src/agents/organizer-file-import-agent.ts
+++ b/apps/wodsmith-start/src/agents/organizer-file-import-agent.ts
@@ -324,7 +324,7 @@ export class OrganizerFileImportAgent extends Agent<Env, AgentState> {
 			},
 		})
 
-		if (this.state.status !== "proposals_ready") {
+		if (this.state.status !== "proposals_ready" && !this.state.clarification) {
 			this.setState({
 				...this.state,
 				status: "proposals_ready",
@@ -560,6 +560,7 @@ function buildTools(
 			execute: async (input) => {
 				agent.setState({
 					...agent.state,
+					status: "idle",
 					clarification: {
 						question: input.question,
 						suggestedRouteKind: input.suggestedRouteKind,

--- a/apps/wodsmith-start/src/components/organizer-import/import-review-drawer.tsx
+++ b/apps/wodsmith-start/src/components/organizer-import/import-review-drawer.tsx
@@ -1,0 +1,419 @@
+import { useRouter } from "@tanstack/react-router"
+import { useAgent } from "agents/react"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { toast } from "sonner"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { ScrollArea } from "@/components/ui/scroll-area"
+import {
+	Sheet,
+	SheetContent,
+	SheetDescription,
+	SheetHeader,
+	SheetTitle,
+} from "@/components/ui/sheet"
+import { Textarea } from "@/components/ui/textarea"
+import { VOLUNTEER_ROLE_LABELS } from "@/db/schemas/volunteers"
+import { useSession } from "@/utils/auth-client"
+import type {
+	AgentState,
+	VolunteerProposal,
+} from "@/lib/organizer-file-import/schemas"
+import { isApplicableVolunteer } from "@/lib/organizer-file-import/validate"
+import {
+	type ApplyImportResult,
+	applyOrganizerImportFn,
+	undoImportFn,
+} from "@/server-fns/organizer-file-import-fns"
+import type { PageIntent } from "./use-page-intent"
+
+interface ImportReviewDrawerProps {
+	importRunId: string
+	competition: { id: string; name: string; organizingTeamId: string }
+	intent: PageIntent
+	onClose: () => void
+}
+
+const STATUS_LABEL: Record<AgentState["status"], string> = {
+	idle: "Idle",
+	parsing: "Reading the file…",
+	thinking: "Drafting proposals…",
+	proposals_ready: "Ready for review",
+	error: "Something went wrong",
+}
+
+export function ImportReviewDrawer({
+	importRunId,
+	competition,
+	intent,
+	onClose,
+}: ImportReviewDrawerProps) {
+	const router = useRouter()
+	const session = useSession()
+	const userId = session?.userId ?? "anonymous"
+	const agent = useAgent<AgentState>({
+		agent: "organizer-file-import-agent",
+		// The runId is a valid name segment as-is (ULID is uppercase Crockford
+		// base32, accepted case-insensitively by the server.ts route regex).
+		name: `${importRunId}__${userId}`,
+	})
+
+	const status = agent.state?.status ?? "parsing"
+	const proposals = agent.state?.volunteerProposals ?? []
+	const thinkingLog = agent.state?.thinkingLog ?? []
+	const clarification = agent.state?.clarification ?? null
+	const parseWarnings = agent.state?.parseWarnings ?? []
+	const summary = agent.state?.summary
+	const errorMessage = agent.state?.errorMessage
+
+	const [excluded, setExcluded] = useState<Set<string>>(new Set())
+	const [isApplying, setIsApplying] = useState(false)
+	const [refineText, setRefineText] = useState("")
+	const [receipt, setReceipt] = useState<ApplyImportResult | null>(null)
+	const startedRef = useRef(false)
+
+	// One drag → one run: kick the agent off exactly once when the drawer mounts.
+	useEffect(() => {
+		if (startedRef.current) return
+		startedRef.current = true
+		agent.stub
+			.start({
+				importRunId,
+				competitionId: competition.id,
+				routeKind: intent.routeKind,
+				eventId: intent.eventId,
+			})
+			.catch((err: unknown) => {
+				toast.error(
+					err instanceof Error ? err.message : "Failed to start the import",
+				)
+			})
+	}, [agent.stub, importRunId, competition.id, intent.routeKind, intent.eventId])
+
+	const pending = useMemo(
+		() => proposals.filter((p) => p.status === "pending"),
+		[proposals],
+	)
+	const applicable = useMemo(
+		() => pending.filter(isApplicableVolunteer),
+		[pending],
+	)
+	const blocked = useMemo(
+		() => pending.filter((p) => !isApplicableVolunteer(p)),
+		[pending],
+	)
+	const included = useMemo(
+		() => applicable.filter((p) => !excluded.has(p.proposalId)),
+		[applicable, excluded],
+	)
+
+	const isWorking = status === "parsing" || status === "thinking"
+
+	function toggleExclude(proposalId: string) {
+		setExcluded((prev) => {
+			const next = new Set(prev)
+			if (next.has(proposalId)) next.delete(proposalId)
+			else next.add(proposalId)
+			return next
+		})
+	}
+
+	async function handleConfirm() {
+		if (included.length === 0) return
+		setIsApplying(true)
+		try {
+			const result = await applyOrganizerImportFn({
+				data: { importRunId, volunteerProposals: included },
+			})
+			const appliedIds = result.results
+				.filter((r) => r.status === "applied")
+				.map((r) => r.proposalId)
+			if (appliedIds.length > 0) {
+				await agent.stub.markApplied({ proposalIds: appliedIds }).catch(() => {})
+			}
+			await router.invalidate()
+			setReceipt(result)
+			toast.success(
+				`Imported ${result.applied} volunteer${result.applied === 1 ? "" : "s"}.`,
+			)
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Failed to apply the import",
+			)
+		} finally {
+			setIsApplying(false)
+		}
+	}
+
+	async function handleRefine() {
+		const instruction = refineText.trim()
+		if (!instruction || isWorking) return
+		setRefineText("")
+		try {
+			await agent.stub.refine({ instruction })
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Failed to refine")
+		}
+	}
+
+	async function handleUndo() {
+		try {
+			const res = await undoImportFn({ data: { importRunId } })
+			await router.invalidate()
+			toast.success(
+				`Undone — removed ${res.removed} invitation${res.removed === 1 ? "" : "s"}.`,
+			)
+			onClose()
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Failed to undo")
+		}
+	}
+
+	const latestActivity = thinkingLog[thinkingLog.length - 1]?.message
+
+	return (
+		<Sheet
+			open
+			onOpenChange={(next) => {
+				if (!next) onClose()
+			}}
+		>
+			<SheetContent
+				side="right"
+				className="flex w-full flex-col gap-0 p-0 sm:max-w-xl"
+			>
+				<SheetHeader className="border-b p-4">
+					<SheetTitle>Import {intent.label}</SheetTitle>
+					<SheetDescription>
+						Drafted from your file for {competition.name}. Nothing is saved until
+						you confirm.
+					</SheetDescription>
+				</SheetHeader>
+
+				{receipt ? (
+					<ImportReceipt receipt={receipt} onUndo={handleUndo} onDone={onClose} />
+				) : (
+					<>
+						<div className="flex items-center gap-2 border-b px-4 py-2 text-sm">
+							{isWorking && (
+								<span className="inline-block h-2 w-2 animate-pulse rounded-full bg-primary" />
+							)}
+							<span className="font-medium">{STATUS_LABEL[status]}</span>
+							{latestActivity && (
+								<span className="truncate text-muted-foreground">
+									· {latestActivity}
+								</span>
+							)}
+						</div>
+
+						<ScrollArea className="flex-1">
+							<div className="space-y-3 p-4">
+								{errorMessage && (
+									<p className="rounded border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+										{errorMessage}
+									</p>
+								)}
+
+								{clarification && (
+									<div className="rounded border border-amber-400/50 bg-amber-50 p-3 text-sm dark:bg-amber-950/30">
+										<p className="font-medium">{clarification.question}</p>
+									</div>
+								)}
+
+								{parseWarnings.length > 0 && (
+									<ul className="space-y-1 rounded border bg-muted/40 p-3 text-xs text-muted-foreground">
+										{parseWarnings.slice(0, 5).map((w) => (
+											<li key={w}>• {w}</li>
+										))}
+									</ul>
+								)}
+
+								{pending.length === 0 && !isWorking && !clarification && (
+									<p className="py-8 text-center text-sm text-muted-foreground">
+										No people to import were found in this file.
+									</p>
+								)}
+
+								{applicable.map((proposal) => (
+									<ProposalCard
+										key={proposal.proposalId}
+										proposal={proposal}
+										excluded={excluded.has(proposal.proposalId)}
+										onToggle={() => toggleExclude(proposal.proposalId)}
+									/>
+								))}
+
+								{blocked.length > 0 && (
+									<div className="space-y-2 pt-2">
+										<p className="text-xs font-semibold uppercase text-muted-foreground">
+											Won't import ({blocked.length})
+										</p>
+										{blocked.map((proposal) => (
+											<ProposalCard
+												key={proposal.proposalId}
+												proposal={proposal}
+												blocked
+											/>
+										))}
+									</div>
+								)}
+
+								{summary && status === "proposals_ready" && (
+									<p className="pt-2 text-xs text-muted-foreground">{summary}</p>
+								)}
+							</div>
+						</ScrollArea>
+
+						<div className="space-y-3 border-t p-4">
+							<div className="flex gap-2">
+								<Textarea
+									value={refineText}
+									onChange={(e) => setRefineText(e.target.value)}
+									placeholder="Refine in words — e.g. 'make coaches head judges, skip anyone with no email'"
+									rows={2}
+									className="resize-none text-sm"
+									onKeyDown={(e) => {
+										if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+											e.preventDefault()
+											void handleRefine()
+										}
+									}}
+								/>
+								<Button
+									variant="outline"
+									onClick={handleRefine}
+									disabled={isWorking || refineText.trim().length === 0}
+								>
+									Refine
+								</Button>
+							</div>
+							<Button
+								className="w-full"
+								onClick={handleConfirm}
+								disabled={isApplying || isWorking || included.length === 0}
+							>
+								{included.length === 0
+									? "Nothing to confirm"
+									: `Add ${included.length} ${intent.label.toLowerCase()} · sends invites`}
+							</Button>
+						</div>
+					</>
+				)}
+			</SheetContent>
+		</Sheet>
+	)
+}
+
+function ProposalCard({
+	proposal,
+	excluded,
+	blocked,
+	onToggle,
+}: {
+	proposal: VolunteerProposal
+	excluded?: boolean
+	blocked?: boolean
+	onToggle?: () => void
+}) {
+	const label = proposal.name || proposal.email || proposal.rowKey
+	return (
+		<div
+			className={`rounded border p-3 text-sm ${
+				excluded || blocked ? "opacity-60" : ""
+			}`}
+		>
+			<div className="flex items-start justify-between gap-2">
+				<div className="min-w-0">
+					<p className="font-medium">{label}</p>
+					{proposal.email && (
+						<p className="truncate text-xs text-muted-foreground">
+							{proposal.email}
+						</p>
+					)}
+				</div>
+				{!blocked && onToggle && (
+					<Button
+						size="sm"
+						variant={excluded ? "outline" : "ghost"}
+						onClick={onToggle}
+					>
+						{excluded ? "Add back" : "Exclude"}
+					</Button>
+				)}
+			</div>
+
+			<div className="mt-2 flex flex-wrap gap-1">
+				{proposal.roleTypes.map((role) => (
+					<Badge key={role} variant="secondary">
+						{VOLUNTEER_ROLE_LABELS[role] ?? role}
+					</Badge>
+				))}
+				{proposal.matchKind === "existing_member" && (
+					<Badge variant="outline">Already a volunteer</Badge>
+				)}
+				{proposal.matchKind === "existing_invite" && (
+					<Badge variant="outline">Already invited</Badge>
+				)}
+				{proposal.confidence !== "high" && (
+					<Badge variant="outline">{proposal.confidence} confidence</Badge>
+				)}
+			</div>
+
+			{proposal.warnings.length > 0 && (
+				<ul className="mt-2 space-y-0.5 text-xs text-amber-600 dark:text-amber-400">
+					{proposal.warnings.map((w) => (
+						<li key={w}>⚠ {w}</li>
+					))}
+				</ul>
+			)}
+		</div>
+	)
+}
+
+function ImportReceipt({
+	receipt,
+	onUndo,
+	onDone,
+}: {
+	receipt: ApplyImportResult
+	onUndo: () => void
+	onDone: () => void
+}) {
+	return (
+		<div className="flex flex-1 flex-col justify-between p-4">
+			<div className="space-y-4">
+				<div className="rounded border bg-muted/40 p-4">
+					<p className="text-lg font-semibold">
+						{receipt.applied} added
+						{receipt.skipped > 0 && ` · ${receipt.skipped} skipped`}
+						{receipt.failed > 0 && ` · ${receipt.failed} failed`}
+					</p>
+					<p className="mt-1 text-sm text-muted-foreground">
+						Invitation emails were sent to the added volunteers.
+					</p>
+				</div>
+
+				{receipt.failed > 0 && (
+					<ul className="space-y-1 text-xs text-destructive">
+						{receipt.results
+							.filter((r) => r.status === "failed")
+							.map((r) => (
+								<li key={r.proposalId}>
+									{r.rowKey}: {r.reason}
+								</li>
+							))}
+					</ul>
+				)}
+			</div>
+
+			<div className="flex gap-2">
+				<Button variant="outline" onClick={onUndo} className="flex-1">
+					Undo import
+				</Button>
+				<Button onClick={onDone} className="flex-1">
+					Done
+				</Button>
+			</div>
+		</div>
+	)
+}

--- a/apps/wodsmith-start/src/components/organizer-import/import-review-drawer.tsx
+++ b/apps/wodsmith-start/src/components/organizer-import/import-review-drawer.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Label } from "@/components/ui/label"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
 	Sheet,
@@ -50,12 +51,12 @@ export function ImportReviewDrawer({
 }: ImportReviewDrawerProps) {
 	const router = useRouter()
 	const session = useSession()
-	const userId = session?.userId ?? "anonymous"
+	const userId = session?.userId ?? null
 	const agent = useAgent<AgentState>({
 		agent: "organizer-file-import-agent",
 		// The runId is a valid name segment as-is (ULID is uppercase Crockford
 		// base32, accepted case-insensitively by the server.ts route regex).
-		name: `${importRunId}__${userId}`,
+		name: `${importRunId}__${userId ?? "pending"}`,
 	})
 
 	const status = agent.state?.status ?? "parsing"
@@ -74,6 +75,7 @@ export function ImportReviewDrawer({
 
 	// One drag → one run: kick the agent off exactly once when the drawer mounts.
 	useEffect(() => {
+		if (!userId) return
 		if (startedRef.current) return
 		startedRef.current = true
 		agent.stub
@@ -88,7 +90,14 @@ export function ImportReviewDrawer({
 					err instanceof Error ? err.message : "Failed to start the import",
 				)
 			})
-	}, [agent.stub, importRunId, competition.id, intent.routeKind, intent.eventId])
+	}, [
+		agent.stub,
+		importRunId,
+		competition.id,
+		intent.routeKind,
+		intent.eventId,
+		userId,
+	])
 
 	const pending = useMemo(
 		() => proposals.filter((p) => p.status === "pending"),
@@ -129,13 +138,33 @@ export function ImportReviewDrawer({
 				.filter((r) => r.status === "applied")
 				.map((r) => r.proposalId)
 			if (appliedIds.length > 0) {
-				await agent.stub.markApplied({ proposalIds: appliedIds }).catch(() => {})
+				await agent.stub
+					.markApplied({ proposalIds: appliedIds })
+					.catch(() => {})
 			}
 			await router.invalidate()
 			setReceipt(result)
-			toast.success(
-				`Imported ${result.applied} volunteer${result.applied === 1 ? "" : "s"}.`,
-			)
+			if (result.failed > 0) {
+				toast.warning(
+					`Imported ${result.applied} volunteer${
+						result.applied === 1 ? "" : "s"
+					}; ${result.failed} failed.`,
+				)
+			} else if (result.skipped > 0) {
+				toast.warning(
+					result.applied > 0
+						? `Imported ${result.applied} volunteer${
+								result.applied === 1 ? "" : "s"
+							}; ${result.skipped} skipped.`
+						: "No volunteers were imported. Review the skipped rows.",
+				)
+			} else {
+				toast.success(
+					`Imported ${result.applied} volunteer${
+						result.applied === 1 ? "" : "s"
+					}.`,
+				)
+			}
 		} catch (err) {
 			toast.error(
 				err instanceof Error ? err.message : "Failed to apply the import",
@@ -185,13 +214,18 @@ export function ImportReviewDrawer({
 				<SheetHeader className="border-b p-4">
 					<SheetTitle>Import {intent.label}</SheetTitle>
 					<SheetDescription>
-						Drafted from your file for {competition.name}. Nothing is saved until
-						you confirm.
+						Drafted from your file for {competition.name}. Nothing is saved
+						until you confirm.
 					</SheetDescription>
 				</SheetHeader>
 
 				{receipt ? (
-					<ImportReceipt receipt={receipt} onUndo={handleUndo} onDone={onClose} />
+					<ImportReceipt
+						receipt={receipt}
+						onUndo={handleUndo}
+						onReviewRemaining={() => setReceipt(null)}
+						onDone={onClose}
+					/>
 				) : (
 					<>
 						<div className="flex items-center gap-2 border-b px-4 py-2 text-sm">
@@ -259,14 +293,20 @@ export function ImportReviewDrawer({
 								)}
 
 								{summary && status === "proposals_ready" && (
-									<p className="pt-2 text-xs text-muted-foreground">{summary}</p>
+									<p className="pt-2 text-xs text-muted-foreground">
+										{summary}
+									</p>
 								)}
 							</div>
 						</ScrollArea>
 
 						<div className="space-y-3 border-t p-4">
 							<div className="flex gap-2">
+								<Label htmlFor="import-refine-instructions" className="sr-only">
+									Refinement instructions
+								</Label>
 								<Textarea
+									id="import-refine-instructions"
 									value={refineText}
 									onChange={(e) => setRefineText(e.target.value)}
 									placeholder="Refine in words — e.g. 'make coaches head judges, skip anyone with no email'"
@@ -373,12 +413,18 @@ function ProposalCard({
 function ImportReceipt({
 	receipt,
 	onUndo,
+	onReviewRemaining,
 	onDone,
 }: {
 	receipt: ApplyImportResult
 	onUndo: () => void
+	onReviewRemaining: () => void
 	onDone: () => void
 }) {
+	const skippedRows = receipt.results.filter((r) => r.status === "skipped")
+	const failedRows = receipt.results.filter((r) => r.status === "failed")
+	const hasRemainingRows = skippedRows.length > 0 || failedRows.length > 0
+
 	return (
 		<div className="flex flex-1 flex-col justify-between p-4">
 			<div className="space-y-4">
@@ -389,27 +435,49 @@ function ImportReceipt({
 						{receipt.failed > 0 && ` · ${receipt.failed} failed`}
 					</p>
 					<p className="mt-1 text-sm text-muted-foreground">
-						Invitation emails were sent to the added volunteers.
+						{receipt.applied > 0
+							? "Invitation emails were sent to the added volunteers."
+							: "No invitation emails were sent."}
+						{hasRemainingRows ? " Review the rows below before closing." : ""}
 					</p>
 				</div>
 
-				{receipt.failed > 0 && (
+				{skippedRows.length > 0 && (
+					<ul className="space-y-1 text-xs text-muted-foreground">
+						{skippedRows.map((r) => (
+							<li key={r.proposalId}>
+								{r.rowKey}: {r.reason ?? "skipped"}
+							</li>
+						))}
+					</ul>
+				)}
+
+				{failedRows.length > 0 && (
 					<ul className="space-y-1 text-xs text-destructive">
-						{receipt.results
-							.filter((r) => r.status === "failed")
-							.map((r) => (
-								<li key={r.proposalId}>
-									{r.rowKey}: {r.reason}
-								</li>
-							))}
+						{failedRows.map((r) => (
+							<li key={r.proposalId}>
+								{r.rowKey}: {r.reason}
+							</li>
+						))}
 					</ul>
 				)}
 			</div>
 
-			<div className="flex gap-2">
-				<Button variant="outline" onClick={onUndo} className="flex-1">
-					Undo import
-				</Button>
+			<div className="flex flex-col gap-2 sm:flex-row">
+				{receipt.applied > 0 && (
+					<Button variant="outline" onClick={onUndo} className="flex-1">
+						Undo added invites
+					</Button>
+				)}
+				{hasRemainingRows && (
+					<Button
+						variant="outline"
+						onClick={onReviewRemaining}
+						className="flex-1"
+					>
+						Review remaining
+					</Button>
+				)}
 				<Button onClick={onDone} className="flex-1">
 					Done
 				</Button>

--- a/apps/wodsmith-start/src/components/organizer-import/import-shell.tsx
+++ b/apps/wodsmith-start/src/components/organizer-import/import-shell.tsx
@@ -26,6 +26,7 @@ export function ImportShell({ competition, children }: ImportShellProps) {
 	const [run, setRun] = useState<{ importRunId: string } | null>(null)
 	const dragDepth = useRef(0)
 	const fileInputRef = useRef<HTMLInputElement>(null)
+	const uploadingRef = useRef(false)
 
 	const dropEnabled = intent !== null
 
@@ -34,7 +35,9 @@ export function ImportShell({ competition, children }: ImportShellProps) {
 	}
 
 	function handleDragEnter(e: React.DragEvent) {
-		if (!dropEnabled || !isFileDrag(e)) return
+		if (!isFileDrag(e)) return
+		e.preventDefault()
+		if (!dropEnabled) return
 		dragDepth.current += 1
 		setDragging(true)
 	}
@@ -49,11 +52,13 @@ export function ImportShell({ competition, children }: ImportShellProps) {
 	}
 
 	function handleDragOver(e: React.DragEvent) {
-		if (!dropEnabled || !isFileDrag(e)) return
+		if (!isFileDrag(e)) return
 		e.preventDefault()
+		if (!dropEnabled) return
 	}
 
 	async function handleDrop(e: React.DragEvent) {
+		if (isFileDrag(e)) e.preventDefault()
 		if (!dropEnabled) return
 		e.preventDefault()
 		dragDepth.current = 0
@@ -63,7 +68,8 @@ export function ImportShell({ competition, children }: ImportShellProps) {
 	}
 
 	async function processFile(file: File, pageIntent: PageIntent | null) {
-		if (!pageIntent) return
+		if (!pageIntent || uploadingRef.current) return
+		uploadingRef.current = true
 		setUploading(true)
 		try {
 			const { importRunId } = await createImportRunFn({
@@ -90,12 +96,14 @@ export function ImportShell({ competition, children }: ImportShellProps) {
 				err instanceof Error ? err.message : "Couldn't start the import",
 			)
 		} finally {
+			uploadingRef.current = false
 			setUploading(false)
 		}
 	}
 
 	return (
-		<div
+		<section
+			aria-label="Organizer content"
 			onDragEnter={handleDragEnter}
 			onDragOver={handleDragOver}
 			onDragLeave={handleDragLeave}
@@ -150,6 +158,6 @@ export function ImportShell({ competition, children }: ImportShellProps) {
 					onClose={() => setRun(null)}
 				/>
 			)}
-		</div>
+		</section>
 	)
 }

--- a/apps/wodsmith-start/src/components/organizer-import/import-shell.tsx
+++ b/apps/wodsmith-start/src/components/organizer-import/import-shell.tsx
@@ -1,0 +1,155 @@
+import type React from "react"
+import { useRef, useState } from "react"
+import { toast } from "sonner"
+import { createImportRunFn } from "@/server-fns/organizer-file-import-fns"
+import { ImportReviewDrawer } from "./import-review-drawer"
+import { type PageIntent, usePageIntent } from "./use-page-intent"
+
+interface ImportShellProps {
+	competition: { id: string; name: string; organizingTeamId: string }
+	children: React.ReactNode
+}
+
+const ACCEPT = ".csv,.tsv,.txt,.md,.xlsx,.xls"
+
+/**
+ * Mounts once in the organizer layout and wraps the page. Detects a dragged
+ * file (or a click-to-pick from the dock), creates an import run, uploads the
+ * file privately, and opens the review drawer connected to the agent. The drop
+ * affordance only appears on routes the import agent can fulfill (see
+ * usePageIntent).
+ */
+export function ImportShell({ competition, children }: ImportShellProps) {
+	const intent = usePageIntent()
+	const [dragging, setDragging] = useState(false)
+	const [uploading, setUploading] = useState(false)
+	const [run, setRun] = useState<{ importRunId: string } | null>(null)
+	const dragDepth = useRef(0)
+	const fileInputRef = useRef<HTMLInputElement>(null)
+
+	const dropEnabled = intent !== null
+
+	function isFileDrag(e: React.DragEvent): boolean {
+		return Array.from(e.dataTransfer?.types ?? []).includes("Files")
+	}
+
+	function handleDragEnter(e: React.DragEvent) {
+		if (!dropEnabled || !isFileDrag(e)) return
+		dragDepth.current += 1
+		setDragging(true)
+	}
+
+	function handleDragLeave() {
+		if (!dropEnabled) return
+		dragDepth.current -= 1
+		if (dragDepth.current <= 0) {
+			dragDepth.current = 0
+			setDragging(false)
+		}
+	}
+
+	function handleDragOver(e: React.DragEvent) {
+		if (!dropEnabled || !isFileDrag(e)) return
+		e.preventDefault()
+	}
+
+	async function handleDrop(e: React.DragEvent) {
+		if (!dropEnabled) return
+		e.preventDefault()
+		dragDepth.current = 0
+		setDragging(false)
+		const file = e.dataTransfer?.files?.[0]
+		if (file) await processFile(file, intent)
+	}
+
+	async function processFile(file: File, pageIntent: PageIntent | null) {
+		if (!pageIntent) return
+		setUploading(true)
+		try {
+			const { importRunId } = await createImportRunFn({
+				data: {
+					competitionId: competition.id,
+					routeKind: pageIntent.routeKind,
+					eventId: pageIntent.eventId,
+				},
+			})
+			const formData = new FormData()
+			formData.append("file", file)
+			formData.append("importRunId", importRunId)
+			const res = await fetch("/api/agent-import/upload", {
+				method: "POST",
+				body: formData,
+			})
+			if (!res.ok) {
+				const body = (await res.json().catch(() => ({}))) as { error?: string }
+				throw new Error(body.error ?? "Upload failed")
+			}
+			setRun({ importRunId })
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Couldn't start the import",
+			)
+		} finally {
+			setUploading(false)
+		}
+	}
+
+	return (
+		<div
+			onDragEnter={handleDragEnter}
+			onDragOver={handleDragOver}
+			onDragLeave={handleDragLeave}
+			onDrop={handleDrop}
+		>
+			{children}
+
+			{dragging && intent && (
+				<div className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm">
+					<div className="rounded-lg border-2 border-dashed border-primary px-8 py-6 text-center">
+						<p className="text-lg font-semibold">
+							Drop to import to {intent.label}
+						</p>
+						<p className="mt-1 text-sm text-muted-foreground">
+							CSV, TSV, XLSX, or text · PII stays private
+						</p>
+					</div>
+				</div>
+			)}
+
+			{intent && (
+				<>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept={ACCEPT}
+						className="hidden"
+						onChange={(e) => {
+							const file = e.target.files?.[0]
+							e.target.value = ""
+							if (file) void processFile(file, intent)
+						}}
+					/>
+					<button
+						type="button"
+						disabled={uploading}
+						onClick={() => fileInputRef.current?.click()}
+						className="fixed bottom-6 right-6 z-40 rounded-full border bg-background px-4 py-2 text-sm font-medium shadow-lg transition-colors hover:bg-accent disabled:opacity-60"
+					>
+						{uploading
+							? "Uploading…"
+							: `Import ${intent.label.toLowerCase()} from a file`}
+					</button>
+				</>
+			)}
+
+			{run && intent && (
+				<ImportReviewDrawer
+					importRunId={run.importRunId}
+					competition={competition}
+					intent={intent}
+					onClose={() => setRun(null)}
+				/>
+			)}
+		</div>
+	)
+}

--- a/apps/wodsmith-start/src/components/organizer-import/use-page-intent.ts
+++ b/apps/wodsmith-start/src/components/organizer-import/use-page-intent.ts
@@ -1,0 +1,37 @@
+import { useMatches } from "@tanstack/react-router"
+import {
+	AGENT_IMPORT_ROUTE_KIND,
+	type AgentImportRouteKind,
+} from "@/db/schemas/agent-imports"
+
+export interface PageIntent {
+	routeKind: AgentImportRouteKind
+	eventId?: string
+	/** Human label for the drop overlay ("Drop to import to Volunteers"). */
+	label: string
+}
+
+/**
+ * Derive the file-drop intent from the active organizer route. Only the routes
+ * the import agent can currently fulfill (volunteers + judges) enable the drop
+ * affordance; events/event-detail are a later phase, so this returns null there
+ * and the shell shows no overlay.
+ */
+export function usePageIntent(): PageIntent | null {
+	const matches = useMatches()
+	const last = matches[matches.length - 1]
+	if (!last) return null
+
+	const routeId = String(last.routeId)
+
+	if (routeId.includes("/volunteers/judges")) {
+		return { routeKind: AGENT_IMPORT_ROUTE_KIND.JUDGES, label: "Judges" }
+	}
+	if (routeId.includes("/volunteers")) {
+		return {
+			routeKind: AGENT_IMPORT_ROUTE_KIND.VOLUNTEERS,
+			label: "Volunteers",
+		}
+	}
+	return null
+}

--- a/apps/wodsmith-start/src/components/organizer-import/use-page-intent.ts
+++ b/apps/wodsmith-start/src/components/organizer-import/use-page-intent.ts
@@ -1,3 +1,4 @@
+// @lat: [[organizer-dashboard#Layout and Access Control]]
 import { useMatches } from "@tanstack/react-router"
 import {
 	AGENT_IMPORT_ROUTE_KIND,
@@ -24,10 +25,10 @@ export function usePageIntent(): PageIntent | null {
 
 	const routeId = String(last.routeId)
 
-	if (routeId.includes("/volunteers/judges")) {
+	if (/\/volunteers\/judges\/?$/.test(routeId)) {
 		return { routeKind: AGENT_IMPORT_ROUTE_KIND.JUDGES, label: "Judges" }
 	}
-	if (routeId.includes("/volunteers")) {
+	if (/\/volunteers\/?$/.test(routeId)) {
 		return {
 			routeKind: AGENT_IMPORT_ROUTE_KIND.VOLUNTEERS,
 			label: "Volunteers",

--- a/apps/wodsmith-start/src/config/features.ts
+++ b/apps/wodsmith-start/src/config/features.ts
@@ -23,6 +23,7 @@ export const FEATURES = {
   AI_WORKOUT_GENERATION: "ai_workout_generation",
   AI_PROGRAMMING_ASSISTANT: "ai_programming_assistant",
   AI_JUDGE_SCHEDULING: "ai_judge_scheduling",
+  AI_FILE_IMPORT: "ai_file_import",
 
   // Team features (PRIORITY - Core Monetization)
   MULTI_TEAM_MANAGEMENT: "multi_team_management",

--- a/apps/wodsmith-start/src/db/schema.ts
+++ b/apps/wodsmith-start/src/db/schema.ts
@@ -1,6 +1,7 @@
 // Re-export all tables and types from schema modules
 
 export * from "./schemas/addresses"
+export * from "./schemas/agent-imports"
 export * from "./schemas/coupons"
 export * from "./schemas/affiliates"
 export * from "./schemas/broadcasts"

--- a/apps/wodsmith-start/src/db/schemas/agent-imports.ts
+++ b/apps/wodsmith-start/src/db/schemas/agent-imports.ts
@@ -1,0 +1,103 @@
+import type { InferSelectModel } from "drizzle-orm"
+import {
+	datetime,
+	index,
+	int,
+	json,
+	mysqlTable,
+	text,
+	varchar,
+} from "drizzle-orm/mysql-core"
+import { commonColumns, createAgentImportRunId } from "./common"
+
+/**
+ * Which organizer page a file was dropped onto. Drives the agent's intent
+ * (what kind of proposals to draft) and disambiguation prompts.
+ */
+export const AGENT_IMPORT_ROUTE_KIND = {
+	VOLUNTEERS: "volunteers",
+	JUDGES: "judges",
+	EVENTS: "events",
+	EVENT_DETAIL: "event_detail",
+} as const
+export type AgentImportRouteKind =
+	(typeof AGENT_IMPORT_ROUTE_KIND)[keyof typeof AGENT_IMPORT_ROUTE_KIND]
+
+/**
+ * Lifecycle of a single dropped-file import run. A row is created the moment a
+ * file is dropped (status=created), before any model call, so an abandoned drop
+ * is still tracked for audit + retention.
+ */
+export const AGENT_IMPORT_STATUS = {
+	CREATED: "created",
+	UPLOADED: "uploaded",
+	PARSING: "parsing",
+	THINKING: "thinking",
+	PROPOSALS_READY: "proposals_ready",
+	APPLYING: "applying",
+	APPLIED: "applied",
+	REJECTED: "rejected",
+	ERROR: "error",
+} as const
+export type AgentImportStatus =
+	(typeof AGENT_IMPORT_STATUS)[keyof typeof AGENT_IMPORT_STATUS]
+
+/**
+ * One entity created/updated by a confirmed import, recorded so the Undo path
+ * can reverse exactly what was written. `before` holds a pre-update snapshot so
+ * updates (not just creates) can be undone.
+ */
+export interface AppliedEntity {
+	kind:
+		| "volunteer_invite"
+		| "volunteer_metadata"
+		| "judge_role"
+		| "event_create"
+		| "event_update"
+	/** id of the created/updated row (membershipId, invitationId, trackWorkoutId, …) */
+	entityId: string
+	rowKey: string
+	/** before-snapshot for updates so Undo can restore prior values */
+	before?: Record<string, unknown>
+}
+
+export const agentImportRunsTable = mysqlTable(
+	"agent_import_runs",
+	{
+		...commonColumns,
+		id: varchar({ length: 255 })
+			.primaryKey()
+			.$defaultFn(() => createAgentImportRunId())
+			.notNull(),
+		competitionId: varchar({ length: 255 }).notNull(),
+		organizingTeamId: varchar({ length: 255 }).notNull(),
+		createdByUserId: varchar({ length: 255 }).notNull(),
+		routeKind: varchar({ length: 32 })
+			.$type<AgentImportRouteKind>()
+			.notNull(),
+		// trackWorkoutId when routeKind=event_detail
+		eventId: varchar({ length: 255 }),
+		status: varchar({ length: 32 })
+			.$type<AgentImportStatus>()
+			.default("created")
+			.notNull(),
+		// File metadata — private key only, never a public URL (PII stays server-side).
+		r2Key: varchar({ length: 1024 }),
+		originalFilename: varchar({ length: 512 }),
+		mimeType: varchar({ length: 128 }),
+		// stored as int; file size in bytes
+		fileSize: int(),
+		// sha-256 hex, for idempotency / duplicate-import detection
+		checksum: varchar({ length: 128 }),
+		appliedEntities: json().$type<AppliedEntity[]>(),
+		appliedByUserId: varchar({ length: 255 }),
+		appliedAt: datetime(),
+		errorMessage: text(),
+	},
+	(table) => [
+		index("aimp_competition_idx").on(table.competitionId),
+		index("aimp_checksum_idx").on(table.competitionId, table.checksum),
+	],
+)
+
+export type AgentImportRun = InferSelectModel<typeof agentImportRunsTable>

--- a/apps/wodsmith-start/src/db/schemas/common.ts
+++ b/apps/wodsmith-start/src/db/schemas/common.ts
@@ -137,6 +137,9 @@ export const createEventDivisionMappingId = () => `edm_${ulid()}`
 export const createBroadcastId = () => `bcast_${ulid()}`
 export const createBroadcastRecipientId = () => `brcpt_${ulid()}`
 
+// Agent file-drop import ID generators
+export const createAgentImportRunId = () => `aimp_${ulid()}`
+
 // Competition invite ID generators
 export const createCompetitionInviteSourceId = () => `cisrc_${ulid()}`
 export const createCompetitionInviteId = () => `cinv_${ulid()}`

--- a/apps/wodsmith-start/src/lib/organizer-file-import/parse.ts
+++ b/apps/wodsmith-start/src/lib/organizer-file-import/parse.ts
@@ -62,20 +62,30 @@ export async function parseXlsx(bytes: ArrayBuffer): Promise<ParsedTable> {
 	const sheetName = wb.SheetNames[0]
 	if (!sheetName) return { headers: [], rows: [], warnings: ["Empty workbook"] }
 	const sheet = wb.Sheets[sheetName]
+	const headerRows = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
+		header: 1,
+		blankrows: false,
+		defval: "",
+	})
+	const headers = (headerRows[0] ?? []).map(toCellString).filter(Boolean)
 	const raw = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+		blankrows: false,
 		defval: "",
 	})
 	const rows = raw.map((row) => {
 		const normalized: Record<string, string> = {}
 		for (const key of Object.keys(row)) {
-			normalized[key.trim()] = toCellString(row[key])
+			const header = key.trim()
+			if (header) normalized[header] = toCellString(row[key])
 		}
 		return normalized
 	})
-	const headers = rows.length ? Object.keys(rows[0]) : []
-	const warnings = wb.SheetNames.length > 1
-		? [`Workbook has ${wb.SheetNames.length} sheets; only "${sheetName}" was read.`]
-		: []
+	const warnings =
+		wb.SheetNames.length > 1
+			? [
+					`Workbook has ${wb.SheetNames.length} sheets; only "${sheetName}" was read.`,
+				]
+			: []
 	return { headers, rows, warnings }
 }
 

--- a/apps/wodsmith-start/src/lib/organizer-file-import/parse.ts
+++ b/apps/wodsmith-start/src/lib/organizer-file-import/parse.ts
@@ -1,0 +1,138 @@
+/**
+ * Deterministic file parsing for the file-drop import agent. Bytes are parsed
+ * to rows/text on the server BEFORE the model sees anything — cheaper, safer,
+ * and bounded. The model normalizes/maps columns; it never parses raw bytes.
+ *
+ * CSV/TSV/plain-text use papaparse (pure JS, Workers-safe). XLSX uses SheetJS
+ * via a dynamic import so it never bloats cold start when only CSVs are dropped.
+ */
+
+import Papa from "papaparse"
+
+export interface ParsedTable {
+	headers: string[]
+	rows: Record<string, string>[]
+	warnings: string[]
+}
+
+const MAX_WARNINGS = 20
+
+/** Normalize a sheet/CSV cell to a trimmed string regardless of source type. */
+function toCellString(value: unknown): string {
+	if (value === null || value === undefined) return ""
+	if (typeof value === "string") return value.trim()
+	if (typeof value === "number" || typeof value === "boolean") {
+		return String(value)
+	}
+	return String(value).trim()
+}
+
+export function parseDelimited(text: string, delimiter?: string): ParsedTable {
+	const out = Papa.parse<Record<string, unknown>>(text, {
+		header: true,
+		skipEmptyLines: "greedy",
+		...(delimiter ? { delimiter } : {}),
+	})
+	const warnings = out.errors
+		.slice(0, MAX_WARNINGS)
+		.map((e) => `row ${e.row ?? "?"}: ${e.message}`)
+	const headers = (out.meta.fields ?? []).map((h) => h.trim())
+	const rows = (out.data ?? []).map((row) => {
+		const normalized: Record<string, string> = {}
+		for (const key of Object.keys(row)) {
+			normalized[key.trim()] = toCellString(row[key])
+		}
+		return normalized
+	})
+	return { headers, rows, warnings }
+}
+
+export function parseCsv(text: string): ParsedTable {
+	return parseDelimited(text)
+}
+
+export function parseTsv(text: string): ParsedTable {
+	return parseDelimited(text, "\t")
+}
+
+export async function parseXlsx(bytes: ArrayBuffer): Promise<ParsedTable> {
+	// Dynamic import keeps the (large) SheetJS module out of the cold-start path.
+	const XLSX = await import("xlsx")
+	const wb = XLSX.read(bytes, { type: "array" })
+	const sheetName = wb.SheetNames[0]
+	if (!sheetName) return { headers: [], rows: [], warnings: ["Empty workbook"] }
+	const sheet = wb.Sheets[sheetName]
+	const raw = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+		defval: "",
+	})
+	const rows = raw.map((row) => {
+		const normalized: Record<string, string> = {}
+		for (const key of Object.keys(row)) {
+			normalized[key.trim()] = toCellString(row[key])
+		}
+		return normalized
+	})
+	const headers = rows.length ? Object.keys(rows[0]) : []
+	const warnings = wb.SheetNames.length > 1
+		? [`Workbook has ${wb.SheetNames.length} sheets; only "${sheetName}" was read.`]
+		: []
+	return { headers, rows, warnings }
+}
+
+/**
+ * Parse an uploaded file by mime type / filename into a table. Plain text and
+ * markdown that aren't tabular come back as a single-column table so the model
+ * still receives the content.
+ */
+export async function parseImportFile(input: {
+	bytes: ArrayBuffer
+	mimeType: string | null
+	filename: string | null
+}): Promise<ParsedTable> {
+	const { bytes, mimeType, filename } = input
+	const name = (filename ?? "").toLowerCase()
+	const type = (mimeType ?? "").toLowerCase()
+
+	const isXlsx =
+		type.includes("spreadsheetml") ||
+		type === "application/vnd.ms-excel" ||
+		name.endsWith(".xlsx") ||
+		name.endsWith(".xls")
+	if (isXlsx) return parseXlsx(bytes)
+
+	const text = new TextDecoder().decode(bytes)
+	const isTsv =
+		type.includes("tab-separated") || name.endsWith(".tsv")
+	if (isTsv) return parseTsv(text)
+
+	const isCsv = type.includes("csv") || name.endsWith(".csv")
+	if (isCsv) return parseCsv(text)
+
+	// Plain text / markdown — try CSV parsing; if it yields a single column,
+	// fall back to treating each non-empty line as a row.
+	const table = parseCsv(text)
+	if (table.headers.length > 1) return table
+	const lines = text
+		.split(/\r?\n/)
+		.map((l) => l.trim())
+		.filter(Boolean)
+	return {
+		headers: ["line"],
+		rows: lines.map((line) => ({ line })),
+		warnings: ["Treated as free text — one row per non-empty line."],
+	}
+}
+
+/** Cap what we send to the model: first N rows (header summary is separate). */
+export function boundTableForModel(table: ParsedTable, maxRows = 200): {
+	table: ParsedTable
+	truncated: boolean
+} {
+	if (table.rows.length <= maxRows) {
+		return { table, truncated: false }
+	}
+	return {
+		table: { ...table, rows: table.rows.slice(0, maxRows) },
+		truncated: true,
+	}
+}

--- a/apps/wodsmith-start/src/lib/organizer-file-import/schemas.ts
+++ b/apps/wodsmith-start/src/lib/organizer-file-import/schemas.ts
@@ -1,0 +1,259 @@
+/**
+ * Zod schemas for the organizer file-drop import agent.
+ *
+ * Tool inputs/outputs and persisted agent state all live here so the LLM, the
+ * apply server function, and the client share one source of truth — mirroring
+ * src/lib/judge-scheduler/schemas.ts.
+ */
+
+import { z } from "zod"
+import { AGENT_IMPORT_ROUTE_KIND } from "@/db/schemas/agent-imports"
+import {
+	VOLUNTEER_AVAILABILITY,
+	VOLUNTEER_ROLE_TYPE_VALUES,
+} from "@/db/schemas/volunteers"
+
+// ============================================================================
+// Building blocks
+// ============================================================================
+
+export const confidenceSchema = z.enum(["high", "medium", "low"])
+
+export const routeKindSchema = z.enum([
+	AGENT_IMPORT_ROUTE_KIND.VOLUNTEERS,
+	AGENT_IMPORT_ROUTE_KIND.JUDGES,
+	AGENT_IMPORT_ROUTE_KIND.EVENTS,
+	AGENT_IMPORT_ROUTE_KIND.EVENT_DETAIL,
+])
+
+export const availabilitySchema = z.enum([
+	VOLUNTEER_AVAILABILITY.MORNING,
+	VOLUNTEER_AVAILABILITY.AFTERNOON,
+	VOLUNTEER_AVAILABILITY.ALL_DAY,
+])
+
+export const proposalActionSchema = z.enum([
+	"create",
+	"update",
+	"skip",
+	"needs_input",
+])
+
+/** How a proposal matched against existing data — surfaced inline in the UI. */
+export const matchKindSchema = z.enum([
+	"new",
+	"existing_invite",
+	"existing_member",
+])
+
+/**
+ * Lifecycle status of a single proposal in the agent's state.
+ * - `pending`: streamed in by the model, awaiting organizer review.
+ * - `accepted`: organizer confirmed it; kept so re-runs/refine don't re-propose.
+ */
+export const proposalStatusSchema = z.enum(["pending", "accepted"])
+export type ProposalStatus = z.infer<typeof proposalStatusSchema>
+
+// ============================================================================
+// Volunteer / judge proposal
+// ============================================================================
+
+export const volunteerProposalSchema = z.object({
+	proposalId: z.string().min(1).max(64),
+	// stable key from the source row, for idempotency across refine + apply
+	rowKey: z.string().min(1).max(200),
+	action: proposalActionSchema,
+	name: z.string().max(200).nullable(),
+	email: z.string().email().max(320).nullable(),
+	phone: z.string().max(40).nullable(),
+	roleTypes: z.array(z.enum(VOLUNTEER_ROLE_TYPE_VALUES)).default([]),
+	credentials: z.string().max(200).nullable(),
+	shirtSize: z.string().max(20).nullable(),
+	availability: availabilitySchema.nullable(),
+	// match info surfaced inline ("matched on email", "already a volunteer")
+	matchKind: matchKindSchema.default("new"),
+	matchedMembershipId: z.string().nullable(),
+	confidence: confidenceSchema,
+	rationale: z.string().min(1).max(280),
+	// e.g. "no email — can't invite"
+	warnings: z.array(z.string().max(200)).max(10).default([]),
+	status: proposalStatusSchema.default("pending"),
+})
+export type VolunteerProposal = z.infer<typeof volunteerProposalSchema>
+
+// ============================================================================
+// Event / workout proposal
+// ============================================================================
+
+export const eventProposalSchema = z.object({
+	proposalId: z.string().min(1).max(64),
+	rowKey: z.string().min(1).max(200),
+	action: z.enum(["create", "update", "skip"]),
+	// set for updates — the trackWorkoutId being changed
+	targetTrackWorkoutId: z.string().nullable(),
+	name: z.string().min(1).max(200),
+	description: z.string().max(5000).nullable(),
+	// validated against WORKOUT_SCHEME_VALUES server-side
+	scheme: z.string().max(50).nullable(),
+	scoreType: z.string().max(50).nullable(),
+	timeCap: z.number().int().positive().nullable(),
+	// field-level diff for the inline-diff pattern (C)
+	changedFields: z
+		.record(
+			z.string(),
+			z.object({ before: z.unknown(), after: z.unknown() }),
+		)
+		.default({}),
+	confidence: confidenceSchema,
+	rationale: z.string().min(1).max(280),
+	warnings: z.array(z.string().max(200)).max(10).default([]),
+	status: proposalStatusSchema.default("pending"),
+})
+export type EventProposal = z.infer<typeof eventProposalSchema>
+
+// ============================================================================
+// Clarification — asked when the file doesn't match the page
+// ============================================================================
+
+export const clarificationSchema = z
+	.object({
+		question: z.string().max(300),
+		suggestedRouteKind: routeKindSchema.nullable(),
+	})
+	.nullable()
+export type Clarification = z.infer<typeof clarificationSchema>
+
+// ============================================================================
+// Activity log
+// ============================================================================
+
+export const activityEntrySchema = z.object({
+	id: z.string(),
+	timestamp: z.number(),
+	kind: z.enum([
+		"thinking",
+		"tool",
+		"proposed",
+		"skipped",
+		"done",
+		"error",
+	]),
+	message: z.string(),
+})
+export type ActivityEntry = z.infer<typeof activityEntrySchema>
+
+/** Cap the persisted log so long runs don't bloat DO storage. */
+export const MAX_THINKING_LOG_ENTRIES = 200
+
+// ============================================================================
+// Persisted agent state (synced to client over the websocket)
+// ============================================================================
+
+export const importStatusSchema = z.enum([
+	"idle",
+	"parsing",
+	"thinking",
+	"proposals_ready",
+	"error",
+])
+export type ImportStatus = z.infer<typeof importStatusSchema>
+
+export const agentStateSchema = z.object({
+	importRunId: z.string().nullable(),
+	competitionId: z.string().nullable(),
+	eventId: z.string().nullable(),
+	routeKind: routeKindSchema.nullable(),
+	status: importStatusSchema,
+	volunteerProposals: z.array(volunteerProposalSchema).default([]),
+	eventProposals: z.array(eventProposalSchema).default([]),
+	clarification: clarificationSchema.default(null),
+	thinkingLog: z.array(activityEntrySchema).default([]),
+	parseWarnings: z.array(z.string()).default([]),
+	summary: z.string().nullable(),
+	errorMessage: z.string().nullable(),
+	startedAt: z.number().nullable(),
+	completedAt: z.number().nullable(),
+})
+export type AgentState = z.infer<typeof agentStateSchema>
+
+export const initialAgentState: AgentState = {
+	importRunId: null,
+	competitionId: null,
+	eventId: null,
+	routeKind: null,
+	status: "idle",
+	volunteerProposals: [],
+	eventProposals: [],
+	clarification: null,
+	thinkingLog: [],
+	parseWarnings: [],
+	summary: null,
+	errorMessage: null,
+	startedAt: null,
+	completedAt: null,
+}
+
+// ============================================================================
+// Client → agent kickoff + refine
+// ============================================================================
+
+export const startImportInputSchema = z.object({
+	importRunId: z.string().min(1),
+	competitionId: z.string().min(1),
+	routeKind: routeKindSchema,
+	eventId: z.string().min(1).optional(),
+})
+export type StartImportInput = z.infer<typeof startImportInputSchema>
+
+export const refineInputSchema = z.object({
+	instruction: z.string().min(1).max(500),
+})
+export type RefineInput = z.infer<typeof refineInputSchema>
+
+export const markImportAppliedInputSchema = z.object({
+	proposalIds: z.array(z.string().min(1)).min(1),
+})
+export type MarkImportAppliedInput = z.infer<
+	typeof markImportAppliedInputSchema
+>
+
+// ============================================================================
+// Tool input schemas (what the LLM is allowed to send)
+// ============================================================================
+
+// The model only ever proposes pending items; status/match fields are filled
+// in deterministically by the agent's tools, so they are omitted here.
+export const proposeVolunteerInputSchema = volunteerProposalSchema.omit({
+	status: true,
+	matchKind: true,
+	matchedMembershipId: true,
+	warnings: true,
+})
+
+export const proposeEventCreateInputSchema = eventProposalSchema
+	.omit({
+		status: true,
+		warnings: true,
+		targetTrackWorkoutId: true,
+		changedFields: true,
+	})
+	.extend({ action: z.literal("create") })
+
+export const proposeEventUpdateInputSchema = eventProposalSchema.omit({
+	status: true,
+	warnings: true,
+})
+
+export const revokeProposalInputSchema = z.object({
+	proposalId: z.string().min(1),
+	reason: z.string().min(1).max(240),
+})
+
+export const askClarificationInputSchema = z.object({
+	question: z.string().min(1).max(300),
+	suggestedRouteKind: routeKindSchema.nullable().default(null),
+})
+
+export const markCompleteInputSchema = z.object({
+	summary: z.string().min(1).max(600),
+})

--- a/apps/wodsmith-start/src/lib/organizer-file-import/schemas.ts
+++ b/apps/wodsmith-start/src/lib/organizer-file-import/schemas.ts
@@ -34,7 +34,6 @@ export const availabilitySchema = z.enum([
 
 export const proposalActionSchema = z.enum([
 	"create",
-	"update",
 	"skip",
 	"needs_input",
 ])
@@ -239,10 +238,15 @@ export const proposeEventCreateInputSchema = eventProposalSchema
 	})
 	.extend({ action: z.literal("create") })
 
-export const proposeEventUpdateInputSchema = eventProposalSchema.omit({
-	status: true,
-	warnings: true,
-})
+export const proposeEventUpdateInputSchema = eventProposalSchema
+	.omit({
+		status: true,
+		warnings: true,
+	})
+	.extend({
+		action: z.literal("update"),
+		targetTrackWorkoutId: z.string().min(1),
+	})
 
 export const revokeProposalInputSchema = z.object({
 	proposalId: z.string().min(1),

--- a/apps/wodsmith-start/src/lib/organizer-file-import/validate.ts
+++ b/apps/wodsmith-start/src/lib/organizer-file-import/validate.ts
@@ -1,0 +1,82 @@
+/**
+ * Deterministic, LLM-free validation/classification helpers for the file-drop
+ * import agent. These run in BOTH the agent's proposal tools and the apply
+ * server function so the model is never trusted to gate a write — exactly like
+ * src/lib/judge-scheduler/tools.ts.
+ */
+
+import type { VolunteerProposal } from "./schemas"
+
+/** Flat view of an existing volunteer (membership or pending invitation). */
+export interface ExistingVolunteer {
+	membershipId: string
+	email: string | null
+	name: string | null
+	/** true when this is a pending invitation rather than an accepted member */
+	isInvite: boolean
+}
+
+export interface VolunteerClassification {
+	matchKind: VolunteerProposal["matchKind"]
+	matchedMembershipId: string | null
+	warnings: string[]
+}
+
+/**
+ * Classify a proposed volunteer against existing data: dedup by email
+ * (case-insensitive) and surface blocking warnings. Pure — no I/O, no LLM.
+ */
+export function classifyVolunteer(
+	proposal: Pick<VolunteerProposal, "email" | "name">,
+	existing: ExistingVolunteer[],
+): VolunteerClassification {
+	const warnings: string[] = []
+	const email = proposal.email?.trim().toLowerCase() || null
+
+	if (!email) {
+		warnings.push(
+			"No email — cannot send an invitation; provide one to import.",
+		)
+	}
+
+	const byEmail = email
+		? existing.find((e) => e.email?.trim().toLowerCase() === email)
+		: undefined
+
+	if (byEmail) {
+		return {
+			matchKind: byEmail.isInvite ? "existing_invite" : "existing_member",
+			matchedMembershipId: byEmail.membershipId,
+			warnings,
+		}
+	}
+
+	return { matchKind: "new", matchedMembershipId: null, warnings }
+}
+
+/**
+ * A proposal that cannot be applied as-is. A `create` with no email can't send
+ * an invitation, so it is excluded from confirm by default (surfaced as
+ * "needs email").
+ */
+export function isBlockedVolunteer(
+	proposal: Pick<VolunteerProposal, "action" | "email">,
+): boolean {
+	return proposal.action === "create" && !proposal.email?.trim()
+}
+
+/**
+ * Whether a proposal should actually write on confirm. `skip`/`needs_input`
+ * never write; an existing match downgrades a `create` to a no-op skip.
+ */
+export function isApplicableVolunteer(proposal: VolunteerProposal): boolean {
+	if (proposal.action !== "create" && proposal.action !== "update") {
+		return false
+	}
+	if (isBlockedVolunteer(proposal)) return false
+	if (proposal.action === "create" && proposal.matchKind !== "new") {
+		// already exists — treat as a skip rather than a duplicate invite
+		return false
+	}
+	return true
+}

--- a/apps/wodsmith-start/src/lib/organizer-file-import/validate.ts
+++ b/apps/wodsmith-start/src/lib/organizer-file-import/validate.ts
@@ -70,9 +70,7 @@ export function isBlockedVolunteer(
  * never write; an existing match downgrades a `create` to a no-op skip.
  */
 export function isApplicableVolunteer(proposal: VolunteerProposal): boolean {
-	if (proposal.action !== "create" && proposal.action !== "update") {
-		return false
-	}
+	if (proposal.action !== "create") return false
 	if (isBlockedVolunteer(proposal)) return false
 	if (proposal.action === "create" && proposal.matchKind !== "new") {
 		// already exists — treat as a skip rather than a duplicate invite

--- a/apps/wodsmith-start/src/routeTree.gen.ts
+++ b/apps/wodsmith-start/src/routeTree.gen.ts
@@ -74,6 +74,7 @@ import { Route as CompeteSlugAnnouncementsRouteImport } from './routes/compete/$
 import { Route as ApiWorkoutsSearchRouteImport } from './routes/api/workouts/search'
 import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
 import { Route as ApiAuthTokenRouteImport } from './routes/api/auth/token'
+import { Route as ApiAgentImportUploadRouteImport } from './routes/api/agent-import/upload'
 import { Route as AdminTeamsScheduleRouteImport } from './routes/admin/teams/schedule'
 import { Route as AdminTeamsTeamIdRouteImport } from './routes/admin/teams/$teamId'
 import { Route as DemoStartSsrIndexRouteImport } from './routes/demo/start.ssr.index'
@@ -548,6 +549,11 @@ const ApiWebhooksStripeRoute = ApiWebhooksStripeRouteImport.update({
 const ApiAuthTokenRoute = ApiAuthTokenRouteImport.update({
   id: '/api/auth/token',
   path: '/api/auth/token',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAgentImportUploadRoute = ApiAgentImportUploadRouteImport.update({
+  id: '/api/agent-import/upload',
+  path: '/api/agent-import/upload',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AdminTeamsScheduleRoute = AdminTeamsScheduleRouteImport.update({
@@ -1423,6 +1429,7 @@ export interface FileRoutesByFullPath {
   '/compete/': typeof CompeteIndexRoute
   '/admin/teams/$teamId': typeof AdminTeamsTeamIdRouteWithChildren
   '/admin/teams/schedule': typeof AdminTeamsScheduleRouteWithChildren
+  '/api/agent-import/upload': typeof ApiAgentImportUploadRoute
   '/api/auth/token': typeof ApiAuthTokenRouteWithChildren
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/api/workouts/search': typeof ApiWorkoutsSearchRoute
@@ -1623,6 +1630,7 @@ export interface FileRoutesByTo {
   '/transfer/$transferId': typeof TransferTransferIdRoute
   '/admin': typeof AdminIndexRoute
   '/compete': typeof CompeteIndexRoute
+  '/api/agent-import/upload': typeof ApiAgentImportUploadRoute
   '/api/auth/token': typeof ApiAuthTokenRouteWithChildren
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/api/workouts/search': typeof ApiWorkoutsSearchRoute
@@ -1823,6 +1831,7 @@ export interface FileRoutesById {
   '/compete/': typeof CompeteIndexRoute
   '/admin/teams/$teamId': typeof AdminTeamsTeamIdRouteWithChildren
   '/admin/teams/schedule': typeof AdminTeamsScheduleRouteWithChildren
+  '/api/agent-import/upload': typeof ApiAgentImportUploadRoute
   '/api/auth/token': typeof ApiAuthTokenRouteWithChildren
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/api/workouts/search': typeof ApiWorkoutsSearchRoute
@@ -2032,6 +2041,7 @@ export interface FileRouteTypes {
     | '/compete/'
     | '/admin/teams/$teamId'
     | '/admin/teams/schedule'
+    | '/api/agent-import/upload'
     | '/api/auth/token'
     | '/api/webhooks/stripe'
     | '/api/workouts/search'
@@ -2232,6 +2242,7 @@ export interface FileRouteTypes {
     | '/transfer/$transferId'
     | '/admin'
     | '/compete'
+    | '/api/agent-import/upload'
     | '/api/auth/token'
     | '/api/webhooks/stripe'
     | '/api/workouts/search'
@@ -2431,6 +2442,7 @@ export interface FileRouteTypes {
     | '/compete/'
     | '/admin/teams/$teamId'
     | '/admin/teams/schedule'
+    | '/api/agent-import/upload'
     | '/api/auth/token'
     | '/api/webhooks/stripe'
     | '/api/workouts/search'
@@ -2625,6 +2637,7 @@ export interface RootRouteChildren {
   ApiSitemapRoute: typeof ApiSitemapRoute
   ApiUploadRoute: typeof ApiUploadRoute
   TransferTransferIdRoute: typeof TransferTransferIdRoute
+  ApiAgentImportUploadRoute: typeof ApiAgentImportUploadRoute
   ApiAuthTokenRoute: typeof ApiAuthTokenRouteWithChildren
   ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute
   ApiWorkoutsSearchRoute: typeof ApiWorkoutsSearchRoute
@@ -3104,6 +3117,13 @@ declare module '@tanstack/react-router' {
       path: '/api/auth/token'
       fullPath: '/api/auth/token'
       preLoaderRoute: typeof ApiAuthTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/agent-import/upload': {
+      id: '/api/agent-import/upload'
+      path: '/api/agent-import/upload'
+      fullPath: '/api/agent-import/upload'
+      preLoaderRoute: typeof ApiAgentImportUploadRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/admin/teams/schedule': {
@@ -4804,6 +4824,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSitemapRoute: ApiSitemapRoute,
   ApiUploadRoute: ApiUploadRoute,
   TransferTransferIdRoute: TransferTransferIdRoute,
+  ApiAgentImportUploadRoute: ApiAgentImportUploadRoute,
   ApiAuthTokenRoute: ApiAuthTokenRouteWithChildren,
   ApiWebhooksStripeRoute: ApiWebhooksStripeRoute,
   ApiWorkoutsSearchRoute: ApiWorkoutsSearchRoute,

--- a/apps/wodsmith-start/src/routes/api/agent-import/upload.ts
+++ b/apps/wodsmith-start/src/routes/api/agent-import/upload.ts
@@ -1,0 +1,145 @@
+/**
+ * Private upload route for the organizer file-drop import agent.
+ *
+ * Mirrors the auth/logging shape of /api/upload but stores the dropped file
+ * under a private, unguessable key and returns NO public URL — PII stays
+ * server-side. The agent reads the object back via env.R2_BUCKET.get(key).
+ */
+
+import { env } from "cloudflare:workers"
+import { createFileRoute } from "@tanstack/react-router"
+import { json } from "@tanstack/react-start"
+import { eq } from "drizzle-orm"
+import { getDb } from "@/db"
+import { AGENT_IMPORT_STATUS, agentImportRunsTable } from "@/db/schema"
+import { logInfo, logWarning } from "@/lib/logging"
+import {
+	loadFileImportScopeByRun,
+	requireFileImportTeamAccess,
+} from "@/server/organizer-file-import/access"
+import { getSessionFromCookie } from "@/utils/auth"
+
+const MAX_BYTES = 15 * 1024 * 1024 // 15MB
+
+// CSV/TSV + XLSX + plain text/markdown for MVP. PDF/DOCX text extraction is a
+// later spike — reject them here until pre-extraction lands.
+const ALLOWED_TYPES = new Set([
+	"text/csv",
+	"text/tab-separated-values",
+	"text/plain",
+	"text/markdown",
+	"application/csv",
+	"application/vnd.ms-excel",
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+	"application/octet-stream", // some browsers send this for .csv/.tsv
+])
+const ALLOWED_EXTENSIONS = [".csv", ".tsv", ".txt", ".md", ".xlsx", ".xls"]
+
+function hasAllowedExtension(filename: string): boolean {
+	const lower = filename.toLowerCase()
+	return ALLOWED_EXTENSIONS.some((ext) => lower.endsWith(ext))
+}
+
+export const Route = createFileRoute("/api/agent-import/upload")({
+	server: {
+		handlers: {
+			POST: async ({ request }) => {
+				const session = await getSessionFromCookie()
+				if (!session) {
+					logWarning({ message: "[AgentImport] Unauthorized upload attempt" })
+					return json({ error: "Unauthorized" }, { status: 401 })
+				}
+
+				const formData = await request.formData()
+				const file = formData.get("file") as File | null
+				const importRunId = formData.get("importRunId") as string | null
+
+				if (!file || !importRunId) {
+					return json(
+						{ error: "Missing file or importRunId" },
+						{ status: 400 },
+					)
+				}
+				if (file.size > MAX_BYTES) {
+					return json(
+						{ error: "File too large (max 15MB)" },
+						{ status: 400 },
+					)
+				}
+				if (!ALLOWED_TYPES.has(file.type) && !hasAllowedExtension(file.name)) {
+					return json(
+						{ error: `Unsupported file type: ${file.type || file.name}` },
+						{ status: 400 },
+					)
+				}
+
+				// Authorize against the run's competition (defense in depth) and
+				// confirm the uploader owns the run.
+				const scope = await loadFileImportScopeByRun(importRunId)
+				try {
+					await requireFileImportTeamAccess({
+						teamId: scope.organizingTeamId,
+						scope,
+					})
+				} catch (err) {
+					logWarning({
+						message: "[AgentImport] Upload authorization denied",
+						attributes: {
+							importRunId,
+							reason: err instanceof Error ? err.message : String(err),
+						},
+					})
+					return json({ error: "Forbidden" }, { status: 403 })
+				}
+				if (scope.createdByUserId !== session.user.id) {
+					return json({ error: "Forbidden" }, { status: 403 })
+				}
+
+				const bytes = await file.arrayBuffer()
+				const digest = await crypto.subtle.digest("SHA-256", bytes)
+				const checksum = [...new Uint8Array(digest)]
+					.map((b) => b.toString(16).padStart(2, "0"))
+					.join("")
+
+				const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_")
+				const key = `agent-imports/${scope.competitionId}/${importRunId}/${safeName}`
+
+				await env.R2_BUCKET.put(key, bytes, {
+					httpMetadata: { contentType: file.type || "application/octet-stream" },
+					customMetadata: {
+						uploadedBy: session.user.id,
+						importRunId,
+						purpose: "agent-import",
+					},
+				})
+
+				const db = getDb()
+				await db
+					.update(agentImportRunsTable)
+					.set({
+						status: AGENT_IMPORT_STATUS.UPLOADED,
+						r2Key: key,
+						originalFilename: file.name,
+						mimeType: file.type || null,
+						fileSize: file.size,
+						checksum,
+					})
+					.where(eq(agentImportRunsTable.id, importRunId))
+
+				logInfo({
+					message: "[AgentImport] upload completed",
+					attributes: { importRunId, key, checksum },
+				})
+
+				// No public URL — PII stays server-side.
+				return json({
+					key,
+					checksum,
+					originalFilename: file.name,
+					fileSize: file.size,
+					mimeType: file.type,
+				})
+			},
+		},
+	},
+})

--- a/apps/wodsmith-start/src/routes/api/agent-import/upload.ts
+++ b/apps/wodsmith-start/src/routes/api/agent-import/upload.ts
@@ -40,6 +40,12 @@ function hasAllowedExtension(filename: string): boolean {
 	return ALLOWED_EXTENSIONS.some((ext) => lower.endsWith(ext))
 }
 
+function isSupportedUpload(file: File): boolean {
+	const hasExtension = hasAllowedExtension(file.name)
+	if (file.type === "application/octet-stream") return hasExtension
+	return ALLOWED_TYPES.has(file.type) || hasExtension
+}
+
 export const Route = createFileRoute("/api/agent-import/upload")({
 	server: {
 		handlers: {
@@ -51,22 +57,20 @@ export const Route = createFileRoute("/api/agent-import/upload")({
 				}
 
 				const formData = await request.formData()
-				const file = formData.get("file") as File | null
-				const importRunId = formData.get("importRunId") as string | null
+				const file = formData.get("file")
+				const importRunId = formData.get("importRunId")
 
-				if (!file || !importRunId) {
-					return json(
-						{ error: "Missing file or importRunId" },
-						{ status: 400 },
-					)
+				if (!(file instanceof File) || typeof importRunId !== "string") {
+					return json({ error: "Missing file or importRunId" }, { status: 400 })
+				}
+				const normalizedImportRunId = importRunId.trim()
+				if (!normalizedImportRunId) {
+					return json({ error: "Missing importRunId" }, { status: 400 })
 				}
 				if (file.size > MAX_BYTES) {
-					return json(
-						{ error: "File too large (max 15MB)" },
-						{ status: 400 },
-					)
+					return json({ error: "File too large (max 15MB)" }, { status: 400 })
 				}
-				if (!ALLOWED_TYPES.has(file.type) && !hasAllowedExtension(file.name)) {
+				if (!isSupportedUpload(file)) {
 					return json(
 						{ error: `Unsupported file type: ${file.type || file.name}` },
 						{ status: 400 },
@@ -75,7 +79,19 @@ export const Route = createFileRoute("/api/agent-import/upload")({
 
 				// Authorize against the run's competition (defense in depth) and
 				// confirm the uploader owns the run.
-				const scope = await loadFileImportScopeByRun(importRunId)
+				let scope: Awaited<ReturnType<typeof loadFileImportScopeByRun>>
+				try {
+					scope = await loadFileImportScopeByRun(normalizedImportRunId)
+				} catch (err) {
+					logWarning({
+						message: "[AgentImport] Import run lookup failed",
+						attributes: {
+							importRunId: normalizedImportRunId,
+							reason: err instanceof Error ? err.message : String(err),
+						},
+					})
+					return json({ error: "Import run not found" }, { status: 404 })
+				}
 				try {
 					await requireFileImportTeamAccess({
 						teamId: scope.organizingTeamId,
@@ -85,7 +101,7 @@ export const Route = createFileRoute("/api/agent-import/upload")({
 					logWarning({
 						message: "[AgentImport] Upload authorization denied",
 						attributes: {
-							importRunId,
+							importRunId: normalizedImportRunId,
 							reason: err instanceof Error ? err.message : String(err),
 						},
 					})
@@ -102,13 +118,15 @@ export const Route = createFileRoute("/api/agent-import/upload")({
 					.join("")
 
 				const safeName = file.name.replace(/[^a-zA-Z0-9._-]/g, "_")
-				const key = `agent-imports/${scope.competitionId}/${importRunId}/${safeName}`
+				const key = `agent-imports/${scope.competitionId}/${normalizedImportRunId}/${safeName}`
 
 				await env.R2_BUCKET.put(key, bytes, {
-					httpMetadata: { contentType: file.type || "application/octet-stream" },
+					httpMetadata: {
+						contentType: file.type || "application/octet-stream",
+					},
 					customMetadata: {
 						uploadedBy: session.user.id,
-						importRunId,
+						importRunId: normalizedImportRunId,
 						purpose: "agent-import",
 					},
 				})
@@ -124,11 +142,11 @@ export const Route = createFileRoute("/api/agent-import/upload")({
 						fileSize: file.size,
 						checksum,
 					})
-					.where(eq(agentImportRunsTable.id, importRunId))
+					.where(eq(agentImportRunsTable.id, normalizedImportRunId))
 
 				logInfo({
 					message: "[AgentImport] upload completed",
-					attributes: { importRunId, key, checksum },
+					attributes: { importRunId: normalizedImportRunId, key, checksum },
 				})
 
 				// No public URL — PII stays server-side.

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId.tsx
@@ -15,6 +15,7 @@ import {
 } from "@tanstack/react-router"
 import { CompetitionHeader } from "@/components/competition-header"
 import { CompetitionSidebar } from "@/components/competition-sidebar"
+import { ImportShell } from "@/components/organizer-import/import-shell"
 import { OrganizerBreadcrumb } from "@/components/organizer-breadcrumb"
 import { PendingOrganizerBanner } from "@/components/pending-organizer-banner"
 import { getCompetitionByIdFn } from "@/server-fns/competition-detail-fns"
@@ -150,7 +151,15 @@ function CompetitionLayout() {
         />
 
         {/* Child route content */}
-        <Outlet />
+        <ImportShell
+          competition={{
+            id: competition.id,
+            name: competition.name,
+            organizingTeamId: competition.organizingTeamId,
+          }}
+        >
+          <Outlet />
+        </ImportShell>
       </div>
     </CompetitionSidebar>
   )

--- a/apps/wodsmith-start/src/server-fns/organizer-file-import-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/organizer-file-import-fns.ts
@@ -1,0 +1,349 @@
+/**
+ * Server functions backing the organizer file-drop import agent.
+ *
+ * - `createImportRunFn`: create the durable import-run row (authorize before a
+ *   byte is uploaded) and return the id the upload + agent name key off.
+ * - `loadFileImportContextFn`: GET probe so the dock/drawer can render a
+ *   paywall when the team lacks AI_FILE_IMPORT, instead of throwing.
+ * - `applyOrganizerImportFn`: the ONLY place writes happen — triggered by an
+ *   explicit organizer confirm, never the model. Re-validates, invites via the
+ *   existing inviteUserToTeam helper, records created entities for Undo.
+ * - `undoImportFn`: reverse a confirmed import (delete created invitations).
+ */
+
+import { createServerFn } from "@tanstack/react-start"
+import { eq } from "drizzle-orm"
+import { z } from "zod"
+import { getDb } from "@/db"
+import {
+	AGENT_IMPORT_STATUS,
+	agentImportRunsTable,
+	type AppliedEntity,
+	competitionsTable,
+	teamInvitationTable,
+} from "@/db/schema"
+import { createAgentImportRunId } from "@/db/schemas/common"
+import { logInfo } from "@/lib/logging"
+import {
+	routeKindSchema,
+	volunteerProposalSchema,
+} from "@/lib/organizer-file-import/schemas"
+import {
+	isApplicableVolunteer,
+	isBlockedVolunteer,
+} from "@/lib/organizer-file-import/validate"
+import {
+	loadFileImportScope,
+	loadFileImportScopeByRun,
+	requireFileImportRequestAccess,
+	requireFileImportTeamAccess,
+} from "@/server/organizer-file-import/access"
+import { inviteUserToTeam } from "@/server/team-members"
+import { getSessionFromCookie } from "@/utils/auth"
+import { sendVolunteerDirectInviteEmail } from "@/utils/email"
+
+// ============================================================================
+// createImportRunFn
+// ============================================================================
+
+const createRunSchema = z.object({
+	competitionId: z.string().min(1),
+	routeKind: routeKindSchema,
+	eventId: z.string().min(1).optional(),
+})
+
+export const createImportRunFn = createServerFn({ method: "POST" })
+	.inputValidator((data: unknown) => createRunSchema.parse(data))
+	.handler(async ({ data }): Promise<{ importRunId: string }> => {
+		const session = await getSessionFromCookie()
+		if (!session) {
+			throw new Error("NOT_AUTHORIZED: Not authenticated")
+		}
+		const scope = await requireFileImportRequestAccess({
+			competitionId: data.competitionId,
+			routeKind: data.routeKind,
+			eventId: data.eventId ?? null,
+		})
+
+		const db = getDb()
+		const id = createAgentImportRunId()
+		await db.insert(agentImportRunsTable).values({
+			id,
+			competitionId: scope.competitionId,
+			organizingTeamId: scope.organizingTeamId,
+			createdByUserId: session.user.id,
+			routeKind: data.routeKind,
+			eventId: data.eventId ?? null,
+			status: AGENT_IMPORT_STATUS.CREATED,
+		})
+
+		logInfo({
+			message: "[AgentImport] run created",
+			attributes: {
+				importRunId: id,
+				competitionId: scope.competitionId,
+				routeKind: data.routeKind,
+			},
+		})
+		return { importRunId: id }
+	})
+
+// ============================================================================
+// loadFileImportContextFn — paywall probe
+// ============================================================================
+
+const loadContextSchema = z.object({
+	competitionId: z.string().min(1),
+	routeKind: routeKindSchema,
+	eventId: z.string().min(1).optional(),
+})
+
+export const loadFileImportContextFn = createServerFn({ method: "GET" })
+	.inputValidator((data: unknown) => loadContextSchema.parse(data))
+	.handler(async ({ data }): Promise<{ hasAccess: boolean }> => {
+		const scope = await loadFileImportScope({
+			competitionId: data.competitionId,
+			routeKind: data.routeKind,
+			eventId: data.eventId ?? null,
+		})
+		try {
+			await requireFileImportTeamAccess({
+				teamId: scope.organizingTeamId,
+				scope,
+			})
+		} catch (err) {
+			if (err instanceof Error && err.message.includes("AI File Import")) {
+				return { hasAccess: false }
+			}
+			throw err
+		}
+		return { hasAccess: true }
+	})
+
+// ============================================================================
+// applyOrganizerImportFn — the only write path
+// ============================================================================
+
+const applyImportSchema = z.object({
+	importRunId: z.string().min(1),
+	volunteerProposals: z.array(volunteerProposalSchema).default([]),
+})
+
+export interface ApplyImportRowResult {
+	rowKey: string
+	proposalId: string
+	status: "applied" | "skipped" | "failed"
+	entityId?: string
+	reason?: string
+}
+
+export interface ApplyImportResult {
+	applied: number
+	skipped: number
+	failed: number
+	results: ApplyImportRowResult[]
+}
+
+export const applyOrganizerImportFn = createServerFn({ method: "POST" })
+	.inputValidator((data: unknown) => applyImportSchema.parse(data))
+	.handler(async ({ data }): Promise<ApplyImportResult> => {
+		const session = await getSessionFromCookie()
+		if (!session) {
+			throw new Error("NOT_AUTHORIZED: Not authenticated")
+		}
+		const scope = await loadFileImportScopeByRun(data.importRunId)
+		await requireFileImportTeamAccess({ teamId: scope.organizingTeamId, scope })
+
+		if (!scope.competitionTeamId) {
+			throw new Error("This competition has no volunteer team to import into")
+		}
+		const competitionTeamId = scope.competitionTeamId
+
+		const db = getDb()
+		const run = await db.query.agentImportRunsTable.findFirst({
+			where: eq(agentImportRunsTable.id, data.importRunId),
+		})
+		const appliedEntities: AppliedEntity[] = [...(run?.appliedEntities ?? [])]
+		// Idempotency: a (importRunId, rowKey) already applied is a no-op.
+		const appliedRowKeys = new Set(appliedEntities.map((e) => e.rowKey))
+
+		const [competition] = await db
+			.select({ name: competitionsTable.name })
+			.from(competitionsTable)
+			.where(eq(competitionsTable.id, scope.competitionId))
+		const competitionName = competition?.name ?? "a competition"
+
+		const results: ApplyImportRowResult[] = []
+		let applied = 0
+		let skipped = 0
+		let failed = 0
+
+		for (const proposal of data.volunteerProposals) {
+			if (appliedRowKeys.has(proposal.rowKey)) {
+				results.push({
+					rowKey: proposal.rowKey,
+					proposalId: proposal.proposalId,
+					status: "skipped",
+					reason: "already applied",
+				})
+				skipped++
+				continue
+			}
+
+			// Re-validate deterministically — the model is never trusted to gate.
+			if (!isApplicableVolunteer(proposal)) {
+				const reason = isBlockedVolunteer(proposal)
+					? "missing email"
+					: proposal.matchKind !== "new"
+						? "duplicate"
+						: "not applicable"
+				results.push({
+					rowKey: proposal.rowKey,
+					proposalId: proposal.proposalId,
+					status: "skipped",
+					reason,
+				})
+				skipped++
+				continue
+			}
+
+			const email = proposal.email
+			if (!email) {
+				results.push({
+					rowKey: proposal.rowKey,
+					proposalId: proposal.proposalId,
+					status: "skipped",
+					reason: "missing email",
+				})
+				skipped++
+				continue
+			}
+
+			try {
+				const metadata: Record<string, unknown> = {
+					volunteerRoleTypes:
+						proposal.roleTypes.length > 0 ? proposal.roleTypes : ["general"],
+					inviteSource: "direct",
+					inviteEmail: email,
+				}
+				if (proposal.name) metadata.inviteName = proposal.name
+				if (proposal.credentials) metadata.credentials = proposal.credentials
+				if (proposal.shirtSize) metadata.shirtSize = proposal.shirtSize
+				if (proposal.availability)
+					metadata.availability = proposal.availability
+
+				const res = await inviteUserToTeam({
+					teamId: competitionTeamId,
+					email,
+					roleId: "volunteer",
+					isSystemRole: true,
+					metadata: JSON.stringify(metadata),
+					skipPermissionCheck: true,
+					forceInvitation: true,
+					emailOverrideFn: async ({ email: to, token, inviterName }) => {
+						await sendVolunteerDirectInviteEmail({
+							email: to,
+							invitationToken: token,
+							competitionName,
+							inviterName,
+						})
+					},
+				})
+
+				const entityId = res.invitationId ?? res.userId ?? ""
+				appliedEntities.push({
+					kind: "volunteer_invite",
+					entityId,
+					rowKey: proposal.rowKey,
+				})
+				appliedRowKeys.add(proposal.rowKey)
+				results.push({
+					rowKey: proposal.rowKey,
+					proposalId: proposal.proposalId,
+					status: "applied",
+					entityId,
+				})
+				applied++
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err)
+				results.push({
+					rowKey: proposal.rowKey,
+					proposalId: proposal.proposalId,
+					status: "failed",
+					reason: message,
+				})
+				failed++
+			}
+		}
+
+		await db
+			.update(agentImportRunsTable)
+			.set({
+				appliedEntities,
+				status: AGENT_IMPORT_STATUS.APPLIED,
+				appliedAt: new Date(),
+				appliedByUserId: session.user.id,
+			})
+			.where(eq(agentImportRunsTable.id, data.importRunId))
+
+		logInfo({
+			message: "[AgentImport] proposals applied",
+			attributes: {
+				importRunId: data.importRunId,
+				applied,
+				skipped,
+				failed,
+			},
+		})
+		return { applied, skipped, failed, results }
+	})
+
+// ============================================================================
+// undoImportFn — reverse a confirmed import (creates only)
+// ============================================================================
+
+const undoImportSchema = z.object({
+	importRunId: z.string().min(1),
+})
+
+export const undoImportFn = createServerFn({ method: "POST" })
+	.inputValidator((data: unknown) => undoImportSchema.parse(data))
+	.handler(async ({ data }): Promise<{ removed: number }> => {
+		const scope = await loadFileImportScopeByRun(data.importRunId)
+		await requireFileImportTeamAccess({ teamId: scope.organizingTeamId, scope })
+
+		const db = getDb()
+		const run = await db.query.agentImportRunsTable.findFirst({
+			where: eq(agentImportRunsTable.id, data.importRunId),
+		})
+		const entities = run?.appliedEntities ?? []
+
+		let removed = 0
+		for (const entity of entities) {
+			// Undo deletes invitations we created. It cannot un-send the email
+			// that was already dispatched on confirm (the confirm copy says so).
+			if (
+				entity.kind === "volunteer_invite" &&
+				entity.entityId.startsWith("tinv_")
+			) {
+				await db
+					.delete(teamInvitationTable)
+					.where(eq(teamInvitationTable.id, entity.entityId))
+				removed++
+			}
+		}
+
+		await db
+			.update(agentImportRunsTable)
+			.set({
+				appliedEntities: [],
+				status: AGENT_IMPORT_STATUS.REJECTED,
+			})
+			.where(eq(agentImportRunsTable.id, data.importRunId))
+
+		logInfo({
+			message: "[AgentImport] import undone",
+			attributes: { importRunId: data.importRunId, removed },
+		})
+		return { removed }
+	})

--- a/apps/wodsmith-start/src/server-fns/organizer-file-import-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/organizer-file-import-fns.ts
@@ -12,7 +12,7 @@
  */
 
 import { createServerFn } from "@tanstack/react-start"
-import { eq } from "drizzle-orm"
+import { and, eq } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import {
@@ -38,9 +38,12 @@ import {
 	requireFileImportRequestAccess,
 	requireFileImportTeamAccess,
 } from "@/server/organizer-file-import/access"
+import { readImportFile } from "@/server/organizer-file-import/context"
 import { inviteUserToTeam } from "@/server/team-members"
 import { getSessionFromCookie } from "@/utils/auth"
 import { sendVolunteerDirectInviteEmail } from "@/utils/email"
+
+const EMAIL_IN_TEXT_PATTERN = /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi
 
 // ============================================================================
 // createImportRunFn
@@ -152,6 +155,9 @@ export const applyOrganizerImportFn = createServerFn({ method: "POST" })
 			throw new Error("NOT_AUTHORIZED: Not authenticated")
 		}
 		const scope = await loadFileImportScopeByRun(data.importRunId)
+		if (scope.createdByUserId !== session.user.id) {
+			throw new Error("NOT_AUTHORIZED: Import run belongs to another organizer")
+		}
 		await requireFileImportTeamAccess({ teamId: scope.organizingTeamId, scope })
 
 		if (!scope.competitionTeamId) {
@@ -163,15 +169,25 @@ export const applyOrganizerImportFn = createServerFn({ method: "POST" })
 		const run = await db.query.agentImportRunsTable.findFirst({
 			where: eq(agentImportRunsTable.id, data.importRunId),
 		})
+		if (!run) {
+			throw new Error("Import run not found")
+		}
 		const appliedEntities: AppliedEntity[] = [...(run?.appliedEntities ?? [])]
 		// Idempotency: a (importRunId, rowKey) already applied is a no-op.
 		const appliedRowKeys = new Set(appliedEntities.map((e) => e.rowKey))
+		const seenInviteEmails = new Set<string>()
 
 		const [competition] = await db
 			.select({ name: competitionsTable.name })
 			.from(competitionsTable)
 			.where(eq(competitionsTable.id, scope.competitionId))
 		const competitionName = competition?.name ?? "a competition"
+		const { table } = await readImportFile(
+			data.importRunId,
+			scope,
+			session.user.id,
+		)
+		const uploadedEmails = collectEmailsFromRows(table.rows)
 
 		const results: ApplyImportRowResult[] = []
 		let applied = 0
@@ -218,6 +234,28 @@ export const applyOrganizerImportFn = createServerFn({ method: "POST" })
 				skipped++
 				continue
 			}
+			const normalizedEmail = email.trim().toLowerCase()
+			if (!uploadedEmails.has(normalizedEmail)) {
+				results.push({
+					rowKey: proposal.rowKey,
+					proposalId: proposal.proposalId,
+					status: "skipped",
+					reason: "email not found in uploaded file",
+				})
+				skipped++
+				continue
+			}
+			if (seenInviteEmails.has(normalizedEmail)) {
+				results.push({
+					rowKey: proposal.rowKey,
+					proposalId: proposal.proposalId,
+					status: "skipped",
+					reason: "duplicate email in import",
+				})
+				skipped++
+				continue
+			}
+			seenInviteEmails.add(normalizedEmail)
 
 			try {
 				const metadata: Record<string, unknown> = {
@@ -229,8 +267,7 @@ export const applyOrganizerImportFn = createServerFn({ method: "POST" })
 				if (proposal.name) metadata.inviteName = proposal.name
 				if (proposal.credentials) metadata.credentials = proposal.credentials
 				if (proposal.shirtSize) metadata.shirtSize = proposal.shirtSize
-				if (proposal.availability)
-					metadata.availability = proposal.availability
+				if (proposal.availability) metadata.availability = proposal.availability
 
 				const res = await inviteUserToTeam({
 					teamId: competitionTeamId,
@@ -276,15 +313,31 @@ export const applyOrganizerImportFn = createServerFn({ method: "POST" })
 			}
 		}
 
+		const nextStatus =
+			failed > 0
+				? AGENT_IMPORT_STATUS.ERROR
+				: applied > 0
+					? AGENT_IMPORT_STATUS.APPLIED
+					: AGENT_IMPORT_STATUS.PROPOSALS_READY
+
 		await db
 			.update(agentImportRunsTable)
 			.set({
 				appliedEntities,
-				status: AGENT_IMPORT_STATUS.APPLIED,
-				appliedAt: new Date(),
-				appliedByUserId: session.user.id,
+				status: nextStatus,
+				appliedAt: applied > 0 ? new Date() : run.appliedAt,
+				appliedByUserId: applied > 0 ? session.user.id : run.appliedByUserId,
+				errorMessage:
+					failed > 0
+						? `${failed} row${failed === 1 ? "" : "s"} failed during apply`
+						: null,
 			})
-			.where(eq(agentImportRunsTable.id, data.importRunId))
+			.where(
+				and(
+					eq(agentImportRunsTable.id, data.importRunId),
+					eq(agentImportRunsTable.createdByUserId, session.user.id),
+				),
+			)
 
 		logInfo({
 			message: "[AgentImport] proposals applied",
@@ -309,7 +362,14 @@ const undoImportSchema = z.object({
 export const undoImportFn = createServerFn({ method: "POST" })
 	.inputValidator((data: unknown) => undoImportSchema.parse(data))
 	.handler(async ({ data }): Promise<{ removed: number }> => {
+		const session = await getSessionFromCookie()
+		if (!session) {
+			throw new Error("NOT_AUTHORIZED: Not authenticated")
+		}
 		const scope = await loadFileImportScopeByRun(data.importRunId)
+		if (scope.createdByUserId !== session.user.id) {
+			throw new Error("NOT_AUTHORIZED: Import run belongs to another organizer")
+		}
 		await requireFileImportTeamAccess({ teamId: scope.organizingTeamId, scope })
 
 		const db = getDb()
@@ -339,7 +399,12 @@ export const undoImportFn = createServerFn({ method: "POST" })
 				appliedEntities: [],
 				status: AGENT_IMPORT_STATUS.REJECTED,
 			})
-			.where(eq(agentImportRunsTable.id, data.importRunId))
+			.where(
+				and(
+					eq(agentImportRunsTable.id, data.importRunId),
+					eq(agentImportRunsTable.createdByUserId, session.user.id),
+				),
+			)
 
 		logInfo({
 			message: "[AgentImport] import undone",
@@ -347,3 +412,15 @@ export const undoImportFn = createServerFn({ method: "POST" })
 		})
 		return { removed }
 	})
+
+function collectEmailsFromRows(rows: Record<string, string>[]): Set<string> {
+	const emails = new Set<string>()
+	for (const row of rows) {
+		for (const value of Object.values(row)) {
+			for (const match of value.matchAll(EMAIL_IN_TEXT_PATTERN)) {
+				emails.add(match[0].toLowerCase())
+			}
+		}
+	}
+	return emails
+}

--- a/apps/wodsmith-start/src/server.ts
+++ b/apps/wodsmith-start/src/server.ts
@@ -99,6 +99,7 @@ initWorkersLogger({
 
 // Workers runtime requires Durable Object classes to be exported from the entry point
 export { JudgeSchedulerAgent } from "./agents/judge-scheduler-agent"
+export { OrganizerFileImportAgent } from "./agents/organizer-file-import-agent"
 export { ManualRegistrationWorkflow } from "./workflows/manual-registration-workflow"
 // Workers runtime requires Workflow classes to be exported from the entry point
 export { StripeCheckoutWorkflow } from "./workflows/stripe-checkout-workflow"
@@ -106,6 +107,7 @@ export { StripeCheckoutWorkflow } from "./workflows/stripe-checkout-workflow"
 // Threshold for logging slow requests (in ms)
 const SLOW_REQUEST_THRESHOLD_MS = 2000
 
+// @lat: [[architecture#AI Agents]]
 // Create the base TanStack Start entry with default fetch handling
 const startEntry = createServerEntry({
   async fetch(request) {
@@ -121,6 +123,7 @@ const startEntry = createServerEntry({
       const namespace = parts[1]
       const name = parts[2]
       if (namespace === "judge-scheduler-agent") {
+        // @lat: [[architecture#AI Agents#Judge Scheduling]]
         // Agent instance names are `<trackWorkoutId>__<userId>` (or
         // `idle__<userId>` for the placeholder before a workout is
         // selected). Reject anything else so an attacker can't spawn /
@@ -145,12 +148,14 @@ const startEntry = createServerEntry({
         return stub.fetch(request)
       }
       if (namespace === "organizer-file-import-agent") {
+        // @lat: [[architecture#AI Agents#Organizer file-drop import]]
         // Agent instance names are `<importRunId>__<userId>`. The importRunId
         // is a ULID-suffixed id (`aimp_<ULID>`); ULID's uppercase Crockford
         // base32 is accepted case-insensitively by this regex, and the only
         // double underscore is the `__` separator. Reject anything else so a
         // caller can't materialize arbitrary DO identities via this route.
-        const match = /^([a-z0-9_-]{1,128})__([a-z0-9_-]{1,128})$/i.exec(name)
+        const match =
+          /^(aimp_[0-9A-HJKMNP-TV-Z]{26})__([a-z0-9_-]{1,128})$/i.exec(name)
         if (!match) {
           return new Response("Invalid agent name", { status: 400 })
         }

--- a/apps/wodsmith-start/src/server.ts
+++ b/apps/wodsmith-start/src/server.ts
@@ -21,6 +21,7 @@ import { getAgentByName } from "agents"
 import { sendBatchToPostHog } from "evlog/posthog"
 import { createWorkersLogger, initWorkersLogger } from "evlog/workers"
 import type { JudgeSchedulerAgent } from "./agents/judge-scheduler-agent"
+import type { OrganizerFileImportAgent } from "./agents/organizer-file-import-agent"
 import { withEvlog } from "./lib/evlog"
 import {
   extractRequestInfo,
@@ -140,6 +141,26 @@ const startEntry = createServerEntry({
         // class for the agents library's name-persistence helper.
         const ns =
           env.JUDGE_SCHEDULER_AGENT as unknown as DurableObjectNamespace<JudgeSchedulerAgent>
+        const stub = await getAgentByName(ns, name)
+        return stub.fetch(request)
+      }
+      if (namespace === "organizer-file-import-agent") {
+        // Agent instance names are `<importRunId>__<userId>`. The importRunId
+        // is a ULID-suffixed id (`aimp_<ULID>`); ULID's uppercase Crockford
+        // base32 is accepted case-insensitively by this regex, and the only
+        // double underscore is the `__` separator. Reject anything else so a
+        // caller can't materialize arbitrary DO identities via this route.
+        const match = /^([a-z0-9_-]{1,128})__([a-z0-9_-]{1,128})$/i.exec(name)
+        if (!match) {
+          return new Response("Invalid agent name", { status: 400 })
+        }
+        const [, , userId] = match
+        const session = await getSessionFromRequestCookie(request)
+        if (!session?.userId || session.userId !== userId) {
+          return new Response("Unauthorized", { status: 401 })
+        }
+        const ns =
+          env.ORGANIZER_FILE_IMPORT_AGENT as unknown as DurableObjectNamespace<OrganizerFileImportAgent>
         const stub = await getAgentByName(ns, name)
         return stub.fetch(request)
       }

--- a/apps/wodsmith-start/src/server/organizer-file-import/access.ts
+++ b/apps/wodsmith-start/src/server/organizer-file-import/access.ts
@@ -5,6 +5,7 @@ import { FEATURES } from "@/config/features"
 import { getDb } from "@/db"
 import {
 	type AgentImportRouteKind,
+	AGENT_IMPORT_ROUTE_KIND,
 	agentImportRunsTable,
 	competitionsTable,
 	programmingTracksTable,
@@ -40,6 +41,7 @@ export interface FileImportRunScope extends FileImportScope {
  * event, when present, belongs to the competition. Mirrors
  * judge-scheduler/access.ts#loadAiSchedulingScope.
  */
+// @lat: [[architecture#AI Agents#Organizer file-drop import]]
 export async function loadFileImportScope(input: {
 	competitionId: string
 	routeKind: AgentImportRouteKind
@@ -61,6 +63,9 @@ export async function loadFileImportScope(input: {
 	}
 
 	const eventId = input.eventId ?? null
+	if (input.routeKind === AGENT_IMPORT_ROUTE_KIND.EVENT_DETAIL && !eventId) {
+		throw new Error("Event detail imports require an event")
+	}
 	if (eventId) {
 		const [row] = await db
 			.select({ trackWorkoutId: trackWorkoutsTable.id })

--- a/apps/wodsmith-start/src/server/organizer-file-import/access.ts
+++ b/apps/wodsmith-start/src/server/organizer-file-import/access.ts
@@ -1,0 +1,243 @@
+import "server-only"
+
+import { and, eq } from "drizzle-orm"
+import { FEATURES } from "@/config/features"
+import { getDb } from "@/db"
+import {
+	type AgentImportRouteKind,
+	agentImportRunsTable,
+	competitionsTable,
+	programmingTracksTable,
+	ROLES_ENUM,
+	SYSTEM_ROLES_ENUM,
+	teamMembershipTable,
+	teamRoleTable,
+	trackWorkoutsTable,
+	userTable,
+} from "@/db/schema"
+import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
+import { hasFeature } from "@/server/entitlements"
+
+export interface FileImportScope {
+	competitionId: string
+	organizingTeamId: string
+	competitionTeamId: string | null
+	routeKind: AgentImportRouteKind
+	eventId: string | null
+}
+
+export interface FileImportRunScope extends FileImportScope {
+	importRunId: string
+	createdByUserId: string
+	r2Key: string | null
+	originalFilename: string | null
+	mimeType: string | null
+	status: string
+}
+
+/**
+ * Resolve the competition (+ optional event) a drop targets and prove the
+ * event, when present, belongs to the competition. Mirrors
+ * judge-scheduler/access.ts#loadAiSchedulingScope.
+ */
+export async function loadFileImportScope(input: {
+	competitionId: string
+	routeKind: AgentImportRouteKind
+	eventId?: string | null
+}): Promise<FileImportScope> {
+	const db = getDb()
+
+	const [competition] = await db
+		.select({
+			id: competitionsTable.id,
+			organizingTeamId: competitionsTable.organizingTeamId,
+			competitionTeamId: competitionsTable.competitionTeamId,
+		})
+		.from(competitionsTable)
+		.where(eq(competitionsTable.id, input.competitionId))
+
+	if (!competition) {
+		throw new Error("Competition not found")
+	}
+
+	const eventId = input.eventId ?? null
+	if (eventId) {
+		const [row] = await db
+			.select({ trackWorkoutId: trackWorkoutsTable.id })
+			.from(trackWorkoutsTable)
+			.innerJoin(
+				programmingTracksTable,
+				eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+			)
+			.where(
+				and(
+					eq(trackWorkoutsTable.id, eventId),
+					eq(programmingTracksTable.competitionId, input.competitionId),
+				),
+			)
+		if (!row) {
+			throw new Error("Event does not belong to this competition")
+		}
+	}
+
+	return {
+		competitionId: competition.id,
+		organizingTeamId: competition.organizingTeamId,
+		competitionTeamId: competition.competitionTeamId,
+		routeKind: input.routeKind,
+		eventId,
+	}
+}
+
+/** Resolve scope from a persisted import-run row (upload route + apply/undo). */
+export async function loadFileImportScopeByRun(
+	importRunId: string,
+): Promise<FileImportRunScope> {
+	const db = getDb()
+	const run = await db.query.agentImportRunsTable.findFirst({
+		where: eq(agentImportRunsTable.id, importRunId),
+	})
+	if (!run) {
+		throw new Error("Import run not found")
+	}
+	const scope = await loadFileImportScope({
+		competitionId: run.competitionId,
+		routeKind: run.routeKind,
+		eventId: run.eventId,
+	})
+	return {
+		...scope,
+		importRunId: run.id,
+		createdByUserId: run.createdByUserId,
+		r2Key: run.r2Key,
+		originalFilename: run.originalFilename,
+		mimeType: run.mimeType,
+		status: run.status,
+	}
+}
+
+/**
+ * Authorize the current request for the organizer team that owns the
+ * competition: ownership + MANAGE_COMPETITIONS + the AI_FILE_IMPORT entitlement.
+ */
+export async function requireFileImportTeamAccess({
+	teamId,
+	scope,
+}: {
+	teamId: string
+	scope: FileImportScope
+}): Promise<void> {
+	if (scope.organizingTeamId !== teamId) {
+		throw new Error("Competition does not belong to this team")
+	}
+
+	const { requireTeamPermission } = await import("@/utils/team-auth")
+	await requireTeamPermission(teamId, TEAM_PERMISSIONS.MANAGE_COMPETITIONS)
+
+	const entitled = await hasFeature(teamId, FEATURES.AI_FILE_IMPORT)
+	if (!entitled) {
+		throw new Error("Your plan does not include AI File Import")
+	}
+}
+
+/** Request-context entrypoint: resolve scope then require team access. */
+export async function requireFileImportRequestAccess(input: {
+	competitionId: string
+	routeKind: AgentImportRouteKind
+	eventId?: string | null
+}): Promise<FileImportScope> {
+	const scope = await loadFileImportScope(input)
+	await requireFileImportTeamAccess({ teamId: scope.organizingTeamId, scope })
+	return scope
+}
+
+/**
+ * Durable Object agent authorization.
+ *
+ * Agent callables run outside TanStack Start's request AsyncLocalStorage, so
+ * they re-check permissions directly from persistent data using the user id
+ * baked into the agent name (already validated by the Worker WS route).
+ * Mirrors judge-scheduler/access.ts#requireAiSchedulingAgentAccess.
+ */
+export async function requireFileImportAgentAccess(
+	input: {
+		competitionId: string
+		routeKind: AgentImportRouteKind
+		eventId?: string | null
+	},
+	userId: string,
+): Promise<FileImportScope> {
+	const scope = await loadFileImportScope(input)
+	const db = getDb()
+	const user = await db.query.userTable.findFirst({
+		where: eq(userTable.id, userId),
+		columns: { id: true, role: true },
+	})
+	if (!user) {
+		throw new Error("NOT_AUTHORIZED: Not authenticated")
+	}
+
+	if (user.role !== ROLES_ENUM.ADMIN) {
+		const hasPermission = await userHasManageCompetitionsPermission({
+			userId,
+			teamId: scope.organizingTeamId,
+		})
+		if (!hasPermission) {
+			throw new Error(
+				"FORBIDDEN: You don't have the required permission in this team",
+			)
+		}
+	}
+
+	const entitled = await hasFeature(
+		scope.organizingTeamId,
+		FEATURES.AI_FILE_IMPORT,
+	)
+	if (!entitled) {
+		throw new Error("Your plan does not include AI File Import")
+	}
+
+	return scope
+}
+
+async function userHasManageCompetitionsPermission({
+	userId,
+	teamId,
+}: {
+	userId: string
+	teamId: string
+}): Promise<boolean> {
+	const db = getDb()
+	const membership = await db.query.teamMembershipTable.findFirst({
+		where: and(
+			eq(teamMembershipTable.userId, userId),
+			eq(teamMembershipTable.teamId, teamId),
+			eq(teamMembershipTable.isActive, true),
+		),
+		columns: {
+			roleId: true,
+			isSystemRole: true,
+		},
+	})
+
+	if (!membership) return false
+
+	if (membership.isSystemRole) {
+		return (
+			membership.roleId === SYSTEM_ROLES_ENUM.OWNER ||
+			membership.roleId === SYSTEM_ROLES_ENUM.ADMIN
+		)
+	}
+
+	const role = await db.query.teamRoleTable.findFirst({
+		where: and(
+			eq(teamRoleTable.id, membership.roleId),
+			eq(teamRoleTable.teamId, teamId),
+		),
+		columns: { permissions: true },
+	})
+
+	return (
+		role?.permissions.includes(TEAM_PERMISSIONS.MANAGE_COMPETITIONS) ?? false
+	)
+}

--- a/apps/wodsmith-start/src/server/organizer-file-import/context.ts
+++ b/apps/wodsmith-start/src/server/organizer-file-import/context.ts
@@ -1,0 +1,170 @@
+import "server-only"
+
+import { env } from "cloudflare:workers"
+import { and, eq } from "drizzle-orm"
+import { getDb } from "@/db"
+import { agentImportRunsTable, competitionsTable } from "@/db/schema"
+import {
+	SYSTEM_ROLES_ENUM,
+	teamInvitationTable,
+	teamMembershipTable,
+} from "@/db/schemas/teams"
+import { userTable } from "@/db/schemas/users"
+import type { VolunteerMembershipMetadata } from "@/db/schemas/volunteers"
+import {
+	boundTableForModel,
+	type ParsedTable,
+	parseImportFile,
+} from "@/lib/organizer-file-import/parse"
+import type { ExistingVolunteer } from "@/lib/organizer-file-import/validate"
+
+/** Flat page facts the model sees instead of raw DB rows. */
+export interface FileImportPageContext {
+	competitionId: string
+	competitionName: string
+	routeKind: string
+	eventId: string | null
+}
+
+export async function loadPageContext(input: {
+	competitionId: string
+	routeKind: string
+	eventId: string | null
+}): Promise<FileImportPageContext> {
+	const db = getDb()
+	const [competition] = await db
+		.select({ name: competitionsTable.name })
+		.from(competitionsTable)
+		.where(eq(competitionsTable.id, input.competitionId))
+	return {
+		competitionId: input.competitionId,
+		competitionName: competition?.name ?? "this competition",
+		routeKind: input.routeKind,
+		eventId: input.eventId,
+	}
+}
+
+/**
+ * Existing volunteers (volunteer system-role memberships + pending sign-ups)
+ * for a competition's volunteer team, flattened for dedup matching. Mirrors the
+ * membership join in judge-scheduler/context.ts#loadJudgeRoster but returns the
+ * whole roster (not only judges) with the email/name needed to match imports.
+ */
+export async function loadExistingVolunteers(
+	competitionTeamId: string | null,
+): Promise<ExistingVolunteer[]> {
+	if (!competitionTeamId) return []
+	const db = getDb()
+
+	// Accepted volunteers are memberships; pending ones are invitations. Dedup
+	// must consider both — inviteVolunteerFn checks both before inviting.
+	const [memberships, invitations] = await Promise.all([
+		db
+			.select({
+				id: teamMembershipTable.id,
+				userId: teamMembershipTable.userId,
+				metadata: teamMembershipTable.metadata,
+				firstName: userTable.firstName,
+				lastName: userTable.lastName,
+				email: userTable.email,
+			})
+			.from(teamMembershipTable)
+			.leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+			.where(
+				and(
+					eq(teamMembershipTable.teamId, competitionTeamId),
+					eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+					eq(teamMembershipTable.isSystemRole, true),
+				),
+			),
+		db
+			.select({
+				id: teamInvitationTable.id,
+				email: teamInvitationTable.email,
+				metadata: teamInvitationTable.metadata,
+				acceptedAt: teamInvitationTable.acceptedAt,
+			})
+			.from(teamInvitationTable)
+			.where(
+				and(
+					eq(teamInvitationTable.teamId, competitionTeamId),
+					eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+					eq(teamInvitationTable.isSystemRole, true),
+				),
+			),
+	])
+
+	// Members first so an accepted-member match wins over a stale invitation.
+	const members: ExistingVolunteer[] = memberships.map((m) => {
+		const meta = parseVolunteerMetadata(m.metadata)
+		const email = m.email ?? meta?.signupEmail ?? null
+		const name = formatName(m.firstName, m.lastName) ?? meta?.signupName ?? null
+		return {
+			membershipId: m.id,
+			email,
+			name,
+			isInvite: false,
+		}
+	})
+
+	const invited: ExistingVolunteer[] = invitations
+		.filter((inv) => inv.acceptedAt === null)
+		.map((inv) => {
+			const meta = parseVolunteerMetadata(inv.metadata)
+			return {
+				membershipId: inv.id,
+				email: inv.email ?? null,
+				name: meta?.signupName ?? null,
+				isInvite: true,
+			}
+		})
+
+	return [...members, ...invited]
+}
+
+/**
+ * Read the uploaded file for a run from private R2 storage and parse it to a
+ * bounded table — server-side only, so PII never reaches the model unparsed.
+ */
+export async function readImportFile(importRunId: string): Promise<{
+	table: ParsedTable
+	truncated: boolean
+}> {
+	const db = getDb()
+	const run = await db.query.agentImportRunsTable.findFirst({
+		where: eq(agentImportRunsTable.id, importRunId),
+	})
+	if (!run?.r2Key) {
+		throw new Error("Import file has not been uploaded yet")
+	}
+	const object = await env.R2_BUCKET.get(run.r2Key)
+	if (!object) {
+		throw new Error("Import file not found in storage")
+	}
+	const bytes = await object.arrayBuffer()
+	const parsed = await parseImportFile({
+		bytes,
+		mimeType: run.mimeType,
+		filename: run.originalFilename,
+	})
+	return boundTableForModel(parsed)
+}
+
+function parseVolunteerMetadata(
+	raw: string | null,
+): VolunteerMembershipMetadata | null {
+	if (!raw) return null
+	try {
+		return JSON.parse(raw) as VolunteerMembershipMetadata
+	} catch {
+		return null
+	}
+}
+
+function formatName(
+	firstName: string | null | undefined,
+	lastName: string | null | undefined,
+): string | null {
+	const full = [firstName, lastName].filter(Boolean).join(" ").trim()
+	return full || null
+}

--- a/apps/wodsmith-start/src/server/organizer-file-import/context.ts
+++ b/apps/wodsmith-start/src/server/organizer-file-import/context.ts
@@ -1,10 +1,11 @@
 import "server-only"
 
 import { env } from "cloudflare:workers"
-import { and, eq } from "drizzle-orm"
+import { and, eq, gt, isNull } from "drizzle-orm"
 import { getDb } from "@/db"
 import { agentImportRunsTable, competitionsTable } from "@/db/schema"
 import {
+	INVITATION_STATUS,
 	SYSTEM_ROLES_ENUM,
 	teamInvitationTable,
 	teamMembershipTable,
@@ -17,6 +18,7 @@ import {
 	parseImportFile,
 } from "@/lib/organizer-file-import/parse"
 import type { ExistingVolunteer } from "@/lib/organizer-file-import/validate"
+import type { FileImportScope } from "./access"
 
 /** Flat page facts the model sees instead of raw DB rows. */
 export interface FileImportPageContext {
@@ -26,6 +28,7 @@ export interface FileImportPageContext {
 	eventId: string | null
 }
 
+// @lat: [[architecture#AI Agents#Organizer file-drop import]]
 export async function loadPageContext(input: {
 	competitionId: string
 	routeKind: string
@@ -50,6 +53,7 @@ export async function loadPageContext(input: {
  * membership join in judge-scheduler/context.ts#loadJudgeRoster but returns the
  * whole roster (not only judges) with the email/name needed to match imports.
  */
+// @lat: [[architecture#AI Agents#Organizer file-drop import]]
 export async function loadExistingVolunteers(
 	competitionTeamId: string | null,
 ): Promise<ExistingVolunteer[]> {
@@ -62,7 +66,6 @@ export async function loadExistingVolunteers(
 		db
 			.select({
 				id: teamMembershipTable.id,
-				userId: teamMembershipTable.userId,
 				metadata: teamMembershipTable.metadata,
 				firstName: userTable.firstName,
 				lastName: userTable.lastName,
@@ -82,7 +85,6 @@ export async function loadExistingVolunteers(
 				id: teamInvitationTable.id,
 				email: teamInvitationTable.email,
 				metadata: teamInvitationTable.metadata,
-				acceptedAt: teamInvitationTable.acceptedAt,
 			})
 			.from(teamInvitationTable)
 			.where(
@@ -90,6 +92,9 @@ export async function loadExistingVolunteers(
 					eq(teamInvitationTable.teamId, competitionTeamId),
 					eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
 					eq(teamInvitationTable.isSystemRole, true),
+					eq(teamInvitationTable.status, INVITATION_STATUS.PENDING),
+					isNull(teamInvitationTable.acceptedAt),
+					gt(teamInvitationTable.expiresAt, new Date()),
 				),
 			),
 	])
@@ -107,17 +112,15 @@ export async function loadExistingVolunteers(
 		}
 	})
 
-	const invited: ExistingVolunteer[] = invitations
-		.filter((inv) => inv.acceptedAt === null)
-		.map((inv) => {
-			const meta = parseVolunteerMetadata(inv.metadata)
-			return {
-				membershipId: inv.id,
-				email: inv.email ?? null,
-				name: meta?.signupName ?? null,
-				isInvite: true,
-			}
-		})
+	const invited: ExistingVolunteer[] = invitations.map((inv) => {
+		const meta = parseVolunteerMetadata(inv.metadata)
+		return {
+			membershipId: inv.id,
+			email: inv.email ?? null,
+			name: meta?.signupName ?? null,
+			isInvite: true,
+		}
+	})
 
 	return [...members, ...invited]
 }
@@ -126,13 +129,27 @@ export async function loadExistingVolunteers(
  * Read the uploaded file for a run from private R2 storage and parse it to a
  * bounded table — server-side only, so PII never reaches the model unparsed.
  */
-export async function readImportFile(importRunId: string): Promise<{
+// @lat: [[architecture#AI Agents#Organizer file-drop import]]
+export async function readImportFile(
+	importRunId: string,
+	scope: FileImportScope,
+	userId: string,
+): Promise<{
 	table: ParsedTable
 	truncated: boolean
 }> {
 	const db = getDb()
 	const run = await db.query.agentImportRunsTable.findFirst({
-		where: eq(agentImportRunsTable.id, importRunId),
+		where: and(
+			eq(agentImportRunsTable.id, importRunId),
+			eq(agentImportRunsTable.competitionId, scope.competitionId),
+			eq(agentImportRunsTable.organizingTeamId, scope.organizingTeamId),
+			eq(agentImportRunsTable.routeKind, scope.routeKind),
+			eq(agentImportRunsTable.createdByUserId, userId),
+			scope.eventId
+				? eq(agentImportRunsTable.eventId, scope.eventId)
+				: isNull(agentImportRunsTable.eventId),
+		),
 	})
 	if (!run?.r2Key) {
 		throw new Error("Import file has not been uploaded yet")
@@ -150,6 +167,7 @@ export async function readImportFile(importRunId: string): Promise<{
 	return boundTableForModel(parsed)
 }
 
+// @lat: [[architecture#AI Agents#Organizer file-drop import]]
 function parseVolunteerMetadata(
 	raw: string | null,
 ): VolunteerMembershipMetadata | null {
@@ -161,6 +179,7 @@ function parseVolunteerMetadata(
 	}
 }
 
+// @lat: [[architecture#AI Agents#Organizer file-drop import]]
 function formatName(
 	firstName: string | null | undefined,
 	lastName: string | null | undefined,

--- a/apps/wodsmith-start/src/types/env.d.ts
+++ b/apps/wodsmith-start/src/types/env.d.ts
@@ -17,6 +17,7 @@ declare global {
     // that aren't included in `wrangler types` output (Durable Objects, AI, etc.).
     interface Env {
       JUDGE_SCHEDULER_AGENT: DurableObjectNamespace
+      ORGANIZER_FILE_IMPORT_AGENT: DurableObjectNamespace
       AI: Ai
       /** Cloudflare account id — routed through AI Gateway by the agents */
       CF_ACCOUNT_ID: string

--- a/apps/wodsmith-start/test/lib/organizer-file-import/parse.test.ts
+++ b/apps/wodsmith-start/test/lib/organizer-file-import/parse.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+import {
+	boundTableForModel,
+	parseCsv,
+	parseImportFile,
+	parseTsv,
+} from "@/lib/organizer-file-import/parse"
+
+function bytesOf(text: string): ArrayBuffer {
+	return new TextEncoder().encode(text).buffer as ArrayBuffer
+}
+
+describe("parseCsv", () => {
+	it("detects headers and maps rows by column", () => {
+		const table = parseCsv("Name,Email\nAda,ada@example.com\nGrace,grace@example.com")
+		expect(table.headers).toEqual(["Name", "Email"])
+		expect(table.rows).toEqual([
+			{ Name: "Ada", Email: "ada@example.com" },
+			{ Name: "Grace", Email: "grace@example.com" },
+		])
+	})
+
+	it("skips empty lines and trims headers and cells", () => {
+		const table = parseCsv(" Name , Email \nAda , ada@example.com \n\n\n")
+		expect(table.headers).toEqual(["Name", "Email"])
+		expect(table.rows).toEqual([{ Name: "Ada", Email: "ada@example.com" }])
+	})
+})
+
+describe("parseTsv", () => {
+	it("splits on tabs", () => {
+		const table = parseTsv("Name\tRole\nAda\tHead Judge")
+		expect(table.headers).toEqual(["Name", "Role"])
+		expect(table.rows).toEqual([{ Name: "Ada", Role: "Head Judge" }])
+	})
+})
+
+describe("parseImportFile", () => {
+	it("parses a CSV by mime type into a multi-column table", async () => {
+		const table = await parseImportFile({
+			bytes: bytesOf("Name,Email\nAda,ada@example.com"),
+			mimeType: "text/csv",
+			filename: "roster.csv",
+		})
+		expect(table.headers).toEqual(["Name", "Email"])
+		expect(table.rows).toHaveLength(1)
+	})
+
+	it("falls back to one row per line for non-tabular plain text", async () => {
+		const table = await parseImportFile({
+			bytes: bytesOf("Ada Lovelace\nGrace Hopper\n"),
+			mimeType: "text/plain",
+			filename: "names.txt",
+		})
+		expect(table.headers).toEqual(["line"])
+		expect(table.rows).toEqual([
+			{ line: "Ada Lovelace" },
+			{ line: "Grace Hopper" },
+		])
+		expect(table.warnings.length).toBeGreaterThan(0)
+	})
+
+	it("routes by extension when the mime type is generic", async () => {
+		const table = await parseImportFile({
+			bytes: bytesOf("Name\tEmail\nAda\tada@example.com"),
+			mimeType: "application/octet-stream",
+			filename: "roster.tsv",
+		})
+		expect(table.headers).toEqual(["Name", "Email"])
+	})
+})
+
+describe("boundTableForModel", () => {
+	it("returns the table untouched when under the cap", () => {
+		const table = { headers: ["a"], rows: [{ a: "1" }], warnings: [] }
+		const { table: out, truncated } = boundTableForModel(table, 200)
+		expect(truncated).toBe(false)
+		expect(out.rows).toHaveLength(1)
+	})
+
+	it("caps rows and flags truncation", () => {
+		const rows = Array.from({ length: 250 }, (_, i) => ({ a: String(i) }))
+		const { table: out, truncated } = boundTableForModel(
+			{ headers: ["a"], rows, warnings: [] },
+			200,
+		)
+		expect(truncated).toBe(true)
+		expect(out.rows).toHaveLength(200)
+	})
+})

--- a/apps/wodsmith-start/test/lib/organizer-file-import/parse.test.ts
+++ b/apps/wodsmith-start/test/lib/organizer-file-import/parse.test.ts
@@ -4,6 +4,7 @@ import {
 	parseCsv,
 	parseImportFile,
 	parseTsv,
+	parseXlsx,
 } from "@/lib/organizer-file-import/parse"
 
 function bytesOf(text: string): ArrayBuffer {
@@ -32,6 +33,21 @@ describe("parseTsv", () => {
 		const table = parseTsv("Name\tRole\nAda\tHead Judge")
 		expect(table.headers).toEqual(["Name", "Role"])
 		expect(table.rows).toEqual([{ Name: "Ada", Role: "Head Judge" }])
+	})
+})
+
+describe("parseXlsx", () => {
+	it("keeps headers when the sheet has no data rows", async () => {
+		const XLSX = await import("xlsx")
+		const ws = XLSX.utils.aoa_to_sheet([["Name", "Email", "Role"]])
+		const wb = XLSX.utils.book_new()
+		XLSX.utils.book_append_sheet(wb, ws, "Roster")
+		const bytes = XLSX.write(wb, { type: "array", bookType: "xlsx" })
+
+		const table = await parseXlsx(bytes)
+
+		expect(table.headers).toEqual(["Name", "Email", "Role"])
+		expect(table.rows).toEqual([])
 	})
 })
 

--- a/apps/wodsmith-start/test/lib/organizer-file-import/validate.test.ts
+++ b/apps/wodsmith-start/test/lib/organizer-file-import/validate.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest"
+import type { VolunteerProposal } from "@/lib/organizer-file-import/schemas"
+import {
+	classifyVolunteer,
+	type ExistingVolunteer,
+	isApplicableVolunteer,
+	isBlockedVolunteer,
+} from "@/lib/organizer-file-import/validate"
+
+const EXISTING: ExistingVolunteer[] = [
+	{ membershipId: "tmem_1", email: "ada@example.com", name: "Ada", isInvite: false },
+	{ membershipId: "tinv_2", email: "grace@example.com", name: "Grace", isInvite: true },
+]
+
+function proposal(overrides: Partial<VolunteerProposal> = {}): VolunteerProposal {
+	return {
+		proposalId: "v1",
+		rowKey: "v1",
+		action: "create",
+		name: "New Person",
+		email: "new@example.com",
+		phone: null,
+		roleTypes: [],
+		credentials: null,
+		shirtSize: null,
+		availability: null,
+		matchKind: "new",
+		matchedMembershipId: null,
+		confidence: "high",
+		rationale: "test",
+		warnings: [],
+		status: "pending",
+		...overrides,
+	}
+}
+
+describe("classifyVolunteer", () => {
+	it("warns when there is no email", () => {
+		const result = classifyVolunteer({ email: null, name: "No Email" }, EXISTING)
+		expect(result.matchKind).toBe("new")
+		expect(result.warnings.length).toBeGreaterThan(0)
+	})
+
+	it("matches an existing member by email, case-insensitively", () => {
+		const result = classifyVolunteer(
+			{ email: "ADA@example.com", name: "Ada" },
+			EXISTING,
+		)
+		expect(result.matchKind).toBe("existing_member")
+		expect(result.matchedMembershipId).toBe("tmem_1")
+	})
+
+	it("distinguishes an existing pending invitation", () => {
+		const result = classifyVolunteer(
+			{ email: "grace@example.com", name: "Grace" },
+			EXISTING,
+		)
+		expect(result.matchKind).toBe("existing_invite")
+		expect(result.matchedMembershipId).toBe("tinv_2")
+	})
+
+	it("classifies an unknown email as new", () => {
+		const result = classifyVolunteer(
+			{ email: "fresh@example.com", name: "Fresh" },
+			EXISTING,
+		)
+		expect(result.matchKind).toBe("new")
+		expect(result.matchedMembershipId).toBeNull()
+	})
+})
+
+describe("isBlockedVolunteer", () => {
+	it("blocks a create with no email", () => {
+		expect(isBlockedVolunteer({ action: "create", email: null })).toBe(true)
+		expect(isBlockedVolunteer({ action: "create", email: "  " })).toBe(true)
+	})
+
+	it("does not block a create with an email", () => {
+		expect(isBlockedVolunteer({ action: "create", email: "a@b.com" })).toBe(false)
+	})
+})
+
+describe("isApplicableVolunteer", () => {
+	it("applies a new create with an email", () => {
+		expect(isApplicableVolunteer(proposal())).toBe(true)
+	})
+
+	it("skips a create with no email", () => {
+		expect(isApplicableVolunteer(proposal({ email: null }))).toBe(false)
+	})
+
+	it("skips a duplicate (already a member)", () => {
+		expect(
+			isApplicableVolunteer(
+				proposal({ matchKind: "existing_member", matchedMembershipId: "tmem_1" }),
+			),
+		).toBe(false)
+	})
+
+	it("skips needs_input and skip actions", () => {
+		expect(isApplicableVolunteer(proposal({ action: "needs_input" }))).toBe(false)
+		expect(isApplicableVolunteer(proposal({ action: "skip" }))).toBe(false)
+	})
+})

--- a/lat.md/architecture.md
+++ b/lat.md/architecture.md
@@ -183,6 +183,8 @@ Every AI feature is gated by a `features` row in the database; access is granted
 3. Agent WebSocket route — requires a valid session and an agent name ending in the current user id; because this route is handled before TanStack Start request context exists, [[apps/wodsmith-start/src/server.ts]] validates the raw request cookie via [[apps/wodsmith-start/src/utils/auth.ts#getSessionFromRequestCookie]]
 4. Agent's `@callable()` entrypoint — calls [[apps/wodsmith-start/src/server/judge-scheduler/access.ts#requireAiSchedulingAgentAccess]] with the user id from the authenticated agent name before loading roster context or burning Workers AI tokens; this path uses direct DB permission checks and avoids Start cookie helpers because Durable Objects do not have Start request context
 
+The organizer file-drop import agent reproduces this same four-layer contract through [[apps/wodsmith-start/src/server/organizer-file-import/access.ts#requireFileImportAgentAccess]] (plus run-scoped and request-scoped variants for the upload route and write fns) gated by the `AI_FILE_IMPORT` feature.
+
 ### AI judge scheduling
 
 [[apps/wodsmith-start/src/agents/judge-scheduler-agent.ts#JudgeSchedulerAgent]] proposes judge rotations for one event at a time.
@@ -200,3 +202,13 @@ Intent-based tools the agent calls (per Anthropic's "Building Effective Agents")
 - `mark_complete` — final summary
 
 The organizer page at [[apps/wodsmith-start/src/routes/compete/organizer/$competitionId/judges-ai.tsx]] mirrors the existing rotation timeline visuals (heats × lanes grid, color-coded coverage). Each streamed proposal renders with its confidence badge, rationale, and any soft violations; the organizer toggles per-proposal Accept/Reject. "Save as Draft" calls [[apps/wodsmith-start/src/server-fns/judge-scheduler-ai-fns.ts#applyAiProposalsFn]], which revalidates proposal membership, event ownership, lane bounds, and slot overlaps before writing `competition_judge_rotations`. The organizer still publishes via the existing rotation timeline screen so versioning + materialization stay in one place.
+
+### Organizer file-drop import
+
+[[apps/wodsmith-start/src/agents/organizer-file-import-agent.ts#OrganizerFileImportAgent]] turns a roster file dropped onto an organizer page into reviewed volunteer/judge invitations: the model proposes, the organizer confirms once, and only then does anything write.
+
+Dropping a file on `/volunteers` or `/volunteers/judges` (detected by [[apps/wodsmith-start/src/components/organizer-import/use-page-intent.ts#usePageIntent]]) creates an `agent_import_runs` row via [[apps/wodsmith-start/src/server-fns/organizer-file-import-fns.ts#createImportRunFn]] *before any model call* — the durable anchor for audit, retention, idempotency, and the Undo receipt. The file is POSTed to the private route [[apps/wodsmith-start/src/routes/api/agent-import/upload.ts]] which stores it under an unguessable R2 key (`agent-imports/{competitionId}/{importRunId}/{file}`) and returns no public URL, so PII stays server-side.
+
+The review drawer ([[apps/wodsmith-start/src/components/organizer-import/import-review-drawer.tsx#ImportReviewDrawer]], mounted by the layout shell [[apps/wodsmith-start/src/components/organizer-import/import-shell.tsx#ImportShell]]) connects the agent and calls `start`, which reads + parses the file server-side ([[apps/wodsmith-start/src/lib/organizer-file-import/parse.ts#parseImportFile]]) then runs `generateText` through the AI Gateway with PROPOSAL-ONLY tools (`get_page_context`, `get_import_table`, `propose_volunteer`, `revoke_proposal`, `ask_clarification`, `mark_complete`). Duplicate detection runs deterministically server-side in [[apps/wodsmith-start/src/lib/organizer-file-import/validate.ts#classifyVolunteer]], so existing-volunteer emails never reach the model. `refine(instruction)` re-drafts the list in words before confirming.
+
+Confirm is the only write path: [[apps/wodsmith-start/src/server-fns/organizer-file-import-fns.ts#applyOrganizerImportFn]] re-validates every proposal deterministically, invites each new volunteer via the existing [[apps/wodsmith-start/src/server/team-members.ts#inviteUserToTeam]] helper (sending invite emails on confirm), and records created entities on the run for the receipt and [[apps/wodsmith-start/src/server-fns/organizer-file-import-fns.ts#undoImportFn]] (which deletes created invitations but cannot un-send email). The MVP covers the volunteers/judges path; events/event-detail imports and the inline-diff surface are later phases.

--- a/lat.md/organizer-dashboard.md
+++ b/lat.md/organizer-dashboard.md
@@ -10,6 +10,8 @@ Access requires authentication plus one of: platform admin role, or owner/admin 
 
 The layout header renders [[apps/wodsmith-start/src/components/competition-header.tsx#CompetitionHeader]], which groups publication, visibility, registration, and competition metadata into compact fields under the competition name. The registration field combines open/closed state with the registration date range so organizers can scan state and timing without reading a long inline sentence. The header's actions are "View public page" and (for series competitions) "Go to Series" — there is no Edit button because the sidebar's "Competition details" link already navigates to the edit page.
 
+The layout also wraps child routes in [[apps/wodsmith-start/src/components/organizer-import/import-shell.tsx#ImportShell]], the always-mounted file-drop import surface. [[apps/wodsmith-start/src/components/organizer-import/use-page-intent.ts#usePageIntent]] maps the active route to an import intent — currently only `/volunteers` (volunteers) and `/volunteers/judges` (judges) enable the drop overlay and the persistent "Import from a file" dock; other organizer pages render nothing. Dropping (or picking) a file opens the agent-backed review drawer (see [[architecture#AI Agents#Organizer file-drop import]]).
+
 ## Overview Page
 
 The index page shows at-a-glance competition stats and quick action cards for common organizer tasks.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -670,8 +670,8 @@ importers:
         specifier: ^3.1.14
         version: 3.1.14(@ai-sdk/provider@3.0.10)(ai@6.0.77(zod@4.2.1))
       xlsx:
-        specifier: ^0.18.5
-        version: 0.18.5
+        specifier: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
+        version: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz
       zod:
         specifier: ^4.2.1
         version: 4.2.1
@@ -7226,10 +7226,6 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
-  adler-32@1.3.1:
-    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
-    engines: {node: '>=0.8'}
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -7742,10 +7738,6 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
-  cfb@1.2.2:
-    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
-    engines: {node: '>=0.8'}
-
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
@@ -7852,10 +7844,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  codepage@1.15.0:
-    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
-    engines: {node: '>=0.8'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -8028,11 +8016,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  crc-32@1.2.2:
-    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
-    engines: {node: '>=0.8'}
-    hasBin: true
 
   cron-schedule@6.0.0:
     resolution: {integrity: sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==}
@@ -9131,10 +9114,6 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
-
-  frac@1.1.2:
-    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
-    engines: {node: '>=0.8'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -12143,10 +12122,6 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
-  ssf@0.11.2:
-    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
-    engines: {node: '>=0.8'}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -13026,14 +13001,6 @@ packages:
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
-  wmf@1.0.2:
-    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
-    engines: {node: '>=0.8'}
-
-  word@0.3.0:
-    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
-    engines: {node: '>=0.8'}
-
   workerd@1.20250508.0:
     resolution: {integrity: sha512-ffLxe7dXSuGoA6jb3Qx2SClIV1aLHfJQ6RhGhzYHjQgv7dL6fdUOSIIGgzmu2mRKs+WFSujp6c8WgKquco6w3w==}
     engines: {node: '>=16'}
@@ -13136,8 +13103,9 @@ packages:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
 
-  xlsx@0.18.5:
-    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
+    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true
 
@@ -21921,8 +21889,6 @@ snapshots:
 
   address@1.2.2: {}
 
-  adler-32@1.3.1: {}
-
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -22597,11 +22563,6 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  cfb@1.2.2:
-    dependencies:
-      adler-32: 1.3.1
-      crc-32: 1.2.2
-
   chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
@@ -22737,8 +22698,6 @@ snapshots:
     optional: true
 
   clsx@2.1.1: {}
-
-  codepage@1.15.0: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -22893,8 +22852,6 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.6.3
-
-  crc-32@1.2.2: {}
 
   cron-schedule@6.0.0: {}
 
@@ -24003,8 +23960,6 @@ snapshots:
     optional: true
 
   forwarded@0.2.0: {}
-
-  frac@1.1.2: {}
 
   fraction.js@5.3.4: {}
 
@@ -27613,10 +27568,6 @@ snapshots:
 
   srvx@0.9.8: {}
 
-  ssf@0.11.2:
-    dependencies:
-      frac: 1.1.2
-
   stackback@0.0.2: {}
 
   stacktracey@2.1.8:
@@ -28572,10 +28523,6 @@ snapshots:
 
   wildcard@2.0.1: {}
 
-  wmf@1.0.2: {}
-
-  word@0.3.0: {}
-
   workerd@1.20250508.0:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20250508.0
@@ -28679,15 +28626,7 @@ snapshots:
 
   xdg-basedir@5.1.0: {}
 
-  xlsx@0.18.5:
-    dependencies:
-      adler-32: 1.3.1
-      cfb: 1.2.2
-      codepage: 1.15.0
-      crc-32: 1.2.2
-      ssf: 0.11.2
-      wmf: 1.0.2
-      word: 0.3.0
+  xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz: {}
 
   xml-js@1.6.11:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start':
         specifier: ^1.132.0
-        version: 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
+        version: 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)
       alchemy:
         specifier: 'catalog:'
         version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(stripe@17.7.0)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
@@ -187,7 +187,7 @@ importers:
         version: 6.0.77(zod@4.2.1)
       alchemy:
         specifier: 'catalog:'
-        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
+        version: 0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(stripe@17.7.0)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -554,13 +554,13 @@ importers:
         version: 1.144.0(@tanstack/query-core@5.90.15)(@tanstack/react-query@5.90.15(react@19.2.3))(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@tanstack/router-core@1.168.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/react-start':
         specifier: ^1.132.0
-        version: 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)
+        version: 1.145.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@tanstack/router-plugin':
         specifier: ^1.132.0
-        version: 1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1)
+        version: 1.144.0(@tanstack/react-router@1.144.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(webpack@5.102.1(esbuild@0.19.12))
       '@vimeo/player':
         specifier: ^2.30.3
         version: 2.30.3
@@ -612,6 +612,9 @@ importers:
       mysql2:
         specifier: ^3.16.2
         version: 3.16.2
+      papaparse:
+        specifier: ^5.5.3
+        version: 5.5.3
       posthog-js:
         specifier: ^1.310.1
         version: 1.311.0
@@ -666,6 +669,9 @@ importers:
       workers-ai-provider:
         specifier: ^3.1.14
         version: 3.1.14(@ai-sdk/provider@3.0.10)(ai@6.0.77(zod@4.2.1))
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^4.2.1
         version: 4.2.1
@@ -703,6 +709,9 @@ importers:
       '@types/node':
         specifier: ^22.19.3
         version: 22.19.3
+      '@types/papaparse':
+        specifier: ^5.5.2
+        version: 5.5.2
       '@types/react':
         specifier: ^19.2.0
         version: 19.2.7
@@ -6944,6 +6953,9 @@ packages:
   '@types/node@22.19.3':
     resolution: {integrity: sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==}
 
+  '@types/papaparse@5.5.2':
+    resolution: {integrity: sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==}
+
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
 
@@ -7213,6 +7225,10 @@ packages:
   address@1.2.2:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
+
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -7726,6 +7742,10 @@ packages:
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
@@ -7832,6 +7852,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
 
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
@@ -8004,6 +8028,11 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cron-schedule@6.0.0:
     resolution: {integrity: sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==}
@@ -9102,6 +9131,10 @@ packages:
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
@@ -10762,6 +10795,9 @@ packages:
   pako@1.0.11:
     resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
 
+  papaparse@5.5.3:
+    resolution: {integrity: sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==}
+
   param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
 
@@ -12107,6 +12143,10 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -12986,6 +13026,14 @@ packages:
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
+
   workerd@1.20250508.0:
     resolution: {integrity: sha512-ffLxe7dXSuGoA6jb3Qx2SClIV1aLHfJQ6RhGhzYHjQgv7dL6fdUOSIIGgzmu2mRKs+WFSujp6c8WgKquco6w3w==}
     engines: {node: '>=16'}
@@ -13087,6 +13135,11 @@ packages:
   xdg-basedir@5.1.0:
     resolution: {integrity: sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ==}
     engines: {node: '>=12'}
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
@@ -18779,7 +18832,7 @@ snapshots:
 
   '@oozcitak/util@10.0.0': {}
 
-  '@opennextjs/aws@3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
+  '@opennextjs/aws@3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@ast-grep/napi': 0.40.0
       '@aws-sdk/client-cloudfront': 3.398.0
@@ -18808,25 +18861,7 @@ snapshots:
     dependencies:
       '@ast-grep/napi': 0.40.0
       '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
-      cloudflare: 4.5.0
-      enquirer: 2.4.1
-      glob: 12.0.0
-      next: 15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      ts-tqdm: 0.8.6
-      wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
-      yargs: 18.0.0
-    transitivePeerDependencies:
-      - aws-crt
-      - encoding
-      - supports-color
-    optional: true
-
-  '@opennextjs/cloudflare@1.14.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))':
-    dependencies:
-      '@ast-grep/napi': 0.40.0
-      '@dotenvx/dotenvx': 1.31.0
-      '@opennextjs/aws': 3.9.4(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
+      '@opennextjs/aws': 3.9.4(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       cloudflare: 4.5.0
       enquirer: 2.4.1
       glob: 12.0.0
@@ -21574,6 +21609,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/papaparse@5.5.2':
+    dependencies:
+      '@types/node': 22.19.3
+
   '@types/parse-json@4.0.2': {}
 
   '@types/prismjs@1.26.5': {}
@@ -21882,6 +21921,8 @@ snapshots:
 
   address@1.2.2: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -22041,80 +22082,6 @@ snapshots:
       '@cloudflare/vite-plugin': 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
       '@opennextjs/cloudflare': 1.14.3(next@15.5.7(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0)
       stripe: 17.7.0
-      vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - '@aws-sdk/client-rds-data'
-      - '@electric-sql/pglite'
-      - '@libsql/client-wasm'
-      - '@neondatabase/serverless'
-      - '@op-engineering/op-sqlite'
-      - '@opentelemetry/api'
-      - '@planetscale/database'
-      - '@prisma/client'
-      - '@tidbcloud/serverless'
-      - '@types/better-sqlite3'
-      - '@types/pg'
-      - '@types/sql.js'
-      - '@upstash/redis'
-      - '@vercel/postgres'
-      - '@xata.io/client'
-      - aws-crt
-      - better-sqlite3
-      - bufferutil
-      - bun-types
-      - expo-sqlite
-      - gel
-      - knex
-      - kysely
-      - mysql2
-      - pg
-      - postgres
-      - prisma
-      - sql.js
-      - sqlite3
-      - utf-8-validate
-      - workerd
-
-  alchemy@0.82.2(@aws-sdk/client-dynamodb@3.808.0)(@aws-sdk/client-lambda@3.808.0)(@aws-sdk/client-s3@3.808.0)(@aws-sdk/client-sqs@3.808.0)(@aws-sdk/client-sts@3.398.0)(@cloudflare/vite-plugin@1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opennextjs/cloudflare@1.14.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)))(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0)):
-    dependencies:
-      '@aws-sdk/credential-providers': 3.958.0
-      '@cloudflare/unenv-preset': 2.7.7(unenv@2.0.0-rc.21)(workerd@1.20251217.0)
-      '@cloudflare/workers-types': 4.20251205.0
-      '@iarna/toml': 2.2.5
-      '@octokit/rest': 21.1.1
-      '@smithy/node-config-provider': 4.3.7
-      '@smithy/types': 4.11.0
-      aws4fetch: 1.0.20
-      drizzle-orm: 0.45.1(@cloudflare/workers-types@4.20251205.0)(@opentelemetry/api@1.9.0)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(gel@2.0.1)(mysql2@3.16.2)
-      env-paths: 3.0.0
-      esbuild: 0.25.10
-      execa: 9.6.1
-      fast-json-patch: 3.1.1
-      fast-xml-parser: 5.3.3
-      find-process: 2.0.0
-      glob: 10.5.0
-      jszip: 3.10.1
-      libsodium-wrappers: 0.7.15
-      miniflare: 4.20251217.0
-      neverthrow: 8.2.0
-      open: 10.2.0
-      openapi-types: 12.1.3
-      pathe: 2.0.3
-      picocolors: 1.1.1
-      proper-lockfile: 4.1.2
-      signal-exit: 4.1.0
-      unenv: 2.0.0-rc.21
-      wrangler: 4.56.0(@cloudflare/workers-types@4.20251205.0)
-      ws: 8.18.3
-      yaml: 2.8.2
-    optionalDependencies:
-      '@aws-sdk/client-dynamodb': 3.808.0
-      '@aws-sdk/client-lambda': 3.808.0
-      '@aws-sdk/client-s3': 3.808.0
-      '@aws-sdk/client-sqs': 3.808.0
-      '@aws-sdk/client-sts': 3.398.0
-      '@cloudflare/vite-plugin': 1.19.0(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2))(workerd@1.20251217.0)(wrangler@4.56.0)
-      '@opennextjs/cloudflare': 1.14.3(next@15.5.7(@opentelemetry/api@1.9.0)(@playwright/test@1.60.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(wrangler@4.56.0(@cloudflare/workers-types@4.20251205.0))
       vite: 7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.44.1)(tsx@4.20.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@aws-sdk/client-rds-data'
@@ -22630,6 +22597,11 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@5.2.0:
     dependencies:
       assertion-error: 2.0.1
@@ -22765,6 +22737,8 @@ snapshots:
     optional: true
 
   clsx@2.1.1: {}
+
+  codepage@1.15.0: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -22919,6 +22893,8 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.6.3
+
+  crc-32@1.2.2: {}
 
   cron-schedule@6.0.0: {}
 
@@ -24027,6 +24003,8 @@ snapshots:
     optional: true
 
   forwarded@0.2.0: {}
+
+  frac@1.1.2: {}
 
   fraction.js@5.3.4: {}
 
@@ -26026,6 +26004,8 @@ snapshots:
 
   pako@1.0.11: {}
 
+  papaparse@5.5.3: {}
+
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -27633,6 +27613,10 @@ snapshots:
 
   srvx@0.9.8: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stackback@0.0.2: {}
 
   stacktracey@2.1.8:
@@ -28588,6 +28572,10 @@ snapshots:
 
   wildcard@2.0.1: {}
 
+  wmf@1.0.2: {}
+
+  word@0.3.0: {}
+
   workerd@1.20250508.0:
     optionalDependencies:
       '@cloudflare/workerd-darwin-64': 1.20250508.0
@@ -28690,6 +28678,16 @@ snapshots:
       is-wsl: 3.1.0
 
   xdg-basedir@5.1.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-js@1.6.11:
     dependencies:


### PR DESCRIPTION
## Summary

Drag a roster onto any organizer **Volunteers** / **Judges** page. An agent reads the file, matches it against existing volunteers, drafts proposed invitations, and **writes nothing until the organizer confirms once**. PII stays server-side; source files are stored privately.

Clones the AI Judge Scheduler's blessed pattern: *model proposes → server validates → organizer confirms*.

## What's included

**Data model & infra**
- `agent_import_runs` table (audit / retention / idempotency / Undo anchor) + `AI_FILE_IMPORT` feature flag
- `OrganizerFileImportAgent` Durable Object — namespace + binding in `alchemy.run.ts`, WS routing + class re-export in `server.ts`, `Env` augmentation in `env.d.ts`

**Private upload** — `/api/agent-import/upload` stores the file under an unguessable R2 key (`agent-imports/{competitionId}/{importRunId}/{file}`), computes a sha-256 checksum, and returns **no public URL**.

**Agent** — proposal-only tools (`get_page_context`, `get_import_table`, `propose_volunteer`, `revoke_proposal`, `ask_clarification`, `mark_complete`), a `refine(instruction)` loop, and intent disambiguation. Duplicate detection runs **deterministically server-side** (`classifyVolunteer`) so existing-volunteer emails never reach the model.

**Confirm / Undo** — `applyOrganizerImportFn` is the only write path: re-validates each proposal, invites via the existing `inviteUserToTeam` helper (sends invite emails on confirm), and records created entities for the receipt + `undoImportFn`.

**UI** — `ImportShell` mounted once in the organizer layout: full-page drop overlay + persistent click-to-upload dock (gated to volunteers/judges via `usePageIntent`). `ImportReviewDrawer` renders the proposals *as the preview* with per-row exclude, refine-by-prompt, a single confirm, and a receipt with Undo.

## The 4-layer entitlement contract

Re-checked at the page loader, the write server fn, the agent WS route, and the agent `@callable()` entrypoint (`requireFileImportAgentAccess`), all gated by `AI_FILE_IMPORT`.

## Tests & checks
- `parse` + `validate` unit tests — **18 passing**
- `pnpm type-check` clean (0 errors), Biome clean
- `lat.md` updated (architecture + organizer-dashboard); `lat check` passes

## Before enabling
- [ ] `pnpm db:push` to apply the new `agent_import_runs` table to the dev branch
- [ ] Seed the `AI_FILE_IMPORT` feature and grant it to the target team(s)
- [ ] `pnpm alchemy:dev` to deploy the new DO binding locally

## Follow-ups (intentionally out of scope)
- Events / event-detail import + inline-diff surface (schemas are forward-compatible)
- XLSX parsing verified under Workers + a binary fixture test
- Full-screen review variant; hard-private bucket / signed reads for source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds drag-and-drop roster import to organizer Volunteers and Judges. Files parse server-side, match existing volunteers, stream proposals for review, and only apply after a single confirm; uploads are private.

- **New Features**
  - Private upload at /api/agent-import/upload to R2 with checksum, 15MB cap, and type whitelist.
  - Session-scoped agent per drop with isolated runs and clean reconnects.
  - Server-side parsing for CSV/TSV/XLSX/TXT/MD with deterministic dedupe; the model only sees bounded tables and existing-volunteer emails never leave the server.
  - Review drawer: per-row exclude, optional refine instruction, single confirm, and Undo.
  - Single apply path re-validates, sends invites, and records created entities for audit/Undo.
  - New `agent_import_runs` table and `AI_FILE_IMPORT` flag with four-layer access checks; import surface is mounted once in the organizer layout and only shown on Volunteers/Judges routes.

- **Bug Fixes**
  - Preserve clarification/refine notes across reconnects and refine cycles in the review drawer.

<sup>Written for commit bc9166b885ad10eae3bb3599f87f11a9bc6cefe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-assisted organizer file-drop import for volunteer/judge management on the volunteers pages. Drag-and-drop or choose CSV/TSV/XLSX to parse rows, review AI-drafted proposals, optionally refine, confirm to apply invitations, and undo if needed.
  * Added an upload workflow and import-run tracking to support the end-to-end review/apply experience (including progress, thinking notes, and parse warnings).

* **Chores**
  * Added spreadsheet/CSV parsing libraries.

* **Tests**
  * Added unit tests for the import file parsers and volunteer classification logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->