### PR TITLE
feat(crew): add private import upload and CSV preview

### DIFF
--- a/apps/crew/src/lib/crew/imports/column-mapping.ts
+++ b/apps/crew/src/lib/crew/imports/column-mapping.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Import CSV Preview#Parser Warnings]]
 import type {
   ColumnMapping,
   CrewImportKind,

--- a/apps/crew/src/lib/crew/imports/column-mapping.ts
+++ b/apps/crew/src/lib/crew/imports/column-mapping.ts
@@ -1,0 +1,149 @@
+import type {
+  ColumnMapping,
+  CrewImportKind,
+  ImportFieldDefinition,
+} from "./types"
+
+export const volunteerImportFields: ImportFieldDefinition[] = [
+  {
+    key: "email",
+    label: "Email",
+    required: true,
+    aliases: ["email", "email address", "volunteer email", "e-mail"],
+  },
+  {
+    key: "firstName",
+    label: "First name",
+    aliases: ["first name", "firstname", "given name"],
+  },
+  {
+    key: "lastName",
+    label: "Last name",
+    aliases: ["last name", "lastname", "surname", "family name"],
+  },
+  {
+    key: "name",
+    label: "Name",
+    aliases: ["name", "full name", "volunteer", "volunteer name"],
+  },
+  {
+    key: "phone",
+    label: "Phone",
+    aliases: ["phone", "phone number", "mobile", "cell"],
+  },
+  {
+    key: "role",
+    label: "Role",
+    aliases: ["role", "crew role", "job", "position", "assignment"],
+  },
+  {
+    key: "division",
+    label: "Division",
+    aliases: ["division", "division name", "category", "level"],
+  },
+  {
+    key: "availability",
+    label: "Availability",
+    aliases: ["availability", "available", "shift", "shifts"],
+  },
+  {
+    key: "notes",
+    label: "Notes",
+    aliases: ["notes", "note", "comments", "comment"],
+  },
+]
+
+export const heatScheduleImportFields: ImportFieldDefinition[] = [
+  {
+    key: "workout",
+    label: "Workout",
+    required: true,
+    aliases: ["workout", "event", "workout name", "event name"],
+  },
+  {
+    key: "heat",
+    label: "Heat",
+    required: true,
+    aliases: ["heat", "heat number", "heat #", "heat no", "heat name"],
+  },
+  {
+    key: "division",
+    label: "Division",
+    aliases: ["division", "division name", "category", "level"],
+  },
+  {
+    key: "scheduledTime",
+    label: "Scheduled time",
+    aliases: ["scheduled time", "start time", "time", "heat time"],
+  },
+  {
+    key: "durationMinutes",
+    label: "Duration minutes",
+    aliases: ["duration", "duration minutes", "minutes", "time cap"],
+  },
+  {
+    key: "venue",
+    label: "Venue",
+    aliases: ["venue", "floor", "area", "location"],
+  },
+  {
+    key: "laneCount",
+    label: "Lane count",
+    aliases: ["lanes", "lane count", "lane_count"],
+  },
+  {
+    key: "notes",
+    label: "Notes",
+    aliases: ["notes", "note", "comments", "comment"],
+  },
+]
+
+export function getImportFields(kind: CrewImportKind) {
+  return kind === "volunteers"
+    ? volunteerImportFields
+    : heatScheduleImportFields
+}
+
+export function inferColumnMapping(
+  headers: string[],
+  kind: CrewImportKind,
+): ColumnMapping {
+  const normalizedHeaders = new Map(
+    headers.map((header) => [normalizeHeader(header), header]),
+  )
+  const mapping: ColumnMapping = {}
+
+  for (const field of getImportFields(kind)) {
+    for (const alias of field.aliases) {
+      const header = normalizedHeaders.get(normalizeHeader(alias))
+      if (header) {
+        mapping[field.key] = header
+        break
+      }
+    }
+  }
+
+  return mapping
+}
+
+export function sanitizeColumnMapping(
+  mapping: ColumnMapping,
+  headers: string[],
+  kind: CrewImportKind,
+): ColumnMapping {
+  const allowedFields = new Set(getImportFields(kind).map((field) => field.key))
+  const allowedHeaders = new Set(headers)
+  const sanitized: ColumnMapping = {}
+
+  for (const [field, header] of Object.entries(mapping)) {
+    if (allowedFields.has(field) && allowedHeaders.has(header)) {
+      sanitized[field] = header
+    }
+  }
+
+  return sanitized
+}
+
+export function normalizeHeader(header: string) {
+  return header.trim().toLowerCase().replace(/[_-]+/g, " ").replace(/\s+/g, " ")
+}

--- a/apps/crew/src/lib/crew/imports/csv.ts
+++ b/apps/crew/src/lib/crew/imports/csv.ts
@@ -1,0 +1,175 @@
+import type { CsvParseResult, CsvRecord, ImportIssue } from "./types"
+
+interface ParseCsvOptions {
+  maxRows?: number
+}
+
+export function parseCsv(
+  input: string,
+  options: ParseCsvOptions = {},
+): CsvParseResult {
+  const fileIssues: ImportIssue[] = []
+  const records = parseCsvRecords(stripBom(input), fileIssues)
+  const headers = records[0]?.map((header) => header.trim()) ?? []
+
+  if (headers.length === 0 || headers.every((header) => header.length === 0)) {
+    return {
+      headers: [],
+      rows: [],
+      fileIssues: [
+        ...fileIssues,
+        {
+          code: "missing_headers",
+          severity: "error",
+          message: "CSV must include a header row.",
+        },
+      ],
+      skippedRowCount: 0,
+    }
+  }
+
+  const rows: CsvRecord[] = []
+  let skippedRowCount = 0
+  const dataRecords = records.slice(1)
+  const maxRows = options.maxRows ?? Number.POSITIVE_INFINITY
+
+  dataRecords.forEach((record, index) => {
+    const rowNumber = index + 2
+
+    if (record.every((value) => value.trim().length === 0)) return
+
+    if (rows.length >= maxRows) {
+      skippedRowCount++
+      return
+    }
+
+    const issues: ImportIssue[] = []
+    if (record.length !== headers.length) {
+      issues.push({
+        code: "malformed_row",
+        severity: "error",
+        rowNumber,
+        message: `Expected ${headers.length} columns but found ${record.length}.`,
+      })
+    }
+
+    rows.push({
+      rowNumber,
+      rawValues: record,
+      values: mapRecordToHeaders(headers, record),
+      issues,
+    })
+  })
+
+  if (skippedRowCount > 0) {
+    fileIssues.push({
+      code: "preview_row_limit",
+      severity: "warning",
+      message: `${skippedRowCount} row${skippedRowCount === 1 ? "" : "s"} were skipped after the preview limit.`,
+    })
+  }
+
+  return { headers, rows, fileIssues, skippedRowCount }
+}
+
+function parseCsvRecords(input: string, issues: ImportIssue[]) {
+  const rows: string[][] = []
+  let currentRow: string[] = []
+  let currentValue = ""
+  let inQuotes = false
+  let justClosedQuote = false
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index]
+    const nextChar = input[index + 1]
+
+    if (inQuotes) {
+      if (char === '"' && nextChar === '"') {
+        currentValue += '"'
+        index++
+      } else if (char === '"') {
+        inQuotes = false
+        justClosedQuote = true
+      } else {
+        currentValue += char
+      }
+      continue
+    }
+
+    if (char === '"') {
+      if (currentValue.length === 0 || justClosedQuote) {
+        inQuotes = true
+        justClosedQuote = false
+      } else {
+        currentValue += char
+      }
+      continue
+    }
+
+    if (char === ",") {
+      currentRow.push(currentValue)
+      currentValue = ""
+      justClosedQuote = false
+      continue
+    }
+
+    if (char === "\n") {
+      currentRow.push(currentValue)
+      rows.push(currentRow)
+      currentRow = []
+      currentValue = ""
+      justClosedQuote = false
+      continue
+    }
+
+    if (char === "\r") {
+      if (nextChar === "\n") continue
+      currentRow.push(currentValue)
+      rows.push(currentRow)
+      currentRow = []
+      currentValue = ""
+      justClosedQuote = false
+      continue
+    }
+
+    currentValue += char
+    if (char.trim().length > 0) {
+      justClosedQuote = false
+    }
+  }
+
+  if (inQuotes) {
+    issues.push({
+      code: "unterminated_quote",
+      severity: "error",
+      message: "CSV has an unterminated quoted field.",
+    })
+  }
+
+  if (currentValue.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentValue)
+    rows.push(currentRow)
+  }
+
+  return rows
+}
+
+function mapRecordToHeaders(headers: string[], record: string[]) {
+  const values: Record<string, string> = {}
+
+  headers.forEach((header, index) => {
+    values[header] = record[index]?.trim() ?? ""
+  })
+
+  if (record.length > headers.length) {
+    record.slice(headers.length).forEach((value, index) => {
+      values[`__extra_${index + 1}`] = value.trim()
+    })
+  }
+
+  return values
+}
+
+function stripBom(value: string) {
+  return value.charCodeAt(0) === 0xfeff ? value.slice(1) : value
+}

--- a/apps/crew/src/lib/crew/imports/csv.ts
+++ b/apps/crew/src/lib/crew/imports/csv.ts
@@ -29,8 +29,8 @@ export function parseCsv(
     }
   }
 
