### PR TITLE
feat(crew): add event setup and concierge dashboard

### DIFF
--- a/apps/crew/src/lib/crew-event-display.ts
+++ b/apps/crew/src/lib/crew-event-display.ts
@@ -1,0 +1,18 @@
+// @lat: [[crew#Event Setup Dashboard]]
+export function formatCrewValue(value: string) {
+  return value.replaceAll("_", " ")
+}
+
+// @lat: [[crew#Event Setup Dashboard]]
+export function getSafeHttpUrl(value: string | null | undefined) {
+  if (!value) return null
+
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : null
+  } catch {
+    return null
+  }
+}

--- a/apps/crew/src/lib/crew-event-setup.ts
+++ b/apps/crew/src/lib/crew-event-setup.ts
@@ -81,8 +81,7 @@ export function parseCrewSettings(
         staffingLead: readText(parsedSetup.staffingLead),
         checklist: readChecklist(parsedSetup.checklist),
         internalNotes: readText(parsedSetup.internalNotes),
-        assumptions:
-          readText(parsedSetup.assumptions) || readRootAssumptions(parsed),
+        assumptions: readSetupAssumptions(parsedSetup, parsed),
       },
       baseSettings: parsed,
       parseError: null,
@@ -150,6 +149,17 @@ function readRootAssumptions(settings: Record<string, unknown>) {
   }
 
   return ""
