### PR TITLE
feat(crew): apply volunteer and heat schedule imports

### DIFF
--- a/apps/crew/src/lib/crew/imports/apply.test.ts
+++ b/apps/crew/src/lib/crew/imports/apply.test.ts
@@ -4,8 +4,12 @@ import {
   buildHeatScheduleApplyPlan,
   buildVolunteerApplyPlan,
   getAppliedHeatSupportTargets,
+  getMutationAffectedRows,
+  markHeatUpdateSkippedForPublicationConflict,
   mergeImportedJsonMetadata,
   parseImportedScheduledTime,
+  selectCrewImportProgrammingTrack,
+  summarizeApplyRows,
 } from "./apply"
 import type { HeatScheduleImportRow } from "./types"
 import type { PreviewImportRow } from "./types"
@@ -76,12 +80,9 @@ function heatRow(
 }
 
 describe("buildVolunteerApplyPlan", () => {
-  it("skips duplicate preview rows and does not create either duplicate email", () => {
+  it("skips duplicate emails within the apply run", () => {
     const plan = buildVolunteerApplyPlan(
-      [
-        volunteerRow(2, "ian@example.com", "skip"),
-        volunteerRow(3, "IAN@example.com", "skip"),
-      ],
+      [volunteerRow(2, "ian@example.com"), volunteerRow(3, "IAN@example.com")],
       {
         importId: "cimp_test",
         existingInvitations: [],
@@ -89,13 +90,15 @@ describe("buildVolunteerApplyPlan", () => {
       },
     )
 
-    expect(plan.summary.createdCount).toBe(0)
-    expect(plan.summary.skippedCount).toBe(2)
-    expect(plan.rows).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ action: "skip", operation: "skip" }),
+    expect(plan.summary.createdCount).toBe(1)
+    expect(plan.summary.skippedCount).toBe(1)
+    expect(plan.rows[1]).toMatchObject({
+      action: "skip",
+      operation: "skip",
+      warnings: expect.arrayContaining([
+        expect.objectContaining({ code: "duplicate_email_apply" }),
       ]),
-    )
+    })
   })
 
   it("updates existing volunteer memberships before considering invitations", () => {
@@ -213,6 +216,71 @@ describe("buildHeatScheduleApplyPlan", () => {
     ).toBe("2026-06-21T16:30:00.000Z")
   })
 
+  it("errors instead of guessing when workout lookup keys are ambiguous", () => {
+    const plan = buildHeatScheduleApplyPlan(
+      [heatRow(2, 1, "9:00 AM", { workout: "Event 2" })],
+      {
+        ...context,
+        trackWorkouts: [
+          { id: "trwk_label", label: "Event 2", trackOrder: 1 },
+          { id: "trwk_order", label: "Clean", trackOrder: 2 },
+        ],
+        existingHeats: [],
+      },
+    )
+
+    expect(plan.summary.errorRowCount).toBe(1)
+    expect(plan.rows[0]).toMatchObject({
+      action: "error",
+      operation: "error",
+      errors: expect.arrayContaining([
+        expect.objectContaining({ code: "ambiguous_workout_lookup" }),
+      ]),
+    })
+  })
+
+  it("surfaces invalid persisted scheduled-time values as row errors", () => {
+    const plan = buildHeatScheduleApplyPlan(
+      [
+        heatRow(2, 1, "9:00 AM", {
+          scheduledTime: 0 as unknown as string,
+        }),
+      ],
+      context,
+    )
+
+    expect(plan.summary.errorRowCount).toBe(1)
+    expect(plan.rows[0]?.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "invalid_scheduled_time" }),
+      ]),
+    )
+  })
+
+  it("turns a no-op heat update into a skipped publication-conflict audit row", () => {
+    const plan = buildHeatScheduleApplyPlan([heatRow(2, 1, "9:00 AM")], context)
+
+    expect(plan.summary.updatedCount).toBe(1)
+
+    const row = plan.rows[0]
+    expect(row).toBeDefined()
+    if (!row) throw new Error("Expected heat update row")
+
+    markHeatUpdateSkippedForPublicationConflict(row)
+
+    const summary = summarizeApplyRows(plan.rows)
+
+    expect(row).toMatchObject({
+      action: "skip",
+      operation: "skip",
+      warnings: expect.arrayContaining([
+        expect.objectContaining({ code: "published_heat_update_conflict" }),
+      ]),
+    })
+    expect(summary.updatedCount).toBe(0)
+    expect(summary.skippedCount).toBe(1)
+  })
+
   it("excludes published-skip and invalid-time heat rows from support targets", () => {
     const plan = buildHeatScheduleApplyPlan(
       [
@@ -273,5 +341,54 @@ describe("buildHeatScheduleApplyPlan", () => {
 
     expect([...supportTargets.trackWorkoutIds]).toEqual(["trwk_1"])
     expect([...supportTargets.venueIds]).toEqual(["cvenue_1"])
+  })
+})
+
+describe("import apply helpers", () => {
+  it("reads mutation affected-row counts across supported driver result shapes", () => {
+    expect(getMutationAffectedRows({ rowsAffected: 1 })).toBe(1)
+    expect(getMutationAffectedRows([{ affectedRows: 0 }])).toBe(0)
+  })
+
+  it("selects the Crew import programming track deterministically", () => {
+    expect(
+      selectCrewImportProgrammingTrack(
+        [
+          {
+            id: "ptrk_public",
+            name: "Alpha",
+            type: "team_owned",
+            isPublic: 1,
+          },
+          {
+            id: "ptrk_import",
+            name: "Test Event - Events",
+            type: "team_owned",
+            isPublic: 0,
+          },
+        ],
+        "Test Event - Events",
+      )?.id,
+    ).toBe("ptrk_import")
+
+    expect(
+      selectCrewImportProgrammingTrack(
+        [
+          {
+            id: "ptrk_public",
+            name: "Alpha",
+            type: "team_owned",
+            isPublic: 1,
+          },
+          {
+            id: "ptrk_private",
+            name: "Zulu",
+            type: "team_owned",
+            isPublic: 0,
+          },
+        ],
+        "Missing - Events",
+      )?.id,
+    ).toBe("ptrk_private")
   })
 })

--- a/apps/crew/src/lib/crew/imports/apply.test.ts
+++ b/apps/crew/src/lib/crew/imports/apply.test.ts
@@ -1,0 +1,185 @@
+// @lat: [[crew#Import Apply#Confirmed Mutation]]
+import { describe, expect, it } from "vitest"
+import {
+  buildHeatScheduleApplyPlan,
+  buildVolunteerApplyPlan,
+  parseImportedScheduledTime,
+} from "./apply"
+import type { PreviewImportRow } from "./types"
+
+function volunteerRow(
+  rowNumber: number,
+  email: string,
+  action: PreviewImportRow["action"] = "create",
+): PreviewImportRow {
+  return {
+    rowNumber,
+    rawRow: {},
+    targetType: "team_invitation",
+    action,
+    normalizedRow: {
+      firstName: "Test",
+      lastName: "Volunteer",
+      name: "Test Volunteer",
+      email,
+      phone: "",
+      role: "Judge",
+      division: "RX",
+      availability: "all day",
+      notes: "Bring clipboard",
+    },
+    warnings:
+      action === "skip"
+        ? [
+            {
+              code: "duplicate_email",
+              severity: "warning",
+              rowNumber,
+              field: "email",
+              message: "Email appears more than once in this file.",
+            },
+          ]
+        : [],
+    errors: [],
+  }
+}
+
+function heatRow(
+  rowNumber: number,
+  heatNumber: number,
+  scheduledTime: string,
+): PreviewImportRow {
+  return {
+    rowNumber,
+    rawRow: {},
+    targetType: "competition_heat",
+    action: "create",
+    normalizedRow: {
+      workout: "Event 1",
+      heatNumber,
+      heatLabel: `Heat ${heatNumber}`,
+      division: "RX",
+      scheduledTime,
+      durationMinutes: 12,
+      venue: "Main floor",
+      laneCount: 8,
+      notes: "Imported",
+    },
+    warnings: [],
+    errors: [],
+  }
+}
+
+describe("buildVolunteerApplyPlan", () => {
+  it("skips duplicate preview rows and does not create either duplicate email", () => {
+    const plan = buildVolunteerApplyPlan(
+      [
+        volunteerRow(2, "ian@example.com", "skip"),
+        volunteerRow(3, "IAN@example.com", "skip"),
+      ],
+      {
+        importId: "cimp_test",
+        existingInvitations: [],
+        existingMemberships: [],
+      },
+    )
+
+    expect(plan.summary.createdCount).toBe(0)
+    expect(plan.summary.skippedCount).toBe(2)
+    expect(plan.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ action: "skip", operation: "skip" }),
+      ]),
+    )
+  })
+
+  it("updates existing volunteer memberships before considering invitations", () => {
+    const plan = buildVolunteerApplyPlan([volunteerRow(2, "ian@example.com")], {
+      importId: "cimp_test",
+      existingInvitations: [
+        {
+          id: "tinv_1",
+          email: "ian@example.com",
+          acceptedAt: null,
+          status: "pending",
+        },
+      ],
+      existingMemberships: [
+        { id: "tmem_1", email: "IAN@example.com", isActive: true },
+      ],
+    })
+
+    expect(plan.summary.updatedCount).toBe(1)
+    expect(plan.rows[0]).toMatchObject({
+      action: "update",
+      targetType: "team_membership",
+      targetId: "tmem_1",
+      operation: "update_membership",
+    })
+    expect(plan.rows[0]?.metadata).toContain('"volunteerRoleTypes":["judge"]')
+  })
+
+  it("updates an existing pending invitation instead of creating a duplicate", () => {
+    const plan = buildVolunteerApplyPlan([volunteerRow(2, "ian@example.com")], {
+      importId: "cimp_test",
+      existingInvitations: [
+        {
+          id: "tinv_1",
+          email: "IAN@example.com",
+          acceptedAt: null,
+          status: "pending",
+        },
+      ],
+      existingMemberships: [],
+    })
+
+    expect(plan.summary.updatedCount).toBe(1)
+    expect(plan.rows[0]).toMatchObject({
+      action: "update",
+      targetType: "team_invitation",
+      targetId: "tinv_1",
+      operation: "update_invitation",
+    })
+  })
+})
+
+describe("buildHeatScheduleApplyPlan", () => {
+  const context = {
+    competitionStartDate: "2026-06-20",
+    timezone: "America/Denver",
+    trackWorkouts: [{ id: "trwk_1", label: "Event 1", trackOrder: 1 }],
+    divisions: [{ id: "div_rx", label: "RX" }],
+    venues: [{ id: "cvenue_1", name: "Main Floor" }],
+    existingHeats: [{ id: "cheat_1", trackWorkoutId: "trwk_1", heatNumber: 1 }],
+  }
+
+  it("updates existing heats and skips duplicate rows in the same apply run", () => {
+    const plan = buildHeatScheduleApplyPlan(
+      [heatRow(2, 1, "9:00 AM"), heatRow(3, 1, "9:12 AM")],
+      context,
+    )
+
+    expect(plan.summary.updatedCount).toBe(1)
+    expect(plan.summary.skippedCount).toBe(1)
+    expect(plan.rows[0]).toMatchObject({
+      action: "update",
+      targetId: "cheat_1",
+      scheduledTime: new Date("2026-06-20T15:00:00.000Z"),
+    })
+    expect(plan.rows[1]?.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "duplicate_heat_apply" }),
+      ]),
+    )
+  })
+
+  it("parses imported wall-clock heat times in the competition timezone", () => {
+    expect(
+      parseImportedScheduledTime(
+        "2026-06-21 10:30 AM",
+        "2026-06-20",
+        "America/Denver",
+      )?.toISOString(),
+    ).toBe("2026-06-21T16:30:00.000Z")
+  })
+})

--- a/apps/crew/src/lib/crew/imports/apply.test.ts
+++ b/apps/crew/src/lib/crew/imports/apply.test.ts
@@ -3,8 +3,11 @@ import { describe, expect, it } from "vitest"
 import {
   buildHeatScheduleApplyPlan,
   buildVolunteerApplyPlan,
+  getAppliedHeatSupportTargets,
+  mergeImportedJsonMetadata,
   parseImportedScheduledTime,
 } from "./apply"
+import type { HeatScheduleImportRow } from "./types"
 import type { PreviewImportRow } from "./types"
 
 function volunteerRow(
@@ -48,6 +51,7 @@ function heatRow(
   rowNumber: number,
   heatNumber: number,
   scheduledTime: string,
+  overrides: Partial<HeatScheduleImportRow> = {},
 ): PreviewImportRow {
   return {
     rowNumber,
@@ -64,6 +68,7 @@ function heatRow(
       venue: "Main floor",
       laneCount: 8,
       notes: "Imported",
+      ...overrides,
     },
     warnings: [],
     errors: [],
@@ -117,6 +122,31 @@ describe("buildVolunteerApplyPlan", () => {
       operation: "update_membership",
     })
     expect(plan.rows[0]?.metadata).toContain('"volunteerRoleTypes":["judge"]')
+  })
+
+  it("preserves approved status when merging imported metadata for existing memberships", () => {
+    const plan = buildVolunteerApplyPlan([volunteerRow(2, "ian@example.com")], {
+      importId: "cimp_test",
+      existingInvitations: [],
+      existingMemberships: [
+        { id: "tmem_1", email: "ian@example.com", isActive: true },
+      ],
+    })
+
+    const merged = mergeImportedJsonMetadata(
+      JSON.stringify({
+        status: "approved",
+        volunteerRoleTypes: ["general"],
+      }),
+      plan.rows[0]?.metadata ?? null,
+      { preserveExistingApprovedStatus: true },
+    )
+
+    expect(JSON.parse(merged ?? "{}")).toMatchObject({
+      status: "approved",
+      volunteerRoleTypes: ["judge"],
+      crewImportId: "cimp_test",
+    })
   })
 
   it("updates an existing pending invitation instead of creating a duplicate", () => {
@@ -181,5 +211,67 @@ describe("buildHeatScheduleApplyPlan", () => {
         "America/Denver",
       )?.toISOString(),
     ).toBe("2026-06-21T16:30:00.000Z")
+  })
+
+  it("excludes published-skip and invalid-time heat rows from support targets", () => {
+    const plan = buildHeatScheduleApplyPlan(
+      [
+        heatRow(2, 1, "9:00 AM", { venue: "Side Floor" }),
+        heatRow(3, 2, "not a time", {
+          workout: "Event 2",
+          venue: "Side Floor",
+        }),
+        heatRow(4, 2, "10:00 AM"),
+      ],
+      {
+        competitionStartDate: "2026-06-20",
+        timezone: "America/Denver",
+        trackWorkouts: [
+          { id: "trwk_1", label: "Event 1", trackOrder: 1 },
+          { id: "trwk_2", label: "Event 2", trackOrder: 2 },
+        ],
+        divisions: [{ id: "div_rx", label: "RX" }],
+        venues: [
+          { id: "cvenue_1", name: "Main Floor" },
+          { id: "cvenue_2", name: "Side Floor" },
+        ],
+        existingHeats: [
+          {
+            id: "cheat_published",
+            trackWorkoutId: "trwk_1",
+            heatNumber: 1,
+            schedulePublishedAt: new Date("2026-06-20T15:00:00.000Z"),
+          },
+        ],
+      },
+    )
+
+    expect(plan.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          rowNumber: 2,
+          operation: "skip",
+          warnings: expect.arrayContaining([
+            expect.objectContaining({ code: "published_heat_not_updated" }),
+          ]),
+        }),
+        expect.objectContaining({
+          rowNumber: 3,
+          operation: "error",
+          errors: expect.arrayContaining([
+            expect.objectContaining({ code: "invalid_scheduled_time" }),
+          ]),
+        }),
+        expect.objectContaining({
+          rowNumber: 4,
+          operation: "create_heat",
+        }),
+      ]),
+    )
+
+    const supportTargets = getAppliedHeatSupportTargets(plan.rows)
+
+    expect([...supportTargets.trackWorkoutIds]).toEqual(["trwk_1"])
+    expect([...supportTargets.venueIds]).toEqual(["cvenue_1"])
   })
 })