-  const duplicateHeaders = findDuplicateHeaders(headers)
-  if (duplicateHeaders.length > 0) {
+  const duplicateHeaderGroups = findDuplicateHeaderGroups(headers)
+  if (duplicateHeaderGroups.length > 0) {
     return {
       headers,
       rows: [],
@@ -39,7 +39,7 @@ export function parseCsv(
         {
           code: "duplicate_headers",
           severity: "error",
-          message: `CSV headers must be unique. Duplicate header${duplicateHeaders.length === 1 ? "" : "s"}: ${duplicateHeaders.join(", ")}.`,
+          message: `CSV headers must be unique. Duplicate header group${duplicateHeaderGroups.length === 1 ? "" : "s"}: ${duplicateHeaderGroups.join("; ")}.`,
         },
       ],
       skippedRowCount: 0,
@@ -172,24 +172,29 @@ function parseCsvRecords(input: string, issues: ImportIssue[]) {
   return rows
 }
 
-function findDuplicateHeaders(headers: string[]) {
-  const seenHeaders = new Map<string, string>()
-  const duplicateHeaders = new Set<string>()
+function findDuplicateHeaderGroups(headers: string[]) {
+  const headersByNormalizedLabel = new Map<
+    string,
+    Array<{ columnNumber: number; label: string }>
+  >()
 
-  for (const header of headers) {
+  headers.forEach((header, index) => {
     const label = header.trim()
-    if (!label) continue
+    if (!label) return
 
     const key = label.toLowerCase().replace(/\s+/g, " ")
-    const firstLabel = seenHeaders.get(key)
-    if (firstLabel) {
-      duplicateHeaders.add(firstLabel)
-    } else {
-      seenHeaders.set(key, label)
-    }
-  }
+    const group = headersByNormalizedLabel.get(key) ?? []
+    group.push({ columnNumber: index + 1, label })
+    headersByNormalizedLabel.set(key, group)
+  })
 
-  return [...duplicateHeaders]
+  return [...headersByNormalizedLabel.values()]
+    .filter((group) => group.length > 1)
+    .map((group) =>
+      group
+        .map((header) => `${header.label} (column ${header.columnNumber})`)
+        .join(" / "),
+    )
 }
 
 function mapRecordToHeaders(headers: string[], record: string[]) {

--- a/apps/crew/src/lib/crew/imports/csv.ts
+++ b/apps/crew/src/lib/crew/imports/csv.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Import CSV Preview#Parser Warnings]]
 import type { CsvParseResult, CsvRecord, ImportIssue } from "./types"
 
 interface ParseCsvOptions {
@@ -22,6 +23,23 @@ export function parseCsv(
           code: "missing_headers",
           severity: "error",
           message: "CSV must include a header row.",
+        },
+      ],
+      skippedRowCount: 0,
+    }
+  }
+
+  const duplicateHeaders = findDuplicateHeaders(headers)
+  if (duplicateHeaders.length > 0) {
+    return {
+      headers,
+      rows: [],
+      fileIssues: [
+        ...fileIssues,
+        {
+          code: "duplicate_headers",
+          severity: "error",
+          message: `CSV headers must be unique. Duplicate header${duplicateHeaders.length === 1 ? "" : "s"}: ${duplicateHeaders.join(", ")}.`,
         },
       ],
       skippedRowCount: 0,
@@ -152,6 +170,26 @@ function parseCsvRecords(input: string, issues: ImportIssue[]) {
   }
 
   return rows
+}
+
+function findDuplicateHeaders(headers: string[]) {
+  const seenHeaders = new Map<string, string>()
+  const duplicateHeaders = new Set<string>()
+
+  for (const header of headers) {
+    const label = header.trim()
+    if (!label) continue
+
+    const key = label.toLowerCase().replace(/\s+/g, " ")
+    const firstLabel = seenHeaders.get(key)
+    if (firstLabel) {
+      duplicateHeaders.add(firstLabel)
+    } else {
+      seenHeaders.set(key, label)
+    }
+  }
+
+  return [...duplicateHeaders]
 }
 
 function mapRecordToHeaders(headers: string[], record: string[]) {

--- a/apps/crew/src/lib/crew/imports/dedupe.ts
+++ b/apps/crew/src/lib/crew/imports/dedupe.ts
@@ -1,0 +1,37 @@
+import type { ImportIssue, PreviewImportRow, VolunteerImportRow } from "./types"
+
+export function addDuplicateEmailWarnings(rows: PreviewImportRow[]) {
+  const rowsByEmail = new Map<string, PreviewImportRow[]>()
+
+  for (const row of rows) {
+    const email = (row.normalizedRow as VolunteerImportRow).email
+    if (!email) continue
+
+    const existing = rowsByEmail.get(email) ?? []
+    existing.push(row)
+    rowsByEmail.set(email, existing)
+  }
+
+  for (const [email, duplicates] of rowsByEmail) {
+    if (duplicates.length < 2) continue
+
+    for (const row of duplicates) {
+      row.warnings.push(createDuplicateEmailIssue(row.rowNumber, email))
+      if (row.action !== "error") row.action = "skip"
+    }
+  }
+}
+
+function createDuplicateEmailIssue(
+  rowNumber: number,
+  email: string,
+): ImportIssue {
+  return {
+    code: "duplicate_email",
+    severity: "warning",
+    rowNumber,
+    field: "email",
+    value: email,
+    message: "Email appears more than once in this file.",
+  }
+}

--- a/apps/crew/src/lib/crew/imports/dedupe.ts
+++ b/apps/crew/src/lib/crew/imports/dedupe.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Import CSV Preview#Parser Warnings]]
 import type { ImportIssue, PreviewImportRow, VolunteerImportRow } from "./types"
 
 export function addDuplicateEmailWarnings(rows: PreviewImportRow[]) {

--- a/apps/crew/src/lib/crew/imports/normalize-heat-row.ts
+++ b/apps/crew/src/lib/crew/imports/normalize-heat-row.ts
@@ -1,9 +1,13 @@
+// @lat: [[crew#Import CSV Preview#Parser Warnings]]
 import type {
   ColumnMapping,
   CsvRecord,
   HeatScheduleImportRow,
   ImportIssue,
 } from "./types"
+
+const positiveIntegerTokenPattern =
+  /(?:^|[^A-Za-z0-9+\-.])([1-9]\d*)(?=$|[^A-Za-z0-9.])/
 
 export function normalizeHeatScheduleRow(
   record: CsvRecord,
@@ -79,10 +83,10 @@ function getMappedValue(
 }
 
 function parsePositiveInteger(value: string) {
-  const match = value.match(/\d+/)
+  const match = value.trim().match(positiveIntegerTokenPattern)
   if (!match) return null
 
-  const parsed = Number(match[0])
+  const parsed = Number(match[1])
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null
 }
 

--- a/apps/crew/src/lib/crew/imports/normalize-heat-row.ts
+++ b/apps/crew/src/lib/crew/imports/normalize-heat-row.ts
@@ -1,0 +1,93 @@
+import type {
+  ColumnMapping,
+  CsvRecord,
+  HeatScheduleImportRow,
+  ImportIssue,
+} from "./types"
+
+export function normalizeHeatScheduleRow(
+  record: CsvRecord,
+  mapping: ColumnMapping,
+) {
+  const heatLabel = getMappedValue(record, mapping, "heat")
+  const normalized: HeatScheduleImportRow = {
+    workout: getMappedValue(record, mapping, "workout"),
+    heatNumber: parsePositiveInteger(heatLabel),
+    heatLabel,
+    division: getMappedValue(record, mapping, "division"),
+    scheduledTime: getMappedValue(record, mapping, "scheduledTime"),
+    durationMinutes: parseOptionalPositiveInteger(
+      getMappedValue(record, mapping, "durationMinutes"),
+    ),
+    venue: getMappedValue(record, mapping, "venue"),
+    laneCount: parseOptionalPositiveInteger(
+      getMappedValue(record, mapping, "laneCount"),
+    ),
+    notes: getMappedValue(record, mapping, "notes"),
+  }
+  const issues: ImportIssue[] = []
+
+  if (!normalized.workout) {
+    issues.push({
+      code: "missing_required_field",
+      severity: "error",
+      rowNumber: record.rowNumber,
+      field: "workout",
+      message: "Workout is required.",
+    })
+  }
+
+  if (!heatLabel) {
+    issues.push({
+      code: "missing_required_field",
+      severity: "error",
+      rowNumber: record.rowNumber,
+      field: "heat",
+      message: "Heat is required.",
+    })
+  } else if (normalized.heatNumber === null) {
+    issues.push({
+      code: "invalid_heat_number",
+      severity: "error",
+      rowNumber: record.rowNumber,
+      field: "heat",
+      value: heatLabel,
+      message: "Heat must contain a positive number.",
+    })
+  }
+
+  if (!normalized.scheduledTime) {
+    issues.push({
+      code: "missing_scheduled_time",
+      severity: "warning",
+      rowNumber: record.rowNumber,
+      field: "scheduledTime",
+      message: "Scheduled time is not mapped for this heat.",
+    })
+  }
+
+  return { normalized, issues }
+}
+
+function getMappedValue(
+  record: CsvRecord,
+  mapping: ColumnMapping,
+  field: string,
+) {
+  const header = mapping[field]
+  return header ? (record.values[header] ?? "").trim() : ""
+}
+
+function parsePositiveInteger(value: string) {
+  const match = value.match(/\d+/)
+  if (!match) return null
+
+  const parsed = Number(match[0])
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null
+}
+
+function parseOptionalPositiveInteger(value: string) {
+  if (!value.trim()) return null
+
+  return parsePositiveInteger(value)
+}

--- a/apps/crew/src/lib/crew/imports/normalize-heat-row.ts
+++ b/apps/crew/src/lib/crew/imports/normalize-heat-row.ts
@@ -6,8 +6,9 @@ import type {
   ImportIssue,
 } from "./types"
 
+// Keep sign and decimal boundaries symmetrical so signed labels never parse.
 const positiveIntegerTokenPattern =
-  /(?:^|[^A-Za-z0-9+\-.])([1-9]\d*)(?=$|[^A-Za-z0-9.])/
+  /(?:^|[^A-Za-z0-9+\-.])([1-9]\d*)(?=$|[^A-Za-z0-9+\-.])/
 
 export function normalizeHeatScheduleRow(
   record: CsvRecord,

--- a/apps/crew/src/lib/crew/imports/normalize-volunteer-row.ts
+++ b/apps/crew/src/lib/crew/imports/normalize-volunteer-row.ts
@@ -1,0 +1,102 @@
+import type {
+  ColumnMapping,
+  CsvRecord,
+  ImportIssue,
+  VolunteerImportRow,
+} from "./types"
+
+export function normalizeVolunteerRow(
+  record: CsvRecord,
+  mapping: ColumnMapping,
+) {
+  const firstName = getMappedValue(record, mapping, "firstName")
+  const lastName = getMappedValue(record, mapping, "lastName")
+  const name = getMappedValue(record, mapping, "name")
+  const splitName = splitFullName(name)
+  const normalized: VolunteerImportRow = {
+    firstName: firstName || splitName.firstName,
+    lastName: lastName || splitName.lastName,
+    name,
+    email: normalizeEmail(getMappedValue(record, mapping, "email")),
+    phone: getMappedValue(record, mapping, "phone"),
+    role: getMappedValue(record, mapping, "role"),
+    division: getMappedValue(record, mapping, "division"),
+    availability: getMappedValue(record, mapping, "availability"),
+    notes: getMappedValue(record, mapping, "notes"),
+  }
+  const issues: ImportIssue[] = []
+
+  if (!normalized.email) {
+    issues.push({
+      code: "missing_required_field",
+      severity: "error",
+      rowNumber: record.rowNumber,
+      field: "email",
+      message: "Email is required.",
+    })
+  } else if (!isLikelyEmail(normalized.email)) {
+    issues.push({
+      code: "invalid_email",
+      severity: "error",
+      rowNumber: record.rowNumber,
+      field: "email",
+      value: normalized.email,
+      message: "Email does not look valid.",
+    })
+  }
+
+  if (!normalized.firstName && !normalized.lastName && !normalized.name) {
+    issues.push({
+      code: "missing_required_field",
+      severity: "error",
+      rowNumber: record.rowNumber,
+      field: "name",
+      message: "A name, first name, or last name is required.",
+    })
+  }
+
+  if (!normalized.role) {
+    issues.push({
+      code: "missing_role",
+      severity: "warning",
+      rowNumber: record.rowNumber,
+      field: "role",
+      message: "Role is not mapped for this volunteer.",
+    })
+  }
+
+  return { normalized, issues }
+}
+
+function getMappedValue(
+  record: CsvRecord,
+  mapping: ColumnMapping,
+  field: string,
+) {
+  const header = mapping[field]
+  return header ? (record.values[header] ?? "").trim() : ""
+}
+
+function normalizeEmail(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function isLikelyEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+}
+
+function splitFullName(value: string) {
+  const parts = value.trim().split(/\s+/).filter(Boolean)
+
+  if (parts.length <= 1) {
+    return {
+      firstName: parts[0] ?? "",
+      lastName: "",
+    }
+  }
+
+  return {
+    firstName: parts[0] ?? "",
+    lastName: parts.slice(1).join(" "),
+  }
+}

--- a/apps/crew/src/lib/crew/imports/normalize-volunteer-row.ts
+++ b/apps/crew/src/lib/crew/imports/normalize-volunteer-row.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Import CSV Preview#Parser Warnings]]
 import type {
   ColumnMapping,
   CsvRecord,

--- a/apps/crew/src/lib/crew/imports/preview.test.ts
+++ b/apps/crew/src/lib/crew/imports/preview.test.ts
@@ -1,0 +1,121 @@
+// @lat: [[crew#Import CSV Preview#Parser Warnings]]
+import { describe, expect, it } from "vitest"
+import { parseCsv } from "./csv"
+import { buildCrewImportPreview } from "./preview"
+import type { CrewImportPreviewContext } from "./types"
+
+const previewContext: CrewImportPreviewContext = {
+  roleLabels: ["Lane judges", "Check-in"],
+  divisions: [
+    { id: "div_rx", label: "RX" },
+    { id: "div_scaled", label: "Scaled" },
+  ],
+  workouts: [
+    { id: "tw_1", label: "Event 1", trackOrder: 1 },
+    { id: "tw_2", label: "Final", trackOrder: 2 },
+  ],
+  heats: [
+    { trackWorkoutId: "tw_1", heatNumber: 1, divisionId: "div_rx" },
+    { trackWorkoutId: "tw_1", heatNumber: 2, divisionId: "div_scaled" },
+  ],
+}
+
+describe("parseCsv", () => {
+  it("parses quoted commas and escaped quotes", () => {
+    const parsed = parseCsv(
+      'Name,Email,Notes\n"Jones, Ian",ian@example.com,"Said ""yes"""',
+    )
+
+    expect(parsed.headers).toEqual(["Name", "Email", "Notes"])
+    expect(parsed.rows[0]?.values).toMatchObject({
+      Name: "Jones, Ian",
+      Email: "ian@example.com",
+      Notes: 'Said "yes"',
+    })
+  })
+
+  it("marks malformed rows without dropping row data", () => {
+    const parsed = parseCsv("Name,Email\nIan,ian@example.com,extra")
+
+    expect(parsed.rows[0]?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "malformed_row", severity: "error" }),
+      ]),
+    )
+    expect(parsed.rows[0]?.values.__extra_1).toBe("extra")
+  })
+})
+
+describe("buildCrewImportPreview", () => {
+  it("flags duplicate volunteer emails and unknown reference values", () => {
+    const preview = buildCrewImportPreview({
+      kind: "volunteers",
+      context: previewContext,
+      csvText: [
+        "Full Name,Email,Role,Division",
+        "Ian Jones,IAN@example.com,Lane judges,RX",
+        "I J,ian@example.com,Unknown role,Masters",
+      ].join("\n"),
+    })
+
+    expect(preview.warningCount).toBeGreaterThanOrEqual(3)
+    expect(preview.rows[0]?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "duplicate_email" }),
+      ]),
+    )
+    expect(preview.rows[1]?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "duplicate_email" }),
+        expect.objectContaining({ code: "unknown_role" }),
+        expect.objectContaining({ code: "unknown_division" }),
+      ]),
+    )
+    expect(preview.rows[1]?.action).toBe("skip")
+  })
+
+  it("flags missing volunteer required fields", () => {
+    const preview = buildCrewImportPreview({
+      kind: "volunteers",
+      context: previewContext,
+      csvText: "Name,Role\n,Lane judges",
+    })
+
+    expect(preview.errorCount).toBeGreaterThanOrEqual(2)
+    expect(preview.fileIssues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "missing_required_mapping" }),
+      ]),
+    )
+    expect(preview.rows[0]?.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "missing_required_field" }),
+      ]),
+    )
+  })
+
+  it("previews heat schedule rows with unknown workout, division, and heat warnings", () => {
+    const preview = buildCrewImportPreview({
+      kind: "heat_schedule",
+      context: previewContext,
+      csvText: [
+        "Workout,Heat,Division,Start Time",
+        "Event 1,Heat 9,RX,9:00 AM",
+        "Unknown,Heat 1,Masters,9:12 AM",
+      ].join("\n"),
+    })
+
+    expect(preview.rows[0]?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "unknown_heat" }),
+      ]),
+    )
+    expect(preview.rows[1]?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "unknown_workout" }),
+        expect.objectContaining({ code: "unknown_division" }),
+      ]),
+    )
+    expect(preview.errorCount).toBe(0)
+  })
+})

