### PR TITLE
feat(crew): add staffing calculator

### DIFF
--- a/apps/crew/src/lib/crew-staffing-calculator.ts
+++ b/apps/crew/src/lib/crew-staffing-calculator.ts
@@ -1,0 +1,203 @@
+export type StaffingRoleGroup = "judge" | "volunteer"
+
+export type StaffingRoleBasis = "event" | "floor" | "lane" | "lanePerFloor"
+
+export interface StaffingRoleAssumption {
+  id: string
+  label: string
+  group: StaffingRoleGroup
+  basis: StaffingRoleBasis
+  peoplePerUnit: number
+}
+
+export interface StaffingCalculatorInputs {
+  lanes: number
+  floors: number
+  heats: number
+  heatDurationMinutes: number
+  shiftLengthHours: number
+  roleAssumptions: StaffingRoleAssumption[]
+}
+
+export interface StaffingRoleEstimate {
+  id: string
+  label: string
+  group: StaffingRoleGroup
+  basis: StaffingRoleBasis
+  peoplePerUnit: number
+  concurrentPeople: number
+  personMinutes: number
+  shiftSlots: number
+}
+
+export interface StaffingCalculatorEstimate {
+  eventMinutes: number
+  shiftLengthMinutes: number
+  totalConcurrentPeople: number
+  totalShiftSlots: number
+  judgeConcurrentPeople: number
+  judgeShiftSlots: number
+  volunteerConcurrentPeople: number
+  volunteerShiftSlots: number
+  roleEstimates: StaffingRoleEstimate[]
+}
+
+export const defaultStaffingRoleAssumptions: StaffingRoleAssumption[] = [
+  {
+    id: "lane-judges",
+    label: "Lane judges",
+    group: "judge",
+    basis: "lanePerFloor",
+    peoplePerUnit: 1,
+  },
+  {
+    id: "floor-leads",
+    label: "Floor leads",
+    group: "judge",
+    basis: "floor",
+    peoplePerUnit: 1,
+  },
+  {
+    id: "score-runners",
+    label: "Score runners",
+    group: "volunteer",
+    basis: "floor",
+    peoplePerUnit: 1,
+  },
+  {
+    id: "equipment-reset",
+    label: "Equipment reset",
+    group: "volunteer",
+    basis: "lanePerFloor",
+    peoplePerUnit: 0.5,
+  },
+  {
+    id: "athlete-control",
+    label: "Athlete control",
+    group: "volunteer",
+    basis: "event",
+    peoplePerUnit: 2,
+  },
+  {
+    id: "check-in",
+    label: "Check-in",
+    group: "volunteer",
+    basis: "event",
+    peoplePerUnit: 2,
+  },
+]
+
+export const defaultStaffingCalculatorInputs: StaffingCalculatorInputs = {
+  lanes: 8,
+  floors: 1,
+  heats: 24,
+  heatDurationMinutes: 12,
+  shiftLengthHours: 4,
+  roleAssumptions: defaultStaffingRoleAssumptions,
+}
+
+export function estimateCrewStaffing(
+  inputs: StaffingCalculatorInputs,
+): StaffingCalculatorEstimate {
+  const normalizedInputs = normalizeStaffingCalculatorInputs(inputs)
+  const eventMinutes =
+    normalizedInputs.heats * normalizedInputs.heatDurationMinutes
+  const shiftLengthMinutes = normalizedInputs.shiftLengthHours * 60
+
+  const roleEstimates = normalizedInputs.roleAssumptions.map((role) => {
+    const concurrentPeople = Math.ceil(
+      role.peoplePerUnit * getRoleBasisUnits(role.basis, normalizedInputs),
+    )
+    const personMinutes = concurrentPeople * eventMinutes
+
+    return {
+      ...role,
+      concurrentPeople,
+      personMinutes,
+      shiftSlots: Math.ceil(personMinutes / shiftLengthMinutes),
+    }
+  })
+
+  return {
+    eventMinutes,
+    shiftLengthMinutes,
+    totalConcurrentPeople: sumRoleValue(roleEstimates, "concurrentPeople"),
+    totalShiftSlots: sumRoleValue(roleEstimates, "shiftSlots"),
+    judgeConcurrentPeople: sumRoleValue(
+      roleEstimates.filter((role) => role.group === "judge"),
+      "concurrentPeople",
+    ),
+    judgeShiftSlots: sumRoleValue(
+      roleEstimates.filter((role) => role.group === "judge"),
+      "shiftSlots",
+    ),
+    volunteerConcurrentPeople: sumRoleValue(
+      roleEstimates.filter((role) => role.group === "volunteer"),
+      "concurrentPeople",
+    ),
+    volunteerShiftSlots: sumRoleValue(
+      roleEstimates.filter((role) => role.group === "volunteer"),
+      "shiftSlots",
+    ),
+    roleEstimates,
+  }
+}
+
+export function formatStaffingDuration(minutes: number) {
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+
+  if (hours === 0) return `${remainingMinutes}m`
+  if (remainingMinutes === 0) return `${hours}h`
+
+  return `${hours}h ${remainingMinutes}m`
+}
+
+function normalizeStaffingCalculatorInputs(
+  inputs: StaffingCalculatorInputs,
+): StaffingCalculatorInputs {
+  return {
+    lanes: clampWholeNumber(inputs.lanes, 1),
+    floors: clampWholeNumber(inputs.floors, 1),
+    heats: clampWholeNumber(inputs.heats, 1),
+    heatDurationMinutes: clampWholeNumber(inputs.heatDurationMinutes, 1),
+    shiftLengthHours: clampDecimal(inputs.shiftLengthHours, 0.25),
+    roleAssumptions: inputs.roleAssumptions.map((role) => ({
+      ...role,
+      peoplePerUnit: clampDecimal(role.peoplePerUnit, 0),
+    })),
+  }
+}
+
+function getRoleBasisUnits(
+  basis: StaffingRoleBasis,
+  inputs: StaffingCalculatorInputs,
+) {
+  switch (basis) {
+    case "event":
+      return 1
+    case "floor":
+      return inputs.floors
+    case "lane":
+      return inputs.lanes
+    case "lanePerFloor":
+      return inputs.lanes * inputs.floors
+  }
+}
+
+function sumRoleValue(
+  roles: StaffingRoleEstimate[],
+  key: "concurrentPeople" | "shiftSlots",
+) {
+  return roles.reduce((total, role) => total + role[key], 0)
+}
+
+function clampWholeNumber(value: number, minimum: number) {
+  if (!Number.isFinite(value)) return minimum
+  return Math.max(minimum, Math.round(value))
+}
+
+function clampDecimal(value: number, minimum: number) {
+  if (!Number.isFinite(value)) return minimum
+  return Math.max(minimum, value)
+}