--- a/apps/crew/src/lib/crew/imports/apply.test.ts
+++ b/apps/crew/src/lib/crew/imports/apply.test.ts
@@ -5,6 +5,7 @@ import {
   buildVolunteerApplyPlan,
   getAppliedHeatSupportTargets,
   getMutationAffectedRows,
+  isImportedHeatUpdateAlreadyApplied,
   markHeatUpdateSkippedForPublicationConflict,
   mergeImportedJsonMetadata,
   parseImportedScheduledTime,
@@ -279,6 +280,61 @@ describe("buildHeatScheduleApplyPlan", () => {
     })
     expect(summary.updatedCount).toBe(0)
     expect(summary.skippedCount).toBe(1)
+  })
+
+  it("recognizes an identical unpublished heat update as an idempotent success", () => {
+    const plan = buildHeatScheduleApplyPlan([heatRow(2, 1, "9:00 AM")], context)
+    const row = plan.rows[0]
+    expect(row).toBeDefined()
+    if (!row) throw new Error("Expected heat update row")
+
+    expect(
+      isImportedHeatUpdateAlreadyApplied(
+        {
+          trackWorkoutId: "trwk_1",
+          heatNumber: 1,
+          scheduledTime: new Date("2026-06-20T15:00:00.000Z"),
+          venueId: "cvenue_1",
+          divisionId: "div_rx",
+          durationMinutes: 12,
+          notes: "Imported",
+          schedulePublishedAt: null,
+        },
+        row,
+      ),
+    ).toBe(true)
+
+    expect(
+      isImportedHeatUpdateAlreadyApplied(
+        {
+          trackWorkoutId: "trwk_1",
+          heatNumber: 1,
+          scheduledTime: new Date("2026-06-20T15:00:00.000Z"),
+          venueId: "cvenue_1",
+          divisionId: "div_rx",
+          durationMinutes: 12,
+          notes: "Imported",
+          schedulePublishedAt: new Date("2026-06-20T15:05:00.000Z"),
+        },
+        row,
+      ),
+    ).toBe(false)
+
+    expect(
+      isImportedHeatUpdateAlreadyApplied(
+        {
+          trackWorkoutId: "trwk_1",
+          heatNumber: 1,
+          scheduledTime: new Date("2026-06-20T15:12:00.000Z"),
+          venueId: "cvenue_1",
+          divisionId: "div_rx",
+          durationMinutes: 12,
+          notes: "Imported",
+          schedulePublishedAt: null,
+        },
+        row,
+      ),
+    ).toBe(false)
   })
 
   it("excludes published-skip and invalid-time heat rows from support targets", () => {

--- a/apps/crew/src/lib/crew/imports/apply.ts
+++ b/apps/crew/src/lib/crew/imports/apply.ts
@@ -1,0 +1,685 @@
+// @lat: [[crew#Import Apply#Confirmed Mutation]]
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_INVITE_SOURCE,
+  VOLUNTEER_ROLE_LABELS,
+  VOLUNTEER_ROLE_TYPES,
+  type VolunteerAvailability,
+  type VolunteerMembershipMetadata,
+  type VolunteerRoleType,
+} from "../../../db/schemas/volunteers"
+import { parseTimeInTimezone } from "../../../utils/timezone-utils"
+import type {
+  HeatScheduleImportRow,
+  ImportIssue,
+  PreviewImportRow,
+  VolunteerImportRow,
+} from "./types"
+
+export type CrewApplyAction = "create" | "update" | "skip" | "error"
+
+export interface CrewApplySummary {
+  createdCount: number
+  updatedCount: number
+  skippedCount: number
+  errorRowCount: number
+  warningCount: number
+  errorCount: number
+}
+
+export interface ExistingVolunteerInvitation {
+  id: string
+  email: string
+  acceptedAt?: Date | null
+  status?: string | null
+}
+
+export interface ExistingVolunteerMembership {
+  id: string
+  email: string
+  isActive?: boolean | null
+}
+
+export interface VolunteerApplyRowPlan {
+  rowNumber: number
+  action: CrewApplyAction
+  targetType: "team_invitation" | "team_membership" | null
+  targetId: string | null
+  email: string
+  metadata: string | null
+  warnings: ImportIssue[]
+  errors: ImportIssue[]
+  operation:
+    | "create_invitation"
+    | "update_invitation"
+    | "update_membership"
+    | "skip"
+    | "error"
+}
+
+export interface VolunteerApplyPlan {
+  rows: VolunteerApplyRowPlan[]
+  summary: CrewApplySummary
+}
+
+export interface HeatApplyTrackWorkout {
+  id: string
+  label: string
+  trackOrder: number
+}
+
+export interface HeatApplyVenue {
+  id: string
+  name: string
+}
+
+export interface ExistingHeat {
+  id: string
+  trackWorkoutId: string
+  heatNumber: number
+  schedulePublishedAt?: Date | null
+}
+
+export interface HeatApplyContext {
+  competitionStartDate: string
+  timezone: string
+  trackWorkouts: HeatApplyTrackWorkout[]
+  divisions: Array<{ id: string; label: string }>
+  venues: HeatApplyVenue[]
+  existingHeats: ExistingHeat[]
+}
+
+export interface HeatApplyRowPlan {
+  rowNumber: number
+  action: CrewApplyAction
+  targetType: "competition_heat" | null
+  targetId: string | null
+  trackWorkoutId: string | null
+  heatNumber: number | null
+  scheduledTime: Date | null
+  venueId: string | null
+  divisionId: string | null
+  durationMinutes: number | null
+  notes: string | null
+  warnings: ImportIssue[]
+  errors: ImportIssue[]
+  operation: "create_heat" | "update_heat" | "skip" | "error"
+}
+
+export interface HeatApplyPlan {
+  rows: HeatApplyRowPlan[]
+  summary: CrewApplySummary
+}
+
+const roleLabelToType = new Map<string, VolunteerRoleType>(
+  Object.entries(VOLUNTEER_ROLE_LABELS).flatMap(([value, label]) => [
+    [normalizeLookupValue(label), value as VolunteerRoleType],
+    [normalizeLookupValue(value), value as VolunteerRoleType],
+  ]),
+)
+
+roleLabelToType.set("headjudge", VOLUNTEER_ROLE_TYPES.HEAD_JUDGE)
+roleLabelToType.set("lanejudge", VOLUNTEER_ROLE_TYPES.JUDGE)
+roleLabelToType.set("lanejudges", VOLUNTEER_ROLE_TYPES.JUDGE)
+roleLabelToType.set("scoring", VOLUNTEER_ROLE_TYPES.SCOREKEEPER)
+roleLabelToType.set("scorekeeping", VOLUNTEER_ROLE_TYPES.SCOREKEEPER)
+roleLabelToType.set("checkin", VOLUNTEER_ROLE_TYPES.CHECK_IN)
+
+export function buildVolunteerApplyPlan(
+  rows: PreviewImportRow[],
+  context: {
+    importId: string
+    existingInvitations: ExistingVolunteerInvitation[]
+    existingMemberships: ExistingVolunteerMembership[]
+  },
+): VolunteerApplyPlan {
+  const invitationsByEmail = new Map(
+    context.existingInvitations.map((invitation) => [
+      normalizeEmail(invitation.email),
+      invitation,
+    ]),
+  )
+  const membershipsByEmail = new Map(
+    context.existingMemberships.map((membership) => [
+      normalizeEmail(membership.email),
+      membership,
+    ]),
+  )
+  const seenEmails = new Set<string>()
+
+  const plannedRows = rows.map((row): VolunteerApplyRowPlan => {
+    const volunteer = row.normalizedRow as VolunteerImportRow
+    const email = normalizeEmail(volunteer.email)
+    const warnings = cloneIssues(row.warnings)
+    const errors = cloneIssues(row.errors)
+
+    if (row.action === "error" || errors.length > 0) {
+      return createVolunteerPlan(
+        row.rowNumber,
+        "error",
+        email,
+        warnings,
+        errors,
+      )
+    }
+
+    if (row.action === "skip") {
+      return createVolunteerPlan(row.rowNumber, "skip", email, warnings, errors)
+    }
+
+    if (!email) {
+      errors.push(
+        createApplyIssue(
+          row.rowNumber,
+          "email",
+          "missing_email",
+          "Email is required to apply this volunteer.",
+        ),
+      )
+      return createVolunteerPlan(
+        row.rowNumber,
+        "error",
+        email,
+        warnings,
+        errors,
+      )
+    }
+
+    if (seenEmails.has(email)) {
+      warnings.push(
+        createApplyIssue(
+          row.rowNumber,
+          "email",
+          "duplicate_email_apply",
+          "Email was already handled by another row in this apply run.",
+        ),
+      )
+      return createVolunteerPlan(row.rowNumber, "skip", email, warnings, errors)
+    }
+    seenEmails.add(email)
+
+    const metadata = buildVolunteerImportMetadata(volunteer, context.importId)
+    const existingMembership = membershipsByEmail.get(email)
+    if (existingMembership) {
+      if (existingMembership.isActive === false) {
+        warnings.push(
+          createApplyIssue(
+            row.rowNumber,
+            "email",
+            "inactive_existing_membership",
+            "A matching inactive volunteer membership already exists.",
+          ),
+        )
+        return createVolunteerPlan(
+          row.rowNumber,
+          "skip",
+          email,
+          warnings,
+          errors,
+        )
+      }
+
+      return {
+        rowNumber: row.rowNumber,
+        action: "update",
+        targetType: "team_membership",
+        targetId: existingMembership.id,
+        email,
+        metadata,
+        warnings,
+        errors,
+        operation: "update_membership",
+      }
+    }
+
+    const existingInvitation = invitationsByEmail.get(email)
+    if (existingInvitation) {
+      if (
+        existingInvitation.acceptedAt ||
+        existingInvitation.status === "accepted"
+      ) {
+        warnings.push(
+          createApplyIssue(
+            row.rowNumber,
+            "email",
+            "accepted_existing_invitation",
+            "A matching accepted volunteer invitation already exists.",
+          ),
+        )
+        return createVolunteerPlan(
+          row.rowNumber,
+          "skip",
+          email,
+          warnings,
+          errors,
+        )
+      }
+
+      return {
+        rowNumber: row.rowNumber,
+        action: "update",
+        targetType: "team_invitation",
+        targetId: existingInvitation.id,
+        email,
+        metadata,
+        warnings,
+        errors,
+        operation: "update_invitation",
+      }
+    }
+
+    return {
+      rowNumber: row.rowNumber,
+      action: "create",
+      targetType: "team_invitation",
+      targetId: null,
+      email,
+      metadata,
+      warnings,
+      errors,
+      operation: "create_invitation",
+    }
+  })
+
+  return { rows: plannedRows, summary: summarizeApplyRows(plannedRows) }
+}
+
+export function buildHeatScheduleApplyPlan(
+  rows: PreviewImportRow[],
+  context: HeatApplyContext,
+): HeatApplyPlan {
+  const trackWorkoutByLookup = buildTrackWorkoutLookup(context.trackWorkouts)
+  const divisionByLookup = new Map(
+    context.divisions.map((division) => [
+      normalizeLookupValue(division.label),
+      division,
+    ]),
+  )
+  const venueByLookup = new Map(
+    context.venues.map((venue) => [normalizeLookupValue(venue.name), venue]),
+  )
+  const existingHeatByKey = new Map(
+    context.existingHeats.map((heat) => [
+      heatKey(heat.trackWorkoutId, heat.heatNumber),
+      heat,
+    ]),
+  )
+  const seenHeatKeys = new Set<string>()
+
+  const plannedRows = rows.map((row): HeatApplyRowPlan => {
+    const heat = row.normalizedRow as HeatScheduleImportRow
+    const warnings = cloneIssues(row.warnings)
+    const errors = cloneIssues(row.errors)
+
+    if (row.action === "error" || errors.length > 0) {
+      return createHeatPlan(row.rowNumber, "error", warnings, errors)
+    }
+
+    if (row.action === "skip") {
+      return createHeatPlan(row.rowNumber, "skip", warnings, errors)
+    }
+
+    const trackWorkout = trackWorkoutByLookup.get(
+      normalizeLookupValue(heat.workout),
+    )
+    if (!trackWorkout) {
+      errors.push(
+        createApplyIssue(
+          row.rowNumber,
+          "workout",
+          "unresolved_workout",
+          "Workout could not be matched or created for this row.",
+        ),
+      )
+    }
+
+    if (heat.heatNumber === null) {
+      errors.push(
+        createApplyIssue(
+          row.rowNumber,
+          "heat",
+          "unresolved_heat_number",
+          "Heat number is required to apply this row.",
+        ),
+      )
+    }
+
+    const scheduledTime = parseImportedScheduledTime(
+      heat.scheduledTime,
+      context.competitionStartDate,
+      context.timezone,
+    )
+    if (heat.scheduledTime && !scheduledTime) {
+      errors.push(
+        createApplyIssue(
+          row.rowNumber,
+          "scheduledTime",
+          "invalid_scheduled_time",
+          "Scheduled time could not be parsed in the event timezone.",
+        ),
+      )
+    }
+
+    const division = heat.division
+      ? divisionByLookup.get(normalizeLookupValue(heat.division))
+      : null
+    if (heat.division && !division) {
+      warnings.push(
+        createApplyIssue(
+          row.rowNumber,
+          "division",
+          "unmatched_division_for_apply",
+          "Division was not matched, so this heat will remain mixed.",
+        ),
+      )
+    }
+
+    const venue = heat.venue
+      ? venueByLookup.get(normalizeLookupValue(heat.venue))
+      : null
+    if (heat.venue && !venue) {
+      warnings.push(
+        createApplyIssue(
+          row.rowNumber,
+          "venue",
+          "unmatched_venue_for_apply",
+          "Venue was not matched, so this heat will not be assigned to a venue.",
+        ),
+      )
+    }
+
+    if (errors.length > 0 || !trackWorkout || heat.heatNumber === null) {
+      return createHeatPlan(row.rowNumber, "error", warnings, errors)
+    }
+
+    const key = heatKey(trackWorkout.id, heat.heatNumber)
+    if (seenHeatKeys.has(key)) {
+      warnings.push(
+        createApplyIssue(
+          row.rowNumber,
+          "heat",
+          "duplicate_heat_apply",
+          "This workout and heat number was already handled by another row in this apply run.",
+        ),
+      )
+      return createHeatPlan(row.rowNumber, "skip", warnings, errors)
+    }
+    seenHeatKeys.add(key)
+
+    const existingHeat = existingHeatByKey.get(key)
+    if (existingHeat?.schedulePublishedAt) {
+      warnings.push(
+        createApplyIssue(
+          row.rowNumber,
+          "heat",
+          "published_heat_not_updated",
+          "A published heat already exists for this workout and heat number, so the import row was skipped.",
+        ),
+      )
+      return createHeatPlan(row.rowNumber, "skip", warnings, errors)
+    }
+
+    return {
+      rowNumber: row.rowNumber,
+      action: existingHeat ? "update" : "create",
+      targetType: "competition_heat",
+      targetId: existingHeat?.id ?? null,
+      trackWorkoutId: trackWorkout.id,
+      heatNumber: heat.heatNumber,
+      scheduledTime,
+      venueId: venue?.id ?? null,
+      divisionId: division?.id ?? null,
+      durationMinutes: heat.durationMinutes,
+      notes: heat.notes || null,
+      warnings,
+      errors,
+      operation: existingHeat ? "update_heat" : "create_heat",
+    }
+  })
+
+  return { rows: plannedRows, summary: summarizeApplyRows(plannedRows) }
+}
+
+export function buildTrackWorkoutLookup(
+  trackWorkouts: HeatApplyTrackWorkout[],
+) {
+  return new Map(
+    trackWorkouts.flatMap((workout) => [
+      [normalizeLookupValue(workout.label), workout],
+      [normalizeLookupValue(String(workout.trackOrder)), workout],
+      [normalizeLookupValue(`event ${workout.trackOrder}`), workout],
+      [normalizeLookupValue(`workout ${workout.trackOrder}`), workout],
+    ]),
+  )
+}
+
+export function parseImportedScheduledTime(
+  value: string,
+  competitionStartDate: string,
+  timezone: string,
+) {
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const dateAndTime = splitImportedDateTime(trimmed, competitionStartDate)
+  if (!dateAndTime) return null
+
+  const time = normalizeImportedTime(dateAndTime.time)
+  if (!time) return null
+
+  return parseTimeInTimezone(time, dateAndTime.date, timezone)
+}
+
+export function normalizeLookupValue(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, "and")
+    .replace(/[^a-z0-9]+/g, "")
+}
+
+function buildVolunteerImportMetadata(
+  row: VolunteerImportRow,
+  importId: string,
+) {
+  const displayName =
+    row.name || [row.firstName, row.lastName].filter(Boolean).join(" ")
+  const roleType = parseVolunteerRoleType(row.role)
+  const availability = parseVolunteerAvailability(row.availability)
+  const metadata: VolunteerMembershipMetadata & Record<string, unknown> = {
+    volunteerRoleTypes: [roleType ?? VOLUNTEER_ROLE_TYPES.GENERAL],
+    status: "pending",
+    inviteSource: VOLUNTEER_INVITE_SOURCE.DIRECT,
+    signupEmail: row.email,
+    signupName: displayName || undefined,
+    signupPhone: row.phone || undefined,
+    availability,
+    availabilityNotes: availability ? undefined : row.availability || undefined,
+    internalNotes: buildVolunteerNotes(row),
+    crewImportId: importId,
+  }
+
+  return JSON.stringify(removeUndefined(metadata))
+}
+
+function buildVolunteerNotes(row: VolunteerImportRow) {
+  const parts = [
+    row.notes,
+    row.role ? `Imported role: ${row.role}` : "",
+    row.division ? `Imported division: ${row.division}` : "",
+  ].filter(Boolean)
+
+  return parts.length > 0 ? parts.join("\n") : undefined
+}
+
+function parseVolunteerRoleType(value: string): VolunteerRoleType | null {
+  if (!value) return null
+  return roleLabelToType.get(normalizeLookupValue(value)) ?? null
+}
+
+function parseVolunteerAvailability(
+  value: string,
+): VolunteerAvailability | undefined {
+  const normalized = normalizeLookupValue(value)
+  if (!normalized) return undefined
+  if (normalized === "morning" || normalized === "am") {
+    return VOLUNTEER_AVAILABILITY.MORNING
+  }
+  if (normalized === "afternoon" || normalized === "pm") {
+    return VOLUNTEER_AVAILABILITY.AFTERNOON
+  }
+  if (
+    normalized === "allday" ||
+    normalized === "full" ||
+    normalized === "fullday"
+  ) {
+    return VOLUNTEER_AVAILABILITY.ALL_DAY
+  }
+  return undefined
+}
+
+function splitImportedDateTime(value: string, competitionStartDate: string) {
+  const isoDateMatch = value.match(/^(\d{4}-\d{2}-\d{2})[ T]+(.+)$/)
+  if (isoDateMatch) {
+    return { date: isoDateMatch[1], time: isoDateMatch[2] }
+  }
+
+  const slashDateMatch = value.match(
+    /^(\d{1,2})\/(\d{1,2})(?:\/(\d{2,4}))?\s+(.+)$/,
+  )
+  if (slashDateMatch) {
+    const [, month, day, year, time] = slashDateMatch
+    const competitionYear = competitionStartDate.slice(0, 4)
+    const fullYear = year
+      ? year.length === 2
+        ? `20${year}`
+        : year
+      : competitionYear
+    return {
+      date: `${fullYear}-${month.padStart(2, "0")}-${day.padStart(2, "0")}`,
+      time,
+    }
+  }
+
+  return { date: competitionStartDate, time: value }
+}
+
+function normalizeImportedTime(value: string) {
+  const trimmed = value.trim().toLowerCase()
+  const match = trimmed.match(/^(\d{1,2})(?::(\d{2}))?\s*(a\.?m\.?|p\.?m\.?)?$/)
+  if (!match) return null
+
+  let hours = Number(match[1])
+  const minutes = Number(match[2] ?? "0")
+  const meridiem = match[3]?.replace(/\./g, "")
+
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null
+
+  if (meridiem) {
+    if (hours < 1 || hours > 12) return null
+    if (meridiem === "pm" && hours !== 12) hours += 12
+    if (meridiem === "am" && hours === 12) hours = 0
+  }
+
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`
+}
+
+function summarizeApplyRows(
+  rows: Array<{
+    action: CrewApplyAction
+    warnings: ImportIssue[]
+    errors: ImportIssue[]
+  }>,
+): CrewApplySummary {
+  return {
+    createdCount: rows.filter((row) => row.action === "create").length,
+    updatedCount: rows.filter((row) => row.action === "update").length,
+    skippedCount: rows.filter((row) => row.action === "skip").length,
+    errorRowCount: rows.filter((row) => row.action === "error").length,
+    warningCount: rows.reduce((total, row) => total + row.warnings.length, 0),
+    errorCount: rows.reduce((total, row) => total + row.errors.length, 0),
+  }
+}
+
+function createVolunteerPlan(
+  rowNumber: number,
+  action: "skip" | "error",
+  email: string,
+  warnings: ImportIssue[],
+  errors: ImportIssue[],
+): VolunteerApplyRowPlan {
+  return {
+    rowNumber,
+    action,
+    targetType: null,
+    targetId: null,
+    email,
+    metadata: null,
+    warnings,
+    errors,
+    operation: action,
+  }
+}
+
+function createHeatPlan(
+  rowNumber: number,
+  action: "skip" | "error",
+  warnings: ImportIssue[],
+  errors: ImportIssue[],
+): HeatApplyRowPlan {
+  return {
+    rowNumber,
+    action,
+    targetType: null,
+    targetId: null,
+    trackWorkoutId: null,
+    heatNumber: null,
+    scheduledTime: null,
+    venueId: null,
+    divisionId: null,
+    durationMinutes: null,
+    notes: null,
+    warnings,
+    errors,
+    operation: action,
+  }
+}
+
+function createApplyIssue(
+  rowNumber: number,
+  field: string,
+  code: string,
+  message: string,
+): ImportIssue {
+  return {
+    code,
+    severity:
+      code.startsWith("invalid") ||
+      code.startsWith("missing") ||
+      code.startsWith("unresolved")
+        ? "error"
+        : "warning",
+    rowNumber,
+    field,
+    message,
+  }
+}
+
+function cloneIssues(issues: ImportIssue[]) {
+  return issues.map((issue) => ({ ...issue }))
+}
+
+function heatKey(trackWorkoutId: string, heatNumber: number) {
+  return `${trackWorkoutId}:${heatNumber}`
+}
+
+function normalizeEmail(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function removeUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T
+}

--- a/apps/crew/src/lib/crew/imports/apply.ts
+++ b/apps/crew/src/lib/crew/imports/apply.ts
@@ -85,6 +85,17 @@ export interface ExistingHeat {
   schedulePublishedAt?: Date | null
 }
 
+export interface ImportedHeatUpdateSnapshot {
+  trackWorkoutId: string
+  heatNumber: number
+  scheduledTime: Date | string | null
+  venueId: string | null
+  divisionId: string | null
+  durationMinutes: number | null
+  notes: string | null
+  schedulePublishedAt: Date | null
+}
+
 export interface HeatApplyContext {
   competitionStartDate: string
   timezone: string
@@ -538,6 +549,22 @@ export function markHeatUpdateSkippedForPublicationConflict(
   })
 }
 
+export function isImportedHeatUpdateAlreadyApplied(
+  currentHeat: ImportedHeatUpdateSnapshot,
+  row: HeatApplyRowPlan,
+) {
+  return (
+    currentHeat.schedulePublishedAt === null &&
+    currentHeat.trackWorkoutId === row.trackWorkoutId &&
+    currentHeat.heatNumber === row.heatNumber &&
+    getDateTime(currentHeat.scheduledTime) === getDateTime(row.scheduledTime) &&
+    currentHeat.venueId === row.venueId &&
+    currentHeat.divisionId === row.divisionId &&
+    currentHeat.durationMinutes === row.durationMinutes &&
+    currentHeat.notes === row.notes
+  )
+}
+
 export function mergeImportedJsonMetadata(
   existingMetadata: string | null | undefined,
   importedMetadata: string | null,
@@ -820,6 +847,11 @@ function getTrackWorkoutLookupKeys(workout: HeatApplyTrackWorkout) {
 function hasImportedScheduledTimeValue(value: unknown) {
   if (typeof value === "string") return value.trim().length > 0
   return value !== null && value !== undefined
+}
+
+function getDateTime(value: Date | string | null) {
+  if (!value) return null
+  return value instanceof Date ? value.getTime() : new Date(value).getTime()
 }
 
 function cloneIssues(issues: ImportIssue[]) {

--- a/apps/crew/src/lib/crew/imports/apply.ts
+++ b/apps/crew/src/lib/crew/imports/apply.ts
@@ -68,6 +68,11 @@ export interface HeatApplyTrackWorkout {
   trackOrder: number
 }
 
+export interface TrackWorkoutLookupDetails {
+  workoutByLookup: Map<string, HeatApplyTrackWorkout>
+  ambiguousLookupKeys: Set<string>
+}
+
 export interface HeatApplyVenue {
   id: string
   name: string
@@ -114,6 +119,13 @@ export interface HeatApplyPlan {
 export interface HeatApplySupportTargets {
   trackWorkoutIds: Set<string>
   venueIds: Set<string>
+}
+
+export interface CrewImportProgrammingTrackCandidate {
+  id: string
+  name: string
+  type?: string | null
+  isPublic?: number | null
 }
 
 const roleLabelToType = new Map<string, VolunteerRoleType>(
@@ -293,7 +305,9 @@ export function buildHeatScheduleApplyPlan(
   rows: PreviewImportRow[],
   context: HeatApplyContext,
 ): HeatApplyPlan {
-  const trackWorkoutByLookup = buildTrackWorkoutLookup(context.trackWorkouts)
+  const trackWorkoutLookup = buildTrackWorkoutLookupDetails(
+    context.trackWorkouts,
+  )
   const divisionByLookup = new Map(
     context.divisions.map((division) => [
       normalizeLookupValue(division.label),
@@ -324,10 +338,22 @@ export function buildHeatScheduleApplyPlan(
       return createHeatPlan(row.rowNumber, "skip", warnings, errors)
     }
 
-    const trackWorkout = trackWorkoutByLookup.get(
-      normalizeLookupValue(heat.workout),
-    )
-    if (!trackWorkout) {
+    const workoutLookupKey =
+      typeof heat.workout === "string" ? normalizeLookupValue(heat.workout) : ""
+    const isAmbiguousWorkout =
+      trackWorkoutLookup.ambiguousLookupKeys.has(workoutLookupKey)
+    const trackWorkout =
+      trackWorkoutLookup.workoutByLookup.get(workoutLookupKey)
+    if (isAmbiguousWorkout) {
+      errors.push(
+        createApplyIssue(
+          row.rowNumber,
+          "workout",
+          "ambiguous_workout_lookup",
+          "Workout label matches multiple existing event lookup keys.",
+        ),
+      )
+    } else if (!trackWorkout) {
       errors.push(
         createApplyIssue(
           row.rowNumber,
@@ -354,7 +380,7 @@ export function buildHeatScheduleApplyPlan(
       context.competitionStartDate,
       context.timezone,
     )
-    if (heat.scheduledTime && !scheduledTime) {
+    if (hasImportedScheduledTimeValue(heat.scheduledTime) && !scheduledTime) {
       errors.push(
         createApplyIssue(
           row.rowNumber,
@@ -448,14 +474,30 @@ export function buildHeatScheduleApplyPlan(
 export function buildTrackWorkoutLookup(
   trackWorkouts: HeatApplyTrackWorkout[],
 ) {
-  return new Map(
-    trackWorkouts.flatMap((workout) => [
-      [normalizeLookupValue(workout.label), workout],
-      [normalizeLookupValue(String(workout.trackOrder)), workout],
-      [normalizeLookupValue(`event ${workout.trackOrder}`), workout],
-      [normalizeLookupValue(`workout ${workout.trackOrder}`), workout],
-    ]),
-  )
+  return buildTrackWorkoutLookupDetails(trackWorkouts).workoutByLookup
+}
+
+export function buildTrackWorkoutLookupDetails(
+  trackWorkouts: HeatApplyTrackWorkout[],
+): TrackWorkoutLookupDetails {
+  const workoutByLookup = new Map<string, HeatApplyTrackWorkout>()
+  const ambiguousLookupKeys = new Set<string>()
+
+  for (const workout of trackWorkouts) {
+    for (const key of getTrackWorkoutLookupKeys(workout)) {
+      const existing = workoutByLookup.get(key)
+      if (!existing) {
+        workoutByLookup.set(key, workout)
+        continue
+      }
+
+      if (existing.id !== workout.id) {
+        ambiguousLookupKeys.add(key)
+      }
+    }
+  }
+
+  return { workoutByLookup, ambiguousLookupKeys }
 }
 
 export function getAppliedHeatSupportTargets(
@@ -479,6 +521,21 @@ export function getAppliedHeatSupportTargets(
   }
 
   return { trackWorkoutIds, venueIds }
+}
+
+export function markHeatUpdateSkippedForPublicationConflict(
+  row: HeatApplyRowPlan,
+) {
+  row.action = "skip"
+  row.operation = "skip"
+  row.warnings.push({
+    code: "published_heat_update_conflict",
+    severity: "warning",
+    rowNumber: row.rowNumber,
+    field: "heat",
+    message:
+      "The heat was published while this import was being applied, so the row was skipped.",
+  })
 }
 
 export function mergeImportedJsonMetadata(
@@ -508,10 +565,12 @@ export function mergeImportedJsonMetadata(
 }
 
 export function parseImportedScheduledTime(
-  value: string,
+  value: unknown,
   competitionStartDate: string,
   timezone: string,
 ) {
+  if (typeof value !== "string") return null
+
   const trimmed = value.trim()
   if (!trimmed) return null
 
@@ -522,6 +581,34 @@ export function parseImportedScheduledTime(
   if (!time) return null
 
   return parseTimeInTimezone(time, dateAndTime.date, timezone)
+}
+
+export function getMutationAffectedRows(result: unknown) {
+  return (
+    (result as { rowsAffected?: number }).rowsAffected ??
+    (result as [{ affectedRows?: number }])[0]?.affectedRows ??
+    0
+  )
+}
+
+export function selectCrewImportProgrammingTrack(
+  tracks: CrewImportProgrammingTrackCandidate[],
+  preferredName: string,
+) {
+  const sortedTracks = [...tracks].sort((a, b) => {
+    const nameCompare = a.name.localeCompare(b.name)
+    if (nameCompare !== 0) return nameCompare
+    return a.id.localeCompare(b.id)
+  })
+
+  return (
+    sortedTracks.find((track) => track.name === preferredName) ??
+    sortedTracks.find(
+      (track) => track.type === "team_owned" && track.isPublic === 0,
+    ) ??
+    sortedTracks[0] ??
+    null
+  )
 }
 
 export function normalizeLookupValue(value: string) {
@@ -639,7 +726,7 @@ function normalizeImportedTime(value: string) {
   return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`
 }
 