--- a/apps/crew/src/lib/crew/imports/preview.test.ts
+++ b/apps/crew/src/lib/crew/imports/preview.test.ts
@@ -44,6 +44,20 @@ describe("parseCsv", () => {
     )
     expect(parsed.rows[0]?.values.__extra_1).toBe("extra")
   })
+
+  it("rejects duplicate non-empty headers before row mapping", () => {
+    const parsed = parseCsv("Name,Email,email\nIan,first@example.com,second")
+
+    expect(parsed.rows).toHaveLength(0)
+    expect(parsed.fileIssues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "duplicate_headers",
+          severity: "error",
+        }),
+      ]),
+    )
+  })
 })
 
 describe("buildCrewImportPreview", () => {
@@ -117,5 +131,34 @@ describe("buildCrewImportPreview", () => {
       ]),
     )
     expect(preview.errorCount).toBe(0)
+  })
+
+  it("rejects signed negative heat numbers", () => {
+    const preview = buildCrewImportPreview({
+      kind: "heat_schedule",
+      context: previewContext,
+      csvText: "Workout,Heat,Start Time\nEvent 1,-3,9:00 AM",
+    })
+
+    expect(preview.rows[0]?.action).toBe("error")
+    expect(preview.rows[0]?.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid_heat_number" }),
+      ]),
+    )
+  })
+
+  it("flags unknown heat when a known workout has no loaded heats", () => {
+    const preview = buildCrewImportPreview({
+      kind: "heat_schedule",
+      context: { ...previewContext, heats: [] },
+      csvText: "Workout,Heat,Start Time\nEvent 1,Heat 1,9:00 AM",
+    })
+
+    expect(preview.rows[0]?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "unknown_heat" }),
+      ]),
+    )
   })
 })

--- a/apps/crew/src/lib/crew/imports/preview.test.ts
+++ b/apps/crew/src/lib/crew/imports/preview.test.ts
@@ -57,6 +57,9 @@ describe("parseCsv", () => {
         }),
       ]),
     )
+    expect(parsed.fileIssues[0]?.message).toContain(
+      "Email (column 2) / email (column 3)",
+    )
   })
 })
 
@@ -133,19 +136,21 @@ describe("buildCrewImportPreview", () => {
     expect(preview.errorCount).toBe(0)
   })
 