--- a/apps/crew/src/lib/crew-staffing-calculator.ts
+++ b/apps/crew/src/lib/crew-staffing-calculator.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Staffing Calculator#Inputs and Role Assumptions]]
 export type StaffingRoleGroup = "judge" | "volunteer"
 
 export type StaffingRoleBasis = "event" | "floor" | "lane" | "lanePerFloor"
@@ -42,6 +43,7 @@ export interface StaffingCalculatorEstimate {
   roleEstimates: StaffingRoleEstimate[]
 }
 
+// @lat: [[crew#Staffing Calculator#Default Assumptions]]
 export const defaultStaffingRoleAssumptions: StaffingRoleAssumption[] = [
   {
     id: "lane-judges",
@@ -96,6 +98,7 @@ export const defaultStaffingCalculatorInputs: StaffingCalculatorInputs = {
   roleAssumptions: defaultStaffingRoleAssumptions,
 }
 
+// @lat: [[crew#Staffing Calculator#Shift Coverage]]
 export function estimateCrewStaffing(
   inputs: StaffingCalculatorInputs,
 ): StaffingCalculatorEstimate {
@@ -143,6 +146,7 @@ export function estimateCrewStaffing(
   }
 }
 
+// @lat: [[crew#Staffing Calculator#Duration Display]]
 export function formatStaffingDuration(minutes: number) {
   const hours = Math.floor(minutes / 60)
   const remainingMinutes = minutes % 60
@@ -153,7 +157,8 @@ export function formatStaffingDuration(minutes: number) {
   return `${hours}h ${remainingMinutes}m`
 }
 
-function normalizeStaffingCalculatorInputs(
+// @lat: [[crew#Staffing Calculator#Input Normalization]]
+export function normalizeStaffingCalculatorInputs(
   inputs: StaffingCalculatorInputs,
 ): StaffingCalculatorInputs {
   return {

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as EventsRouteImport } from './routes/events'
+import { Route as CalculatorRouteImport } from './routes/calculator'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as EventsNewRouteImport } from './routes/events/new'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
@@ -21,6 +22,11 @@ import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$even
 const EventsRoute = EventsRouteImport.update({
   id: '/events',
   path: '/events',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const CalculatorRoute = CalculatorRouteImport.update({
+  id: '/calculator',
+  path: '/calculator',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -61,6 +67,7 @@ const EventsEventIdScheduleRoute = EventsEventIdScheduleRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/calculator': typeof CalculatorRoute
   '/events': typeof EventsRouteWithChildren
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
@@ -71,6 +78,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/calculator': typeof CalculatorRoute
   '/events': typeof EventsRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
@@ -81,6 +89,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/calculator': typeof CalculatorRoute
   '/events': typeof EventsRouteWithChildren
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
@@ -93,6 +102,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/calculator'
     | '/events'
     | '/events/$eventId'
     | '/events/new'
@@ -103,6 +113,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/calculator'
     | '/events'
     | '/events/new'
     | '/events/$eventId/schedule'
@@ -112,6 +123,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/calculator'
     | '/events'
     | '/events/$eventId'
     | '/events/new'
@@ -123,6 +135,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  CalculatorRoute: typeof CalculatorRoute
   EventsRoute: typeof EventsRouteWithChildren
 }
 
@@ -133,6 +146,13 @@ declare module '@tanstack/react-router' {
       path: '/events'
       fullPath: '/events'
       preLoaderRoute: typeof EventsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/calculator': {
+      id: '/calculator'
+      path: '/calculator'
+      fullPath: '/calculator'
+      preLoaderRoute: typeof CalculatorRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/': {
@@ -220,6 +240,7 @@ const EventsRouteWithChildren =
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  CalculatorRoute: CalculatorRoute,
   EventsRoute: EventsRouteWithChildren,
 }
 export const routeTree = rootRouteImport

--- a/apps/crew/src/routes/__root.tsx
+++ b/apps/crew/src/routes/__root.tsx
@@ -1,5 +1,4 @@
 import type { ErrorComponentProps } from "@tanstack/react-router"
-import type { ReactNode } from "react"
 import {
   createRootRoute,
   HeadContent,
@@ -7,6 +6,7 @@ import {
   Outlet,
   Scripts,
 } from "@tanstack/react-router"
+import type { ReactNode } from "react"
 import { Toaster } from "sonner"
 
 import appCss from "../styles.css?url"
@@ -53,6 +53,15 @@ function RootComponent() {
             <span>WODsmith Crew</span>
           </Link>
           <nav className="flex items-center gap-1 text-sm">
+            <Link
+              to="/calculator"
+              activeProps={{
+                className: "bg-muted text-foreground",
+              }}
+              className="rounded-md px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Calculator
+            </Link>
             <Link
               to="/events"
               activeProps={{

--- a/apps/crew/src/routes/calculator.tsx
+++ b/apps/crew/src/routes/calculator.tsx
@@ -1,0 +1,336 @@
+import { createFileRoute } from "@tanstack/react-router"
+import type { ChangeEvent, ReactNode } from "react"
+import { useMemo, useState } from "react"
+import {
+  defaultStaffingCalculatorInputs,
+  estimateCrewStaffing,
+  formatStaffingDuration,
+  type StaffingCalculatorInputs,
+  type StaffingRoleAssumption,
+  type StaffingRoleBasis,
+  type StaffingRoleEstimate,
+  type StaffingRoleGroup,
+} from "@/lib/crew-staffing-calculator"
+
+export const Route = createFileRoute("/calculator")({
+  component: StaffingCalculatorPage,
+})
+
+function StaffingCalculatorPage() {
+  const [inputs, setInputs] = useState<StaffingCalculatorInputs>(
+    defaultStaffingCalculatorInputs,
+  )
+  const estimate = useMemo(() => estimateCrewStaffing(inputs), [inputs])
+
+  function updateNumberField(
+    key: keyof Pick<
+      StaffingCalculatorInputs,
+      "lanes" | "floors" | "heats" | "heatDurationMinutes" | "shiftLengthHours"
+    >,
+    value: string,
+  ) {
+    const nextValue = Number(value)
+    setInputs((current) => ({
+      ...current,
+      [key]: Number.isFinite(nextValue) ? nextValue : 0,
+    }))
+  }
+
+  function updateRole(
+    roleId: string,
+    updates: Partial<StaffingRoleAssumption>,
+  ) {
+    setInputs((current) => ({
+      ...current,
+      roleAssumptions: current.roleAssumptions.map((role) =>
+        role.id === roleId ? { ...role, ...updates } : role,
+      ),
+    }))
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:px-6">
+      <div className="flex flex-col justify-between gap-4 md:flex-row md:items-end">
+        <div>
+          <p className="text-sm font-medium uppercase tracking-[0.18em] text-muted-foreground">
+            Staffing calculator
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold">
+            Estimate judges, volunteers, and shift coverage.
+          </h1>
+          <p className="mt-2 max-w-3xl text-muted-foreground">
+            Adjust event assumptions to get a deterministic staffing estimate
+            before building a final schedule.
+          </p>
+        </div>
+        <SummaryBadge
+          label="Workout block"
+          value={formatStaffingDuration(estimate.eventMinutes)}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[22rem_1fr]">
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-lg font-semibold">Event assumptions</h2>
+          <div className="mt-5 grid gap-4">
+            <NumberField
+              label="Lanes per floor"
+              value={inputs.lanes}
+              min={1}
+              step={1}
+              onChange={(event) =>
+                updateNumberField("lanes", event.target.value)
+              }
+            />
+            <NumberField
+              label="Floors"
+              value={inputs.floors}
+              min={1}
+              step={1}
+              onChange={(event) =>
+                updateNumberField("floors", event.target.value)
+              }
+            />
+            <NumberField
+              label="Heats"
+              value={inputs.heats}
+              min={1}
+              step={1}
+              onChange={(event) =>
+                updateNumberField("heats", event.target.value)
+              }
+            />
+            <NumberField
+              label="Heat duration"
+              value={inputs.heatDurationMinutes}
+              min={1}
+              step={1}
+              suffix="min"
+              onChange={(event) =>
+                updateNumberField("heatDurationMinutes", event.target.value)
+              }
+            />
+            <NumberField
+              label="Shift length"
+              value={inputs.shiftLengthHours}
+              min={0.25}
+              step={0.25}
+              suffix="hr"
+              onChange={(event) =>
+                updateNumberField("shiftLengthHours", event.target.value)
+              }
+            />
+          </div>
+        </section>
+
+        <section className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-3">
+            <SummaryPanel
+              label="Judges"
+              primary={estimate.judgeShiftSlots}
+              secondary={`${estimate.judgeConcurrentPeople} concurrent`}
+            />
+            <SummaryPanel
+              label="Volunteers"
+              primary={estimate.volunteerShiftSlots}
+              secondary={`${estimate.volunteerConcurrentPeople} concurrent`}
+            />
+            <SummaryPanel
+              label="Total shift slots"
+              primary={estimate.totalShiftSlots}
+              secondary={`${estimate.totalConcurrentPeople} people on deck`}
+            />
+          </div>
+
+          <section className="rounded-md border bg-card shadow-sm">
+            <div className="border-b p-5">
+              <h2 className="text-lg font-semibold">Role assumptions</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Tune the default role mix without creating assignments.
+              </p>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[720px] text-sm">
+                <thead>
+                  <tr className="border-b text-left text-muted-foreground">
+                    <th className="px-5 py-3 font-medium">Role</th>
+                    <th className="px-5 py-3 font-medium">Type</th>
+                    <th className="px-5 py-3 font-medium">Basis</th>
+                    <th className="px-5 py-3 font-medium">People</th>
+                    <th className="px-5 py-3 font-medium">Concurrent</th>
+                    <th className="px-5 py-3 font-medium">Shift slots</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {estimate.roleEstimates.map((role) => (
+                    <RoleRow
+                      key={role.id}
+                      role={role}
+                      onChange={(updates) => updateRole(role.id, updates)}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <h2 className="text-lg font-semibold">Coverage notes</h2>
+            <dl className="mt-4 grid gap-4 text-sm sm:grid-cols-3">
+              <Fact
+                label="Heat time"
+                value={`${inputs.heats} x ${inputs.heatDurationMinutes} min`}
+              />
+              <Fact
+                label="Shift length"
+                value={formatStaffingDuration(estimate.shiftLengthMinutes)}
+              />
+              <Fact
+                label="Coverage formula"
+                value="Concurrent people x event minutes"
+              />
+            </dl>
+          </section>
+        </section>
+      </div>
+    </main>
+  )
+}
+
+interface NumberFieldProps {
+  label: string
+  value: number
+  min: number
+  step: number
+  suffix?: string
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+}
+
+function NumberField({
+  label,
+  value,
+  min,
+  step,
+  suffix,
+  onChange,
+}: NumberFieldProps) {
+  return (
+    <label className="space-y-2">
+      <span className="text-sm font-medium">{label}</span>
+      <span className="flex items-center overflow-hidden rounded-md border bg-background">
+        <input
+          type="number"
+          min={min}
+          step={step}
+          value={value}
+          onChange={onChange}
+          className="h-10 min-w-0 flex-1 bg-transparent px-3 text-sm outline-none"
+        />
+        {suffix ? (
+          <span className="border-l px-3 text-sm text-muted-foreground">
+            {suffix}
+          </span>
+        ) : null}
+      </span>
+    </label>
+  )
+}
+
+interface RoleRowProps {
+  role: StaffingRoleEstimate
+  onChange: (updates: Partial<StaffingRoleAssumption>) => void
+}
+
+function RoleRow({ role, onChange }: RoleRowProps) {
+  return (
+    <tr className="border-b last:border-b-0">
+      <td className="px-5 py-3 font-medium">{role.label}</td>
+      <td className="px-5 py-3">
+        <select
+          value={role.group}
+          onChange={(event) =>
+            onChange({ group: event.target.value as StaffingRoleGroup })
+          }
+          className="h-9 rounded-md border bg-background px-2"
+        >
+          <option value="judge">Judge</option>
+          <option value="volunteer">Volunteer</option>
+        </select>
+      </td>
+      <td className="px-5 py-3">
+        <select
+          value={role.basis}
+          onChange={(event) =>
+            onChange({ basis: event.target.value as StaffingRoleBasis })
+          }
+          className="h-9 rounded-md border bg-background px-2"
+        >
+          <option value="event">Event</option>
+          <option value="floor">Floor</option>
+          <option value="lane">Lane</option>
+          <option value="lanePerFloor">Lane per floor</option>
+        </select>
+      </td>
+      <td className="px-5 py-3">
+        <input
+          type="number"
+          min={0}
+          step={0.25}
+          value={role.peoplePerUnit}
+          onChange={(event) =>
+            onChange({ peoplePerUnit: Number(event.target.value) })
+          }
+          className="h-9 w-24 rounded-md border bg-background px-2"
+        />
+      </td>
+      <td className="px-5 py-3 font-medium">{role.concurrentPeople}</td>
+      <td className="px-5 py-3 font-medium">{role.shiftSlots}</td>
+    </tr>
+  )
+}
+
+interface SummaryPanelProps {
+  label: string
+  primary: number
+  secondary: string
+}
+
+function SummaryPanel({ label, primary, secondary }: SummaryPanelProps) {
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-3xl font-semibold">{primary}</p>
+      <p className="mt-1 text-sm text-muted-foreground">{secondary}</p>
+    </section>
+  )
+}
+
+interface SummaryBadgeProps {
+  label: string
+  value: string
+}
+
+function SummaryBadge({ label, value }: SummaryBadgeProps) {
+  return (
+    <div className="w-fit rounded-md border bg-card px-4 py-3 shadow-sm">
+      <p className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </p>
+      <p className="text-lg font-semibold">{value}</p>
+    </div>
+  )
+}
+
+interface FactProps {
+  label: string
+  value: ReactNode
+}
+
+function Fact({ label, value }: FactProps) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-medium">{value}</dd>
+    </div>
+  )
+}

--- a/apps/crew/src/routes/calculator.tsx
+++ b/apps/crew/src/routes/calculator.tsx
@@ -5,6 +5,7 @@ import {
   defaultStaffingCalculatorInputs,
   estimateCrewStaffing,
   formatStaffingDuration,
+  normalizeStaffingCalculatorInputs,
   type StaffingCalculatorInputs,
   type StaffingRoleAssumption,
   type StaffingRoleBasis,
@@ -18,7 +19,7 @@ export const Route = createFileRoute("/calculator")({
 
 function StaffingCalculatorPage() {
   const [inputs, setInputs] = useState<StaffingCalculatorInputs>(
-    defaultStaffingCalculatorInputs,
+    normalizeStaffingCalculatorInputs(defaultStaffingCalculatorInputs),
   )
   const estimate = useMemo(() => estimateCrewStaffing(inputs), [inputs])
 
@@ -30,22 +31,26 @@ function StaffingCalculatorPage() {
     value: string,
   ) {
     const nextValue = Number(value)
-    setInputs((current) => ({
-      ...current,
-      [key]: Number.isFinite(nextValue) ? nextValue : 0,
-    }))
+    setInputs((current) =>
+      normalizeStaffingCalculatorInputs({
+        ...current,
+        [key]: Number.isFinite(nextValue) ? nextValue : 0,
+      }),
+    )
   }
 
   function updateRole(
     roleId: string,
     updates: Partial<StaffingRoleAssumption>,
   ) {
-    setInputs((current) => ({
-      ...current,
-      roleAssumptions: current.roleAssumptions.map((role) =>
-        role.id === roleId ? { ...role, ...updates } : role,
-      ),
-    }))
+    setInputs((current) =>
+      normalizeStaffingCalculatorInputs({
+        ...current,
+        roleAssumptions: current.roleAssumptions.map((role) =>
+          role.id === roleId ? { ...role, ...updates } : role,
+        ),
+      }),
+    )
   }
 
   return (

--- a/apps/crew/src/routes/index.tsx
+++ b/apps/crew/src/routes/index.tsx
@@ -23,8 +23,14 @@ function HomePage() {
         </div>
         <div className="flex flex-wrap gap-3">
           <Link
-            to="/events"
+            to="/calculator"
             className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Estimate staffing
+          </Link>
+          <Link
+            to="/events"
+            className="rounded-md border px-4 py-2 text-sm font-medium hover:bg-muted"
           >
             View events
           </Link>
@@ -42,6 +48,7 @@ function HomePage() {
           <h2 className="text-lg font-semibold">Crew shell routes</h2>
           <div className="grid gap-3 text-sm">
             {[
+              ["/calculator", "Staffing calculator"],
               ["/events", "Crew event list"],
               ["/events/new", "Event setup placeholder"],
               ["/events/$eventId", "Event operations overview"],

--- a/apps/crew/test/lib/crew-staffing-calculator.test.ts
+++ b/apps/crew/test/lib/crew-staffing-calculator.test.ts
@@ -42,6 +42,7 @@ function baseInputs(
 }
 
 describe("estimateCrewStaffing", () => {
+  // @lat: [[crew#Staffing Calculator#Role Basis]]
   it("scales lane judge assumptions by floors and lanes", () => {
     const estimate = estimateCrewStaffing(
       baseInputs({ lanes: 10, floors: 2 }),
@@ -55,6 +56,7 @@ describe("estimateCrewStaffing", () => {
     expect(estimate.judgeConcurrentPeople).toBe(22)
   })
 
+  // @lat: [[crew#Staffing Calculator#Shift Coverage]]
   it("converts heat time into shift slots for coverage", () => {
     const estimate = estimateCrewStaffing(
       baseInputs({ heats: 40, heatDurationMinutes: 12, shiftLengthHours: 4 }),
@@ -69,6 +71,7 @@ describe("estimateCrewStaffing", () => {
     expect(laneJudges?.shiftSlots).toBe(16)
   })
 
+  // @lat: [[crew#Staffing Calculator#Staffing Groups]]
   it("keeps judge and volunteer estimates separated", () => {
     const estimate = estimateCrewStaffing(baseInputs())
 
@@ -80,6 +83,7 @@ describe("estimateCrewStaffing", () => {
     )
   })
 
+  // @lat: [[crew#Staffing Calculator#Input Normalization]]
   it("normalizes invalid minimums without producing zero coverage", () => {
     const estimate = estimateCrewStaffing(
       baseInputs({
@@ -98,6 +102,7 @@ describe("estimateCrewStaffing", () => {
 })
 
 describe("formatStaffingDuration", () => {
+  // @lat: [[crew#Staffing Calculator#Duration Display]]
   it("formats full hours and mixed durations", () => {
     expect(formatStaffingDuration(45)).toBe("45m")
     expect(formatStaffingDuration(120)).toBe("2h")

--- a/apps/crew/test/lib/crew-staffing-calculator.test.ts
+++ b/apps/crew/test/lib/crew-staffing-calculator.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+import {
+  estimateCrewStaffing,
+  formatStaffingDuration,
+  type StaffingCalculatorInputs,
+} from "@/lib/crew-staffing-calculator"
+
+function baseInputs(
+  overrides: Partial<StaffingCalculatorInputs> = {},
+): StaffingCalculatorInputs {
+  return {
+    lanes: 8,
+    floors: 1,
+    heats: 20,
+    heatDurationMinutes: 12,
+    shiftLengthHours: 4,
+    roleAssumptions: [
+      {
+        id: "lane-judges",
+        label: "Lane judges",
+        group: "judge",
+        basis: "lanePerFloor",
+        peoplePerUnit: 1,
+      },
+      {
+        id: "floor-leads",
+        label: "Floor leads",
+        group: "judge",
+        basis: "floor",
+        peoplePerUnit: 1,
+      },
+      {
+        id: "athlete-control",
+        label: "Athlete control",
+        group: "volunteer",
+        basis: "event",
+        peoplePerUnit: 2,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe("estimateCrewStaffing", () => {
+  it("scales lane judge assumptions by floors and lanes", () => {
+    const estimate = estimateCrewStaffing(
+      baseInputs({ lanes: 10, floors: 2 }),
+    )
+
+    const laneJudges = estimate.roleEstimates.find(
+      (role) => role.id === "lane-judges",
+    )
+
+    expect(laneJudges?.concurrentPeople).toBe(20)
+    expect(estimate.judgeConcurrentPeople).toBe(22)
+  })
+
+  it("converts heat time into shift slots for coverage", () => {
+    const estimate = estimateCrewStaffing(
+      baseInputs({ heats: 40, heatDurationMinutes: 12, shiftLengthHours: 4 }),
+    )
+
+    const laneJudges = estimate.roleEstimates.find(
+      (role) => role.id === "lane-judges",
+    )
+
+    expect(estimate.eventMinutes).toBe(480)
+    expect(laneJudges?.personMinutes).toBe(3840)
+    expect(laneJudges?.shiftSlots).toBe(16)
+  })
+
+  it("keeps judge and volunteer estimates separated", () => {
+    const estimate = estimateCrewStaffing(baseInputs())
+
+    expect(estimate.judgeConcurrentPeople).toBe(9)
+    expect(estimate.volunteerConcurrentPeople).toBe(2)
+    expect(estimate.totalConcurrentPeople).toBe(11)
+    expect(estimate.totalShiftSlots).toBe(
+      estimate.judgeShiftSlots + estimate.volunteerShiftSlots,
+    )
+  })
+
+  it("normalizes invalid minimums without producing zero coverage", () => {
+    const estimate = estimateCrewStaffing(
+      baseInputs({
+        lanes: 0,
+        floors: Number.NaN,
+        heats: -4,
+        heatDurationMinutes: 0,
+        shiftLengthHours: 0,
+      }),
+    )
+
+    expect(estimate.eventMinutes).toBe(1)
+    expect(estimate.shiftLengthMinutes).toBe(15)
+    expect(estimate.totalConcurrentPeople).toBeGreaterThan(0)
+  })
+})
+
+describe("formatStaffingDuration", () => {
+  it("formats full hours and mixed durations", () => {
+    expect(formatStaffingDuration(45)).toBe("45m")
+    expect(formatStaffingDuration(120)).toBe("2h")
+    expect(formatStaffingDuration(135)).toBe("2h 15m")
+  })
+})

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -8,6 +8,42 @@ Crew event setup pages let an operator create and review a normal competition wi
 
 Additional setup dashboard state is stored in the existing `crew_event_settings.settings` JSON text field until a later slice proves that dedicated typed columns or tables are needed.
 
+## Staffing Calculator
+
+The public Crew calculator route estimates event-day staffing needs from event dimensions and editable role assumptions.
+
+It is deterministic planning math only; it does not create rosters, shifts, assignments, invitations, imports, or persisted setup state.
+
+### Inputs and Role Assumptions
+
+Calculator inputs model the minimum event dimensions operators need before scheduling.
+
+Those dimensions are lanes per floor, floor count, heat count, heat duration, shift length, and role assumptions. Role assumptions are grouped as judges or volunteers and use one of four bases: whole event, floor, lane, or lane per floor.
+
+### Default Assumptions
+
+Default assumptions seed the UI with lane judges, floor leads, score runners, equipment reset, athlete control, and check-in coverage. They are UI defaults only and must not be treated as saved event configuration.
+
+### Role Basis
+
+Lane-per-floor roles scale by `lanes * floors`; floor roles scale by floor count; lane roles scale by lane count; event roles scale once for the whole workout block.
+
+### Shift Coverage
+
+Shift coverage is estimated from `concurrent people * event minutes`, then rounded up by shift length to produce shift slots. The result is a coverage estimate, not a staffed shift board.
+
+### Staffing Groups
+
+Judge and volunteer totals stay separated in the estimate while also rolling up to a total concurrent headcount and total shift-slot count.
+
+### Input Normalization
+
+Calculator inputs are normalized before rendering and calculation: counts are whole numbers with a minimum of one, shift length has a quarter-hour minimum, and role multipliers cannot go below zero.
+
+### Duration Display
+
+Operator-facing durations render in compact hour/minute labels so workout block and shift length summaries stay scannable.
+
 ## Add Thin Crew Tables
 
 Crew-owned database tables live in `@repo/wodsmith-db` so Start and Crew consume one shared schema source. App DB files remain forwarding shims and do not own `mysqlTable` definitions.


### PR DESCRIPTION
## Summary
- Add a public Crew `/calculator` route for estimating judges, volunteers, concurrent staffing, and shift slots.
- Add pure staffing calculator helpers with default role assumptions for lanes, floors, heats, heat duration, and shift length.
- Link the calculator from the Crew shell nav/home route list and update the generated TanStack route tree.
- Cover role/time assumptions with focused Vitest unit tests.

## Validation
- `pnpm check:schema-ownership` passed.
- `pnpm --filter crew type-check` passed.
- `pnpm --filter crew build` passed after creating ignored validation-only `apps/crew/.alchemy/local/wrangler.jsonc` from the checked-in Crew wrangler config. No Alchemy/deploy command was run.
- `pnpm --filter crew lint` exited 0; it still reports existing repo warnings outside this slice.
- `pnpm --filter crew exec vitest run test/lib/crew-staffing-calculator.test.ts` passed: 5 tests.
- `git diff --check` passed.

## Notes
- `pnpm --filter crew test` was attempted and failed on pre-existing/unrelated suites: missing legacy imports under `routes/compete/...` and `routes/api/webhooks/stripe`, plus existing invite permission timeout/assertion failures. The new calculator test passed during that full run.
- `pnpm install` completed, with the known optional `better-sqlite3` native rebuild failure from Python 3.7 on this machine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public Crew staffing calculator at `/calculator` to estimate judges, volunteers, concurrent staffing, and shift slots from simple event inputs. Adds nav/home links, a helper library with defaults and normalization, and tests.

- **New Features**
  - New `/calculator` route with inputs for lanes, floors, heats, heat duration, and shift length; shows per‑role concurrent coverage and shift slots.
  - Helper library: `estimateCrewStaffing`, `formatStaffingDuration`, `normalizeStaffingCalculatorInputs`, and default role assumptions; supports `event`, `floor`, `lane`, and `lanePerFloor`; returns per‑role and group totals; covered by `vitest` tests for scaling, coverage, normalization, and formatting.
  - Crew shell updates: adds “Calculator” nav link and home CTA; updates route tree via `@tanstack/react-router`.
  - Operator notes in `lat.md/crew.md`.

<sup>Written for commit 99ec4b08fd6ebeb2be08c1fb55c5e2173749fa38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/529?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a staffing calculator tool to estimate crew requirements based on event parameters (lanes, floors, heats, shift duration).
  * Displays per-role staffing estimates with judges and volunteers breakdown and coverage details.
  * Allows customization of role assumptions for refined estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->