-function summarizeApplyRows(
+export function summarizeApplyRows(
   rows: Array<{
     action: CrewApplyAction
     warnings: ImportIssue[]
@@ -711,13 +798,28 @@ function createApplyIssue(
     severity:
       code.startsWith("invalid") ||
       code.startsWith("missing") ||
-      code.startsWith("unresolved")
+      code.startsWith("unresolved") ||
+      code.startsWith("ambiguous")
         ? "error"
         : "warning",
     rowNumber,
     field,
     message,
   }
+}
+
+function getTrackWorkoutLookupKeys(workout: HeatApplyTrackWorkout) {
+  return [
+    normalizeLookupValue(workout.label),
+    normalizeLookupValue(String(workout.trackOrder)),
+    normalizeLookupValue(`event ${workout.trackOrder}`),
+    normalizeLookupValue(`workout ${workout.trackOrder}`),
+  ]
+}
+
+function hasImportedScheduledTimeValue(value: unknown) {
+  if (typeof value === "string") return value.trim().length > 0
+  return value !== null && value !== undefined
 }
 
 function cloneIssues(issues: ImportIssue[]) {

--- a/apps/crew/src/lib/crew/imports/apply.ts
+++ b/apps/crew/src/lib/crew/imports/apply.ts
@@ -111,6 +111,11 @@ export interface HeatApplyPlan {
   summary: CrewApplySummary
 }
 
+export interface HeatApplySupportTargets {
+  trackWorkoutIds: Set<string>
+  venueIds: Set<string>
+}
+
 const roleLabelToType = new Map<string, VolunteerRoleType>(
   Object.entries(VOLUNTEER_ROLE_LABELS).flatMap(([value, label]) => [
     [normalizeLookupValue(label), value as VolunteerRoleType],
@@ -451,6 +456,55 @@ export function buildTrackWorkoutLookup(
       [normalizeLookupValue(`workout ${workout.trackOrder}`), workout],
     ]),
   )
+}
+
+export function getAppliedHeatSupportTargets(
+  rows: HeatApplyRowPlan[],
+): HeatApplySupportTargets {
+  const trackWorkoutIds = new Set<string>()
+  const venueIds = new Set<string>()
+
+  for (const row of rows) {
+    if (row.operation !== "create_heat" && row.operation !== "update_heat") {
+      continue
+    }
+
+    if (row.trackWorkoutId) {
+      trackWorkoutIds.add(row.trackWorkoutId)
+    }
+
+    if (row.venueId) {
+      venueIds.add(row.venueId)
+    }
+  }
+
+  return { trackWorkoutIds, venueIds }
+}
+
+export function mergeImportedJsonMetadata(
+  existingMetadata: string | null | undefined,
+  importedMetadata: string | null,
+  options: { preserveExistingApprovedStatus?: boolean } = {},
+) {
+  if (!existingMetadata) return importedMetadata
+  if (!importedMetadata) return existingMetadata
+
+  try {
+    const existing = JSON.parse(existingMetadata) as Record<string, unknown>
+    const imported = JSON.parse(importedMetadata) as Record<string, unknown>
+    const merged = { ...existing, ...imported }
+
+    if (
+      options.preserveExistingApprovedStatus &&
+      existing.status === "approved"
+    ) {
+      merged.status = "approved"
+    }
+
+    return JSON.stringify(merged)
+  } catch {
+    return importedMetadata
+  }
 }
 
 export function parseImportedScheduledTime(

--- a/apps/crew/src/routes/events/$eventId/imports.tsx
+++ b/apps/crew/src/routes/events/$eventId/imports.tsx
@@ -1,11 +1,13 @@
 import type { ChangeEvent, FormEvent, ReactNode } from "react"
 import { useMemo, useState } from "react"
 import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
 import {
   AlertTriangle,
   CheckCircle2,
   FileSpreadsheet,
   Loader2,
+  PlayCircle,
   Upload,
 } from "lucide-react"
 import { toast } from "sonner"
@@ -23,7 +25,9 @@ import type {
   VolunteerImportRow,
 } from "@/lib/crew/imports/types"
 import {
+  applyCrewImportFn,
   getCrewImportsPageFn,
+  type CrewImportApplyResult,
   type CrewImportHistoryItem,
   type CrewImportReferenceData,
   type PersistedCrewImportPreview,
@@ -50,6 +54,15 @@ function EventImportsPage() {
   function handlePreviewComplete(preview: PersistedCrewImportPreview) {
     setLatestPreview(preview)
     setActiveTab(preview.kind)
+  }
+
+  async function handleApplyComplete(result: CrewImportApplyResult) {
+    setLatestPreview((current) =>
+      current && current.importId === result.importId
+        ? { ...current, status: result.status }
+        : current,
+    )
+    await router.invalidate()
   }
 
   return (
@@ -94,7 +107,13 @@ function EventImportsPage() {
             onPreviewComplete={handlePreviewComplete}
             onHistoryRefresh={() => router.invalidate()}
           />
-          <PreviewPanel preview={latestPreview} expectedKind={activeTab} />
+          <PreviewPanel
+            key={latestPreview?.importId ?? activeTab}
+            eventId={eventId}
+            preview={latestPreview}
+            expectedKind={activeTab}
+            onApplyComplete={handleApplyComplete}
+          />
         </div>
       ) : null}
 
@@ -286,12 +305,22 @@ function ImportUploadPanel({
 }
 
 function PreviewPanel({
+  eventId,
   preview,
   expectedKind,
+  onApplyComplete,
 }: {
+  eventId: string
   preview: PersistedCrewImportPreview | null
   expectedKind: CrewImportKind
+  onApplyComplete: (result: CrewImportApplyResult) => Promise<void>
 }) {
+  const applyImport = useServerFn(applyCrewImportFn)
+  const [isApplying, setIsApplying] = useState(false)
+  const [applyResult, setApplyResult] = useState<CrewImportApplyResult | null>(
+    null,
+  )
+
   if (!preview || preview.kind !== expectedKind) {
     return (
       <section className="rounded-md border bg-card p-5 shadow-sm">
@@ -304,6 +333,40 @@ function PreviewPanel({
     )
   }
 
+  const canApply = preview.status === "previewed"
+  const appliedCount = applyResult
+    ? applyResult.createdCount + applyResult.updatedCount
+    : 0
+
+  async function handleApply() {
+    if (!preview) return
+
+    const confirmed = window.confirm(
+      `Apply ${formatKind(preview.kind).toLowerCase()} import ${preview.importId}? This will mutate Crew data from the persisted preview rows.`,
+    )
+    if (!confirmed) return
+
+    setIsApplying(true)
+    try {
+      const result = await applyImport({
+        data: {
+          eventId,
+          importId: preview.importId,
+          confirmed: true,
+        },
+      })
+      setApplyResult(result)
+      await onApplyComplete(result)
+      toast.success("Import applied")
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to apply import",
+      )
+    } finally {
+      setIsApplying(false)
+    }
+  }
+
   return (
     <section className="space-y-4 rounded-md border bg-card p-5 shadow-sm">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -313,7 +376,22 @@ function PreviewPanel({
             Import {preview.importId}
           </p>
         </div>
-        <StatusBadge status={preview.status} />
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusBadge status={applyResult?.status ?? preview.status} />
+          <button
+            type="button"
+            onClick={handleApply}
+            disabled={!canApply || isApplying}
+            className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isApplying ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <PlayCircle className="size-4" />
+            )}
+            Apply
+          </button>
+        </div>
       </div>
 
       <div className="grid gap-3 sm:grid-cols-3">
@@ -321,6 +399,14 @@ function PreviewPanel({
         <SummaryMetric label="Warnings" value={preview.warningCount} />
         <SummaryMetric label="Errors" value={preview.errorCount} />
       </div>
+
+      {applyResult ? (
+        <div className="grid gap-3 sm:grid-cols-3">
+          <SummaryMetric label="Applied" value={appliedCount} />
+          <SummaryMetric label="Created" value={applyResult.createdCount} />
+          <SummaryMetric label="Skipped" value={applyResult.skippedCount} />
+        </div>
+      ) : null}
 
       {preview.fileIssues.length > 0 ? (
         <IssueList issues={preview.fileIssues} />
@@ -523,6 +609,9 @@ function HistoryPanel({ history }: { history: CrewImportHistoryItem[] }) {
                 <th className="px-3 py-2 font-medium">Warnings</th>
                 <th className="px-3 py-2 font-medium">Errors</th>
                 <th className="px-3 py-2 font-medium">Created</th>
+                <th className="px-3 py-2 font-medium">Updated</th>
+                <th className="px-3 py-2 font-medium">Skipped</th>
+                <th className="px-3 py-2 font-medium">Uploaded</th>
               </tr>
             </thead>
             <tbody>
@@ -543,6 +632,9 @@ function HistoryPanel({ history }: { history: CrewImportHistoryItem[] }) {
                   <td className="px-3 py-2">{item.rowCount}</td>
                   <td className="px-3 py-2">{item.warningCount}</td>
                   <td className="px-3 py-2">{item.errorCount}</td>
+                  <td className="px-3 py-2">{item.createdCount}</td>
+                  <td className="px-3 py-2">{item.updatedCount}</td>
+                  <td className="px-3 py-2">{item.skippedCount}</td>
                   <td className="px-3 py-2">
                     {formatHistoryDate(item.createdAt)}
                   </td>

--- a/apps/crew/src/server-fns/crew-import-fns.ts
+++ b/apps/crew/src/server-fns/crew-import-fns.ts
@@ -1,9 +1,13 @@
 // @lat: [[crew#Import CSV Preview#Preview Records]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
-import { loadCrewImportsPageData } from "../server/crew-imports"
+import {
+  applyCrewImportRecord,
+  loadCrewImportsPageData,
+} from "../server/crew-imports"
 
 export type {
+  CrewImportApplyResult,
   CrewImportHistoryItem,
   CrewImportReferenceData,
   CrewImportsPageData,
@@ -14,6 +18,16 @@ const getCrewImportsPageInputSchema = z.object({
   eventId: z.string().min(1, "Event ID is required"),
 })
 
+const applyCrewImportInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  importId: z.string().min(1, "Import ID is required"),
+  confirmed: z.literal(true),
+})
+
 export const getCrewImportsPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => getCrewImportsPageInputSchema.parse(data))
   .handler(async ({ data }) => await loadCrewImportsPageData(data.eventId))
+
+export const applyCrewImportFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => applyCrewImportInputSchema.parse(data))
+  .handler(async ({ data }) => await applyCrewImportRecord(data))

--- a/apps/crew/src/server/crew-imports.ts
+++ b/apps/crew/src/server/crew-imports.ts
@@ -1,5 +1,6 @@
 // @lat: [[crew#Import CSV Preview#Preview Records]]
-import { desc, eq, inArray } from "drizzle-orm"
+import { createId } from "@paralleldrive/cuid2"
+import { and, asc, desc, eq, inArray } from "drizzle-orm"
 import { z } from "zod"
 import {
   CREW_IMPORT_KIND,
@@ -9,20 +10,51 @@ import {
   crewImportRowsTable,
   crewImportsTable,
   type CrewImport,
+  type CrewImportRow,
 } from "../db/schemas/crew-imports"
-import { createCrewImportId } from "../db/schemas/common"
+import {
+  createCompetitionHeatId,
+  createCompetitionVenueId,
+  createCrewImportId,
+  createProgrammingTrackId,
+  createTeamInvitationId,
+  createTrackWorkoutId,
+} from "../db/schemas/common"
 import {
   competitionHeatsTable,
+  competitionVenuesTable,
   competitionsTable,
 } from "../db/schemas/competitions"
 import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
 import {
+  PROGRAMMING_TRACK_TYPE,
   programmingTracksTable,
   trackWorkoutsTable,
 } from "../db/schemas/programming"
 import { scalingLevelsTable } from "../db/schemas/scaling"
+import {
+  INVITATION_STATUS,
+  SYSTEM_ROLES_ENUM,
+  teamInvitationTable,
+  teamMembershipTable,
+} from "../db/schemas/teams"
+import { userTable } from "../db/schemas/users"
 import { workouts } from "../db/schemas/workouts"
 import { getDb } from "../db"
+import {
+  buildHeatScheduleApplyPlan,
+  buildTrackWorkoutLookup,
+  buildVolunteerApplyPlan,
+  normalizeLookupValue,
+  type CrewApplySummary,
+  type ExistingVolunteerInvitation,
+  type ExistingVolunteerMembership,
+  type HeatApplyContext,
+  type HeatApplyRowPlan,
+  type HeatApplyTrackWorkout,
+  type HeatApplyVenue,
+  type VolunteerApplyRowPlan,
+} from "../lib/crew/imports/apply"
 import {
   buildCrewImportPreview,
   defaultCrewImportRoleLabels,
@@ -33,15 +65,27 @@ import {
   type CrewImportKind,
   type CrewImportPreview,
   type CrewImportPreviewContext,
+  type HeatScheduleImportRow,
+  type ImportIssue,
   type PreviewImportRow,
+  type VolunteerImportRow,
 } from "../lib/crew/imports/types"
 import { parseCompetitionSettings } from "../utils/competition-settings"
+import { DEFAULT_TIMEZONE } from "../utils/timezone-utils"
 import { requireLocalCrewOperatorAccess } from "./crew-local-access"
 
 export const MAX_CREW_IMPORT_BYTES = 1_000_000
 
+type DbClient = ReturnType<typeof getDb>
+type CrewEventRecord = Awaited<ReturnType<typeof requireCrewEvent>>
+
 export type CrewImportErrorCode =
   | "EVENT_NOT_FOUND"
+  | "IMPORT_NOT_FOUND"
+  | "IMPORT_ALREADY_APPLIED"
+  | "INVALID_IMPORT_STATUS"
+  | "CONFIRMATION_REQUIRED"
+  | "UNSUPPORTED_IMPORT_KIND"
   | "INVALID_FILE_TYPE"
   | "INVALID_COLUMN_MAPPING"
   | "PAYLOAD_TOO_LARGE"
@@ -68,6 +112,12 @@ const uploadCrewImportInputSchema = z.object({
   columnMapping: z.record(z.string(), z.string()).optional(),
 })
 
+const applyCrewImportInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  importId: z.string().min(1, "Import ID is required"),
+  confirmed: z.literal(true),
+})
+
 export interface CrewImportHistoryItem {
   id: string
   kind: CrewImport["kind"]
@@ -82,6 +132,27 @@ export interface CrewImportHistoryItem {
   skippedCount: number
   createdAt: Date
   updatedAt: Date
+}
+
+type CrewImportApplySummaryValue =
+  | string
+  | number
+  | boolean
+  | null
+  | string[]
+  | number[]
+  | boolean[]
+
+export interface CrewImportApplyResult {
+  importId: string
+  kind: CrewImport["kind"]
+  status: CrewImport["status"]
+  createdCount: number
+  updatedCount: number
+  skippedCount: number
+  errorCount: number
+  warningCount: number
+  summary: Record<string, CrewImportApplySummaryValue>
 }
 
 export interface CrewImportReferenceData {
@@ -185,6 +256,71 @@ export async function createCrewImportPreviewRecord(input: {
   }
 }
 
+export async function applyCrewImportRecord(input: {
+  eventId: string
+  importId: string
+  confirmed: true
+}): Promise<CrewImportApplyResult> {
+  requireLocalCrewOperatorAccess("Crew imports")
+
+  const data = applyCrewImportInputSchema.parse(input)
+  if (!data.confirmed) {
+    throw new CrewImportError(
+      "CONFIRMATION_REQUIRED",
+      "Confirm the import apply before mutating Crew data.",
+      400,
+    )
+  }
+
+  const [event, importRecord, rows] = await Promise.all([
+    requireCrewEvent(data.eventId),
+    requireCrewImport(data.eventId, data.importId),
+    listCrewImportRows(data.importId),
+  ])
+
+  if (importRecord.status === CREW_IMPORT_STATUS.APPLIED) {
+    throw new CrewImportError(
+      "IMPORT_ALREADY_APPLIED",
+      "This import has already been applied.",
+      409,
+    )
+  }
+
+  if (importRecord.status !== CREW_IMPORT_STATUS.PREVIEWED) {
+    throw new CrewImportError(
+      "INVALID_IMPORT_STATUS",
+      "Only previewed imports can be applied.",
+      409,
+    )
+  }
+
+  const previewRows = rows.map((row) =>
+    toPersistedPreviewRow(importRecord.kind, row),
+  )
+
+  if (importRecord.kind === CREW_IMPORT_KIND.VOLUNTEERS) {
+    return await applyVolunteerImport({
+      event,
+      importRecord,
+      previewRows,
+    })
+  }
+
+  if (importRecord.kind === CREW_IMPORT_KIND.HEAT_SCHEDULE) {
+    return await applyHeatScheduleImport({
+      event,
+      importRecord,
+      previewRows,
+    })
+  }
+
+  throw new CrewImportError(
+    "UNSUPPORTED_IMPORT_KIND",
+    "This import kind does not have an apply path yet.",
+    400,
+  )
+}
+
 async function persistCrewImportPreview({
   eventId,
   importId,
@@ -246,6 +382,620 @@ async function persistCrewImportPreview({
   })
 }
 
+async function applyVolunteerImport({
+  event,
+  importRecord,
+  previewRows,
+}: {
+  event: CrewEventRecord
+  importRecord: CrewImport
+  previewRows: PreviewImportRow[]
+}): Promise<CrewImportApplyResult> {
+  const db = getDb()
+  const [existingInvitations, existingMemberships] = await Promise.all([
+    listVolunteerInvitations(db, event.competitionTeamId),
+    listVolunteerMemberships(db, event.competitionTeamId),
+  ])
+  const invitationMetadataById = new Map(
+    existingInvitations.map((invitation) => [
+      invitation.id,
+      invitation.metadata,
+    ]),
+  )
+  const membershipMetadataById = new Map(
+    existingMemberships.map((membership) => [
+      membership.id,
+      membership.metadata,
+    ]),
+  )
+  const plan = buildVolunteerApplyPlan(previewRows, {
+    importId: importRecord.id,
+    existingInvitations,
+    existingMemberships,
+  })
+  const timestamp = new Date()
+
+  await db.transaction(async (tx) => {
+    const client = tx as unknown as DbClient
+
+    for (const row of plan.rows) {
+      if (row.operation === "create_invitation") {
+        row.targetId = await createVolunteerInvitation(
+          client,
+          event.competitionTeamId,
+          row,
+          timestamp,
+        )
+      } else if (row.operation === "update_invitation" && row.targetId) {
+        await updateVolunteerInvitation(
+          client,
+          row.targetId,
+          mergeJsonMetadata(
+            invitationMetadataById.get(row.targetId),
+            row.metadata,
+          ),
+          timestamp,
+        )
+      } else if (row.operation === "update_membership" && row.targetId) {
+        await updateVolunteerMembership(
+          client,
+          row.targetId,
+          mergeJsonMetadata(
+            membershipMetadataById.get(row.targetId),
+            row.metadata,
+          ),
+          timestamp,
+        )
+      }
+
+      await updateImportRowAudit(client, importRecord.id, row, timestamp)
+    }
+
+    await updateImportApplySummary(
+      client,
+      importRecord,
+      plan.summary,
+      timestamp,
+      {
+        kind: CREW_IMPORT_KIND.VOLUNTEERS,
+        appliedRowCount: plan.summary.createdCount + plan.summary.updatedCount,
+        knownLimitations: [
+          "Pending no-account volunteers are written as team invitations and are not assignable until they accept or become approved memberships.",
+        ],
+      },
+    )
+  })
+
+  return toApplyResult(importRecord, plan.summary, {
+    kind: CREW_IMPORT_KIND.VOLUNTEERS,
+    appliedRowCount: plan.summary.createdCount + plan.summary.updatedCount,
+  })
+}
+
+async function applyHeatScheduleImport({
+  event,
+  importRecord,
+  previewRows,
+}: {
+  event: CrewEventRecord
+  importRecord: CrewImport
+  previewRows: PreviewImportRow[]
+}): Promise<CrewImportApplyResult> {
+  const db = getDb()
+  const timestamp = new Date()
+  let resultSummary: CrewApplySummary | null = null
+  let extraSummary: CrewImportApplyResult["summary"] = {}
+
+  await db.transaction(async (tx) => {
+    const client = tx as unknown as DbClient
+    const trackWorkoutResult = await ensureImportedTrackWorkouts(
+      client,
+      event,
+      previewRows,
+      timestamp,
+      importRecord.id,
+    )
+    const venueResult = await ensureImportedVenues(
+      client,
+      event.id,
+      previewRows,
+      timestamp,
+    )
+    const divisions = await listDivisionsForCrewEvent(client, event)
+    const existingHeats = await listExistingHeats(
+      client,
+      event.id,
+      trackWorkoutResult.trackWorkouts.map((workout) => workout.id),
+    )
+    const plan = buildHeatScheduleApplyPlan(previewRows, {
+      competitionStartDate: event.startDate,
+      timezone: event.timezone ?? DEFAULT_TIMEZONE,
+      trackWorkouts: trackWorkoutResult.trackWorkouts,
+      divisions,
+      venues: venueResult.venues,
+      existingHeats,
+    })
+
+    for (const row of plan.rows) {
+      if (row.operation === "create_heat") {
+        row.targetId = await createImportedHeat(
+          client,
+          event.id,
+          row,
+          timestamp,
+        )
+      } else if (row.operation === "update_heat" && row.targetId) {
+        await updateImportedHeat(client, row, timestamp)
+      }
+
+      await updateImportRowAudit(client, importRecord.id, row, timestamp)
+    }
+
+    resultSummary = plan.summary
+    extraSummary = {
+      kind: CREW_IMPORT_KIND.HEAT_SCHEDULE,
+      appliedRowCount: plan.summary.createdCount + plan.summary.updatedCount,
+      createdTrackWorkoutCount: trackWorkoutResult.createdTrackWorkoutCount,
+      createdVenueCount: venueResult.createdVenueCount,
+      updatedVenueCount: venueResult.updatedVenueCount,
+      timezone: event.timezone ?? DEFAULT_TIMEZONE,
+      schedulePublishedAt: null,
+    }
+
+    await updateImportApplySummary(
+      client,
+      importRecord,
+      plan.summary,
+      timestamp,
+      extraSummary,
+    )
+  })
+
+  if (!resultSummary) {
+    throw new CrewImportError(
+      "INVALID_IMPORT_STATUS",
+      "Heat schedule import could not be applied.",
+      500,
+    )
+  }
+
+  return toApplyResult(importRecord, resultSummary, extraSummary)
+}
+
+async function listVolunteerInvitations(
+  db: DbClient,
+  competitionTeamId: string,
+): Promise<Array<ExistingVolunteerInvitation & { metadata: string | null }>> {
+  return await db
+    .select({
+      id: teamInvitationTable.id,
+      email: teamInvitationTable.email,
+      acceptedAt: teamInvitationTable.acceptedAt,
+      status: teamInvitationTable.status,
+      metadata: teamInvitationTable.metadata,
+    })
+    .from(teamInvitationTable)
+    .where(
+      and(
+        eq(teamInvitationTable.teamId, competitionTeamId),
+        eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamInvitationTable.isSystemRole, true),
+      ),
+    )
+}
+
+async function listVolunteerMemberships(
+  db: DbClient,
+  competitionTeamId: string,
+): Promise<Array<ExistingVolunteerMembership & { metadata: string | null }>> {
+  const rows = await db
+    .select({
+      id: teamMembershipTable.id,
+      email: userTable.email,
+      isActive: teamMembershipTable.isActive,
+      metadata: teamMembershipTable.metadata,
+    })
+    .from(teamMembershipTable)
+    .innerJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(
+      and(
+        eq(teamMembershipTable.teamId, competitionTeamId),
+        eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamMembershipTable.isSystemRole, true),
+      ),
+    )
+
+  return rows.flatMap((row) =>
+    row.email
+      ? [
+          {
+            ...row,
+            email: row.email,
+          },
+        ]
+      : [],
+  )
+}
+
+async function createVolunteerInvitation(
+  db: DbClient,
+  competitionTeamId: string,
+  row: VolunteerApplyRowPlan,
+  timestamp: Date,
+) {
+  const invitationId = createTeamInvitationId()
+  const expiresAt = new Date(timestamp)
+  expiresAt.setDate(expiresAt.getDate() + 30)
+
+  await db.insert(teamInvitationTable).values({
+    id: invitationId,
+    teamId: competitionTeamId,
+    email: row.email,
+    roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+    isSystemRole: true,
+    token: createId(),
+    invitedBy: null,
+    expiresAt,
+    status: INVITATION_STATUS.PENDING,
+    metadata: row.metadata,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  })
+
+  return invitationId
+}
+
+async function updateVolunteerInvitation(
+  db: DbClient,
+  invitationId: string,
+  metadata: string | null,
+  timestamp: Date,
+) {
+  const expiresAt = new Date(timestamp)
+  expiresAt.setDate(expiresAt.getDate() + 30)
+
+  await db
+    .update(teamInvitationTable)
+    .set({
+      roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+      isSystemRole: true,
+      status: INVITATION_STATUS.PENDING,
+      expiresAt,
+      metadata,
+      updatedAt: timestamp,
+    })
+    .where(eq(teamInvitationTable.id, invitationId))
+}
+
+async function updateVolunteerMembership(
+  db: DbClient,
+  membershipId: string,
+  metadata: string | null,
+  timestamp: Date,
+) {
+  await db
+    .update(teamMembershipTable)
+    .set({
+      roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+      isSystemRole: true,
+      isActive: true,
+      metadata,
+      updatedAt: timestamp,
+    })
+    .where(eq(teamMembershipTable.id, membershipId))
+}
+
+async function ensureImportedTrackWorkouts(
+  db: DbClient,
+  event: CrewEventRecord,
+  rows: PreviewImportRow[],
+  timestamp: Date,
+  importId: string,
+) {
+  const trackWorkouts = await listWorkoutsForCompetitionWithDb(db, event.id)
+  const lookup = buildTrackWorkoutLookup(trackWorkouts)
+  const labels = getRequiredHeatWorkoutLabels(rows).filter(
+    (label) => !lookup.has(normalizeLookupValue(label)),
+  )
+
+  if (labels.length === 0) {
+    return { trackWorkouts, createdTrackWorkoutCount: 0 }
+  }
+
+  const track = await ensureCompetitionTrack(db, event, timestamp)
+  let nextOrder =
+    trackWorkouts.reduce(
+      (maxOrder, workout) => Math.max(maxOrder, workout.trackOrder),
+      0,
+    ) + 1
+
+  for (const label of labels) {
+    const workoutId = `workout_${createId()}`
+    await db.insert(workouts).values({
+      id: workoutId,
+      name: label,
+      description: `Imported from Crew heat schedule import ${importId}. Update workout details before publishing scores.`,
+      scope: "private",
+      scheme: "time",
+      scoreType: "min",
+      roundsToScore: 1,
+      teamId: event.organizingTeamId,
+      scalingGroupId: getCrewEventScalingGroupId(event),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })
+
+    const trackWorkoutId = createTrackWorkoutId()
+    const trackOrder = nextOrder
+    nextOrder += 1
+    await db.insert(trackWorkoutsTable).values({
+      id: trackWorkoutId,
+      trackId: track.id,
+      workoutId,
+      trackOrder,
+      pointsMultiplier: 100,
+      heatStatus: "draft",
+      eventStatus: "draft",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })
+
+    trackWorkouts.push({ id: trackWorkoutId, label, trackOrder })
+    lookup.set(normalizeLookupValue(label), {
+      id: trackWorkoutId,
+      label,
+      trackOrder,
+    })
+  }
+
+  return {
+    trackWorkouts,
+    createdTrackWorkoutCount: labels.length,
+  }
+}
+
+async function ensureCompetitionTrack(
+  db: DbClient,
+  event: CrewEventRecord,
+  timestamp: Date,
+) {
+  const existingTracks = await db
+    .select({
+      id: programmingTracksTable.id,
+      name: programmingTracksTable.name,
+    })
+    .from(programmingTracksTable)
+    .where(eq(programmingTracksTable.competitionId, event.id))
+    .limit(1)
+
+  const existingTrack = existingTracks[0]
+  if (existingTrack) return existingTrack
+
+  const trackId = createProgrammingTrackId()
+  await db.insert(programmingTracksTable).values({
+    id: trackId,
+    name: `${event.name} - Events`,
+    description: `Competition events for ${event.name}`,
+    type: PROGRAMMING_TRACK_TYPE.TEAM_OWNED,
+    ownerTeamId: event.organizingTeamId,
+    scalingGroupId: getCrewEventScalingGroupId(event),
+    competitionId: event.id,
+    isPublic: 0,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  })
+
+  return { id: trackId, name: `${event.name} - Events` }
+}
+
+async function ensureImportedVenues(
+  db: DbClient,
+  eventId: string,
+  rows: PreviewImportRow[],
+  timestamp: Date,
+) {
+  const existingVenues = await db
+    .select({
+      id: competitionVenuesTable.id,
+      name: competitionVenuesTable.name,
+      laneCount: competitionVenuesTable.laneCount,
+      sortOrder: competitionVenuesTable.sortOrder,
+    })
+    .from(competitionVenuesTable)
+    .where(eq(competitionVenuesTable.competitionId, eventId))
+    .orderBy(asc(competitionVenuesTable.sortOrder))
+
+  const venues: HeatApplyVenue[] = existingVenues.map((venue) => ({
+    id: venue.id,
+    name: venue.name,
+  }))
+  const venueByName = new Map(
+    existingVenues.map((venue) => [normalizeLookupValue(venue.name), venue]),
+  )
+  const requiredVenues = getRequiredHeatVenues(rows)
+  let createdVenueCount = 0
+  let updatedVenueCount = 0
+  let nextSortOrder =
+    existingVenues.reduce(
+      (maxOrder, venue) => Math.max(maxOrder, venue.sortOrder),
+      0,
+    ) + 1
+
+  for (const venue of requiredVenues.values()) {
+    const existing = venueByName.get(normalizeLookupValue(venue.name))
+    if (existing) {
+      if (venue.laneCount !== null && venue.laneCount !== existing.laneCount) {
+        await db
+          .update(competitionVenuesTable)
+          .set({ laneCount: venue.laneCount, updatedAt: timestamp })
+          .where(eq(competitionVenuesTable.id, existing.id))
+        updatedVenueCount += 1
+      }
+      continue
+    }
+
+    const venueId = createCompetitionVenueId()
+    await db.insert(competitionVenuesTable).values({
+      id: venueId,
+      competitionId: eventId,
+      name: venue.name,
+      laneCount: venue.laneCount ?? 3,
+      sortOrder: nextSortOrder,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })
+    nextSortOrder += 1
+    createdVenueCount += 1
+    venues.push({ id: venueId, name: venue.name })
+    venueByName.set(normalizeLookupValue(venue.name), {
+      id: venueId,
+      name: venue.name,
+      laneCount: venue.laneCount ?? 3,
+      sortOrder: nextSortOrder,
+    })
+  }
+
+  return { venues, createdVenueCount, updatedVenueCount }
+}
+
+async function listExistingHeats(
+  db: DbClient,
+  eventId: string,
+  trackWorkoutIds: string[],
+): Promise<HeatApplyContext["existingHeats"]> {
+  if (trackWorkoutIds.length === 0) return []
+
+  return await db
+    .select({
+      id: competitionHeatsTable.id,
+      trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+      heatNumber: competitionHeatsTable.heatNumber,
+      schedulePublishedAt: competitionHeatsTable.schedulePublishedAt,
+    })
+    .from(competitionHeatsTable)
+    .where(
+      and(
+        eq(competitionHeatsTable.competitionId, eventId),
+        inArray(competitionHeatsTable.trackWorkoutId, trackWorkoutIds),
+      ),
+    )
+}
+
+async function createImportedHeat(
+  db: DbClient,
+  eventId: string,
+  row: HeatApplyRowPlan,
+  timestamp: Date,
+) {
+  if (!row.trackWorkoutId || row.heatNumber === null) {
+    throw new Error(
+      "Cannot create imported heat without workout and heat number",
+    )
+  }
+
+  const heatId = createCompetitionHeatId()
+  await db.insert(competitionHeatsTable).values({
+    id: heatId,
+    competitionId: eventId,
+    trackWorkoutId: row.trackWorkoutId,
+    heatNumber: row.heatNumber,
+    scheduledTime: row.scheduledTime,
+    venueId: row.venueId,
+    divisionId: row.divisionId,
+    durationMinutes: row.durationMinutes,
+    notes: row.notes,
+    schedulePublishedAt: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  })
+
+  return heatId
+}
+
+async function updateImportedHeat(
+  db: DbClient,
+  row: HeatApplyRowPlan,
+  timestamp: Date,
+) {
+  if (!row.targetId || !row.trackWorkoutId || row.heatNumber === null) {
+    throw new Error("Cannot update imported heat without an existing heat")
+  }
+
+  await db
+    .update(competitionHeatsTable)
+    .set({
+      trackWorkoutId: row.trackWorkoutId,
+      heatNumber: row.heatNumber,
+      scheduledTime: row.scheduledTime,
+      venueId: row.venueId,
+      divisionId: row.divisionId,
+      durationMinutes: row.durationMinutes,
+      notes: row.notes,
+      schedulePublishedAt: null,
+      updatedAt: timestamp,
+    })
+    .where(eq(competitionHeatsTable.id, row.targetId))
+}
+
+async function updateImportRowAudit(
+  db: DbClient,
+  importId: string,
+  row: VolunteerApplyRowPlan | HeatApplyRowPlan,
+  timestamp: Date,
+) {
+  await db
+    .update(crewImportRowsTable)
+    .set({
+      targetType: toCrewImportTargetType(row.targetType),
+      targetId: row.targetId,
+      action: toCrewImportAction(row.action),
+      warnings: toIssueList(row.warnings),
+      errors: toIssueList(row.errors),
+      updatedAt: timestamp,
+    })
+    .where(
+      and(
+        eq(crewImportRowsTable.importId, importId),
+        eq(crewImportRowsTable.rowNumber, row.rowNumber),
+      ),
+    )
+}
+
+async function updateImportApplySummary(
+  db: DbClient,
+  importRecord: CrewImport,
+  summary: CrewApplySummary,
+  timestamp: Date,
+  extraSummary: CrewImportApplyResult["summary"],
+) {
+  await db
+    .update(crewImportsTable)
+    .set({
+      status: CREW_IMPORT_STATUS.APPLIED,
+      createdCount: summary.createdCount,
+      updatedCount: summary.updatedCount,
+      skippedCount: summary.skippedCount,
+      warningCount: summary.warningCount,
+      errorCount: summary.errorCount,
+      appliedAt: timestamp,
+      updatedAt: timestamp,
+      summary: {
+        ...(importRecord.summary ?? {}),
+        apply: {
+          ...extraSummary,
+          createdCount: summary.createdCount,
+          updatedCount: summary.updatedCount,
+          skippedCount: summary.skippedCount,
+          errorRowCount: summary.errorRowCount,
+          warningCount: summary.warningCount,
+          errorCount: summary.errorCount,
+          appliedAt: timestamp.toISOString(),
+        },
+      },
+    })
+    .where(eq(crewImportsTable.id, importRecord.id))
+}
+
 function toCrewImportRowInsert(
   importId: string,
   row: PreviewImportRow,
@@ -270,6 +1020,208 @@ function toCrewImportRowInsert(
     errors: toIssueList(row.errors),
     createdAt: timestamp,
     updatedAt: timestamp,
+  }
+}
+
+async function requireCrewImport(eventId: string, importId: string) {
+  const db = getDb()
+  const [importRecord] = await db
+    .select()
+    .from(crewImportsTable)
+    .where(
+      and(
+        eq(crewImportsTable.id, importId),
+        eq(crewImportsTable.competitionId, eventId),
+      ),
+    )
+    .limit(1)
+
+  if (!importRecord) {
+    throw new CrewImportError(
+      "IMPORT_NOT_FOUND",
+      "Crew import preview not found.",
+      404,
+    )
+  }
+
+  return importRecord
+}
+
+async function listCrewImportRows(importId: string) {
+  const db = getDb()
+  return await db
+    .select()
+    .from(crewImportRowsTable)
+    .where(eq(crewImportRowsTable.importId, importId))
+    .orderBy(asc(crewImportRowsTable.rowNumber))
+}
+
+function toPersistedPreviewRow(
+  kind: CrewImport["kind"],
+  row: CrewImportRow,
+): PreviewImportRow {
+  return {
+    rowNumber: row.rowNumber,
+    rawRow: toRecord(row.rawRow),
+    normalizedRow:
+      kind === CREW_IMPORT_KIND.VOLUNTEERS
+        ? (toRecord(row.normalizedRow) as unknown as VolunteerImportRow)
+        : (toRecord(row.normalizedRow) as unknown as HeatScheduleImportRow),
+    targetType:
+      row.targetType === CREW_IMPORT_ROW_TARGET_TYPE.COMPETITION_HEAT
+        ? "competition_heat"
+        : "team_invitation",
+    action:
+      row.action === CREW_IMPORT_ROW_ACTION.SKIP
+        ? "skip"
+        : row.action === CREW_IMPORT_ROW_ACTION.ERROR
+          ? "error"
+          : "create",
+    warnings: fromIssueList(row.warnings),
+    errors: fromIssueList(row.errors),
+  }
+}
+
+async function listDivisionsForCrewEvent(db: DbClient, event: CrewEventRecord) {
+  const scalingGroupId = getCrewEventScalingGroupId(event)
+  return scalingGroupId
+    ? await listDivisionsForGroupWithDb(db, scalingGroupId)
+    : []
+}
+
+async function listDivisionsForGroupWithDb(
+  db: DbClient,
+  scalingGroupId: string,
+) {
+  return await db
+    .select({
+      id: scalingLevelsTable.id,
+      label: scalingLevelsTable.label,
+    })
+    .from(scalingLevelsTable)
+    .where(eq(scalingLevelsTable.scalingGroupId, scalingGroupId))
+}
+
+async function listWorkoutsForCompetitionWithDb(
+  db: DbClient,
+  eventId: string,
+): Promise<HeatApplyTrackWorkout[]> {
+  const rows = await db
+    .select({
+      id: trackWorkoutsTable.id,
+      label: workouts.name,
+      trackOrder: trackWorkoutsTable.trackOrder,
+    })
+    .from(trackWorkoutsTable)
+    .innerJoin(
+      programmingTracksTable,
+      eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+    )
+    .innerJoin(workouts, eq(trackWorkoutsTable.workoutId, workouts.id))
+    .where(eq(programmingTracksTable.competitionId, eventId))
+
+  return rows.map((row) => ({
+    id: row.id,
+    label: row.label,
+    trackOrder: Number(row.trackOrder),
+  }))
+}
+
+function getCrewEventScalingGroupId(event: CrewEventRecord) {
+  const settings = parseCompetitionSettings(event.settings)
+  return settings?.divisions?.scalingGroupId ?? null
+}
+
+function getRequiredHeatWorkoutLabels(rows: PreviewImportRow[]) {
+  const labels = new Map<string, string>()
+  for (const row of rows) {
+    if (row.action === "error" || row.action === "skip") continue
+    if (row.errors.length > 0) continue
+    const heat = row.normalizedRow as HeatScheduleImportRow
+    if (!heat.workout) continue
+    labels.set(normalizeLookupValue(heat.workout), heat.workout)
+  }
+  return [...labels.values()]
+}
+
+function getRequiredHeatVenues(rows: PreviewImportRow[]) {
+  const venues = new Map<string, { name: string; laneCount: number | null }>()
+
+  for (const row of rows) {
+    if (row.action === "error" || row.action === "skip") continue
+    if (row.errors.length > 0) continue
+    const heat = row.normalizedRow as HeatScheduleImportRow
+    if (!heat.venue) continue
+
+    const key = normalizeLookupValue(heat.venue)
+    const current = venues.get(key)
+    venues.set(key, {
+      name: current?.name ?? heat.venue,
+      laneCount: current?.laneCount ?? heat.laneCount,
+    })
+  }
+
+  return venues
+}
+
+function toCrewImportTargetType(
+  targetType:
+    | VolunteerApplyRowPlan["targetType"]
+    | HeatApplyRowPlan["targetType"],
+) {
+  if (targetType === "team_invitation") {
+    return CREW_IMPORT_ROW_TARGET_TYPE.TEAM_INVITATION
+  }
+  if (targetType === "team_membership") {
+    return CREW_IMPORT_ROW_TARGET_TYPE.TEAM_MEMBERSHIP
+  }
+  if (targetType === "competition_heat") {
+    return CREW_IMPORT_ROW_TARGET_TYPE.COMPETITION_HEAT
+  }
+  return null
+}
+
+function toCrewImportAction(action: "create" | "update" | "skip" | "error") {
+  if (action === "create") return CREW_IMPORT_ROW_ACTION.CREATE
+  if (action === "update") return CREW_IMPORT_ROW_ACTION.UPDATE
+  if (action === "skip") return CREW_IMPORT_ROW_ACTION.SKIP
+  return CREW_IMPORT_ROW_ACTION.ERROR
+}
+
+function toApplyResult(
+  importRecord: CrewImport,
+  summary: CrewApplySummary,
+  extraSummary: CrewImportApplyResult["summary"],
+): CrewImportApplyResult {
+  return {
+    importId: importRecord.id,
+    kind: importRecord.kind,
+    status: CREW_IMPORT_STATUS.APPLIED,
+    createdCount: summary.createdCount,
+    updatedCount: summary.updatedCount,
+    skippedCount: summary.skippedCount,
+    warningCount: summary.warningCount,
+    errorCount: summary.errorCount,
+    summary: {
+      ...extraSummary,
+      errorRowCount: summary.errorRowCount,
+    },
+  }
+}
+
+function mergeJsonMetadata(
+  existingMetadata: string | null | undefined,
+  importedMetadata: string | null,
+) {
+  if (!existingMetadata) return importedMetadata
+  if (!importedMetadata) return existingMetadata
+
+  try {
+    const existing = JSON.parse(existingMetadata) as Record<string, unknown>
+    const imported = JSON.parse(importedMetadata) as Record<string, unknown>
+    return JSON.stringify({ ...existing, ...imported })
+  } catch {
+    return importedMetadata
   }
 }
 
@@ -334,6 +1286,11 @@ async function requireCrewEvent(eventId: string) {
   const [event] = await db
     .select({
       id: competitionsTable.id,
+      name: competitionsTable.name,
+      organizingTeamId: competitionsTable.organizingTeamId,
+      competitionTeamId: competitionsTable.competitionTeamId,
+      startDate: competitionsTable.startDate,
+      timezone: competitionsTable.timezone,
       settings: competitionsTable.settings,
     })
     .from(crewEventSettingsTable)
@@ -353,40 +1310,12 @@ async function requireCrewEvent(eventId: string) {
 
 async function listDivisionsForGroup(scalingGroupId: string) {
   const db = getDb()
-  return await db
-    .select({
-      id: scalingLevelsTable.id,
-      label: scalingLevelsTable.label,
-    })
-    .from(scalingLevelsTable)
-    .where(eq(scalingLevelsTable.scalingGroupId, scalingGroupId))
+  return await listDivisionsForGroupWithDb(db, scalingGroupId)
 }
 
 async function listWorkoutsForCompetition(eventId: string) {
   const db = getDb()
-  const tracks = await db
-    .select({ id: programmingTracksTable.id })
-    .from(programmingTracksTable)
-    .where(eq(programmingTracksTable.competitionId, eventId))
-
-  if (tracks.length === 0) return []
-
-  const trackIds = tracks.map((track) => track.id)
-  const rows = await db
-    .select({
-      id: trackWorkoutsTable.id,
-      label: workouts.name,
-      trackOrder: trackWorkoutsTable.trackOrder,
-    })
-    .from(trackWorkoutsTable)
-    .innerJoin(workouts, eq(trackWorkoutsTable.workoutId, workouts.id))
-    .where(inArray(trackWorkoutsTable.trackId, trackIds))
-
-  return rows.map((row) => ({
-    id: row.id,
-    label: row.label,
-    trackOrder: Number(row.trackOrder),
-  }))
+  return await listWorkoutsForCompetitionWithDb(db, eventId)
 }
 
 function getCsvByteLength(csvText: string) {
@@ -414,6 +1343,40 @@ function isCsvFilename(filename: string) {
 
 function toIssueList(issues: PreviewImportRow["warnings"]) {
   return issues.map((issue) => ({ ...issue }) as Record<string, unknown>)
+}
+
+function fromIssueList(value: CrewImportRow["warnings"]): ImportIssue[] {
+  if (!Array.isArray(value)) return []
+
+  return value.flatMap((issue) => {
+    if (!issue || typeof issue !== "object") return []
+    const record = issue as Record<string, unknown>
+    const code = typeof record.code === "string" ? record.code : "import_issue"
+    const severity =
+      record.severity === "error" || record.severity === "warning"
+        ? record.severity
+        : "warning"
+    const message =
+      typeof record.message === "string" ? record.message : "Import issue."
+
+    return [
+      {
+        code,
+        severity,
+        message,
+        field: typeof record.field === "string" ? record.field : undefined,
+        rowNumber:
+          typeof record.rowNumber === "number" ? record.rowNumber : undefined,
+        value: typeof record.value === "string" ? record.value : undefined,
+      },
+    ]
+  })
+}
+
+function toRecord(value: CrewImportRow["rawRow"]) {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, string>)
+    : {}
 }
 
 function toPayload(row: PreviewImportRow["normalizedRow"]) {

--- a/apps/crew/src/server/crew-imports.ts
+++ b/apps/crew/src/server/crew-imports.ts
@@ -45,6 +45,8 @@ import {
   buildHeatScheduleApplyPlan,
   buildTrackWorkoutLookup,
   buildVolunteerApplyPlan,
+  getAppliedHeatSupportTargets,
+  mergeImportedJsonMetadata,
   normalizeLookupValue,
   type CrewApplySummary,
   type ExistingVolunteerInvitation,
@@ -78,6 +80,16 @@ export const MAX_CREW_IMPORT_BYTES = 1_000_000
 
 type DbClient = ReturnType<typeof getDb>
 type CrewEventRecord = Awaited<ReturnType<typeof requireCrewEvent>>
+
+interface PlannedImportedTrackWorkout extends HeatApplyTrackWorkout {
+  workoutId: string
+}
+
+interface PreparedImportedVenue extends HeatApplyVenue {
+  existing: boolean
+  laneCount: number | null
+  sortOrder: number
+}
 
 export type CrewImportErrorCode =
   | "EVENT_NOT_FOUND"
@@ -430,7 +442,7 @@ async function applyVolunteerImport({
         await updateVolunteerInvitation(
           client,
           row.targetId,
-          mergeJsonMetadata(
+          mergeImportedJsonMetadata(
             invitationMetadataById.get(row.targetId),
             row.metadata,
           ),
@@ -440,9 +452,10 @@ async function applyVolunteerImport({
         await updateVolunteerMembership(
           client,
           row.targetId,
-          mergeJsonMetadata(
+          mergeImportedJsonMetadata(
             membershipMetadataById.get(row.targetId),
             row.metadata,
+            { preserveExistingApprovedStatus: true },
           ),
           timestamp,
         )
@@ -488,18 +501,15 @@ async function applyHeatScheduleImport({
 
   await db.transaction(async (tx) => {
     const client = tx as unknown as DbClient
-    const trackWorkoutResult = await ensureImportedTrackWorkouts(
+    const trackWorkoutResult = await prepareImportedTrackWorkouts(
       client,
       event,
       previewRows,
-      timestamp,
-      importRecord.id,
     )
-    const venueResult = await ensureImportedVenues(
+    const venueResult = await prepareImportedVenues(
       client,
       event.id,
       previewRows,
-      timestamp,
     )
     const divisions = await listDivisionsForCrewEvent(client, event)
     const existingHeats = await listExistingHeats(
@@ -515,6 +525,24 @@ async function applyHeatScheduleImport({
       venues: venueResult.venues,
       existingHeats,
     })
+    const supportTargets = getAppliedHeatSupportTargets(plan.rows)
+    const createdTrackWorkoutCount = await createPlannedTrackWorkouts(
+      client,
+      event,
+      trackWorkoutResult.plannedTrackWorkoutsById,
+      supportTargets.trackWorkoutIds,
+      timestamp,
+      importRecord.id,
+    )
+    const appliedVenueResult = await ensureAppliedImportedVenues(
+      client,
+      event.id,
+      venueResult.venuesById,
+      supportTargets.venueIds,
+      previewRows,
+      plan.rows,
+      timestamp,
+    )
 
     for (const row of plan.rows) {
       if (row.operation === "create_heat") {
@@ -535,9 +563,9 @@ async function applyHeatScheduleImport({
     extraSummary = {
       kind: CREW_IMPORT_KIND.HEAT_SCHEDULE,
       appliedRowCount: plan.summary.createdCount + plan.summary.updatedCount,
-      createdTrackWorkoutCount: trackWorkoutResult.createdTrackWorkoutCount,
-      createdVenueCount: venueResult.createdVenueCount,
-      updatedVenueCount: venueResult.updatedVenueCount,
+      createdTrackWorkoutCount,
+      createdVenueCount: appliedVenueResult.createdVenueCount,
+      updatedVenueCount: appliedVenueResult.updatedVenueCount,
       timezone: event.timezone ?? DEFAULT_TIMEZONE,
       schedulePublishedAt: null,
     }
@@ -685,24 +713,25 @@ async function updateVolunteerMembership(
     .where(eq(teamMembershipTable.id, membershipId))
 }
 
-async function ensureImportedTrackWorkouts(
+async function prepareImportedTrackWorkouts(
   db: DbClient,
   event: CrewEventRecord,
   rows: PreviewImportRow[],
-  timestamp: Date,
-  importId: string,
 ) {
   const trackWorkouts = await listWorkoutsForCompetitionWithDb(db, event.id)
   const lookup = buildTrackWorkoutLookup(trackWorkouts)
   const labels = getRequiredHeatWorkoutLabels(rows).filter(
     (label) => !lookup.has(normalizeLookupValue(label)),
   )
+  const plannedTrackWorkoutsById = new Map<
+    string,
+    PlannedImportedTrackWorkout
+  >()
 
   if (labels.length === 0) {
-    return { trackWorkouts, createdTrackWorkoutCount: 0 }
+    return { trackWorkouts, plannedTrackWorkoutsById }
   }
 
-  const track = await ensureCompetitionTrack(db, event, timestamp)
   let nextOrder =
     trackWorkouts.reduce(
       (maxOrder, workout) => Math.max(maxOrder, workout.trackOrder),
@@ -711,9 +740,47 @@ async function ensureImportedTrackWorkouts(
 
   for (const label of labels) {
     const workoutId = `workout_${createId()}`
+    const trackWorkoutId = createTrackWorkoutId()
+    const trackOrder = nextOrder
+    nextOrder += 1
+
+    const plannedTrackWorkout = {
+      id: trackWorkoutId,
+      workoutId,
+      label,
+      trackOrder,
+    }
+
+    trackWorkouts.push(plannedTrackWorkout)
+    plannedTrackWorkoutsById.set(trackWorkoutId, plannedTrackWorkout)
+    lookup.set(normalizeLookupValue(label), plannedTrackWorkout)
+  }
+
+  return { trackWorkouts, plannedTrackWorkoutsById }
+}
+
+async function createPlannedTrackWorkouts(
+  db: DbClient,
+  event: CrewEventRecord,
+  plannedTrackWorkoutsById: Map<string, PlannedImportedTrackWorkout>,
+  appliedTrackWorkoutIds: Set<string>,
+  timestamp: Date,
+  importId: string,
+) {
+  const plannedTrackWorkouts = [...plannedTrackWorkoutsById.values()].filter(
+    (trackWorkout) => appliedTrackWorkoutIds.has(trackWorkout.id),
+  )
+
+  if (plannedTrackWorkouts.length === 0) {
+    return 0
+  }
+
+  const track = await ensureCompetitionTrack(db, event, timestamp)
+
+  for (const trackWorkout of plannedTrackWorkouts) {
     await db.insert(workouts).values({
-      id: workoutId,
-      name: label,
+      id: trackWorkout.workoutId,
+      name: trackWorkout.label,
       description: `Imported from Crew heat schedule import ${importId}. Update workout details before publishing scores.`,
       scope: "private",
       scheme: "time",
@@ -725,33 +792,20 @@ async function ensureImportedTrackWorkouts(
       updatedAt: timestamp,
     })
 
-    const trackWorkoutId = createTrackWorkoutId()
-    const trackOrder = nextOrder
-    nextOrder += 1
     await db.insert(trackWorkoutsTable).values({
-      id: trackWorkoutId,
+      id: trackWorkout.id,
       trackId: track.id,
-      workoutId,
-      trackOrder,
+      workoutId: trackWorkout.workoutId,
+      trackOrder: trackWorkout.trackOrder,
       pointsMultiplier: 100,
       heatStatus: "draft",
       eventStatus: "draft",
       createdAt: timestamp,
       updatedAt: timestamp,
     })
-
-    trackWorkouts.push({ id: trackWorkoutId, label, trackOrder })
-    lookup.set(normalizeLookupValue(label), {
-      id: trackWorkoutId,
-      label,
-      trackOrder,
-    })
   }
 
-  return {
-    trackWorkouts,
-    createdTrackWorkoutCount: labels.length,
-  }
+  return plannedTrackWorkouts.length
 }
 
 async function ensureCompetitionTrack(
@@ -788,11 +842,10 @@ async function ensureCompetitionTrack(
   return { id: trackId, name: `${event.name} - Events` }
 }
 
-async function ensureImportedVenues(
+async function prepareImportedVenues(
   db: DbClient,
   eventId: string,
   rows: PreviewImportRow[],
-  timestamp: Date,
 ) {
   const existingVenues = await db
     .select({
@@ -809,12 +862,22 @@ async function ensureImportedVenues(
     id: venue.id,
     name: venue.name,
   }))
-  const venueByName = new Map(
+  const venuesById = new Map<string, PreparedImportedVenue>(
+    existingVenues.map((venue) => [
+      venue.id,
+      {
+        id: venue.id,
+        name: venue.name,
+        existing: true,
+        laneCount: venue.laneCount,
+        sortOrder: venue.sortOrder,
+      },
+    ]),
+  )
+  const venueByName = new Map<string, { id: string; name: string }>(
     existingVenues.map((venue) => [normalizeLookupValue(venue.name), venue]),
   )
   const requiredVenues = getRequiredHeatVenues(rows)
-  let createdVenueCount = 0
-  let updatedVenueCount = 0
   let nextSortOrder =
     existingVenues.reduce(
       (maxOrder, venue) => Math.max(maxOrder, venue.sortOrder),
@@ -824,38 +887,109 @@ async function ensureImportedVenues(
   for (const venue of requiredVenues.values()) {
     const existing = venueByName.get(normalizeLookupValue(venue.name))
     if (existing) {
-      if (venue.laneCount !== null && venue.laneCount !== existing.laneCount) {
+      continue
+    }
+
+    const venueId = createCompetitionVenueId()
+    const plannedVenue: PreparedImportedVenue = {
+      id: venueId,
+      name: venue.name,
+      existing: false,
+      laneCount: venue.laneCount ?? 3,
+      sortOrder: nextSortOrder,
+    }
+    nextSortOrder += 1
+    venues.push({ id: venueId, name: venue.name })
+    venuesById.set(venueId, plannedVenue)
+    venueByName.set(normalizeLookupValue(venue.name), plannedVenue)
+  }
+
+  return { venues, venuesById }
+}
+
+async function ensureAppliedImportedVenues(
+  db: DbClient,
+  eventId: string,
+  venuesById: Map<string, PreparedImportedVenue>,
+  appliedVenueIds: Set<string>,
+  previewRows: PreviewImportRow[],
+  applyRows: HeatApplyRowPlan[],
+  timestamp: Date,
+) {
+  const laneCountByVenueId = getAppliedVenueLaneCounts(
+    previewRows,
+    applyRows,
+    appliedVenueIds,
+  )
+  let createdVenueCount = 0
+  let updatedVenueCount = 0
+
+  for (const venueId of appliedVenueIds) {
+    const venue = venuesById.get(venueId)
+    if (!venue) continue
+
+    const laneCount = laneCountByVenueId.get(venueId) ?? venue.laneCount
+
+    if (venue.existing) {
+      if (laneCount !== null && laneCount !== venue.laneCount) {
         await db
           .update(competitionVenuesTable)
-          .set({ laneCount: venue.laneCount, updatedAt: timestamp })
-          .where(eq(competitionVenuesTable.id, existing.id))
+          .set({ laneCount, updatedAt: timestamp })
+          .where(eq(competitionVenuesTable.id, venue.id))
         updatedVenueCount += 1
       }
       continue
     }
 
-    const venueId = createCompetitionVenueId()
     await db.insert(competitionVenuesTable).values({
-      id: venueId,
+      id: venue.id,
       competitionId: eventId,
       name: venue.name,
-      laneCount: venue.laneCount ?? 3,
-      sortOrder: nextSortOrder,
+      laneCount: laneCount ?? 3,
+      sortOrder: venue.sortOrder,
       createdAt: timestamp,
       updatedAt: timestamp,
     })
-    nextSortOrder += 1
     createdVenueCount += 1
-    venues.push({ id: venueId, name: venue.name })
-    venueByName.set(normalizeLookupValue(venue.name), {
-      id: venueId,
-      name: venue.name,
-      laneCount: venue.laneCount ?? 3,
-      sortOrder: nextSortOrder,
-    })
   }
 
-  return { venues, createdVenueCount, updatedVenueCount }
+  return { createdVenueCount, updatedVenueCount }
+}
+
+function getAppliedVenueLaneCounts(
+  previewRows: PreviewImportRow[],
+  applyRows: HeatApplyRowPlan[],
+  appliedVenueIds: Set<string>,
+) {
+  const previewRowsByNumber = new Map(
+    previewRows.map((row) => [row.rowNumber, row]),
+  )
+  const laneCountByVenueId = new Map<string, number>()
+
+  for (const applyRow of applyRows) {
+    if (
+      applyRow.operation !== "create_heat" &&
+      applyRow.operation !== "update_heat"
+    ) {
+      continue
+    }
+
+    if (!applyRow.venueId || !appliedVenueIds.has(applyRow.venueId)) {
+      continue
+    }
+
+    const previewRow = previewRowsByNumber.get(applyRow.rowNumber)
+    const heat = previewRow?.normalizedRow as HeatScheduleImportRow | undefined
+    if (
+      heat?.laneCount !== null &&
+      heat?.laneCount !== undefined &&
+      !laneCountByVenueId.has(applyRow.venueId)
+    ) {
+      laneCountByVenueId.set(applyRow.venueId, heat.laneCount)
+    }
+  }
+
+  return laneCountByVenueId
 }
 
 async function listExistingHeats(
@@ -1206,22 +1340,6 @@ function toApplyResult(
       ...extraSummary,
       errorRowCount: summary.errorRowCount,
     },
-  }
-}
-
-function mergeJsonMetadata(
-  existingMetadata: string | null | undefined,
-  importedMetadata: string | null,
-) {
-  if (!existingMetadata) return importedMetadata
-  if (!importedMetadata) return existingMetadata
-
-  try {
-    const existing = JSON.parse(existingMetadata) as Record<string, unknown>
-    const imported = JSON.parse(importedMetadata) as Record<string, unknown>
-    return JSON.stringify({ ...existing, ...imported })
-  } catch {
-    return importedMetadata
   }
 }
 

--- a/apps/crew/src/server/crew-imports.ts
+++ b/apps/crew/src/server/crew-imports.ts
@@ -1,6 +1,6 @@
 // @lat: [[crew#Import CSV Preview#Preview Records]]
 import { createId } from "@paralleldrive/cuid2"
-import { and, asc, desc, eq, inArray } from "drizzle-orm"
+import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm"
 import { z } from "zod"
 import {
   CREW_IMPORT_KIND,
@@ -46,8 +46,12 @@ import {
   buildTrackWorkoutLookup,
   buildVolunteerApplyPlan,
   getAppliedHeatSupportTargets,
+  getMutationAffectedRows,
+  markHeatUpdateSkippedForPublicationConflict,
   mergeImportedJsonMetadata,
   normalizeLookupValue,
+  selectCrewImportProgrammingTrack,
+  summarizeApplyRows,
   type CrewApplySummary,
   type ExistingVolunteerInvitation,
   type ExistingVolunteerMembership,
@@ -95,6 +99,7 @@ export type CrewImportErrorCode =
   | "EVENT_NOT_FOUND"
   | "IMPORT_NOT_FOUND"
   | "IMPORT_ALREADY_APPLIED"
+  | "IMPORT_APPLY_CONFLICT"
   | "INVALID_IMPORT_STATUS"
   | "CONFIRMATION_REQUIRED"
   | "UNSUPPORTED_IMPORT_KIND"
@@ -429,6 +434,7 @@ async function applyVolunteerImport({
 
   await db.transaction(async (tx) => {
     const client = tx as unknown as DbClient
+    await claimCrewImportForApply(client, importRecord, timestamp)
 
     for (const row of plan.rows) {
       if (row.operation === "create_invitation") {
@@ -501,6 +507,8 @@ async function applyHeatScheduleImport({
 
   await db.transaction(async (tx) => {
     const client = tx as unknown as DbClient
+    await claimCrewImportForApply(client, importRecord, timestamp)
+
     const trackWorkoutResult = await prepareImportedTrackWorkouts(
       client,
       event,
@@ -553,16 +561,20 @@ async function applyHeatScheduleImport({
           timestamp,
         )
       } else if (row.operation === "update_heat" && row.targetId) {
-        await updateImportedHeat(client, row, timestamp)
+        const updated = await updateImportedHeat(client, row, timestamp)
+        if (!updated) {
+          markHeatUpdateSkippedForPublicationConflict(row)
+        }
       }
 
       await updateImportRowAudit(client, importRecord.id, row, timestamp)
     }
 
-    resultSummary = plan.summary
+    const finalSummary = summarizeApplyRows(plan.rows)
+    resultSummary = finalSummary
     extraSummary = {
       kind: CREW_IMPORT_KIND.HEAT_SCHEDULE,
-      appliedRowCount: plan.summary.createdCount + plan.summary.updatedCount,
+      appliedRowCount: finalSummary.createdCount + finalSummary.updatedCount,
       createdTrackWorkoutCount,
       createdVenueCount: appliedVenueResult.createdVenueCount,
       updatedVenueCount: appliedVenueResult.updatedVenueCount,
@@ -573,7 +585,7 @@ async function applyHeatScheduleImport({
     await updateImportApplySummary(
       client,
       importRecord,
-      plan.summary,
+      finalSummary,
       timestamp,
       extraSummary,
     )
@@ -588,6 +600,57 @@ async function applyHeatScheduleImport({
   }
 
   return toApplyResult(importRecord, resultSummary, extraSummary)
+}
+
+async function claimCrewImportForApply(
+  db: DbClient,
+  importRecord: CrewImport,
+  timestamp: Date,
+) {
+  const updateResult = await db
+    .update(crewImportsTable)
+    .set({
+      status: CREW_IMPORT_STATUS.APPLIED,
+      updatedAt: timestamp,
+    })
+    .where(
+      and(
+        eq(crewImportsTable.id, importRecord.id),
+        eq(crewImportsTable.status, CREW_IMPORT_STATUS.PREVIEWED),
+      ),
+    )
+
+  if (getMutationAffectedRows(updateResult) > 0) return
+
+  const [freshImport] = await db
+    .select({
+      status: crewImportsTable.status,
+    })
+    .from(crewImportsTable)
+    .where(eq(crewImportsTable.id, importRecord.id))
+    .limit(1)
+
+  if (freshImport?.status === CREW_IMPORT_STATUS.APPLIED) {
+    throw new CrewImportError(
+      "IMPORT_ALREADY_APPLIED",
+      "This import has already been applied.",
+      409,
+    )
+  }
+
+  if (freshImport) {
+    throw new CrewImportError(
+      "INVALID_IMPORT_STATUS",
+      "Only previewed imports can be applied.",
+      409,
+    )
+  }
+
+  throw new CrewImportError(
+    "IMPORT_APPLY_CONFLICT",
+    "This import could not be claimed for apply. Refresh the import history and try again.",
+    409,
+  )
 }
 
 async function listVolunteerInvitations(
@@ -813,22 +876,30 @@ async function ensureCompetitionTrack(
   event: CrewEventRecord,
   timestamp: Date,
 ) {
+  const trackName = getCrewImportTrackName(event)
   const existingTracks = await db
     .select({
       id: programmingTracksTable.id,
       name: programmingTracksTable.name,
+      type: programmingTracksTable.type,
+      isPublic: programmingTracksTable.isPublic,
     })
     .from(programmingTracksTable)
     .where(eq(programmingTracksTable.competitionId, event.id))
-    .limit(1)
+    .orderBy(asc(programmingTracksTable.name), asc(programmingTracksTable.id))
 
-  const existingTrack = existingTracks[0]
-  if (existingTrack) return existingTrack
+  const existingTrack = selectCrewImportProgrammingTrack(
+    existingTracks,
+    trackName,
+  )
+  if (existingTrack) {
+    return { id: existingTrack.id, name: existingTrack.name }
+  }
 
   const trackId = createProgrammingTrackId()
   await db.insert(programmingTracksTable).values({
     id: trackId,
-    name: `${event.name} - Events`,
+    name: trackName,
     description: `Competition events for ${event.name}`,
     type: PROGRAMMING_TRACK_TYPE.TEAM_OWNED,
     ownerTeamId: event.organizingTeamId,
@@ -839,7 +910,11 @@ async function ensureCompetitionTrack(
     updatedAt: timestamp,
   })
 
-  return { id: trackId, name: `${event.name} - Events` }
+  return { id: trackId, name: trackName }
+}
+
+function getCrewImportTrackName(event: CrewEventRecord) {
+  return `${event.name} - Events`
 }
 
 async function prepareImportedVenues(
@@ -1055,7 +1130,7 @@ async function updateImportedHeat(
     throw new Error("Cannot update imported heat without an existing heat")
   }
 
-  await db
+  const updateResult = await db
     .update(competitionHeatsTable)
     .set({
       trackWorkoutId: row.trackWorkoutId,
@@ -1065,10 +1140,16 @@ async function updateImportedHeat(
       divisionId: row.divisionId,
       durationMinutes: row.durationMinutes,
       notes: row.notes,
-      schedulePublishedAt: null,
       updatedAt: timestamp,
     })
-    .where(eq(competitionHeatsTable.id, row.targetId))
+    .where(
+      and(
+        eq(competitionHeatsTable.id, row.targetId),
+        isNull(competitionHeatsTable.schedulePublishedAt),
+      ),
+    )
+
+  return getMutationAffectedRows(updateResult) > 0
 }
 
 async function updateImportRowAudit(

--- a/apps/crew/src/server/crew-imports.ts
+++ b/apps/crew/src/server/crew-imports.ts
@@ -47,6 +47,7 @@ import {
   buildVolunteerApplyPlan,
   getAppliedHeatSupportTargets,
   getMutationAffectedRows,
+  isImportedHeatUpdateAlreadyApplied,
   markHeatUpdateSkippedForPublicationConflict,
   mergeImportedJsonMetadata,
   normalizeLookupValue,
@@ -59,6 +60,7 @@ import {
   type HeatApplyRowPlan,
   type HeatApplyTrackWorkout,
   type HeatApplyVenue,
+  type ImportedHeatUpdateSnapshot,
   type VolunteerApplyRowPlan,
 } from "../lib/crew/imports/apply"
 import {
@@ -1149,7 +1151,36 @@ async function updateImportedHeat(
       ),
     )
 
-  return getMutationAffectedRows(updateResult) > 0
+  if (getMutationAffectedRows(updateResult) > 0) {
+    return true
+  }
+
+  const currentHeat = await getImportedHeatUpdateSnapshot(db, row.targetId)
+  return currentHeat
+    ? isImportedHeatUpdateAlreadyApplied(currentHeat, row)
+    : false
+}
+
+async function getImportedHeatUpdateSnapshot(
+  db: DbClient,
+  heatId: string,
+): Promise<ImportedHeatUpdateSnapshot | null> {
+  const [heat] = await db
+    .select({
+      trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+      heatNumber: competitionHeatsTable.heatNumber,
+      scheduledTime: competitionHeatsTable.scheduledTime,
+      venueId: competitionHeatsTable.venueId,
+      divisionId: competitionHeatsTable.divisionId,
+      durationMinutes: competitionHeatsTable.durationMinutes,
+      notes: competitionHeatsTable.notes,
+      schedulePublishedAt: competitionHeatsTable.schedulePublishedAt,
+    })
+    .from(competitionHeatsTable)
+    .where(eq(competitionHeatsTable.id, heatId))
+    .limit(1)
+
+  return heat ?? null
 }
 
 async function updateImportRowAudit(


### PR DESCRIPTION
## Summary

- Adds confirmed apply support for persisted Crew volunteer and heat schedule import previews.
- Applies volunteer rows through existing competition-team volunteer primitives: pending/no-account volunteers become `team_invitations`, existing approved volunteer memberships are updated, and duplicates/errors are preserved in row audit.
- Applies heat schedule rows into draft schedule primitives by ensuring minimal workouts, programming tracks, track workouts, venues, and `competition_heats` rows without auto-publishing schedules.
- Updates the Crew import center with an explicit Apply confirmation, applied/skipped summary counts, and history columns for created/updated/skipped rows.

## Guardrails

- Requires `confirmed: true` and `previewed` status before mutation.
- Starts from persisted `crew_imports` and `crew_import_rows`, not client-only preview state.
- Dedupes volunteers by lowercased email against both volunteer invitations and memberships.
- Handles heat duplicates by updating existing draft heats, skipping duplicate rows in the same apply run, and skipping already-published heats to avoid public schedule side effects.
- Parses imported heat times as event-local wall-clock times using the competition timezone.
- Leaves pending no-account volunteers unassignable until they accept/become approved memberships; this is recorded in the import summary as a known limitation.

## Validation

- `pnpm check:schema-ownership`
- `pnpm --filter crew test -- src/lib/crew/imports/apply.test.ts src/lib/crew/imports/preview.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (passes with existing repo warnings)
- `pnpm --filter crew build` (used ignored local `.alchemy/local/wrangler.jsonc` copied from the PR #530 worktree)
- `git diff --cached --check`

## Notes

No schema, infrastructure, deployment, queue, email-template, token signup, or public schedule publishing changes are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a confirmed, transactional apply flow for Crew volunteer and heat schedule imports with race-safe guards and idempotent heat updates. Applies persisted previews to invitations/memberships and draft heats, and updates the import UI with an Apply action and result summaries.

- **New Features**
  - Volunteers: dedupe by email; create `team_invitations` for no-account volunteers; prefer updating memberships; skip accepted/inactive; preserve approved status when merging metadata; per-row audit persisted.
  - Heat schedule: create/update draft `competition_heats`; create only needed workouts/tracks/venues (selects a private track or creates one); update venue lane counts from import; skip published heats; parse times in the event timezone; skip duplicates within the same apply run; treat identical unpublished heat updates as already applied; mark mid-apply publish conflicts as skipped; never publishes schedules.
  - Safety: requires `confirmed: true` and `previewed` status; operates only on persisted imports; atomically claims the import before applying to prevent double-apply; refuses re-apply; wraps mutations in a transaction; surfaces specific errors (`IMPORT_ALREADY_APPLIED`, `INVALID_IMPORT_STATUS`, `IMPORT_APPLY_CONFLICT`).
  - UI: Add Apply button with confirmation; show applied/created/updated/skipped metrics; history shows created/updated/skipped counts.
  - API: `applyCrewImportFn` (POST) to apply imports; server writes target IDs and returns a summarized apply result.

<sup>Written for commit 943b50199e7a2ffb4165213230f92576e887ed09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apply previewed crew imports with automatic duplicate detection and conflict resolution.
  * View detailed apply results showing counts of created, updated, and skipped records.
  * Import history table updated to display creation, update, and skip statistics.
  * Apply process validates volunteer invitations/memberships and heat schedule data before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->