-  it("rejects signed negative heat numbers", () => {
-    const preview = buildCrewImportPreview({
-      kind: "heat_schedule",
-      context: previewContext,
-      csvText: "Workout,Heat,Start Time\nEvent 1,-3,9:00 AM",
-    })
+  it("rejects sign-adjacent heat numbers", () => {
+    for (const heatLabel of ["-3", "+3", "3-", "3+"]) {
+      const preview = buildCrewImportPreview({
+        kind: "heat_schedule",
+        context: previewContext,
+        csvText: `Workout,Heat,Start Time\nEvent 1,${heatLabel},9:00 AM`,
+      })
 
-    expect(preview.rows[0]?.action).toBe("error")
-    expect(preview.rows[0]?.errors).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ code: "invalid_heat_number" }),
-      ]),
-    )
+      expect(preview.rows[0]?.action).toBe("error")
+      expect(preview.rows[0]?.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ code: "invalid_heat_number" }),
+        ]),
+      )
+    }
   })
 
   it("flags unknown heat when a known workout has no loaded heats", () => {

--- a/apps/crew/src/lib/crew/imports/preview.ts
+++ b/apps/crew/src/lib/crew/imports/preview.ts
@@ -216,7 +216,7 @@ function buildHeatScheduleRows(
 
     if (workout && normalized.normalized.heatNumber !== null) {
       const knownHeats = knownHeatsByWorkout.get(workout.id)
-      if (knownHeats && !knownHeats.has(normalized.normalized.heatNumber)) {
+      if (!knownHeats || !knownHeats.has(normalized.normalized.heatNumber)) {
         warnings.push({
           code: "unknown_heat",
           severity: "warning",

--- a/apps/crew/src/lib/crew/imports/preview.ts
+++ b/apps/crew/src/lib/crew/imports/preview.ts
@@ -1,0 +1,259 @@
+// @lat: [[crew#Import CSV Preview#Parser Warnings]]
+import { defaultStaffingRoleAssumptions } from "../../crew-staffing-calculator"
+import {
+  getImportFields,
+  inferColumnMapping,
+  normalizeHeader,
+  sanitizeColumnMapping,
+} from "./column-mapping"
+import { parseCsv } from "./csv"
+import { addDuplicateEmailWarnings } from "./dedupe"
+import { normalizeHeatScheduleRow } from "./normalize-heat-row"
+import { normalizeVolunteerRow } from "./normalize-volunteer-row"
+import {
+  CREW_IMPORT_PARSER_VERSION,
+  type ColumnMapping,
+  type CrewImportKind,
+  type CrewImportPreview,
+  type CrewImportPreviewContext,
+  type ImportIssue,
+  type PreviewImportRow,
+} from "./types"
+
+const MAX_PREVIEW_ROWS = 500
+
+export const defaultCrewImportRoleLabels = [
+  ...defaultStaffingRoleAssumptions.map((role) => role.label),
+  "Judge",
+  "Head judge",
+  "Volunteer",
+  "Scoring",
+  "Check-in",
+]
+
+export function buildCrewImportPreview({
+  csvText,
+  kind,
+  columnMapping,
+  context,
+}: {
+  csvText: string
+  kind: CrewImportKind
+  columnMapping?: ColumnMapping
+  context: CrewImportPreviewContext
+}): CrewImportPreview {
+  const parsed = parseCsv(csvText, { maxRows: MAX_PREVIEW_ROWS })
+  const inferredMapping = inferColumnMapping(parsed.headers, kind)
+  const mapping = sanitizeColumnMapping(
+    { ...inferredMapping, ...columnMapping },
+    parsed.headers,
+    kind,
+  )
+  const fileIssues = [
+    ...parsed.fileIssues,
+    ...validateRequiredMapping(kind, mapping),
+  ]
+  const rows =
+    kind === "volunteers"
+      ? buildVolunteerRows(parsed.rows, mapping, context)
+      : buildHeatScheduleRows(parsed.rows, mapping, context)
+  const warningCount =
+    fileIssues.filter((issue) => issue.severity === "warning").length +
+    rows.reduce((total, row) => total + row.warnings.length, 0)
+  const errorCount =
+    fileIssues.filter((issue) => issue.severity === "error").length +
+    rows.reduce((total, row) => total + row.errors.length, 0)
+
+  return {
+    kind,
+    parserVersion: CREW_IMPORT_PARSER_VERSION,
+    headers: parsed.headers,
+    columnMapping: mapping,
+    rows,
+    fileIssues,
+    rowCount: rows.length,
+    skippedRowCount: parsed.skippedRowCount,
+    warningCount,
+    errorCount,
+  }
+}
+
+function buildVolunteerRows(
+  records: ReturnType<typeof parseCsv>["rows"],
+  mapping: ColumnMapping,
+  context: CrewImportPreviewContext,
+) {
+  const knownRoles = new Set(
+    context.roleLabels.map((role) => normalizeLookupValue(role)),
+  )
+  const knownDivisions = new Set(
+    context.divisions.map((division) => normalizeLookupValue(division.label)),
+  )
+  const rows: PreviewImportRow[] = records.map((record) => {
+    const normalized = normalizeVolunteerRow(record, mapping)
+    const warnings = [
+      ...record.issues.filter((issue) => issue.severity === "warning"),
+      ...normalized.issues.filter((issue) => issue.severity === "warning"),
+    ]
+    const errors = [
+      ...record.issues.filter((issue) => issue.severity === "error"),
+      ...normalized.issues.filter((issue) => issue.severity === "error"),
+    ]
+
+    if (
+      normalized.normalized.role &&
+      knownRoles.size > 0 &&
+      !knownRoles.has(normalizeLookupValue(normalized.normalized.role))
+    ) {
+      warnings.push({
+        code: "unknown_role",
+        severity: "warning",
+        rowNumber: record.rowNumber,
+        field: "role",
+        value: normalized.normalized.role,
+        message: "Role does not match the current Crew assumptions.",
+      })
+    }
+
+    if (
+      normalized.normalized.division &&
+      knownDivisions.size > 0 &&
+      !knownDivisions.has(normalizeLookupValue(normalized.normalized.division))
+    ) {
+      warnings.push({
+        code: "unknown_division",
+        severity: "warning",
+        rowNumber: record.rowNumber,
+        field: "division",
+        value: normalized.normalized.division,
+        message: "Division does not match the current event divisions.",
+      })
+    }
+
+    return {
+      rowNumber: record.rowNumber,
+      rawRow: record.values,
+      normalizedRow: normalized.normalized,
+      targetType: "team_invitation",
+      action: errors.length > 0 ? "error" : "create",
+      warnings,
+      errors,
+    }
+  })
+
+  addDuplicateEmailWarnings(rows)
+
+  return rows
+}
+
+function buildHeatScheduleRows(
+  records: ReturnType<typeof parseCsv>["rows"],
+  mapping: ColumnMapping,
+  context: CrewImportPreviewContext,
+): PreviewImportRow[] {
+  const knownDivisions = new Set(
+    context.divisions.map((division) => normalizeLookupValue(division.label)),
+  )
+  const workoutByLabel = new Map(
+    context.workouts.flatMap((workout) => [
+      [normalizeLookupValue(workout.label), workout],
+      [normalizeLookupValue(String(workout.trackOrder)), workout],
+      [normalizeLookupValue(`event ${workout.trackOrder}`), workout],
+      [normalizeLookupValue(`workout ${workout.trackOrder}`), workout],
+    ]),
+  )
+  const knownHeatsByWorkout = new Map<string, Set<number>>()
+  for (const heat of context.heats) {
+    const heatNumbers =
+      knownHeatsByWorkout.get(heat.trackWorkoutId) ?? new Set()
+    heatNumbers.add(heat.heatNumber)
+    knownHeatsByWorkout.set(heat.trackWorkoutId, heatNumbers)
+  }
+
+  return records.map((record) => {
+    const normalized = normalizeHeatScheduleRow(record, mapping)
+    const warnings = [
+      ...record.issues.filter((issue) => issue.severity === "warning"),
+      ...normalized.issues.filter((issue) => issue.severity === "warning"),
+    ]
+    const errors = [
+      ...record.issues.filter((issue) => issue.severity === "error"),
+      ...normalized.issues.filter((issue) => issue.severity === "error"),
+    ]
+    const workout = normalized.normalized.workout
+      ? workoutByLabel.get(normalizeLookupValue(normalized.normalized.workout))
+      : null
+
+    if (
+      normalized.normalized.workout &&
+      context.workouts.length > 0 &&
+      !workout
+    ) {
+      warnings.push({
+        code: "unknown_workout",
+        severity: "warning",
+        rowNumber: record.rowNumber,
+        field: "workout",
+        value: normalized.normalized.workout,
+        message: "Workout does not match the current event workouts.",
+      })
+    }
+
+    if (
+      normalized.normalized.division &&
+      knownDivisions.size > 0 &&
+      !knownDivisions.has(normalizeLookupValue(normalized.normalized.division))
+    ) {
+      warnings.push({
+        code: "unknown_division",
+        severity: "warning",
+        rowNumber: record.rowNumber,
+        field: "division",
+        value: normalized.normalized.division,
+        message: "Division does not match the current event divisions.",
+      })
+    }
+
+    if (workout && normalized.normalized.heatNumber !== null) {
+      const knownHeats = knownHeatsByWorkout.get(workout.id)
+      if (knownHeats && !knownHeats.has(normalized.normalized.heatNumber)) {
+        warnings.push({
+          code: "unknown_heat",
+          severity: "warning",
+          rowNumber: record.rowNumber,
+          field: "heat",
+          value: String(normalized.normalized.heatNumber),
+          message: "Heat number does not match the current event heats.",
+        })
+      }
+    }
+
+    return {
+      rowNumber: record.rowNumber,
+      rawRow: record.values,
+      normalizedRow: normalized.normalized,
+      targetType: "competition_heat",
+      action: errors.length > 0 ? "error" : "create",
+      warnings,
+      errors,
+    }
+  })
+}
+
+function validateRequiredMapping(
+  kind: CrewImportKind,
+  mapping: ColumnMapping,
+): ImportIssue[] {
+  return getImportFields(kind)
+    .filter((field) => field.required && !mapping[field.key])
+    .map((field) => ({
+      code: "missing_required_mapping",
+      severity: "error",
+      field: field.key,
+      message: `${field.label} must be mapped before preview.`,
+    }))
+}
+
+function normalizeLookupValue(value: string) {
+  return normalizeHeader(value)
+}

--- a/apps/crew/src/lib/crew/imports/types.ts
+++ b/apps/crew/src/lib/crew/imports/types.ts
@@ -1,0 +1,95 @@
+export const CREW_IMPORT_PARSER_VERSION = "crew-csv-preview-v1"
+
+export type CrewImportKind = "volunteers" | "heat_schedule"
+
+export type ImportIssueSeverity = "warning" | "error"
+
+export interface ImportIssue {
+  code: string
+  severity: ImportIssueSeverity
+  message: string
+  field?: string
+  rowNumber?: number
+  value?: string
+}
+
+export interface CsvRecord {
+  rowNumber: number
+  rawValues: string[]
+  values: Record<string, string>
+  issues: ImportIssue[]
+}
+
+export interface CsvParseResult {
+  headers: string[]
+  rows: CsvRecord[]
+  fileIssues: ImportIssue[]
+  skippedRowCount: number
+}
+
+export interface ImportFieldDefinition {
+  key: string
+  label: string
+  required?: boolean
+  aliases: string[]
+}
+
+export type ColumnMapping = Record<string, string>
+
+export interface VolunteerImportRow {
+  firstName: string
+  lastName: string
+  name: string
+  email: string
+  phone: string
+  role: string
+  division: string
+  availability: string
+  notes: string
+}
+
+export interface HeatScheduleImportRow {
+  workout: string
+  heatNumber: number | null
+  heatLabel: string
+  division: string
+  scheduledTime: string
+  durationMinutes: number | null
+  venue: string
+  laneCount: number | null
+  notes: string
+}
+
+export interface CrewImportPreviewContext {
+  roleLabels: string[]
+  divisions: Array<{ id: string; label: string }>
+  workouts: Array<{ id: string; label: string; trackOrder: number }>
+  heats: Array<{
+    trackWorkoutId: string
+    heatNumber: number
+    divisionId: string | null
+  }>
+}
+
+export interface PreviewImportRow {
+  rowNumber: number
+  rawRow: Record<string, string>
+  normalizedRow: VolunteerImportRow | HeatScheduleImportRow
+  action: "create" | "skip" | "error"
+  targetType: "team_invitation" | "competition_heat"
+  warnings: ImportIssue[]
+  errors: ImportIssue[]
+}
+
+export interface CrewImportPreview {
+  kind: CrewImportKind
+  parserVersion: string
+  headers: string[]
+  columnMapping: ColumnMapping
+  rows: PreviewImportRow[]
+  fileIssues: ImportIssue[]
+  rowCount: number
+  skippedRowCount: number
+  warningCount: number
+  errorCount: number
+}

--- a/apps/crew/src/lib/crew/imports/types.ts
+++ b/apps/crew/src/lib/crew/imports/types.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Import CSV Preview#Parser Warnings]]
 export const CREW_IMPORT_PARSER_VERSION = "crew-csv-preview-v1"
 
 export type CrewImportKind = "volunteers" | "heat_schedule"

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -18,6 +18,8 @@ import { Route as EventsEventIdIndexRouteImport } from './routes/events/$eventId
 import { Route as EventsEventIdVolunteersRouteImport } from './routes/events/$eventId/volunteers'
 import { Route as EventsEventIdSetupRouteImport } from './routes/events/$eventId/setup'
 import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$eventId/schedule'
+import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
+import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
 
 const EventsRoute = EventsRouteImport.update({
   id: '/events',
@@ -64,6 +66,16 @@ const EventsEventIdScheduleRoute = EventsEventIdScheduleRouteImport.update({
   path: '/schedule',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdImportsRoute = EventsEventIdImportsRouteImport.update({
+  id: '/imports',
+  path: '/imports',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
+const ApiCrewImportRoute = ApiCrewImportRouteImport.update({
+  id: '/api/crew/import',
+  path: '/api/crew/import',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -71,6 +83,8 @@ export interface FileRoutesByFullPath {
   '/events': typeof EventsRouteWithChildren
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
+  '/api/crew/import': typeof ApiCrewImportRoute
+  '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
@@ -81,6 +95,8 @@ export interface FileRoutesByTo {
   '/calculator': typeof CalculatorRoute
   '/events': typeof EventsRouteWithChildren
   '/events/new': typeof EventsNewRoute
+  '/api/crew/import': typeof ApiCrewImportRoute
+  '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
@@ -93,6 +109,8 @@ export interface FileRoutesById {
   '/events': typeof EventsRouteWithChildren
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
+  '/api/crew/import': typeof ApiCrewImportRoute
+  '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
@@ -106,6 +124,8 @@ export interface FileRouteTypes {
     | '/events'
     | '/events/$eventId'
     | '/events/new'
+    | '/api/crew/import'
+    | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
@@ -116,6 +136,8 @@ export interface FileRouteTypes {
     | '/calculator'
     | '/events'
     | '/events/new'
+    | '/api/crew/import'
+    | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
@@ -127,6 +149,8 @@ export interface FileRouteTypes {
     | '/events'
     | '/events/$eventId'
     | '/events/new'
+    | '/api/crew/import'
+    | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
@@ -137,6 +161,7 @@ export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CalculatorRoute: typeof CalculatorRoute
   EventsRoute: typeof EventsRouteWithChildren
+  ApiCrewImportRoute: typeof ApiCrewImportRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -204,10 +229,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdScheduleRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/imports': {
+      id: '/events/$eventId/imports'
+      path: '/imports'
+      fullPath: '/events/$eventId/imports'
+      preLoaderRoute: typeof EventsEventIdImportsRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
+    '/api/crew/import': {
+      id: '/api/crew/import'
+      path: '/api/crew/import'
+      fullPath: '/api/crew/import'
+      preLoaderRoute: typeof ApiCrewImportRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 interface EventsEventIdRouteChildren {
+  EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
   EventsEventIdScheduleRoute: typeof EventsEventIdScheduleRoute
   EventsEventIdSetupRoute: typeof EventsEventIdSetupRoute
   EventsEventIdVolunteersRoute: typeof EventsEventIdVolunteersRoute
@@ -215,6 +255,7 @@ interface EventsEventIdRouteChildren {
 }
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
+  EventsEventIdImportsRoute: EventsEventIdImportsRoute,
   EventsEventIdScheduleRoute: EventsEventIdScheduleRoute,
   EventsEventIdSetupRoute: EventsEventIdSetupRoute,
   EventsEventIdVolunteersRoute: EventsEventIdVolunteersRoute,
@@ -242,6 +283,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CalculatorRoute: CalculatorRoute,
   EventsRoute: EventsRouteWithChildren,
+  ApiCrewImportRoute: ApiCrewImportRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/crew/src/routes/api/crew/import.ts
+++ b/apps/crew/src/routes/api/crew/import.ts
@@ -1,10 +1,13 @@
 // @lat: [[crew#Import CSV Preview#Private Upload Route]]
 import { createFileRoute } from "@tanstack/react-router"
 import { json } from "@tanstack/react-start"
+import { ZodError } from "zod"
 import {
   createCrewImportPreviewRecord,
+  CrewImportError,
   MAX_CREW_IMPORT_BYTES,
 } from "../../../server/crew-imports"
+import { CrewLocalAccessError } from "../../../server/crew-local-access"
 import type {
   ColumnMapping,
   CrewImportKind,
@@ -36,14 +39,15 @@ export const Route = createFileRoute("/api/crew/import")({
           if (file.size > MAX_CREW_IMPORT_BYTES) {
             return json(
               { error: "CSV is larger than the Crew preview limit." },
-              { status: 400 },
+              { status: 413 },
             )
           }
 
+          const csvText = await file.text()
           const importPreview = await createCrewImportPreviewRecord({
             eventId,
             kind,
-            csvText: await file.text(),
+            csvText,
             originalFilename: file.name,
             mimeType: file.type || null,
             fileSize: file.size,
@@ -55,13 +59,8 @@ export const Route = createFileRoute("/api/crew/import")({
 
           return json({ importPreview })
         } catch (error) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : "Failed to preview Crew import."
-          const status = message.includes("local-operator only") ? 403 : 400
-
-          return json({ error: message }, { status })
+          const response = getImportErrorResponse(error)
+          return json({ error: response.message }, { status: response.status })
         }
       },
     },
@@ -76,9 +75,21 @@ function getTextFormValue(formData: FormData, key: string) {
 function parseColumnMapping(value: string): ColumnMapping | undefined {
   if (!value) return undefined
 
-  const parsed = JSON.parse(value) as unknown
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(value) as unknown
+  } catch {
+    throw new CrewImportError(
+      "INVALID_COLUMN_MAPPING",
+      "Column mapping must be valid JSON.",
+    )
+  }
+
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return undefined
+    throw new CrewImportError(
+      "INVALID_COLUMN_MAPPING",
+      "Column mapping must be a JSON object.",
+    )
   }
 
   const mapping: ColumnMapping = {}
@@ -87,4 +98,21 @@ function parseColumnMapping(value: string): ColumnMapping | undefined {
   }
 
   return mapping
+}
+
+function getImportErrorResponse(error: unknown) {
+  if (error instanceof CrewLocalAccessError) {
+    return { status: 403, message: error.message }
+  }
+
+  if (error instanceof CrewImportError) {
+    return { status: error.status, message: error.publicMessage }
+  }
+
+  if (error instanceof ZodError) {
+    return { status: 400, message: "Import request is invalid." }
+  }
+
+  console.error("Unexpected Crew import preview failure:", error)
+  return { status: 500, message: "Failed to preview Crew import." }
 }

--- a/apps/crew/src/routes/api/crew/import.ts
+++ b/apps/crew/src/routes/api/crew/import.ts
@@ -1,0 +1,90 @@
+// @lat: [[crew#Import CSV Preview#Private Upload Route]]
+import { createFileRoute } from "@tanstack/react-router"
+import { json } from "@tanstack/react-start"
+import {
+  createCrewImportPreviewRecord,
+  MAX_CREW_IMPORT_BYTES,
+} from "../../../server/crew-imports"
+import type {
+  ColumnMapping,
+  CrewImportKind,
+} from "../../../lib/crew/imports/types"
+
+export const Route = createFileRoute("/api/crew/import")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        try {
+          const formData = await request.formData()
+          const eventId = getTextFormValue(formData, "eventId")
+          const kind = getTextFormValue(formData, "kind") as CrewImportKind
+          const sourcePlatform = getTextFormValue(formData, "sourcePlatform")
+          const file = formData.get("file")
+
+          if (!eventId) {
+            return json({ error: "Event ID is required." }, { status: 400 })
+          }
+
+          if (kind !== "volunteers" && kind !== "heat_schedule") {
+            return json({ error: "Invalid import kind." }, { status: 400 })
+          }
+
+          if (!(file instanceof File)) {
+            return json({ error: "CSV file is required." }, { status: 400 })
+          }
+
+          if (file.size > MAX_CREW_IMPORT_BYTES) {
+            return json(
+              { error: "CSV is larger than the Crew preview limit." },
+              { status: 400 },
+            )
+          }
+
+          const importPreview = await createCrewImportPreviewRecord({
+            eventId,
+            kind,
+            csvText: await file.text(),
+            originalFilename: file.name,
+            mimeType: file.type || null,
+            fileSize: file.size,
+            sourcePlatform: sourcePlatform || null,
+            columnMapping: parseColumnMapping(
+              getTextFormValue(formData, "columnMapping"),
+            ),
+          })
+
+          return json({ importPreview })
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : "Failed to preview Crew import."
+          const status = message.includes("local-operator only") ? 403 : 400
+
+          return json({ error: message }, { status })
+        }
+      },
+    },
+  },
+})
+
+function getTextFormValue(formData: FormData, key: string) {
+  const value = formData.get(key)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function parseColumnMapping(value: string): ColumnMapping | undefined {
+  if (!value) return undefined
+
+  const parsed = JSON.parse(value) as unknown
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return undefined
+  }
+
+  const mapping: ColumnMapping = {}
+  for (const [field, header] of Object.entries(parsed)) {
+    if (typeof header === "string") mapping[field] = header
+  }
+
+  return mapping
+}

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -45,6 +45,14 @@ function EventShell() {
             Setup
           </Link>
           <Link
+            to="/events/$eventId/imports"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Imports
+          </Link>
+          <Link
             to="/events/$eventId/volunteers"
             params={{ eventId }}
             activeProps={{ className: "bg-muted text-foreground" }}

--- a/apps/crew/src/routes/events/$eventId/imports.tsx
+++ b/apps/crew/src/routes/events/$eventId/imports.tsx
@@ -1,0 +1,660 @@
+import type { ChangeEvent, FormEvent, ReactNode } from "react"
+import { useMemo, useState } from "react"
+import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  FileSpreadsheet,
+  Loader2,
+  Upload,
+} from "lucide-react"
+import { toast } from "sonner"
+import {
+  getImportFields,
+  inferColumnMapping,
+} from "@/lib/crew/imports/column-mapping"
+import { parseCsv } from "@/lib/crew/imports/csv"
+import type {
+  ColumnMapping,
+  CrewImportKind,
+  HeatScheduleImportRow,
+  ImportIssue,
+  PreviewImportRow,
+  VolunteerImportRow,
+} from "@/lib/crew/imports/types"
+import {
+  getCrewImportsPageFn,
+  type CrewImportHistoryItem,
+  type CrewImportReferenceData,
+  type PersistedCrewImportPreview,
+} from "@/server-fns/crew-import-fns"
+
+export const Route = createFileRoute("/events/$eventId/imports")({
+  loader: async ({ params }) =>
+    await getCrewImportsPageFn({ data: { eventId: params.eventId } }),
+  component: EventImportsPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+type ImportsTab = CrewImportKind | "roles" | "history"
+
+function EventImportsPage() {
+  const router = useRouter()
+  const { eventId } = parentRoute.useParams()
+  const { history, reference } = Route.useLoaderData()
+  const [activeTab, setActiveTab] = useState<ImportsTab>("volunteers")
+  const [latestPreview, setLatestPreview] =
+    useState<PersistedCrewImportPreview | null>(null)
+
+  function handlePreviewComplete(preview: PersistedCrewImportPreview) {
+    setLatestPreview(preview)
+    setActiveTab(preview.kind)
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Imports</h2>
+          <p className="text-sm text-muted-foreground">
+            CSV preview, mapping, warnings, and event import history.
+          </p>
+        </div>
+        <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
+          <ImportTabButton
+            active={activeTab === "volunteers"}
+            label="Volunteers"
+            onClick={() => setActiveTab("volunteers")}
+          />
+          <ImportTabButton
+            active={activeTab === "heat_schedule"}
+            label="Heat schedule"
+            onClick={() => setActiveTab("heat_schedule")}
+          />
+          <ImportTabButton
+            active={activeTab === "roles"}
+            label="Roles"
+            onClick={() => setActiveTab("roles")}
+          />
+          <ImportTabButton
+            active={activeTab === "history"}
+            label="History"
+            onClick={() => setActiveTab("history")}
+          />
+        </div>
+      </div>
+
+      {activeTab === "volunteers" || activeTab === "heat_schedule" ? (
+        <div className="grid gap-6 xl:grid-cols-[minmax(0,24rem)_1fr]">
+          <ImportUploadPanel
+            key={activeTab}
+            eventId={eventId}
+            kind={activeTab}
+            onPreviewComplete={handlePreviewComplete}
+            onHistoryRefresh={() => router.invalidate()}
+          />
+          <PreviewPanel preview={latestPreview} expectedKind={activeTab} />
+        </div>
+      ) : null}
+
+      {activeTab === "roles" ? <ReferencePanel reference={reference} /> : null}
+
+      {activeTab === "history" ? <HistoryPanel history={history} /> : null}
+    </section>
+  )
+}
+
+function ImportUploadPanel({
+  eventId,
+  kind,
+  onPreviewComplete,
+  onHistoryRefresh,
+}: {
+  eventId: string
+  kind: CrewImportKind
+  onPreviewComplete: (preview: PersistedCrewImportPreview) => void
+  onHistoryRefresh: () => Promise<void>
+}) {
+  const [file, setFile] = useState<File | null>(null)
+  const [headers, setHeaders] = useState<string[]>([])
+  const [mapping, setMapping] = useState<ColumnMapping>({})
+  const [sourcePlatform, setSourcePlatform] = useState("")
+  const [clientIssues, setClientIssues] = useState<ImportIssue[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const fields = useMemo(() => getImportFields(kind), [kind])
+
+  async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const selectedFile = event.target.files?.[0] ?? null
+    setFile(selectedFile)
+
+    if (!selectedFile) {
+      setHeaders([])
+      setMapping({})
+      setClientIssues([])
+      return
+    }
+
+    const csv = parseCsv(await selectedFile.text(), { maxRows: 20 })
+    setHeaders(csv.headers)
+    setMapping(inferColumnMapping(csv.headers, kind))
+    setClientIssues(csv.fileIssues)
+  }
+
+  function updateMapping(field: string, header: string) {
+    setMapping((current) => {
+      const next = { ...current }
+      if (header) next[field] = header
+      else delete next[field]
+      return next
+    })
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    if (!file) {
+      toast.error("Choose a CSV file first")
+      return
+    }
+
+    setIsSubmitting(true)
+    const formData = new FormData()
+    formData.append("eventId", eventId)
+    formData.append("kind", kind)
+    formData.append("file", file)
+    formData.append("sourcePlatform", sourcePlatform)
+    formData.append("columnMapping", JSON.stringify(mapping))
+
+    try {
+      const response = await fetch("/api/crew/import", {
+        method: "POST",
+        body: formData,
+      })
+      const payload = (await response.json()) as
+        | { importPreview: PersistedCrewImportPreview }
+        | { error: string }
+
+      if (!response.ok || !("importPreview" in payload)) {
+        throw new Error(
+          "error" in payload ? payload.error : "Failed to preview import",
+        )
+      }
+
+      onPreviewComplete(payload.importPreview)
+      toast.success("Import preview created")
+      await onHistoryRefresh()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to preview import",
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-md border bg-card p-5 shadow-sm"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex size-10 items-center justify-center rounded-md bg-muted">
+          <FileSpreadsheet className="size-5 text-muted-foreground" />
+        </div>
+        <div>
+          <h3 className="font-semibold">{formatKind(kind)} CSV</h3>
+          <p className="text-sm text-muted-foreground">
+            {headers.length > 0
+              ? `${headers.length} columns detected`
+              : "No file selected"}
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-5 space-y-4">
+        <Field label="CSV file" htmlFor={`crew-import-file-${kind}`}>
+          <input
+            id={`crew-import-file-${kind}`}
+            type="file"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            className="block w-full rounded-md border bg-background px-3 py-2 text-sm file:mr-3 file:rounded-md file:border-0 file:bg-muted file:px-3 file:py-1.5 file:text-sm file:font-medium"
+          />
+        </Field>
+        <Field label="Source platform" htmlFor={`crew-import-source-${kind}`}>
+          <input
+            id={`crew-import-source-${kind}`}
+            value={sourcePlatform}
+            onChange={(event) => setSourcePlatform(event.target.value)}
+            className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+          />
+        </Field>
+      </div>
+
+      {clientIssues.length > 0 ? (
+        <IssueList className="mt-4" issues={clientIssues} />
+      ) : null}
+
+      {headers.length > 0 ? (
+        <div className="mt-6 space-y-3">
+          <h4 className="text-sm font-semibold">Mapping</h4>
+          <div className="space-y-3">
+            {fields.map((field) => (
+              <label
+                key={field.key}
+                className="grid gap-1 text-sm sm:grid-cols-[8rem_1fr] sm:items-center"
+              >
+                <span className="text-muted-foreground">
+                  {field.label}
+                  {field.required ? " *" : ""}
+                </span>
+                <select
+                  value={mapping[field.key] ?? ""}
+                  onChange={(event) =>
+                    updateMapping(field.key, event.target.value)
+                  }
+                  className="h-10 rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value="">Not mapped</option>
+                  {headers.map((header) => (
+                    <option key={header} value={header}>
+                      {header}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="mt-6 inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isSubmitting ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <Upload className="size-4" />
+        )}
+        Preview CSV
+      </button>
+    </form>
+  )
+}
+
+function PreviewPanel({
+  preview,
+  expectedKind,
+}: {
+  preview: PersistedCrewImportPreview | null
+  expectedKind: CrewImportKind
+}) {
+  if (!preview || preview.kind !== expectedKind) {
+    return (
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h3 className="font-semibold">Preview</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          The latest {formatKind(expectedKind).toLowerCase()} preview will
+          appear here.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="space-y-4 rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="font-semibold">{preview.originalFilename}</h3>
+          <p className="text-sm text-muted-foreground">
+            Import {preview.importId}
+          </p>
+        </div>
+        <StatusBadge status={preview.status} />
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <SummaryMetric label="Rows" value={preview.rowCount} />
+        <SummaryMetric label="Warnings" value={preview.warningCount} />
+        <SummaryMetric label="Errors" value={preview.errorCount} />
+      </div>
+
+      {preview.fileIssues.length > 0 ? (
+        <IssueList issues={preview.fileIssues} />
+      ) : null}
+
+      <PreviewTable kind={preview.kind} rows={preview.rows} />
+    </section>
+  )
+}
+
+function PreviewTable({
+  kind,
+  rows,
+}: {
+  kind: CrewImportKind
+  rows: PreviewImportRow[]
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-md border bg-background p-4 text-sm text-muted-foreground">
+        No rows were parsed.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <div className="max-h-[32rem] overflow-auto">
+        <table className="w-full min-w-[48rem] text-left text-sm">
+          <thead className="sticky top-0 bg-muted text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2 font-medium">Row</th>
+              {kind === "volunteers" ? (
+                <>
+                  <th className="px-3 py-2 font-medium">Name</th>
+                  <th className="px-3 py-2 font-medium">Email</th>
+                  <th className="px-3 py-2 font-medium">Role</th>
+                  <th className="px-3 py-2 font-medium">Division</th>
+                </>
+              ) : (
+                <>
+                  <th className="px-3 py-2 font-medium">Workout</th>
+                  <th className="px-3 py-2 font-medium">Heat</th>
+                  <th className="px-3 py-2 font-medium">Time</th>
+                  <th className="px-3 py-2 font-medium">Division</th>
+                </>
+              )}
+              <th className="px-3 py-2 font-medium">Issues</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.rowNumber} className="border-t align-top">
+                <td className="px-3 py-2 font-mono text-xs">{row.rowNumber}</td>
+                {kind === "volunteers" ? (
+                  <VolunteerCells
+                    row={row.normalizedRow as VolunteerImportRow}
+                  />
+                ) : (
+                  <HeatCells row={row.normalizedRow as HeatScheduleImportRow} />
+                )}
+                <td className="px-3 py-2">
+                  <RowIssues row={row} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function VolunteerCells({ row }: { row: VolunteerImportRow }) {
+  const displayName =
+    row.name || [row.firstName, row.lastName].filter(Boolean).join(" ")
+
+  return (
+    <>
+      <td className="px-3 py-2">{displayName || "Not mapped"}</td>
+      <td className="px-3 py-2">{row.email || "Not mapped"}</td>
+      <td className="px-3 py-2">{row.role || "Not mapped"}</td>
+      <td className="px-3 py-2">{row.division || "Not mapped"}</td>
+    </>
+  )
+}
+
+function HeatCells({ row }: { row: HeatScheduleImportRow }) {
+  return (
+    <>
+      <td className="px-3 py-2">{row.workout || "Not mapped"}</td>
+      <td className="px-3 py-2">{row.heatLabel || "Not mapped"}</td>
+      <td className="px-3 py-2">{row.scheduledTime || "Not mapped"}</td>
+      <td className="px-3 py-2">{row.division || "Not mapped"}</td>
+    </>
+  )
+}
+
+function RowIssues({ row }: { row: PreviewImportRow }) {
+  const issues = [...row.errors, ...row.warnings]
+
+  if (issues.length === 0) {
+    return (
+      <span className="inline-flex items-center gap-1 text-emerald-700">
+        <CheckCircle2 className="size-4" />
+        Ready
+      </span>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      {issues.map((issue, index) => (
+        <p
+          key={`${issue.code}-${index}`}
+          className={
+            issue.severity === "error" ? "text-destructive" : "text-amber-700"
+          }
+        >
+          {issue.message}
+        </p>
+      ))}
+    </div>
+  )
+}
+
+function ReferencePanel({ reference }: { reference: CrewImportReferenceData }) {
+  return (
+    <div className="grid gap-6 lg:grid-cols-3">
+      <ReferenceSection
+        title="Role assumptions"
+        values={reference.roleLabels}
+      />
+      <ReferenceSection
+        title="Divisions"
+        values={reference.divisions.map((division) => division.label)}
+      />
+      <ReferenceSection
+        title="Workouts"
+        values={reference.workouts.map(
+          (workout) => `${workout.trackOrder}. ${workout.label}`,
+        )}
+      />
+    </div>
+  )
+}
+
+function ReferenceSection({
+  title,
+  values,
+}: {
+  title: string
+  values: string[]
+}) {
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <h3 className="font-semibold">{title}</h3>
+      {values.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {values.map((value) => (
+            <span
+              key={value}
+              className="rounded-md border bg-background px-2 py-1 text-sm"
+            >
+              {value}
+            </span>
+          ))}
+        </div>
+      ) : (
+        <p className="mt-2 text-sm text-muted-foreground">None configured.</p>
+      )}
+    </section>
+  )
+}
+
+function HistoryPanel({ history }: { history: CrewImportHistoryItem[] }) {
+  if (history.length === 0) {
+    return (
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h3 className="font-semibold">Import history</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          No import previews yet.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <h3 className="font-semibold">Import history</h3>
+      <div className="mt-4 overflow-hidden rounded-md border">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[48rem] text-left text-sm">
+            <thead className="bg-muted text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 font-medium">File</th>
+                <th className="px-3 py-2 font-medium">Kind</th>
+                <th className="px-3 py-2 font-medium">Status</th>
+                <th className="px-3 py-2 font-medium">Rows</th>
+                <th className="px-3 py-2 font-medium">Warnings</th>
+                <th className="px-3 py-2 font-medium">Errors</th>
+                <th className="px-3 py-2 font-medium">Created</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map((item) => (
+                <tr key={item.id} className="border-t">
+                  <td className="px-3 py-2">
+                    <p className="font-medium">
+                      {item.originalFilename ?? item.id}
+                    </p>
+                    <p className="font-mono text-xs text-muted-foreground">
+                      {item.id}
+                    </p>
+                  </td>
+                  <td className="px-3 py-2">{formatKind(item.kind)}</td>
+                  <td className="px-3 py-2">
+                    <StatusBadge status={item.status} />
+                  </td>
+                  <td className="px-3 py-2">{item.rowCount}</td>
+                  <td className="px-3 py-2">{item.warningCount}</td>
+                  <td className="px-3 py-2">{item.errorCount}</td>
+                  <td className="px-3 py-2">
+                    {formatHistoryDate(item.createdAt)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function ImportTabButton({
+  active,
+  label,
+  onClick,
+}: {
+  active: boolean
+  label: string
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        active
+          ? "rounded-md border bg-muted px-3 py-2 text-sm font-medium text-foreground"
+          : "rounded-md border px-3 py-2 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"
+      }
+    >
+      {label}
+    </button>
+  )
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string
+  htmlFor: string
+  children: ReactNode
+}) {
+  return (
+    <label className="block text-sm" htmlFor={htmlFor}>
+      <span className="font-medium">{label}</span>
+      <span className="mt-1 block">{children}</span>
+    </label>
+  )
+}
+
+function IssueList({
+  issues,
+  className,
+}: {
+  issues: ImportIssue[]
+  className?: string
+}) {
+  return (
+    <div className={className}>
+      <div className="space-y-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+        {issues.map((issue, index) => (
+          <div key={`${issue.code}-${index}`} className="flex gap-2">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <p>{issue.message}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function SummaryMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border bg-background p-3">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span className="inline-flex w-fit rounded-md border bg-background px-2 py-1 text-xs font-medium">
+      {formatStatus(status)}
+    </span>
+  )
+}
+
+function formatKind(kind: string) {
+  if (kind === "heat_schedule") return "Heat schedule"
+  if (kind === "role_template") return "Role template"
+  if (kind === "unknown") return "Unknown"
+  return "Volunteers"
+}
+
+function formatStatus(status: string) {
+  return status
+    .split("_")
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+function formatHistoryDate(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return String(value)
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date)
+}

--- a/apps/crew/src/routes/events/$eventId/imports.tsx
+++ b/apps/crew/src/routes/events/$eventId/imports.tsx
@@ -638,8 +638,8 @@ function StatusBadge({ status }: { status: string }) {
 function formatKind(kind: string) {
   if (kind === "heat_schedule") return "Heat schedule"
   if (kind === "role_template") return "Role template"
-  if (kind === "unknown") return "Unknown"
-  return "Volunteers"
+  if (kind === "volunteers") return "Volunteers"
+  return "Unknown"
 }
 
 function formatStatus(status: string) {

--- a/apps/crew/src/server-fns/crew-event-settings-fns.ts
+++ b/apps/crew/src/server-fns/crew-event-settings-fns.ts
@@ -1,6 +1,5 @@
 import { createId } from "@paralleldrive/cuid2"
 import { createServerFn } from "@tanstack/react-start"
-import { env } from "cloudflare:workers"
 import { desc, eq } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "../db"
@@ -13,6 +12,7 @@ import {
 } from "../db/schemas/crew-event-settings"
 import { type Competition, competitionsTable } from "../db/schemas/competitions"
 import { teamTable } from "../db/schemas/teams"
+import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
 import { generateSlug } from "../utils/slugify"
 
 type CrewEventCompetition = Pick<
@@ -36,59 +36,8 @@ export interface CrewEventDetails {
   competition: CrewEventCompetition
 }
 
-type CrewRuntimeEnv = typeof env & {
-  NODE_ENV?: string
-  STAGE?: string
-  APP_URL?: string
-  SITE_URL?: string
-}
-
-const localCrewStages = new Set(["dev", "local", "test", "preview"])
-
 function requireLocalCrewSettingsAccess() {
-  const runtimeEnv = env as CrewRuntimeEnv
-  const nodeEnv = runtimeEnv.NODE_ENV?.toLowerCase()
-  const stage = runtimeEnv.STAGE?.toLowerCase()
-  const appUrl = (runtimeEnv.APP_URL ?? runtimeEnv.SITE_URL ?? "").toLowerCase()
-  const appHost = getAppHost(appUrl)
-  const isLocalStage = stage ? localCrewStages.has(stage) : false
-  const isLocalUrl =
-    appHost === "localhost" || appHost === "127.0.0.1" || appHost === "::1"
-  const isProductionLike =
-    nodeEnv === "production" ||
-    stage === "prod" ||
-    stage === "production" ||
-    stage === "demo" ||
-    stage === "staging" ||
-    appUrl.includes("wodsmith.com")
-
-  if (isProductionLike || (!isLocalStage && !isLocalUrl)) {
-    throw new Error(
-      "Crew event settings are local-operator only until Crew auth is wired.",
-    )
-  }
-}
-
-function getAppHost(appUrl: string) {
-  if (!appUrl) return ""
-
-  try {
-    const url = new URL(appUrl)
-    if (url.hostname) return normalizeHost(url.hostname)
-  } catch {
-    // Fall back below for bare local hosts, like localhost:3000.
-  }
-
-  if (appUrl === "::1") return "::1"
-  if (appUrl === "[::1]" || appUrl.startsWith("[::1]:")) return "::1"
-
-  return normalizeHost(appUrl.split(":")[0] ?? "")
-}
-
-function normalizeHost(host: string) {
-  return host.startsWith("[") && host.endsWith("]")
-    ? host.slice(1, -1)
-    : host
+  requireLocalCrewOperatorAccess("Crew event settings")
 }
 
 const lifecycleSchema = z.enum([

--- a/apps/crew/src/server-fns/crew-import-fns.ts
+++ b/apps/crew/src/server-fns/crew-import-fns.ts
@@ -1,0 +1,20 @@
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type {
+  CrewImportHistoryItem,
+  CrewImportReferenceData,
+  CrewImportsPageData,
+  PersistedCrewImportPreview,
+} from "../server/crew-imports"
+
+const getCrewImportsPageInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+export const getCrewImportsPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => getCrewImportsPageInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { loadCrewImportsPageData } = await import("../server/crew-imports")
+    return await loadCrewImportsPageData(data.eventId)
+  })

--- a/apps/crew/src/server-fns/crew-import-fns.ts
+++ b/apps/crew/src/server-fns/crew-import-fns.ts
@@ -1,5 +1,7 @@
+// @lat: [[crew#Import CSV Preview#Preview Records]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
+import { loadCrewImportsPageData } from "../server/crew-imports"
 
 export type {
   CrewImportHistoryItem,
@@ -14,7 +16,4 @@ const getCrewImportsPageInputSchema = z.object({
 
 export const getCrewImportsPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => getCrewImportsPageInputSchema.parse(data))
-  .handler(async ({ data }) => {
-    const { loadCrewImportsPageData } = await import("../server/crew-imports")
-    return await loadCrewImportsPageData(data.eventId)
-  })
+  .handler(async ({ data }) => await loadCrewImportsPageData(data.eventId))

--- a/apps/crew/src/server/crew-imports.ts
+++ b/apps/crew/src/server/crew-imports.ts
@@ -40,6 +40,23 @@ import { requireLocalCrewOperatorAccess } from "./crew-local-access"
 
 export const MAX_CREW_IMPORT_BYTES = 1_000_000
 
+export type CrewImportErrorCode =
+  | "EVENT_NOT_FOUND"
+  | "INVALID_FILE_TYPE"
+  | "INVALID_COLUMN_MAPPING"
+  | "PAYLOAD_TOO_LARGE"
+
+export class CrewImportError extends Error {
+  constructor(
+    public readonly code: CrewImportErrorCode,
+    public readonly publicMessage: string,
+    public readonly status = 400,
+  ) {
+    super(publicMessage)
+    this.name = "CrewImportError"
+  }
+}
+
 const uploadCrewImportInputSchema = z.object({
   eventId: z.string().min(1, "Event ID is required"),
   kind: z.enum([CREW_IMPORT_KIND.VOLUNTEERS, CREW_IMPORT_KIND.HEAT_SCHEDULE]),
@@ -113,13 +130,22 @@ export async function createCrewImportPreviewRecord(input: {
   requireLocalCrewOperatorAccess("Crew imports")
 
   const data = uploadCrewImportInputSchema.parse(input)
+  const fileSize = Math.max(data.fileSize, getCsvByteLength(data.csvText))
 
-  if (data.fileSize > MAX_CREW_IMPORT_BYTES) {
-    throw new Error("CSV is larger than the Crew preview limit.")
+  if (fileSize > MAX_CREW_IMPORT_BYTES) {
+    throw new CrewImportError(
+      "PAYLOAD_TOO_LARGE",
+      "CSV is larger than the Crew preview limit.",
+      413,
+    )
   }
 
-  if (!isCsvFilename(data.originalFilename) && !isCsvMimeType(data.mimeType)) {
-    throw new Error("Crew import preview accepts CSV files only.")
+  if (!isCsvUpload(data.originalFilename, data.mimeType)) {
+    throw new CrewImportError(
+      "INVALID_FILE_TYPE",
+      "Crew import preview accepts CSV files only.",
+      415,
+    )
   }
 
   const reference = await loadCrewImportReferenceData(data.eventId)
@@ -144,7 +170,7 @@ export async function createCrewImportPreviewRecord(input: {
     status,
     originalFilename: data.originalFilename,
     mimeType: data.mimeType ?? null,
-    fileSize: data.fileSize,
+    fileSize,
     sourcePlatform: data.sourcePlatform ?? null,
     createdAt,
   })
@@ -319,7 +345,7 @@ async function requireCrewEvent(eventId: string) {
     .limit(1)
 
   if (!event) {
-    throw new Error("Crew event not found.")
+    throw new CrewImportError("EVENT_NOT_FOUND", "Crew event not found.", 404)
   }
 
   return event
@@ -363,13 +389,22 @@ async function listWorkoutsForCompetition(eventId: string) {
   }))
 }
 
+function getCsvByteLength(csvText: string) {
+  return new TextEncoder().encode(csvText).byteLength
+}
+
+function isCsvUpload(filename: string, mimeType?: string | null) {
+  return isCsvFilename(filename) || isCsvMimeType(mimeType)
+}
+
 function isCsvMimeType(mimeType?: string | null) {
+  if (!mimeType) return false
+
+  const normalizedMimeType = mimeType.split(";")[0]?.trim().toLowerCase()
   return (
-    !mimeType ||
-    mimeType === "text/csv" ||
-    mimeType === "text/plain" ||
-    mimeType === "application/csv" ||
-    mimeType === "application/vnd.ms-excel"
+    normalizedMimeType === "text/csv" ||
+    normalizedMimeType === "application/csv" ||
+    normalizedMimeType === "application/vnd.ms-excel"
   )
 }
 

--- a/apps/crew/src/server/crew-imports.ts
+++ b/apps/crew/src/server/crew-imports.ts
@@ -1,0 +1,386 @@
+// @lat: [[crew#Import CSV Preview#Preview Records]]
+import { desc, eq, inArray } from "drizzle-orm"
+import { z } from "zod"
+import {
+  CREW_IMPORT_KIND,
+  CREW_IMPORT_ROW_ACTION,
+  CREW_IMPORT_ROW_TARGET_TYPE,
+  CREW_IMPORT_STATUS,
+  crewImportRowsTable,
+  crewImportsTable,
+  type CrewImport,
+} from "../db/schemas/crew-imports"
+import { createCrewImportId } from "../db/schemas/common"
+import {
+  competitionHeatsTable,
+  competitionsTable,
+} from "../db/schemas/competitions"
+import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import {
+  programmingTracksTable,
+  trackWorkoutsTable,
+} from "../db/schemas/programming"
+import { scalingLevelsTable } from "../db/schemas/scaling"
+import { workouts } from "../db/schemas/workouts"
+import { getDb } from "../db"
+import {
+  buildCrewImportPreview,
+  defaultCrewImportRoleLabels,
+} from "../lib/crew/imports/preview"
+import {
+  CREW_IMPORT_PARSER_VERSION,
+  type ColumnMapping,
+  type CrewImportKind,
+  type CrewImportPreview,
+  type CrewImportPreviewContext,
+  type PreviewImportRow,
+} from "../lib/crew/imports/types"
+import { parseCompetitionSettings } from "../utils/competition-settings"
+import { requireLocalCrewOperatorAccess } from "./crew-local-access"
+
+export const MAX_CREW_IMPORT_BYTES = 1_000_000
+
+const uploadCrewImportInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  kind: z.enum([CREW_IMPORT_KIND.VOLUNTEERS, CREW_IMPORT_KIND.HEAT_SCHEDULE]),
+  csvText: z.string(),
+  originalFilename: z.string().min(1, "Filename is required"),
+  mimeType: z.string().nullable().optional(),
+  fileSize: z.number().int().min(0),
+  sourcePlatform: z.string().trim().max(100).nullable().optional(),
+  columnMapping: z.record(z.string(), z.string()).optional(),
+})
+
+export interface CrewImportHistoryItem {
+  id: string
+  kind: CrewImport["kind"]
+  status: CrewImport["status"]
+  sourcePlatform: string | null
+  originalFilename: string | null
+  rowCount: number
+  warningCount: number
+  errorCount: number
+  createdCount: number
+  updatedCount: number
+  skippedCount: number
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface CrewImportReferenceData {
+  roleLabels: string[]
+  divisions: CrewImportPreviewContext["divisions"]
+  workouts: CrewImportPreviewContext["workouts"]
+  heats: CrewImportPreviewContext["heats"]
+}
+
+export interface PersistedCrewImportPreview extends CrewImportPreview {
+  importId: string
+  status: CrewImport["status"]
+  originalFilename: string
+  sourcePlatform: string | null
+  createdAt: Date
+}
+
+export interface CrewImportsPageData {
+  history: CrewImportHistoryItem[]
+  reference: CrewImportReferenceData
+}
+
+export async function loadCrewImportsPageData(
+  eventId: string,
+): Promise<CrewImportsPageData> {
+  requireLocalCrewOperatorAccess("Crew imports")
+
+  const [reference, history] = await Promise.all([
+    loadCrewImportReferenceData(eventId),
+    listCrewImportHistory(eventId),
+  ])
+
+  return { reference, history }
+}
+
+export async function createCrewImportPreviewRecord(input: {
+  eventId: string
+  kind: CrewImportKind
+  csvText: string
+  originalFilename: string
+  mimeType?: string | null
+  fileSize: number
+  sourcePlatform?: string | null
+  columnMapping?: ColumnMapping
+}): Promise<PersistedCrewImportPreview> {
+  requireLocalCrewOperatorAccess("Crew imports")
+
+  const data = uploadCrewImportInputSchema.parse(input)
+
+  if (data.fileSize > MAX_CREW_IMPORT_BYTES) {
+    throw new Error("CSV is larger than the Crew preview limit.")
+  }
+
+  if (!isCsvFilename(data.originalFilename) && !isCsvMimeType(data.mimeType)) {
+    throw new Error("Crew import preview accepts CSV files only.")
+  }
+
+  const reference = await loadCrewImportReferenceData(data.eventId)
+  const preview = buildCrewImportPreview({
+    csvText: data.csvText,
+    kind: data.kind,
+    columnMapping: data.columnMapping,
+    context: reference,
+  })
+  const importId = createCrewImportId()
+  const status =
+    preview.fileIssues.some((issue) => issue.severity === "error") &&
+    preview.rows.length === 0
+      ? CREW_IMPORT_STATUS.FAILED
+      : CREW_IMPORT_STATUS.PREVIEWED
+  const createdAt = new Date()
+
+  await persistCrewImportPreview({
+    eventId: data.eventId,
+    importId,
+    preview,
+    status,
+    originalFilename: data.originalFilename,
+    mimeType: data.mimeType ?? null,
+    fileSize: data.fileSize,
+    sourcePlatform: data.sourcePlatform ?? null,
+    createdAt,
+  })
+
+  return {
+    ...preview,
+    importId,
+    status,
+    originalFilename: data.originalFilename,
+    sourcePlatform: data.sourcePlatform ?? null,
+    createdAt,
+  }
+}
+
+async function persistCrewImportPreview({
+  eventId,
+  importId,
+  preview,
+  status,
+  originalFilename,
+  mimeType,
+  fileSize,
+  sourcePlatform,
+  createdAt,
+}: {
+  eventId: string
+  importId: string
+  preview: CrewImportPreview
+  status: CrewImport["status"]
+  originalFilename: string
+  mimeType: string | null
+  fileSize: number
+  sourcePlatform: string | null
+  createdAt: Date
+}) {
+  const db = getDb()
+
+  await db.transaction(async (tx) => {
+    await tx.insert(crewImportsTable).values({
+      id: importId,
+      competitionId: eventId,
+      kind: preview.kind,
+      sourcePlatform,
+      originalFilename,
+      mimeType,
+      status,
+      parserVersion: CREW_IMPORT_PARSER_VERSION,
+      headers: preview.headers,
+      columnMapping: preview.columnMapping,
+      rowCount: preview.rowCount,
+      warningCount: preview.warningCount,
+      errorCount: preview.errorCount,
+      skippedCount: preview.rows.filter((row) => row.action === "skip").length,
+      summary: {
+        fileSize,
+        fileIssues: preview.fileIssues,
+        skippedRowCount: preview.skippedRowCount,
+        previewRowCount: preview.rows.length,
+      },
+      createdAt,
+      updatedAt: createdAt,
+    })
+
+    if (preview.rows.length === 0) return
+
+    await tx
+      .insert(crewImportRowsTable)
+      .values(
+        preview.rows.map((row) =>
+          toCrewImportRowInsert(importId, row, createdAt),
+        ),
+      )
+  })
+}
+
+function toCrewImportRowInsert(
+  importId: string,
+  row: PreviewImportRow,
+  timestamp: Date,
+) {
+  return {
+    importId,
+    rowNumber: row.rowNumber,
+    rawRow: row.rawRow,
+    normalizedRow: toPayload(row.normalizedRow),
+    targetType:
+      row.targetType === "team_invitation"
+        ? CREW_IMPORT_ROW_TARGET_TYPE.TEAM_INVITATION
+        : CREW_IMPORT_ROW_TARGET_TYPE.COMPETITION_HEAT,
+    action:
+      row.action === "skip"
+        ? CREW_IMPORT_ROW_ACTION.SKIP
+        : row.action === "error"
+          ? CREW_IMPORT_ROW_ACTION.ERROR
+          : CREW_IMPORT_ROW_ACTION.CREATE,
+    warnings: toIssueList(row.warnings),
+    errors: toIssueList(row.errors),
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  }
+}
+
+async function listCrewImportHistory(
+  eventId: string,
+): Promise<CrewImportHistoryItem[]> {
+  await requireCrewEvent(eventId)
+
+  const db = getDb()
+  return await db
+    .select({
+      id: crewImportsTable.id,
+      kind: crewImportsTable.kind,
+      status: crewImportsTable.status,
+      sourcePlatform: crewImportsTable.sourcePlatform,
+      originalFilename: crewImportsTable.originalFilename,
+      rowCount: crewImportsTable.rowCount,
+      warningCount: crewImportsTable.warningCount,
+      errorCount: crewImportsTable.errorCount,
+      createdCount: crewImportsTable.createdCount,
+      updatedCount: crewImportsTable.updatedCount,
+      skippedCount: crewImportsTable.skippedCount,
+      createdAt: crewImportsTable.createdAt,
+      updatedAt: crewImportsTable.updatedAt,
+    })
+    .from(crewImportsTable)
+    .where(eq(crewImportsTable.competitionId, eventId))
+    .orderBy(desc(crewImportsTable.createdAt))
+    .limit(25)
+}
+
+async function loadCrewImportReferenceData(
+  eventId: string,
+): Promise<CrewImportReferenceData> {
+  const competition = await requireCrewEvent(eventId)
+  const db = getDb()
+  const settings = parseCompetitionSettings(competition.settings)
+  const scalingGroupId = settings?.divisions?.scalingGroupId ?? null
+  const [divisions, workoutsForEvent, heats] = await Promise.all([
+    scalingGroupId ? listDivisionsForGroup(scalingGroupId) : [],
+    listWorkoutsForCompetition(eventId),
+    db
+      .select({
+        trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+        heatNumber: competitionHeatsTable.heatNumber,
+        divisionId: competitionHeatsTable.divisionId,
+      })
+      .from(competitionHeatsTable)
+      .where(eq(competitionHeatsTable.competitionId, eventId)),
+  ])
+
+  return {
+    roleLabels: defaultCrewImportRoleLabels,
+    divisions,
+    workouts: workoutsForEvent,
+    heats,
+  }
+}
+
+async function requireCrewEvent(eventId: string) {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      settings: competitionsTable.settings,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  if (!event) {
+    throw new Error("Crew event not found.")
+  }
+
+  return event
+}
+
+async function listDivisionsForGroup(scalingGroupId: string) {
+  const db = getDb()
+  return await db
+    .select({
+      id: scalingLevelsTable.id,
+      label: scalingLevelsTable.label,
+    })
+    .from(scalingLevelsTable)
+    .where(eq(scalingLevelsTable.scalingGroupId, scalingGroupId))
+}
+
+async function listWorkoutsForCompetition(eventId: string) {
+  const db = getDb()
+  const tracks = await db
+    .select({ id: programmingTracksTable.id })
+    .from(programmingTracksTable)
+    .where(eq(programmingTracksTable.competitionId, eventId))
+
+  if (tracks.length === 0) return []
+
+  const trackIds = tracks.map((track) => track.id)
+  const rows = await db
+    .select({
+      id: trackWorkoutsTable.id,
+      label: workouts.name,
+      trackOrder: trackWorkoutsTable.trackOrder,
+    })
+    .from(trackWorkoutsTable)
+    .innerJoin(workouts, eq(trackWorkoutsTable.workoutId, workouts.id))
+    .where(inArray(trackWorkoutsTable.trackId, trackIds))
+
+  return rows.map((row) => ({
+    id: row.id,
+    label: row.label,
+    trackOrder: Number(row.trackOrder),
+  }))
+}
+
+function isCsvMimeType(mimeType?: string | null) {
+  return (
+    !mimeType ||
+    mimeType === "text/csv" ||
+    mimeType === "text/plain" ||
+    mimeType === "application/csv" ||
+    mimeType === "application/vnd.ms-excel"
+  )
+}
+
+function isCsvFilename(filename: string) {
+  return filename.toLowerCase().endsWith(".csv")
+}
+
+function toIssueList(issues: PreviewImportRow["warnings"]) {
+  return issues.map((issue) => ({ ...issue }) as Record<string, unknown>)
+}
+
+function toPayload(row: PreviewImportRow["normalizedRow"]) {
+  return { ...row } as Record<string, unknown>
+}

--- a/apps/crew/src/server/crew-local-access.ts
+++ b/apps/crew/src/server/crew-local-access.ts
@@ -1,0 +1,55 @@
+import { env } from "cloudflare:workers"
+
+type CrewRuntimeEnv = typeof env & {
+  NODE_ENV?: string
+  STAGE?: string
+  APP_URL?: string
+  SITE_URL?: string
+}
+
+const localCrewStages = new Set(["dev", "local", "test", "preview"])
+
+// @lat: [[crew#Event Setup Dashboard]] [[crew#Import CSV Preview#Private Upload Route]]
+export function requireLocalCrewOperatorAccess(featureName = "Crew operator") {
+  const runtimeEnv = env as CrewRuntimeEnv
+  const nodeEnv = runtimeEnv.NODE_ENV?.toLowerCase()
+  const stage = runtimeEnv.STAGE?.toLowerCase()
+  const appUrl = (runtimeEnv.APP_URL ?? runtimeEnv.SITE_URL ?? "").toLowerCase()
+  const appHost = getAppHost(appUrl)
+  const isLocalStage = stage ? localCrewStages.has(stage) : false
+  const isLocalUrl =
+    appHost === "localhost" || appHost === "127.0.0.1" || appHost === "::1"
+  const isProductionLike =
+    nodeEnv === "production" ||
+    stage === "prod" ||
+    stage === "production" ||
+    stage === "demo" ||
+    stage === "staging" ||
+    appUrl.includes("wodsmith.com")
+
+  if (isProductionLike || (!isLocalStage && !isLocalUrl)) {
+    throw new Error(
+      `${featureName} access is local-operator only until Crew auth is wired.`,
+    )
+  }
+}
+
+function getAppHost(appUrl: string) {
+  if (!appUrl) return ""
+
+  try {
+    const url = new URL(appUrl)
+    if (url.hostname) return normalizeHost(url.hostname)
+  } catch {
+    // Fall back below for bare local hosts, like localhost:3000.
+  }
+
+  if (appUrl === "::1") return "::1"
+  if (appUrl === "[::1]" || appUrl.startsWith("[::1]:")) return "::1"
+
+  return normalizeHost(appUrl.split(":")[0] ?? "")
+}
+
+function normalizeHost(host: string) {
+  return host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host
+}

--- a/apps/crew/src/server/crew-local-access.ts
+++ b/apps/crew/src/server/crew-local-access.ts
@@ -1,5 +1,12 @@
 import { env } from "cloudflare:workers"
 
+export class CrewLocalAccessError extends Error {
+  constructor(featureName: string) {
+    super(`${featureName} access is local-operator only until Crew auth is wired.`)
+    this.name = "CrewLocalAccessError"
+  }
+}
+
 type CrewRuntimeEnv = typeof env & {
   NODE_ENV?: string
   STAGE?: string
@@ -7,9 +14,10 @@ type CrewRuntimeEnv = typeof env & {
   SITE_URL?: string
 }
 
-const localCrewStages = new Set(["dev", "local", "test", "preview"])
+const localCrewStages = new Set(["dev", "local", "test"])
 
-// @lat: [[crew#Event Setup Dashboard]] [[crew#Import CSV Preview#Private Upload Route]]
+// @lat: [[crew#Event Setup Dashboard]]
+// @lat: [[crew#Import CSV Preview#Private Upload Route]]
 export function requireLocalCrewOperatorAccess(featureName = "Crew operator") {
   const runtimeEnv = env as CrewRuntimeEnv
   const nodeEnv = runtimeEnv.NODE_ENV?.toLowerCase()
@@ -20,7 +28,7 @@ export function requireLocalCrewOperatorAccess(featureName = "Crew operator") {
   const isLocalUrl =
     appHost === "localhost" || appHost === "127.0.0.1" || appHost === "::1"
   const isProductionLike =
-    nodeEnv === "production" ||
+    (nodeEnv === "production" && !isLocalUrl) ||
     stage === "prod" ||
     stage === "production" ||
     stage === "demo" ||
@@ -28,9 +36,7 @@ export function requireLocalCrewOperatorAccess(featureName = "Crew operator") {
     appUrl.includes("wodsmith.com")
 
   if (isProductionLike || (!isLocalStage && !isLocalUrl)) {
-    throw new Error(
-      `${featureName} access is local-operator only until Crew auth is wired.`,
-    )
+    throw new CrewLocalAccessError(featureName)
   }
 }
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -46,7 +46,9 @@ Operator-facing durations render in compact hour/minute labels so workout block 
 
 ## Import CSV Preview
 
-Crew import preview is a private operator workflow for CSV-only volunteer and heat schedule uploads. It parses rows, maps columns, records preview rows in `crew_imports` and `crew_import_rows`, and does not apply rows to volunteer, invitation, heat, shift, or assignment production tables.
+Crew import preview is a private operator workflow for CSV-only volunteer and heat schedule uploads.
+
+[[apps/crew/src/routes/events/$eventId/imports.tsx]] renders upload, mapping, warnings, and history. [[apps/crew/src/routes/api/crew/import.ts]] accepts private preview uploads, while [[apps/crew/src/lib/crew/imports/preview.ts]] and [[apps/crew/src/server/crew-imports.ts]] parse and persist previews without applying rows.
 
 ### Private Upload Route
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -44,6 +44,26 @@ Calculator inputs are normalized before rendering and calculation: counts are wh
 
 Operator-facing durations render in compact hour/minute labels so workout block and shift length summaries stay scannable.
 
+## Import CSV Preview
+
+Crew import preview is a private operator workflow for CSV-only volunteer and heat schedule uploads. It parses rows, maps columns, records preview rows in `crew_imports` and `crew_import_rows`, and does not apply rows to volunteer, invitation, heat, shift, or assignment production tables.
+
+### Private Upload Route
+
+The Crew import upload route is `/api/crew/import`. It is separate from the existing public file upload path and does not write uploaded files to public object storage.
+
+### Parser Warnings
+
+CSV preview reports file-level errors, malformed rows, missing required fields, duplicate volunteer emails, unknown roles, unknown divisions, unknown workouts, and unknown existing heat references before any apply step exists.
+
+### Preview Records
+
+Preview persistence stores import metadata, headers, column mapping, summary counts, raw row payloads, normalized row payloads, planned actions, warnings, and errors in the Crew import tables.
+
+### No Apply
+
+This slice is preview and history only. Applying volunteer invitations, volunteer memberships, heat schedule rows, roster rows, shifts, and assignment confirmations belongs to later Crew import PRs.
+
 ## Add Thin Crew Tables
 
 Crew-owned database tables live in `@repo/wodsmith-db` so Start and Crew consume one shared schema source. App DB files remain forwarding shims and do not own `mysqlTable` definitions.


### PR DESCRIPTION
## Summary
- Add the Crew import center at `/events/$eventId/imports` with volunteer, heat schedule, roles/reference, and history tabs.
- Add private CSV upload/preview route `/api/crew/import` that stores preview/history records in `crew_imports` and `crew_import_rows` without applying imports.
- Add pure CSV parser and preview modules with warning coverage for duplicate emails, missing required fields, unknown roles/divisions/workouts/heats, malformed rows, and file-level errors.

## Validation
- `pnpm check:schema-ownership`
- `pnpm --filter crew exec vitest run src/lib/crew/imports/preview.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (passes with existing warnings elsewhere)
- `pnpm --filter crew build` (used ignored local `.alchemy` copy from the known-good checkout only for validation)
- `git diff --check`

## Notes / Risks
- Preview-only slice: no volunteer, invitation, heat, roster, shift, or assignment writes.
- Uses the existing local-operator-only Crew access guard shape until Crew auth is wired.
- No R2/private object storage was added; raw uploaded files are not persisted, only private DB metadata and row preview records are stored.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Crew Import Center at `/events/$eventId/imports` with a private CSV upload and persisted preview for volunteers and heat schedules. Tightens parsing and validations; previews show issues and history, but no changes are applied to event data yet.

- **New Features**
  - Import Center UI with tabs for Volunteers, Heat schedule, Roles, and History.
  - Private POST endpoint at `/api/crew/import` (local-operator only) uploads CSVs (1MB limit), captures optional “Source platform”, and returns a persisted preview.
  - Column mapping inference and editor; parser handles quotes/commas, errors on missing or duplicate headers and unterminated quotes, and warns after a 500-row preview limit.
  - Preview rules: volunteers flag missing name/email, invalid emails, malformed rows, duplicate emails, and unknown roles/divisions; heat schedules parse heat numbers and reject signed or sign-adjacent values, and warn on unknown workouts/divisions/heats.
  - Previews are saved in `crew_imports` and `crew_import_rows` with normalized rows, actions, issues, and counts; latest preview and history are visible in the UI.

- **Migration**
  - Go to `/events/$eventId/imports`, upload a `.csv`, map columns (optionally set Source platform), and review the preview.
  - Import pages and the endpoint are guarded for local/dev use until Crew auth is wired.
  - Raw files are not stored; only private DB metadata and row previews are persisted.

<sup>Written for commit bc335e029eee24f29fcba69ee3dfff795a3d31c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV import preview system for crew data (volunteers and heat schedules)
  * New "Imports" tab in event settings to upload and preview CSV files
  * Column mapping interface to match CSV headers to expected fields
  * Validation with warnings/errors displayed before applying changes
  * Automatic duplicate email detection
  * Import history tracking with file metadata and status

* **Documentation**
  * Added documentation describing the CSV import preview workflow and validation categories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->