+}
+
+function readSetupAssumptions(
+  setup: Record<string, unknown>,
+  rootSettings: Record<string, unknown>,
+) {
+  if (Object.hasOwn(setup, "assumptions")) {
+    return readText(setup.assumptions)
+  }
+
+  return readRootAssumptions(rootSettings)
 }
 
 function readText(value: unknown) {

--- a/apps/crew/src/lib/crew-event-setup.ts
+++ b/apps/crew/src/lib/crew-event-setup.ts
@@ -1,0 +1,161 @@
+export type CrewSetupChecklistKey =
+  | "eventBasicsConfirmed"
+  | "sourceAccessConfirmed"
+  | "volunteerNeedsDrafted"
+  | "staffingPlanDrafted"
+  | "operatorHandoffReady"
+
+export interface CrewSetupState {
+  desiredGoLiveDate: string
+  sourceContactName: string
+  sourceContactEmail: string
+  volunteerTarget: string
+  staffingLead: string
+  checklist: Record<CrewSetupChecklistKey, boolean>
+  internalNotes: string
+  assumptions: string
+}
+
+export interface ParsedCrewSettings {
+  setup: CrewSetupState
+  baseSettings: Record<string, unknown>
+  parseError: string | null
+}
+
+export const crewSetupChecklistItems: Array<{
+  key: CrewSetupChecklistKey
+  label: string
+}> = [
+  { key: "eventBasicsConfirmed", label: "Event basics confirmed" },
+  { key: "sourceAccessConfirmed", label: "Source access confirmed" },
+  { key: "volunteerNeedsDrafted", label: "Volunteer needs drafted" },
+  { key: "staffingPlanDrafted", label: "Staffing plan drafted" },
+  { key: "operatorHandoffReady", label: "Operator handoff ready" },
+]
+
+const defaultChecklist = {} as Record<CrewSetupChecklistKey, boolean>
+for (const item of crewSetupChecklistItems) {
+  defaultChecklist[item.key] = false
+}
+
+export function createDefaultCrewSetupState(): CrewSetupState {
+  return {
+    desiredGoLiveDate: "",
+    sourceContactName: "",
+    sourceContactEmail: "",
+    volunteerTarget: "",
+    staffingLead: "",
+    checklist: { ...defaultChecklist },
+    internalNotes: "",
+    assumptions: "",
+  }
+}
+
+export function parseCrewSettings(
+  settingsText: string | null,
+): ParsedCrewSettings {
+  const setup = createDefaultCrewSetupState()
+
+  if (!settingsText?.trim()) {
+    return { setup, baseSettings: {}, parseError: null }
+  }
+
+  try {
+    const parsed = JSON.parse(settingsText) as unknown
+    if (!isPlainObject(parsed)) {
+      return {
+        setup,
+        baseSettings: { legacySettings: parsed },
+        parseError: null,
+      }
+    }
+
+    const parsedSetup = isPlainObject(parsed.setup) ? parsed.setup : {}
+
+    return {
+      setup: {
+        desiredGoLiveDate: readText(parsedSetup.desiredGoLiveDate),
+        sourceContactName: readText(parsedSetup.sourceContactName),
+        sourceContactEmail: readText(parsedSetup.sourceContactEmail),
+        volunteerTarget: readText(parsedSetup.volunteerTarget),
+        staffingLead: readText(parsedSetup.staffingLead),
+        checklist: readChecklist(parsedSetup.checklist),
+        internalNotes: readText(parsedSetup.internalNotes),
+        assumptions:
+          readText(parsedSetup.assumptions) || readRootAssumptions(parsed),
+      },
+      baseSettings: parsed,
+      parseError: null,
+    }
+  } catch (error) {
+    return {
+      setup,
+      baseSettings: { legacySettingsText: settingsText },
+      parseError:
+        error instanceof Error
+          ? error.message
+          : "Could not parse settings JSON",
+    }
+  }
+}
+
+export function serializeCrewSettings(
+  settingsText: string | null,
+  setup: CrewSetupState,
+) {
+  const parsed = parseCrewSettings(settingsText)
+
+  return JSON.stringify(
+    {
+      ...parsed.baseSettings,
+      setup,
+    },
+    null,
+    2,
+  )
+}
+
+export function calculateSetupProgress(setup: CrewSetupState) {
+  const completed = crewSetupChecklistItems.filter(
+    (item) => setup.checklist[item.key],
+  ).length
+
+  return {
+    completed,
+    total: crewSetupChecklistItems.length,
+    percent: Math.round((completed / crewSetupChecklistItems.length) * 100),
+  }
+}
+
+function readChecklist(value: unknown): Record<CrewSetupChecklistKey, boolean> {
+  if (!isPlainObject(value)) return { ...defaultChecklist }
+
+  const checklist = {} as Record<CrewSetupChecklistKey, boolean>
+  for (const item of crewSetupChecklistItems) {
+    checklist[item.key] = value[item.key] === true
+  }
+
+  return checklist
+}
+
+function readRootAssumptions(settings: Record<string, unknown>) {
+  if (typeof settings.assumptions === "string") return settings.assumptions
+
+  if (Array.isArray(settings.assumptions)) {
+    return settings.assumptions
+      .filter(
+        (assumption): assumption is string => typeof assumption === "string",
+      )
+      .join("\n")
+  }
+
+  return ""
+}
+
+function readText(value: unknown) {
+  return typeof value === "string" ? value : ""
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as EventsNewRouteImport } from './routes/events/new'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
 import { Route as EventsEventIdIndexRouteImport } from './routes/events/$eventId/index'
 import { Route as EventsEventIdVolunteersRouteImport } from './routes/events/$eventId/volunteers'
+import { Route as EventsEventIdSetupRouteImport } from './routes/events/$eventId/setup'
 import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$eventId/schedule'
 
 const EventsRoute = EventsRouteImport.update({
@@ -47,6 +48,11 @@ const EventsEventIdVolunteersRoute = EventsEventIdVolunteersRouteImport.update({
   path: '/volunteers',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdSetupRoute = EventsEventIdSetupRouteImport.update({
+  id: '/setup',
+  path: '/setup',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const EventsEventIdScheduleRoute = EventsEventIdScheduleRouteImport.update({
   id: '/schedule',
   path: '/schedule',
@@ -59,6 +65,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
+  '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
 }
@@ -67,6 +74,7 @@ export interface FileRoutesByTo {
   '/events': typeof EventsRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
+  '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId': typeof EventsEventIdIndexRoute
 }
@@ -77,6 +85,7 @@ export interface FileRoutesById {
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
+  '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
 }
@@ -88,6 +97,7 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/events/new'
     | '/events/$eventId/schedule'
+    | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
   fileRoutesByTo: FileRoutesByTo
@@ -96,6 +106,7 @@ export interface FileRouteTypes {
     | '/events'
     | '/events/new'
     | '/events/$eventId/schedule'
+    | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
     | '/events/$eventId'
   id:
@@ -105,6 +116,7 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/events/new'
     | '/events/$eventId/schedule'
+    | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
   fileRoutesById: FileRoutesById
@@ -158,6 +170,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdVolunteersRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/setup': {
+      id: '/events/$eventId/setup'
+      path: '/setup'
+      fullPath: '/events/$eventId/setup'
+      preLoaderRoute: typeof EventsEventIdSetupRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/events/$eventId/schedule': {
       id: '/events/$eventId/schedule'
       path: '/schedule'
@@ -170,12 +189,14 @@ declare module '@tanstack/react-router' {
 
 interface EventsEventIdRouteChildren {
   EventsEventIdScheduleRoute: typeof EventsEventIdScheduleRoute
+  EventsEventIdSetupRoute: typeof EventsEventIdSetupRoute
   EventsEventIdVolunteersRoute: typeof EventsEventIdVolunteersRoute
   EventsEventIdIndexRoute: typeof EventsEventIdIndexRoute
 }
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdScheduleRoute: EventsEventIdScheduleRoute,
+  EventsEventIdSetupRoute: EventsEventIdSetupRoute,
   EventsEventIdVolunteersRoute: EventsEventIdVolunteersRoute,
   EventsEventIdIndexRoute: EventsEventIdIndexRoute,
 }

--- a/apps/crew/src/routes/events.tsx
+++ b/apps/crew/src/routes/events.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
+import { formatCrewValue } from "@/lib/crew-event-display"
 import {
   calculateSetupProgress,
   parseCrewSettings,
@@ -40,6 +41,7 @@ function EventsPage() {
         </section>
       ) : (
         <div className="grid gap-4 md:grid-cols-2">
+          {/* @lat: [[crew#Event Setup Dashboard]] */}
           {events.map((event) => {
             const setupProgress = calculateSetupProgress(
               parseCrewSettings(event.settings.settings).setup,
@@ -63,20 +65,20 @@ function EventsPage() {
                     </p>
                   </div>
                   <span className="rounded-md bg-muted px-2 py-1 text-xs font-medium">
-                    {formatValue(event.settings.lifecycle)}
+                    {formatCrewValue(event.settings.lifecycle)}
                   </span>
                 </div>
                 <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-3">
                   <div>
                     <dt className="text-muted-foreground">Plan</dt>
                     <dd className="font-medium">
-                      {formatValue(event.settings.crewPlan)}
+                      {formatCrewValue(event.settings.crewPlan)}
                     </dd>
                   </div>
                   <div>
                     <dt className="text-muted-foreground">Concierge</dt>
                     <dd className="font-medium">
-                      {formatValue(event.settings.conciergeStatus)}
+                      {formatCrewValue(event.settings.conciergeStatus)}
                     </dd>
                   </div>
                   <div>
@@ -112,11 +114,12 @@ function EventsPage() {
   )
 }
 
-function formatValue(value: string) {
-  return value.replaceAll("_", " ")
+interface ProgressBarProps {
+  value: number
 }
 
-function ProgressBar({ value }: { value: number }) {
+// @lat: [[crew#Event Setup Dashboard]]
+function ProgressBar({ value }: ProgressBarProps) {
   return (
     <div className="h-2 overflow-hidden rounded-full bg-muted">
       <div

--- a/apps/crew/src/routes/events.tsx
+++ b/apps/crew/src/routes/events.tsx
@@ -1,4 +1,8 @@
 import { createFileRoute, Link } from "@tanstack/react-router"
+import {
+  calculateSetupProgress,
+  parseCrewSettings,
+} from "@/lib/crew-event-setup"
 import { listCrewEventsFn } from "@/server-fns/crew-event-settings-fns"
 
 export const Route = createFileRoute("/events")({
@@ -36,40 +40,66 @@ function EventsPage() {
         </section>
       ) : (
         <div className="grid gap-4 md:grid-cols-2">
-          {events.map((event) => (
-            <Link
-              key={event.settings.id}
-              to="/events/$eventId"
-              params={{ eventId: event.competition.id }}
-              className="rounded-md border bg-card p-5 shadow-sm transition-colors hover:bg-muted/50"
-            >
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <h2 className="text-lg font-semibold">
-                    {event.competition.name}
-                  </h2>
-                  <p className="text-sm text-muted-foreground">
-                    {event.competition.startDate} to {event.competition.endDate}
-                  </p>
+          {events.map((event) => {
+            const setupProgress = calculateSetupProgress(
+              parseCrewSettings(event.settings.settings).setup,
+            )
+
+            return (
+              <Link
+                key={event.settings.id}
+                to="/events/$eventId"
+                params={{ eventId: event.competition.id }}
+                className="rounded-md border bg-card p-5 shadow-sm transition-colors hover:bg-muted/50"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h2 className="text-lg font-semibold">
+                      {event.competition.name}
+                    </h2>
+                    <p className="text-sm text-muted-foreground">
+                      {event.competition.startDate} to{" "}
+                      {event.competition.endDate}
+                    </p>
+                  </div>
+                  <span className="rounded-md bg-muted px-2 py-1 text-xs font-medium">
+                    {formatValue(event.settings.lifecycle)}
+                  </span>
                 </div>
-                <span className="rounded-md bg-muted px-2 py-1 text-xs font-medium">
-                  {event.settings.lifecycle}
-                </span>
-              </div>
-              <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
-                <div>
-                  <dt className="text-muted-foreground">Plan</dt>
-                  <dd className="font-medium">{event.settings.crewPlan}</dd>
+                <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-3">
+                  <div>
+                    <dt className="text-muted-foreground">Plan</dt>
+                    <dd className="font-medium">
+                      {formatValue(event.settings.crewPlan)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Concierge</dt>
+                    <dd className="font-medium">
+                      {formatValue(event.settings.conciergeStatus)}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-muted-foreground">Source</dt>
+                    <dd className="font-medium">
+                      {event.settings.sourcePlatform ?? "Not set"}
+                    </dd>
+                  </div>
+                </dl>
+                <div className="mt-4 space-y-2">
+                  <div className="flex items-center justify-between gap-4 text-sm">
+                    <span className="text-muted-foreground">
+                      Setup progress
+                    </span>
+                    <span className="font-medium">
+                      {setupProgress.percent}%
+                    </span>
+                  </div>
+                  <ProgressBar value={setupProgress.percent} />
                 </div>
-                <div>
-                  <dt className="text-muted-foreground">Source</dt>
-                  <dd className="font-medium">
-                    {event.settings.sourcePlatform ?? "Not set"}
-                  </dd>
-                </div>
-              </dl>
-            </Link>
-          ))}
+              </Link>
+            )
+          })}
         </div>
       )}
 
@@ -79,5 +109,20 @@ function EventsPage() {
         model.
       </section>
     </main>
+  )
+}
+
+function formatValue(value: string) {
+  return value.replaceAll("_", " ")
+}
+
+function ProgressBar({ value }: { value: number }) {
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${value}%` }}
+      />
+    </div>
   )
 }

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -37,6 +37,14 @@ function EventShell() {
             Overview
           </Link>
           <Link
+            to="/events/$eventId/setup"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Setup
+          </Link>
+          <Link
             to="/events/$eventId/volunteers"
             params={{ eventId }}
             activeProps={{ className: "bg-muted text-foreground" }}

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import { formatCrewValue, getSafeHttpUrl } from "@/lib/crew-event-display"
 import {
   calculateSetupProgress,
   crewSetupChecklistItems,
@@ -22,15 +23,15 @@ function EventOverviewPage() {
       <div className="grid gap-4 md:grid-cols-4">
         <StatusPanel
           label="Lifecycle"
-          value={formatValue(event.settings.lifecycle)}
+          value={formatCrewValue(event.settings.lifecycle)}
         />
         <StatusPanel
           label="Concierge"
-          value={formatValue(event.settings.conciergeStatus)}
+          value={formatCrewValue(event.settings.conciergeStatus)}
         />
         <StatusPanel
           label="Plan"
-          value={formatValue(event.settings.crewPlan)}
+          value={formatCrewValue(event.settings.crewPlan)}
         />
         <StatusPanel
           label="Setup"
@@ -183,7 +184,12 @@ function EventOverviewPage() {
   )
 }
 
-function StatusPanel({ label, value }: { label: string; value: string }) {
+interface StatusPanelProps {
+  label: string
+  value: string
+}
+
+function StatusPanel({ label, value }: StatusPanelProps) {
   return (
     <section className="rounded-md border bg-card p-4 shadow-sm">
       <p className="text-sm text-muted-foreground">{label}</p>
@@ -192,26 +198,24 @@ function StatusPanel({ label, value }: { label: string; value: string }) {
   )
 }
 
-function Fact({
-  label,
-  value,
-  link,
-  mono = false,
-}: {
+interface FactProps {
   label: string
   value: string
   link?: string | null
   mono?: boolean
-}) {
+}
+
+function Fact({ label, value, link, mono = false }: FactProps) {
   const className = mono ? "break-all font-mono" : "break-words font-medium"
+  const safeLink = getSafeHttpUrl(link)
 
   return (
     <div>
       <dt className="text-muted-foreground">{label}</dt>
       <dd className={className}>
-        {link ? (
+        {safeLink ? (
           <a
-            href={link}
+            href={safeLink}
             target="_blank"
             rel="noreferrer"
             className="text-primary underline-offset-4 hover:underline"
@@ -226,7 +230,12 @@ function Fact({
   )
 }
 
-function NoteBlock({ label, value }: { label: string; value: string }) {
+interface NoteBlockProps {
+  label: string
+  value: string
+}
+
+function NoteBlock({ label, value }: NoteBlockProps) {
   return (
     <div className="rounded-md border bg-background p-3">
       <h3 className="font-medium">{label}</h3>
@@ -235,11 +244,11 @@ function NoteBlock({ label, value }: { label: string; value: string }) {
   )
 }
 
-function formatValue(value: string) {
-  return value.replaceAll("_", " ")
+interface ProgressBarProps {
+  value: number
 }
 
-function ProgressBar({ value }: { value: number }) {
+function ProgressBar({ value }: ProgressBarProps) {
   return (
     <div className="h-2 overflow-hidden rounded-full bg-muted">
       <div

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -1,8 +1,9 @@
-import type { FormEvent, ReactNode } from "react"
-import { useEffect, useState } from "react"
-import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
-import { toast } from "sonner"
-import { updateCrewEventSettingsFn } from "@/server-fns/crew-event-settings-fns"
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import {
+  calculateSetupProgress,
+  crewSetupChecklistItems,
+  parseCrewSettings,
+} from "@/lib/crew-event-setup"
 
 export const Route = createFileRoute("/events/$eventId/")({
   component: EventOverviewPage,
@@ -11,311 +12,240 @@ export const Route = createFileRoute("/events/$eventId/")({
 const parentRoute = getRouteApi("/events/$eventId")
 
 function EventOverviewPage() {
-  const router = useRouter()
+  const { eventId } = parentRoute.useParams()
   const { event } = parentRoute.useLoaderData()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [crewOnly, setCrewOnly] = useState(event.settings.crewOnly)
-  const [sourcePlatform, setSourcePlatform] = useState(
-    event.settings.sourcePlatform ?? "",
-  )
-  const [sourceEventUrl, setSourceEventUrl] = useState(
-    event.settings.sourceEventUrl ?? "",
-  )
-  const [externalRegistrationUrl, setExternalRegistrationUrl] = useState(
-    event.settings.externalRegistrationUrl ?? "",
-  )
-  const [lifecycle, setLifecycle] = useState(event.settings.lifecycle)
-  const [conciergeStatus, setConciergeStatus] = useState(
-    event.settings.conciergeStatus,
-  )
-  const [crewPlan, setCrewPlan] = useState(event.settings.crewPlan)
-  const [fullPlatformCreditCents, setFullPlatformCreditCents] = useState(
-    String(event.settings.fullPlatformCreditCents),
-  )
-  const [acquisitionSource, setAcquisitionSource] = useState(
-    event.settings.acquisitionSource ?? "",
-  )
-  const [settings, setSettings] = useState(event.settings.settings ?? "")
-
-  useEffect(() => {
-    setCrewOnly(event.settings.crewOnly)
-    setSourcePlatform(event.settings.sourcePlatform ?? "")
-    setSourceEventUrl(event.settings.sourceEventUrl ?? "")
-    setExternalRegistrationUrl(event.settings.externalRegistrationUrl ?? "")
-    setLifecycle(event.settings.lifecycle)
-    setConciergeStatus(event.settings.conciergeStatus)
-    setCrewPlan(event.settings.crewPlan)
-    setFullPlatformCreditCents(String(event.settings.fullPlatformCreditCents))
-    setAcquisitionSource(event.settings.acquisitionSource ?? "")
-    setSettings(event.settings.settings ?? "")
-  }, [event])
-
-  async function handleSubmit(submitEvent: FormEvent<HTMLFormElement>) {
-    submitEvent.preventDefault()
-    setIsSubmitting(true)
-
-    try {
-      await updateCrewEventSettingsFn({
-        data: {
-          competitionId: event.competition.id,
-          crewOnly,
-          sourcePlatform,
-          sourceEventUrl,
-          externalRegistrationUrl,
-          lifecycle,
-          conciergeStatus,
-          crewPlan,
-          fullPlatformCreditCents: Number(fullPlatformCreditCents || 0),
-          acquisitionSource,
-          settings,
-        },
-      })
-
-      toast.success("Crew settings saved")
-      await router.invalidate()
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to save settings",
-      )
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
+  const parsedSettings = parseCrewSettings(event.settings.settings)
+  const setupProgress = calculateSetupProgress(parsedSettings.setup)
 
   return (
-    <section className="grid gap-6 lg:grid-cols-[1fr_18rem]">
-      <form
-        onSubmit={handleSubmit}
-        className="rounded-md border bg-card p-5 shadow-sm"
-      >
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">Crew settings</h2>
-            <p className="text-sm text-muted-foreground">
-              One Crew settings row attached to this competition.
+    <section className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <StatusPanel
+          label="Lifecycle"
+          value={formatValue(event.settings.lifecycle)}
+        />
+        <StatusPanel
+          label="Concierge"
+          value={formatValue(event.settings.conciergeStatus)}
+        />
+        <StatusPanel
+          label="Plan"
+          value={formatValue(event.settings.crewPlan)}
+        />
+        <StatusPanel
+          label="Setup"
+          value={`${setupProgress.completed}/${setupProgress.total}`}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">Concierge dashboard</h2>
+              <p className="text-sm text-muted-foreground">
+                Operator view for source data, setup progress, and handoff
+                notes.
+              </p>
+            </div>
+            <Link
+              to="/events/$eventId/setup"
+              params={{ eventId }}
+              className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Edit setup
+            </Link>
+          </div>
+
+          <div className="mt-6 space-y-3">
+            <div className="flex items-center justify-between gap-4 text-sm">
+              <span className="font-medium">Setup progress</span>
+              <span className="text-muted-foreground">
+                {setupProgress.percent}%
+              </span>
+            </div>
+            <ProgressBar value={setupProgress.percent} />
+          </div>
+
+          <div className="mt-6 grid gap-4 sm:grid-cols-2">
+            {crewSetupChecklistItems.map((item) => (
+              <div
+                key={item.key}
+                className="flex items-center gap-3 rounded-md border bg-background px-3 py-2 text-sm"
+              >
+                <span
+                  className={
+                    parsedSettings.setup.checklist[item.key]
+                      ? "size-2 rounded-full bg-emerald-500"
+                      : "size-2 rounded-full bg-muted-foreground/35"
+                  }
+                />
+                <span>{item.label}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <aside className="rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+            Competition
+          </h2>
+          <dl className="mt-4 space-y-4 text-sm">
+            <Fact label="ID" value={event.competition.id} mono />
+            <Fact label="Slug" value={event.competition.slug} />
+            <Fact
+              label="Team"
+              value={event.competition.organizingTeamId}
+              mono
+            />
+            <Fact label="Status" value={event.competition.status} />
+          </dl>
+        </aside>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-xl font-semibold">Source</h2>
+          <dl className="mt-4 grid gap-4 text-sm">
+            <Fact
+              label="Platform"
+              value={event.settings.sourcePlatform ?? "Not set"}
+            />
+            <Fact
+              label="Source event URL"
+              value={event.settings.sourceEventUrl ?? "Not set"}
+              link={event.settings.sourceEventUrl}
+            />
+            <Fact
+              label="External registration URL"
+              value={event.settings.externalRegistrationUrl ?? "Not set"}
+              link={event.settings.externalRegistrationUrl}
+            />
+            <Fact
+              label="Acquisition source"
+              value={event.settings.acquisitionSource ?? "Not set"}
+            />
+          </dl>
+        </section>
+
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-xl font-semibold">Operator notes</h2>
+          <dl className="mt-4 grid gap-4 text-sm">
+            <Fact
+              label="Desired go-live date"
+              value={parsedSettings.setup.desiredGoLiveDate || "Not set"}
+            />
+            <Fact
+              label="Staffing lead"
+              value={parsedSettings.setup.staffingLead || "Not set"}
+            />
+            <Fact
+              label="Volunteer target"
+              value={parsedSettings.setup.volunteerTarget || "Not set"}
+            />
+            <Fact
+              label="Source contact"
+              value={
+                [
+                  parsedSettings.setup.sourceContactName,
+                  parsedSettings.setup.sourceContactEmail,
+                ]
+                  .filter(Boolean)
+                  .join(" | ") || "Not set"
+              }
+            />
+          </dl>
+          {parsedSettings.parseError ? (
+            <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              Settings JSON could not be parsed. Saving setup will preserve the
+              previous text under legacySettingsText.
             </p>
-          </div>
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={crewOnly}
-              onChange={(changeEvent) =>
-                setCrewOnly(changeEvent.target.checked)
-              }
-              className="size-4"
-            />
-            Crew-only
-          </label>
+          ) : null}
+        </section>
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h2 className="text-xl font-semibold">Internal notes</h2>
+        <div className="mt-4 grid gap-4 text-sm lg:grid-cols-2">
+          <NoteBlock
+            label="Assumptions"
+            value={
+              parsedSettings.setup.assumptions || "No assumptions recorded."
+            }
+          />
+          <NoteBlock
+            label="Notes"
+            value={parsedSettings.setup.internalNotes || "No notes recorded."}
+          />
         </div>
-
-        <div className="mt-5 grid gap-4 sm:grid-cols-2">
-          <Field label="Lifecycle" htmlFor="crew-settings-lifecycle">
-            <select
-              id="crew-settings-lifecycle"
-              value={lifecycle}
-              onChange={(changeEvent) =>
-                setLifecycle(
-                  changeEvent.target.value as
-                    | "draft"
-                    | "setup"
-                    | "importing"
-                    | "ready"
-                    | "archived",
-                )
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            >
-              <option value="draft">Draft</option>
-              <option value="setup">Setup</option>
-              <option value="importing">Importing</option>
-              <option value="ready">Ready</option>
-              <option value="archived">Archived</option>
-            </select>
-          </Field>
-          <Field
-            label="Concierge status"
-            htmlFor="crew-settings-concierge-status"
-          >
-            <select
-              id="crew-settings-concierge-status"
-              value={conciergeStatus}
-              onChange={(changeEvent) =>
-                setConciergeStatus(
-                  changeEvent.target.value as
-                    | "not_started"
-                    | "in_progress"
-                    | "ready"
-                    | "blocked",
-                )
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            >
-              <option value="not_started">Not started</option>
-              <option value="in_progress">In progress</option>
-              <option value="ready">Ready</option>
-              <option value="blocked">Blocked</option>
-            </select>
-          </Field>
-          <Field label="Crew plan" htmlFor="crew-settings-plan">
-            <select
-              id="crew-settings-plan"
-              value={crewPlan}
-              onChange={(changeEvent) =>
-                setCrewPlan(
-                  changeEvent.target.value as
-                    | "self_serve"
-                    | "concierge"
-                    | "full_platform",
-                )
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            >
-              <option value="self_serve">Self serve</option>
-              <option value="concierge">Concierge</option>
-              <option value="full_platform">Full platform</option>
-            </select>
-          </Field>
-          <Field
-            label="Full platform credit cents"
-            htmlFor="crew-settings-credit-cents"
-          >
-            <input
-              id="crew-settings-credit-cents"
-              type="number"
-              min="0"
-              value={fullPlatformCreditCents}
-              onChange={(changeEvent) =>
-                setFullPlatformCreditCents(changeEvent.target.value)
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            />
-          </Field>
-          <Field
-            label="Source platform"
-            htmlFor="crew-settings-source-platform"
-          >
-            <input
-              id="crew-settings-source-platform"
-              value={sourcePlatform}
-              onChange={(changeEvent) =>
-                setSourcePlatform(changeEvent.target.value)
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            />
-          </Field>
-          <Field
-            label="Acquisition source"
-            htmlFor="crew-settings-acquisition-source"
-          >
-            <input
-              id="crew-settings-acquisition-source"
-              value={acquisitionSource}
-              onChange={(changeEvent) =>
-                setAcquisitionSource(changeEvent.target.value)
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            />
-          </Field>
-          <Field
-            label="Source event URL"
-            htmlFor="crew-settings-source-event-url"
-            wide
-          >
-            <input
-              id="crew-settings-source-event-url"
-              value={sourceEventUrl}
-              onChange={(changeEvent) =>
-                setSourceEventUrl(changeEvent.target.value)
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            />
-          </Field>
-          <Field
-            label="External registration URL"
-            htmlFor="crew-settings-external-registration-url"
-            wide
-          >
-            <input
-              id="crew-settings-external-registration-url"
-              value={externalRegistrationUrl}
-              onChange={(changeEvent) =>
-                setExternalRegistrationUrl(changeEvent.target.value)
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            />
-          </Field>
-          <Field
-            label="Crew assumptions"
-            htmlFor="crew-settings-assumptions"
-            wide
-          >
-            <textarea
-              id="crew-settings-assumptions"
-              value={settings}
-              onChange={(changeEvent) => setSettings(changeEvent.target.value)}
-              className="min-h-36 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
-            />
-          </Field>
-        </div>
-
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="mt-5 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
-        >
-          {isSubmitting ? "Saving..." : "Save settings"}
-        </button>
-      </form>
-
-      <aside className="rounded-md border bg-card p-5 shadow-sm">
-        <h2 className="text-sm font-semibold uppercase text-muted-foreground">
-          Competition
-        </h2>
-        <dl className="mt-4 space-y-4 text-sm">
-          <div>
-            <dt className="text-muted-foreground">ID</dt>
-            <dd className="break-all font-mono">{event.competition.id}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Slug</dt>
-            <dd className="font-medium">{event.competition.slug}</dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Team</dt>
-            <dd className="break-all font-mono">
-              {event.competition.organizingTeamId}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-muted-foreground">Status</dt>
-            <dd className="font-medium">{event.competition.status}</dd>
-          </div>
-        </dl>
-      </aside>
+      </section>
     </section>
   )
 }
 
-function Field({
+function StatusPanel({ label, value }: { label: string; value: string }) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function Fact({
   label,
-  htmlFor,
-  wide = false,
-  children,
+  value,
+  link,
+  mono = false,
 }: {
   label: string
-  htmlFor: string
-  wide?: boolean
-  children: ReactNode
+  value: string
+  link?: string | null
+  mono?: boolean
 }) {
+  const className = mono ? "break-all font-mono" : "break-words font-medium"
+
   return (
-    <label
-      htmlFor={htmlFor}
-      className={wide ? "space-y-2 sm:col-span-2" : "space-y-2"}
-    >
-      <span className="text-sm font-medium" id={`${htmlFor}-label`}>
-        {label}
-      </span>
-      {children}
-    </label>
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className={className}>
+        {link ? (
+          <a
+            href={link}
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            {value}
+          </a>
+        ) : (
+          value
+        )}
+      </dd>
+    </div>
+  )
+}
+
+function NoteBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background p-3">
+      <h3 className="font-medium">{label}</h3>
+      <p className="mt-2 whitespace-pre-wrap text-muted-foreground">{value}</p>
+    </div>
+  )
+}
+
+function formatValue(value: string) {
+  return value.replaceAll("_", " ")
+}
+
+function ProgressBar({ value }: { value: number }) {
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${value}%` }}
+      />
+    </div>
   )
 }

--- a/apps/crew/src/routes/events/$eventId/setup.tsx
+++ b/apps/crew/src/routes/events/$eventId/setup.tsx
@@ -17,6 +17,7 @@ export const Route = createFileRoute("/events/$eventId/setup")({
 
 const parentRoute = getRouteApi("/events/$eventId")
 
+// @lat: [[crew#Event Setup Dashboard]]
 function EventSetupPage() {
   const router = useRouter()
   const { event } = parentRoute.useLoaderData()
@@ -430,17 +431,14 @@ function EventSetupPage() {
   )
 }
 
-function Field({
-  label,
-  htmlFor,
-  wide = false,
-  children,
-}: {
+interface FieldProps {
   label: string
   htmlFor: string
   wide?: boolean
   children: ReactNode
-}) {
+}
+
+function Field({ label, htmlFor, wide = false, children }: FieldProps) {
   return (
     <label
       htmlFor={htmlFor}

--- a/apps/crew/src/routes/events/$eventId/setup.tsx
+++ b/apps/crew/src/routes/events/$eventId/setup.tsx
@@ -1,0 +1,455 @@
+import type { FormEvent, ReactNode } from "react"
+import { useEffect, useState } from "react"
+import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
+import { Save } from "lucide-react"
+import { toast } from "sonner"
+import {
+  crewSetupChecklistItems,
+  parseCrewSettings,
+  serializeCrewSettings,
+  type CrewSetupChecklistKey,
+} from "@/lib/crew-event-setup"
+import { updateCrewEventSettingsFn } from "@/server-fns/crew-event-settings-fns"
+
+export const Route = createFileRoute("/events/$eventId/setup")({
+  component: EventSetupPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+function EventSetupPage() {
+  const router = useRouter()
+  const { event } = parentRoute.useLoaderData()
+  const parsedSettings = parseCrewSettings(event.settings.settings)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [crewOnly, setCrewOnly] = useState(event.settings.crewOnly)
+  const [sourcePlatform, setSourcePlatform] = useState(
+    event.settings.sourcePlatform ?? "",
+  )
+  const [sourceEventUrl, setSourceEventUrl] = useState(
+    event.settings.sourceEventUrl ?? "",
+  )
+  const [externalRegistrationUrl, setExternalRegistrationUrl] = useState(
+    event.settings.externalRegistrationUrl ?? "",
+  )
+  const [lifecycle, setLifecycle] = useState(event.settings.lifecycle)
+  const [conciergeStatus, setConciergeStatus] = useState(
+    event.settings.conciergeStatus,
+  )
+  const [crewPlan, setCrewPlan] = useState(event.settings.crewPlan)
+  const [fullPlatformCreditCents, setFullPlatformCreditCents] = useState(
+    String(event.settings.fullPlatformCreditCents),
+  )
+  const [acquisitionSource, setAcquisitionSource] = useState(
+    event.settings.acquisitionSource ?? "",
+  )
+  const [setup, setSetup] = useState(parsedSettings.setup)
+
+  useEffect(() => {
+    const nextSettings = parseCrewSettings(event.settings.settings)
+    setCrewOnly(event.settings.crewOnly)
+    setSourcePlatform(event.settings.sourcePlatform ?? "")
+    setSourceEventUrl(event.settings.sourceEventUrl ?? "")
+    setExternalRegistrationUrl(event.settings.externalRegistrationUrl ?? "")
+    setLifecycle(event.settings.lifecycle)
+    setConciergeStatus(event.settings.conciergeStatus)
+    setCrewPlan(event.settings.crewPlan)
+    setFullPlatformCreditCents(String(event.settings.fullPlatformCreditCents))
+    setAcquisitionSource(event.settings.acquisitionSource ?? "")
+    setSetup(nextSettings.setup)
+  }, [event])
+
+  async function handleSubmit(submitEvent: FormEvent<HTMLFormElement>) {
+    submitEvent.preventDefault()
+    setIsSubmitting(true)
+
+    try {
+      await updateCrewEventSettingsFn({
+        data: {
+          competitionId: event.competition.id,
+          crewOnly,
+          sourcePlatform,
+          sourceEventUrl,
+          externalRegistrationUrl,
+          lifecycle,
+          conciergeStatus,
+          crewPlan,
+          fullPlatformCreditCents: Number(fullPlatformCreditCents || 0),
+          acquisitionSource,
+          settings: serializeCrewSettings(event.settings.settings, setup),
+        },
+      })
+
+      toast.success("Crew setup saved")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to save setup",
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  function updateChecklist(key: CrewSetupChecklistKey, checked: boolean) {
+    setSetup((current) => ({
+      ...current,
+      checklist: {
+        ...current.checklist,
+        [key]: checked,
+      },
+    }))
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="grid gap-6 lg:grid-cols-[1fr_20rem]"
+    >
+      <section className="space-y-6">
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold">Setup</h2>
+              <p className="text-sm text-muted-foreground">
+                Manage lifecycle, concierge status, source details, and operator
+                assumptions.
+              </p>
+            </div>
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={crewOnly}
+                onChange={(changeEvent) =>
+                  setCrewOnly(changeEvent.target.checked)
+                }
+                className="size-4"
+              />
+              Crew-only
+            </label>
+          </div>
+
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <Field label="Lifecycle" htmlFor="crew-settings-lifecycle">
+              <select
+                id="crew-settings-lifecycle"
+                value={lifecycle}
+                onChange={(changeEvent) =>
+                  setLifecycle(
+                    changeEvent.target.value as
+                      | "draft"
+                      | "setup"
+                      | "importing"
+                      | "ready"
+                      | "archived",
+                  )
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                <option value="draft">Draft</option>
+                <option value="setup">Setup</option>
+                <option value="importing">Importing</option>
+                <option value="ready">Ready</option>
+                <option value="archived">Archived</option>
+              </select>
+            </Field>
+            <Field
+              label="Concierge status"
+              htmlFor="crew-settings-concierge-status"
+            >
+              <select
+                id="crew-settings-concierge-status"
+                value={conciergeStatus}
+                onChange={(changeEvent) =>
+                  setConciergeStatus(
+                    changeEvent.target.value as
+                      | "not_started"
+                      | "in_progress"
+                      | "ready"
+                      | "blocked",
+                  )
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                <option value="not_started">Not started</option>
+                <option value="in_progress">In progress</option>
+                <option value="ready">Ready</option>
+                <option value="blocked">Blocked</option>
+              </select>
+            </Field>
+            <Field label="Crew plan" htmlFor="crew-settings-plan">
+              <select
+                id="crew-settings-plan"
+                value={crewPlan}
+                onChange={(changeEvent) =>
+                  setCrewPlan(
+                    changeEvent.target.value as
+                      | "self_serve"
+                      | "concierge"
+                      | "full_platform",
+                  )
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                <option value="self_serve">Self serve</option>
+                <option value="concierge">Concierge</option>
+                <option value="full_platform">Full platform</option>
+              </select>
+            </Field>
+            <Field
+              label="Full platform credit cents"
+              htmlFor="crew-settings-credit-cents"
+            >
+              <input
+                id="crew-settings-credit-cents"
+                type="number"
+                min="0"
+                value={fullPlatformCreditCents}
+                onChange={(changeEvent) =>
+                  setFullPlatformCreditCents(changeEvent.target.value)
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+          </div>
+        </section>
+
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-xl font-semibold">Source</h2>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Source platform"
+              htmlFor="crew-settings-source-platform"
+            >
+              <input
+                id="crew-settings-source-platform"
+                value={sourcePlatform}
+                onChange={(changeEvent) =>
+                  setSourcePlatform(changeEvent.target.value)
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="Acquisition source"
+              htmlFor="crew-settings-acquisition-source"
+            >
+              <input
+                id="crew-settings-acquisition-source"
+                value={acquisitionSource}
+                onChange={(changeEvent) =>
+                  setAcquisitionSource(changeEvent.target.value)
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="Source event URL"
+              htmlFor="crew-settings-source-event-url"
+              wide
+            >
+              <input
+                id="crew-settings-source-event-url"
+                value={sourceEventUrl}
+                onChange={(changeEvent) =>
+                  setSourceEventUrl(changeEvent.target.value)
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="External registration URL"
+              htmlFor="crew-settings-external-registration-url"
+              wide
+            >
+              <input
+                id="crew-settings-external-registration-url"
+                value={externalRegistrationUrl}
+                onChange={(changeEvent) =>
+                  setExternalRegistrationUrl(changeEvent.target.value)
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+          </div>
+        </section>
+
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-xl font-semibold">Concierge notes</h2>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Desired go-live date"
+              htmlFor="crew-setup-go-live-date"
+            >
+              <input
+                id="crew-setup-go-live-date"
+                type="date"
+                value={setup.desiredGoLiveDate}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    desiredGoLiveDate: changeEvent.target.value,
+                  }))
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="Volunteer target"
+              htmlFor="crew-setup-volunteer-target"
+            >
+              <input
+                id="crew-setup-volunteer-target"
+                value={setup.volunteerTarget}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    volunteerTarget: changeEvent.target.value,
+                  }))
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field label="Staffing lead" htmlFor="crew-setup-staffing-lead">
+              <input
+                id="crew-setup-staffing-lead"
+                value={setup.staffingLead}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    staffingLead: changeEvent.target.value,
+                  }))
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="Source contact name"
+              htmlFor="crew-setup-source-contact-name"
+            >
+              <input
+                id="crew-setup-source-contact-name"
+                value={setup.sourceContactName}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    sourceContactName: changeEvent.target.value,
+                  }))
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="Source contact email"
+              htmlFor="crew-setup-source-contact-email"
+              wide
+            >
+              <input
+                id="crew-setup-source-contact-email"
+                type="email"
+                value={setup.sourceContactEmail}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    sourceContactEmail: changeEvent.target.value,
+                  }))
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field label="Assumptions" htmlFor="crew-setup-assumptions" wide>
+              <textarea
+                id="crew-setup-assumptions"
+                value={setup.assumptions}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    assumptions: changeEvent.target.value,
+                  }))
+                }
+                className="min-h-28 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              />
+            </Field>
+            <Field label="Internal notes" htmlFor="crew-setup-notes" wide>
+              <textarea
+                id="crew-setup-notes"
+                value={setup.internalNotes}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    internalNotes: changeEvent.target.value,
+                  }))
+                }
+                className="min-h-32 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              />
+            </Field>
+          </div>
+        </section>
+      </section>
+
+      <aside className="h-fit rounded-md border bg-card p-5 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+          Setup checklist
+        </h2>
+        <div className="mt-4 space-y-3">
+          {crewSetupChecklistItems.map((item) => (
+            <label
+              key={item.key}
+              className="flex items-start gap-3 rounded-md border bg-background px-3 py-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                checked={setup.checklist[item.key]}
+                onChange={(changeEvent) =>
+                  updateChecklist(item.key, changeEvent.target.checked)
+                }
+                className="mt-0.5 size-4"
+              />
+              <span>{item.label}</span>
+            </label>
+          ))}
+        </div>
+
+        {parsedSettings.parseError ? (
+          <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            Existing settings JSON is invalid. Saving will preserve the raw text
+            as legacySettingsText.
+          </p>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+        >
+          <Save className="size-4" aria-hidden="true" />
+          {isSubmitting ? "Saving..." : "Save setup"}
+        </button>
+      </aside>
+    </form>
+  )
+}
+
+function Field({
+  label,
+  htmlFor,
+  wide = false,
+  children,
+}: {
+  label: string
+  htmlFor: string
+  wide?: boolean
+  children: ReactNode
+}) {
+  return (
+    <label
+      htmlFor={htmlFor}
+      className={wide ? "space-y-2 sm:col-span-2" : "space-y-2"}
+    >
+      <span className="text-sm font-medium" id={`${htmlFor}-label`}>
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}

--- a/apps/crew/src/routes/events/new.tsx
+++ b/apps/crew/src/routes/events/new.tsx
@@ -34,6 +34,7 @@ function NewEventPage() {
   const [crewPlan, setCrewPlan] = useState<
     "self_serve" | "concierge" | "full_platform"
   >("self_serve")
+  // @lat: [[crew#Event Setup Dashboard]]
   const [settings, setSettings] = useState(
     '{\n  "setup": {\n    "assumptions": ""\n  }\n}',
   )
@@ -208,6 +209,7 @@ function NewEventPage() {
               className="min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm"
             />
           </Field>
+          {/* @lat: [[crew#Event Setup Dashboard]] */}
           <Field label="Initial setup JSON" htmlFor="crew-assumptions" wide>
             <textarea
               id="crew-assumptions"
@@ -238,17 +240,14 @@ function NewEventPage() {
   )
 }
 
-function Field({
-  label,
-  htmlFor,
-  wide = false,
-  children,
-}: {
+interface FieldProps {
   label: string
   htmlFor: string
   wide?: boolean
   children: ReactNode
-}) {
+}
+
+function Field({ label, htmlFor, wide = false, children }: FieldProps) {
   return (
     <label
       htmlFor={htmlFor}

--- a/apps/crew/src/routes/events/new.tsx
+++ b/apps/crew/src/routes/events/new.tsx
@@ -34,7 +34,9 @@ function NewEventPage() {
   const [crewPlan, setCrewPlan] = useState<
     "self_serve" | "concierge" | "full_platform"
   >("self_serve")
-  const [settings, setSettings] = useState('{\n  "assumptions": []\n}')
+  const [settings, setSettings] = useState(
+    '{\n  "setup": {\n    "assumptions": ""\n  }\n}',
+  )
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -206,7 +208,7 @@ function NewEventPage() {
               className="min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm"
             />
           </Field>
-          <Field label="Crew assumptions" htmlFor="crew-assumptions" wide>
+          <Field label="Initial setup JSON" htmlFor="crew-assumptions" wide>
             <textarea
               id="crew-assumptions"
               value={settings}

--- a/apps/crew/src/routes/index.tsx
+++ b/apps/crew/src/routes/index.tsx
@@ -45,6 +45,7 @@ function HomePage() {
               ["/events", "Crew event list"],
               ["/events/new", "Event setup placeholder"],
               ["/events/$eventId", "Event operations overview"],
+              ["/events/$eventId/setup", "Event setup dashboard"],
               ["/events/$eventId/volunteers", "Volunteer placeholder"],
               ["/events/$eventId/schedule", "Schedule placeholder"],
             ].map(([path, label]) => (

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -2,6 +2,12 @@
 
 Crew is a concierge-first event operations surface that reuses normal WODsmith competitions while adding thin Crew-specific setup, import, and assignment confirmation records.
 
+## Event Setup Dashboard
+
+Crew event setup pages let an operator create and review a normal competition with one `crew_event_settings` row for lifecycle, source platform URLs, concierge status, crew plan, setup checklist progress, assumptions, and internal handoff notes.
+
+Additional setup dashboard state is stored in the existing `crew_event_settings.settings` JSON text field until a later slice proves that dedicated typed columns or tables are needed.
+
 ## Add Thin Crew Tables
 
 Crew-owned database tables live in `@repo/wodsmith-db` so Start and Crew consume one shared schema source. App DB files remain forwarding shims and do not own `mysqlTable` definitions.


### PR DESCRIPTION
## Summary

- Adds a Crew event overview dashboard for lifecycle, concierge status, setup progress, source links, and operator notes.
- Adds `/events/$eventId/setup` for editing setup/concierge metadata through the existing `crew_event_settings` row and its `settings` JSON text field.
- Preserves the local/operator-only mutation guard from the existing Crew settings server functions and keeps normal `competitions` as the event record.

## Validation

- `pnpm check:schema-ownership`
- `pnpm --filter crew type-check`
- `pnpm --filter crew build`
- `pnpm --filter crew lint` (exits 0; reports existing repo warnings outside this slice)
- focused changed-file lint: `pnpm --filter crew exec -- biome lint src/lib/crew-event-setup.ts src/routes/events.tsx 'src/routes/events/$eventId.tsx' 'src/routes/events/$eventId/index.tsx' 'src/routes/events/$eventId/setup.tsx' src/routes/events/new.tsx src/routes/index.tsx`
- `git diff --check`

## Notes

- No schema or migration changes.
- Crew build required copying an ignored `apps/crew/.alchemy/local` config from an earlier Crew worktree for local validation only; it remains untracked.
- Fresh dependency install logged the known optional `better-sqlite3` native rebuild failure under Python 3.7, but the focused checks above passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Crew event setup and concierge dashboard with a dedicated Setup page and a read-only overview. Operators can track setup progress, manage lifecycle/concierge/source details, and edit event metadata in `crew_event_settings.settings` without schema changes.

- **New Features**
  - Added `/events/$eventId/setup` to manage lifecycle, concierge status, source links, checklist, and notes; keeps the local/operator-only mutation guard.
  - Updated overview with status panels, setup progress bar, checklist readout, operator notes, and an Edit setup link; renders safe clickable source URLs.
  - Event list cards now show lifecycle, concierge status, plan, and setup progress with a progress bar.
  - Introduced helpers: `parseCrewSettings`, `serializeCrewSettings`, `calculateSetupProgress`, default setup state/checklist, and display utils `formatCrewValue` and `getSafeHttpUrl`.
  - New event form seeds `settings` with a `setup` object and an “Initial setup JSON” field.

<sup>Written for commit b2a73b4b1f9c6e115a7acbb7597e6f79a899de50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced dedicated crew event setup page with interactive checklist for tracking setup tasks and monitoring completion progress
  * Added setup progress indicators displayed on the events list view
  * Added "Setup" navigation tab providing quick access to event setup configuration
  * Event overview page now displays consolidated event information in read-only format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->