### PR TITLE
feat(crew): add no-password volunteer signup

### DIFF
--- a/apps/crew/src/components/crew/volunteer-signup-form.tsx
+++ b/apps/crew/src/components/crew/volunteer-signup-form.tsx
@@ -1,0 +1,477 @@
+"use client"
+
+import { useServerFn } from "@tanstack/react-start"
+import { CheckCircle2, Loader2 } from "lucide-react"
+import { useState } from "react"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../ui/card"
+import { Button } from "../ui/button"
+import { Checkbox } from "../ui/checkbox"
+import { Input } from "../ui/input"
+import { Label } from "../ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../ui/select"
+import { Textarea } from "../ui/textarea"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_ROLE_LABELS,
+  VOLUNTEER_ROLE_TYPES,
+  VOLUNTEER_ROLE_TYPE_VALUES,
+  type VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+import {
+  submitCrewVolunteerSignupFn,
+  type PublicCrewVolunteerEvent,
+  type PublicCrewVolunteerQuestion,
+  type PublicCrewVolunteerWaiver,
+} from "../../server-fns/crew-volunteer-fns"
+import { WaiverViewer } from "../compete/waiver-viewer"
+
+interface CrewVolunteerSignupFormProps {
+  event: PublicCrewVolunteerEvent
+  questions: PublicCrewVolunteerQuestion[]
+  waivers: PublicCrewVolunteerWaiver[]
+}
+
+export function CrewVolunteerSignupForm({
+  event,
+  questions,
+  waivers,
+}: CrewVolunteerSignupFormProps) {
+  const submitCrewVolunteerSignup = useServerFn(submitCrewVolunteerSignupFn)
+  const [submitted, setSubmitted] = useState(false)
+  const [isPending, setIsPending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [agreedWaivers, setAgreedWaivers] = useState<Set<string>>(new Set())
+  const [selectedRoleTypes, setSelectedRoleTypes] = useState<
+    Set<VolunteerRoleType>
+  >(new Set([VOLUNTEER_ROLE_TYPES.GENERAL]))
+
+  const handleAnswerChange = (questionId: string, value: string) => {
+    setAnswers((prev) => ({ ...prev, [questionId]: value }))
+  }
+
+  const toggleRoleType = (roleType: VolunteerRoleType, checked: boolean) => {
+    setSelectedRoleTypes((current) => {
+      const next = new Set(current)
+      if (checked) {
+        next.add(roleType)
+      } else {
+        next.delete(roleType)
+      }
+      return next
+    })
+  }
+
+  async function handleSubmit(formData: FormData) {
+    setIsPending(true)
+    setError(null)
+
+    for (const question of questions) {
+      if (
+        question.required &&
+        (!answers[question.id] || answers[question.id].trim() === "")
+      ) {
+        setError(`Please answer the required question: "${question.label}"`)
+        setIsPending(false)
+        return
+      }
+    }
+
+    const missingWaiver = waivers.find(
+      (waiver) => !agreedWaivers.has(waiver.id),
+    )
+    if (missingWaiver) {
+      setError("Please agree to all required waivers before volunteering")
+      setIsPending(false)
+      return
+    }
+
+    const answersArray = Object.entries(answers)
+      .filter(([, value]) => value.trim() !== "")
+      .map(([questionId, answer]) => ({ questionId, answer }))
+
+    try {
+      await submitCrewVolunteerSignup({
+        data: {
+          eventSlug: event.slug,
+          signupName: String(formData.get("name") ?? ""),
+          signupEmail: String(formData.get("email") ?? ""),
+          signupPhone: String(formData.get("phone") ?? ""),
+          credentials: String(formData.get("credentials") ?? ""),
+          availability: String(
+            formData.get("availability") ?? VOLUNTEER_AVAILABILITY.ALL_DAY,
+          ) as "morning" | "afternoon" | "all_day",
+          availabilityNotes: String(formData.get("availabilityNotes") ?? ""),
+          roleTypes: Array.from(selectedRoleTypes),
+          answers: answersArray,
+          waiverIds: Array.from(agreedWaivers),
+          website: String(formData.get("website") ?? ""),
+        },
+      })
+      setSubmitted(true)
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : "Something went wrong. Please try again.",
+      )
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  if (submitted) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <div className="space-y-4 text-center">
+            <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-green-100 dark:bg-green-900">
+              <CheckCircle2 className="h-6 w-6 text-green-600 dark:text-green-400" />
+            </div>
+            <h2 className="text-2xl font-bold">You're on the volunteer list</h2>
+            <p className="text-muted-foreground">
+              Your volunteer application for{" "}
+              <span className="font-medium">{event.name}</span> has been
+              received. The organizers will review your details and follow up
+              with next steps.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Volunteer for {event.name}</CardTitle>
+        <CardDescription>
+          Share your contact details, availability, and preferred roles.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form action={handleSubmit} className="space-y-6">
+          <div className="sr-only" aria-hidden="true">
+            <Label htmlFor="website">Website</Label>
+            <Input
+              type="text"
+              id="website"
+              name="website"
+              tabIndex={-1}
+              autoComplete="off"
+            />
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="name">
+                Full name <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                type="text"
+                id="name"
+                name="name"
+                required
+                disabled={isPending}
+                placeholder="Your full name"
+                autoComplete="name"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="email">
+                Email <span className="text-destructive">*</span>
+              </Label>
+              <Input
+                type="email"
+                id="email"
+                name="email"
+                required
+                disabled={isPending}
+                placeholder="you@example.com"
+                autoComplete="email"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="phone">Phone number</Label>
+            <Input
+              type="tel"
+              id="phone"
+              name="phone"
+              placeholder="(555) 123-4567"
+              disabled={isPending}
+              autoComplete="tel"
+            />
+          </div>
+
+          <div className="space-y-3">
+            <Label>Preferred roles</Label>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {VOLUNTEER_ROLE_TYPE_VALUES.map((roleType) => (
+                <div key={roleType} className="flex items-center gap-2">
+                  <Checkbox
+                    id={`role-${roleType}`}
+                    checked={selectedRoleTypes.has(roleType)}
+                    onCheckedChange={(checked) =>
+                      toggleRoleType(roleType, checked === true)
+                    }
+                    disabled={isPending}
+                  />
+                  <Label
+                    htmlFor={`role-${roleType}`}
+                    className="cursor-pointer font-normal"
+                  >
+                    {VOLUNTEER_ROLE_LABELS[roleType]}
+                  </Label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="credentials">Certifications or credentials</Label>
+            <Textarea
+              id="credentials"
+              name="credentials"
+              placeholder="Judging certifications, medical training, event ops experience..."
+              rows={3}
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="space-y-3">
+            <Label>
+              Availability <span className="text-destructive">*</span>
+            </Label>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <RadioOption
+                id="availability-morning"
+                name="availability"
+                value={VOLUNTEER_AVAILABILITY.MORNING}
+                label="Morning"
+                disabled={isPending}
+              />
+              <RadioOption
+                id="availability-afternoon"
+                name="availability"
+                value={VOLUNTEER_AVAILABILITY.AFTERNOON}
+                label="Afternoon"
+                disabled={isPending}
+              />
+              <RadioOption
+                id="availability-all-day"
+                name="availability"
+                value={VOLUNTEER_AVAILABILITY.ALL_DAY}
+                label="All day"
+                disabled={isPending}
+                defaultChecked
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="availabilityNotes">Availability notes</Label>
+            <Textarea
+              id="availabilityNotes"
+              name="availabilityNotes"
+              placeholder="Timing constraints, role preferences, or anything else organizers should know..."
+              rows={3}
+              disabled={isPending}
+            />
+          </div>
+
+          {waivers.length > 0 && (
+            <div className="space-y-4 border-t pt-4">
+              <p className="text-sm font-medium">Required waivers</p>
+              {waivers.map((waiver) => (
+                <div
+                  key={waiver.id}
+                  className="space-y-3 rounded-md border p-4"
+                >
+                  <h3 className="font-medium">{waiver.title}</h3>
+                  <div className="max-h-64 overflow-y-auto rounded-md border bg-muted/10 p-4">
+                    <WaiverViewer
+                      content={waiver.content}
+                      className="prose prose-sm max-w-none dark:prose-invert"
+                    />
+                  </div>
+                  <div className="flex items-start gap-3 rounded-md bg-muted/20 p-4">
+                    <Checkbox
+                      id={`waiver-${waiver.id}`}
+                      checked={agreedWaivers.has(waiver.id)}
+                      onCheckedChange={(checked) => {
+                        setAgreedWaivers((current) => {
+                          const next = new Set(current)
+                          if (checked === true) {
+                            next.add(waiver.id)
+                          } else {
+                            next.delete(waiver.id)
+                          }
+                          return next
+                        })
+                      }}
+                      disabled={isPending}
+                    />
+                    <Label
+                      htmlFor={`waiver-${waiver.id}`}
+                      className="cursor-pointer text-sm font-medium leading-none"
+                    >
+                      I have read and agree to this waiver
+                      <span className="ml-1 text-destructive">*</span>
+                    </Label>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {questions.length > 0 && (
+            <div className="space-y-4 border-t pt-4">
+              <p className="text-sm font-medium">Additional questions</p>
+              {questions.map((question) => (
+                <div key={question.id} className="space-y-2">
+                  <Label htmlFor={question.id}>
+                    {question.label}
+                    {question.required && (
+                      <span className="ml-1 text-destructive">*</span>
+                    )}
+                  </Label>
+                  {question.helpText && (
+                    <p className="text-sm text-muted-foreground">
+                      {question.helpText}
+                    </p>
+                  )}
+                  <QuestionInput
+                    question={question}
+                    value={answers[question.id] ?? ""}
+                    disabled={isPending}
+                    onChange={(value) => handleAnswerChange(question.id, value)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+
+          {error && (
+            <div className="rounded-md border border-destructive/20 bg-destructive/10 p-4">
+              <p className="text-sm text-destructive">{error}</p>
+            </div>
+          )}
+
+          <Button type="submit" className="w-full" disabled={isPending}>
+            {isPending ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Submitting...
+              </>
+            ) : (
+              "Sign up to volunteer"
+            )}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}
+
+interface RadioOptionProps {
+  id: string
+  name: string
+  value: string
+  label: string
+  disabled: boolean
+  defaultChecked?: boolean
+}
+
+function RadioOption({
+  id,
+  name,
+  value,
+  label,
+  disabled,
+  defaultChecked,
+}: RadioOptionProps) {
+  return (
+    <div className="flex items-center gap-2 rounded-md border p-3">
+      <input
+        type="radio"
+        id={id}
+        name={name}
+        value={value}
+        required
+        disabled={disabled}
+        defaultChecked={defaultChecked}
+        className="h-4 w-4"
+      />
+      <Label htmlFor={id} className="cursor-pointer font-normal">
+        {label}
+      </Label>
+    </div>
+  )
+}
+
+interface QuestionInputProps {
+  question: PublicCrewVolunteerQuestion
+  value: string
+  disabled: boolean
+  onChange: (value: string) => void
+}
+
+function QuestionInput({
+  question,
+  value,
+  disabled,
+  onChange,
+}: QuestionInputProps) {
+  if (question.type === "number") {
+    return (
+      <Input
+        id={question.id}
+        type="number"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        disabled={disabled}
+      />
+    )
+  }
+
+  if (question.type === "select" && question.options) {
+    return (
+      <Select value={value} onValueChange={onChange} disabled={disabled}>
+        <SelectTrigger id={question.id}>
+          <SelectValue placeholder="Select an option" />
+        </SelectTrigger>
+        <SelectContent>
+          {question.options.map((option) => (
+            <SelectItem key={option} value={option}>
+              {option}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    )
+  }
+
+  return (
+    <Input
+      id={question.id}
+      value={value}
+      onChange={(event) => onChange(event.target.value)}
+      disabled={disabled}
+    />
+  )
+}

--- a/apps/crew/src/lib/crew/volunteer-signup.test.ts
+++ b/apps/crew/src/lib/crew/volunteer-signup.test.ts
@@ -115,6 +115,33 @@ describe("planCrewVolunteerSignup", () => {
       reason: "active_membership",
     })
   })
+
+  it("prioritizes accepted invitations over earlier pending invitations", () => {
+    const plan = planCrewVolunteerSignup(
+      { signupEmail: "ada@example.com" },
+      {
+        existingInvitations: [
+          {
+            id: "tinv_pending",
+            email: "ada@example.com",
+            status: INVITATION_STATUS.PENDING,
+          },
+          {
+            id: "tinv_accepted",
+            email: "ADA@example.com",
+            status: INVITATION_STATUS.ACCEPTED,
+          },
+        ],
+        existingMemberships: [],
+      },
+    )
+
+    expect(plan).toMatchObject({
+      action: "reject",
+      targetId: "tinv_accepted",
+      reason: "accepted_invitation",
+    })
+  })
 })
 
 describe("buildCrewVolunteerSignupMetadata", () => {

--- a/apps/crew/src/lib/crew/volunteer-signup.test.ts
+++ b/apps/crew/src/lib/crew/volunteer-signup.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest"
+import { INVITATION_STATUS } from "../../db/schemas/teams"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_INVITE_SOURCE,
+  VOLUNTEER_ROLE_TYPES,
+} from "../../db/schemas/volunteers"
+import {
+  buildCrewVolunteerSignupMetadata,
+  crewVolunteerSignupInputSchema,
+  getCrewVolunteerTokenState,
+  planCrewVolunteerSignup,
+  validateCrewVolunteerSignupRequirements,
+} from "./volunteer-signup"
+
+const baseSignupInput = {
+  eventSlug: "spring-throwdown",
+  signupName: "Ada Lovelace",
+  signupEmail: "ADA@EXAMPLE.COM",
+  signupPhone: "555-0100",
+  credentials: "L1 judge",
+  availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+  availabilityNotes: "Can help wherever needed",
+  roleTypes: [VOLUNTEER_ROLE_TYPES.JUDGE],
+  answers: [{ questionId: "q_required", answer: "Medium" }],
+  waiverIds: ["waiv_123"],
+}
+
+describe("crewVolunteerSignupInputSchema", () => {
+  it("normalizes volunteer email addresses", () => {
+    const parsed = crewVolunteerSignupInputSchema.parse(baseSignupInput)
+
+    expect(parsed.signupEmail).toBe("ada@example.com")
+  })
+})
+
+describe("validateCrewVolunteerSignupRequirements", () => {
+  it("requires required question answers and volunteer waivers", () => {
+    const errors = validateCrewVolunteerSignupRequirements(
+      { answers: [], waiverIds: [] },
+      {
+        questions: [
+          { id: "q_required", label: "T-shirt size", required: true },
+          { id: "q_optional", label: "Anything else?", required: false },
+        ],
+        requiredWaiverIds: ["waiv_123"],
+      },
+    )
+
+    expect(errors).toEqual([
+      'Please answer the required question: "T-shirt size"',
+      "Please agree to all required waivers before volunteering",
+    ])
+  })
+})
+
+describe("planCrewVolunteerSignup", () => {
+  it("updates an existing pending invitation using a normalized email match", () => {
+    const plan = planCrewVolunteerSignup(
+      { signupEmail: "ADA@example.com" },
+      {
+        existingInvitations: [
+          {
+            id: "tinv_1",
+            email: "ada@example.com",
+            status: INVITATION_STATUS.PENDING,
+          },
+        ],
+        existingMemberships: [],
+      },
+    )
+
+    expect(plan).toEqual({
+      action: "update_invitation",
+      targetId: "tinv_1",
+    })
+  })
+
+  it("rejects accepted invitations and active memberships", () => {
+    expect(
+      planCrewVolunteerSignup(
+        { signupEmail: "ada@example.com" },
+        {
+          existingInvitations: [
+            {
+              id: "tinv_1",
+              email: "ada@example.com",
+              status: INVITATION_STATUS.ACCEPTED,
+            },
+          ],
+          existingMemberships: [],
+        },
+      ),
+    ).toMatchObject({
+      action: "reject",
+      reason: "accepted_invitation",
+    })
+
+    expect(
+      planCrewVolunteerSignup(
+        { signupEmail: "ada@example.com" },
+        {
+          existingInvitations: [],
+          existingMemberships: [
+            {
+              id: "tmem_1",
+              email: "ADA@example.com",
+              isActive: true,
+            },
+          ],
+        },
+      ),
+    ).toMatchObject({
+      action: "reject",
+      reason: "active_membership",
+    })
+  })
+})
+
+describe("buildCrewVolunteerSignupMetadata", () => {
+  it("stores pending no-password applications in volunteer metadata shape", () => {
+    const metadata = buildCrewVolunteerSignupMetadata(
+      crewVolunteerSignupInputSchema.parse(baseSignupInput),
+      new Date("2026-06-19T12:00:00.000Z"),
+    )
+
+    expect(metadata).toMatchObject({
+      volunteerRoleTypes: [VOLUNTEER_ROLE_TYPES.JUDGE],
+      credentials: "L1 judge",
+      availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+      status: "pending",
+      inviteSource: VOLUNTEER_INVITE_SOURCE.APPLICATION,
+      signupEmail: "ada@example.com",
+      signupName: "Ada Lovelace",
+      signupPhone: "555-0100",
+      signupWaiverIds: ["waiv_123"],
+      signupWaiverAgreedAt: "2026-06-19T12:00:00.000Z",
+      signupSubmittedAt: "2026-06-19T12:00:00.000Z",
+      crewSignupSource: "public_no_password",
+    })
+  })
+})
+
+describe("getCrewVolunteerTokenState", () => {
+  it("accepts valid tokens and rejects expired or cancelled tokens", () => {
+    const now = new Date("2026-06-19T12:00:00.000Z")
+
+    expect(
+      getCrewVolunteerTokenState(
+        {
+          token: "tok_live",
+          expiresAt: new Date("2026-06-20T12:00:00.000Z"),
+          status: INVITATION_STATUS.PENDING,
+        },
+        now,
+      ),
+    ).toBe("valid")
+
+    expect(
+      getCrewVolunteerTokenState(
+        {
+          token: "tok_expired",
+          expiresAt: new Date("2026-06-18T12:00:00.000Z"),
+          status: INVITATION_STATUS.PENDING,
+        },
+        now,
+      ),
+    ).toBe("expired")
+
+    expect(
+      getCrewVolunteerTokenState(
+        {
+          token: "tok_cancelled",
+          expiresAt: new Date("2026-06-20T12:00:00.000Z"),
+          status: INVITATION_STATUS.CANCELLED,
+        },
+        now,
+      ),
+    ).toBe("bad")
+  })
+})

--- a/apps/crew/src/lib/crew/volunteer-signup.ts
+++ b/apps/crew/src/lib/crew/volunteer-signup.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Import Apply#Confirmed Mutation]]
 import { z } from "zod"
 import { INVITATION_STATUS } from "../../db/schemas/teams"
 import {
@@ -202,6 +203,24 @@ export function planCrewVolunteerSignup(
   },
 ): CrewVolunteerSignupPlan {
   const email = normalizeVolunteerSignupEmail(input.signupEmail)
+  const matchingInvitations = context.existingInvitations.filter(
+    (invitation) => normalizeVolunteerSignupEmail(invitation.email) === email,
+  )
+  const acceptedInvitation = matchingInvitations.find(
+    (invitation) =>
+      invitation.acceptedAt || invitation.status === INVITATION_STATUS.ACCEPTED,
+  )
+
+  if (acceptedInvitation) {
+    return {
+      action: "reject",
+      targetId: acceptedInvitation.id,
+      reason: "accepted_invitation",
+      message:
+        "This email has already accepted a volunteer invitation for this event.",
+    }
+  }
+
   const existingMembership = context.existingMemberships.find(
     (membership) => normalizeVolunteerSignupEmail(membership.email) === email,
   )
@@ -225,25 +244,10 @@ export function planCrewVolunteerSignup(
     }
   }
 
-  const existingInvitation = context.existingInvitations.find(
-    (invitation) => normalizeVolunteerSignupEmail(invitation.email) === email,
-  )
+  const existingInvitation = matchingInvitations[0]
 
   if (!existingInvitation) {
     return { action: "create_invitation", targetId: null }
-  }
-
-  if (
-    existingInvitation.acceptedAt ||
-    existingInvitation.status === INVITATION_STATUS.ACCEPTED
-  ) {
-    return {
-      action: "reject",
-      targetId: existingInvitation.id,
-      reason: "accepted_invitation",
-      message:
-        "This email has already accepted a volunteer invitation for this event.",
-    }
   }
 
   return {

--- a/apps/crew/src/lib/crew/volunteer-signup.ts
+++ b/apps/crew/src/lib/crew/volunteer-signup.ts
@@ -1,0 +1,282 @@
+import { z } from "zod"
+import { INVITATION_STATUS } from "../../db/schemas/teams"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_INVITE_SOURCE,
+  VOLUNTEER_ROLE_TYPES,
+  VOLUNTEER_ROLE_TYPE_VALUES,
+  type VolunteerMembershipMetadata,
+  type VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+
+const volunteerAvailabilityValues = [
+  VOLUNTEER_AVAILABILITY.MORNING,
+  VOLUNTEER_AVAILABILITY.AFTERNOON,
+  VOLUNTEER_AVAILABILITY.ALL_DAY,
+] as const
+
+export const crewVolunteerSignupInputSchema = z.object({
+  eventSlug: z.string().trim().min(1, "Event slug is required").max(255),
+  signupName: z.string().trim().min(1, "Name is required").max(200),
+  signupEmail: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Enter a valid email address")
+    .max(255),
+  signupPhone: z.string().trim().max(50).optional(),
+  credentials: z.string().trim().max(5000).optional(),
+  availability: z.enum(volunteerAvailabilityValues),
+  availabilityNotes: z.string().trim().max(5000).optional(),
+  roleTypes: z.array(z.enum(VOLUNTEER_ROLE_TYPE_VALUES)).max(12).optional(),
+  answers: z
+    .array(
+      z.object({
+        questionId: z.string().trim().min(1),
+        answer: z.string().trim().max(5000),
+      }),
+    )
+    .max(50)
+    .optional(),
+  waiverIds: z.array(z.string().startsWith("waiv_")).max(50).optional(),
+  website: z.string().optional(),
+})
+
+export type CrewVolunteerSignupInput = z.infer<
+  typeof crewVolunteerSignupInputSchema
+>
+
+export interface CrewVolunteerRequiredQuestion {
+  id: string
+  label: string
+  required: boolean
+}
+
+export interface ExistingCrewVolunteerInvitation {
+  id: string
+  email: string
+  acceptedAt?: Date | null
+  status?: string | null
+  metadata?: string | null
+}
+
+export interface ExistingCrewVolunteerMembership {
+  id: string
+  email: string
+  isActive?: boolean | null
+}
+
+export type CrewVolunteerSignupPlan =
+  | {
+      action: "create_invitation"
+      targetId: null
+    }
+  | {
+      action: "update_invitation"
+      targetId: string
+    }
+  | {
+      action: "reject"
+      targetId: string | null
+      reason:
+        | "accepted_invitation"
+        | "active_membership"
+        | "inactive_membership"
+      message: string
+    }
+
+export interface CrewVolunteerTokenRecord {
+  token?: string | null
+  expiresAt?: Date | string | null
+  status?: string | null
+}
+
+export type CrewVolunteerTokenState = "valid" | "missing" | "expired" | "bad"
+
+export type CrewVolunteerSignupMetadata = VolunteerMembershipMetadata & {
+  signupWaiverIds?: string[]
+  signupWaiverAgreedAt?: string
+  signupSubmittedAt?: string
+  crewSignupSource?: "public_no_password"
+}
+
+export function normalizeVolunteerSignupEmail(value: string) {
+  return value.trim().toLowerCase()
+}
+
+export function isCrewVolunteerSignupSpam(
+  input: Pick<CrewVolunteerSignupInput, "website">,
+) {
+  return !!input.website?.trim()
+}
+
+export function normalizeCrewVolunteerRoleTypes(
+  roleTypes: VolunteerRoleType[] | undefined,
+): VolunteerRoleType[] {
+  const normalized = [...new Set(roleTypes ?? [])].filter((roleType) =>
+    VOLUNTEER_ROLE_TYPE_VALUES.includes(roleType),
+  )
+
+  return normalized.length > 0 ? normalized : [VOLUNTEER_ROLE_TYPES.GENERAL]
+}
+
+export function validateCrewVolunteerSignupRequirements(
+  input: Pick<CrewVolunteerSignupInput, "answers" | "waiverIds">,
+  requirements: {
+    questions: CrewVolunteerRequiredQuestion[]
+    requiredWaiverIds: string[]
+  },
+) {
+  const errors: string[] = []
+  const answersByQuestionId = new Map(
+    (input.answers ?? [])
+      .map((answer) => [answer.questionId, answer.answer.trim()] as const)
+      .filter(([, answer]) => answer.length > 0),
+  )
+
+  for (const question of requirements.questions) {
+    if (!question.required) continue
+    if (!answersByQuestionId.has(question.id)) {
+      errors.push(`Please answer the required question: "${question.label}"`)
+    }
+  }
+
+  const agreedWaiverIds = new Set(input.waiverIds ?? [])
+  for (const waiverId of requirements.requiredWaiverIds) {
+    if (!agreedWaiverIds.has(waiverId)) {
+      errors.push("Please agree to all required waivers before volunteering")
+      break
+    }
+  }
+
+  return errors
+}
+
+export function buildCrewVolunteerSignupMetadata(
+  input: CrewVolunteerSignupInput,
+  submittedAt = new Date(),
+): CrewVolunteerSignupMetadata {
+  const waiverIds = [...new Set(input.waiverIds ?? [])]
+  return removeUndefined({
+    volunteerRoleTypes: normalizeCrewVolunteerRoleTypes(input.roleTypes),
+    credentials: emptyToUndefined(input.credentials),
+    availability: input.availability,
+    availabilityNotes: emptyToUndefined(input.availabilityNotes),
+    status: "pending" as const,
+    inviteSource: VOLUNTEER_INVITE_SOURCE.APPLICATION,
+    signupEmail: normalizeVolunteerSignupEmail(input.signupEmail),
+    signupName: input.signupName.trim(),
+    signupPhone: emptyToUndefined(input.signupPhone),
+    signupWaiverIds: waiverIds.length > 0 ? waiverIds : undefined,
+    signupWaiverAgreedAt:
+      waiverIds.length > 0 ? submittedAt.toISOString() : undefined,
+    signupSubmittedAt: submittedAt.toISOString(),
+    crewSignupSource: "public_no_password" as const,
+  })
+}
+
+export function mergeCrewVolunteerSignupMetadata(
+  existingMetadata: string | null | undefined,
+  signupMetadata: CrewVolunteerSignupMetadata,
+) {
+  if (!existingMetadata) return JSON.stringify(signupMetadata)
+
+  try {
+    const existing = JSON.parse(existingMetadata) as Record<string, unknown>
+    return JSON.stringify({
+      ...existing,
+      ...signupMetadata,
+      internalNotes: existing.internalNotes,
+      crewImportId: existing.crewImportId,
+    })
+  } catch {
+    return JSON.stringify(signupMetadata)
+  }
+}
+
+export function planCrewVolunteerSignup(
+  input: Pick<CrewVolunteerSignupInput, "signupEmail">,
+  context: {
+    existingInvitations: ExistingCrewVolunteerInvitation[]
+    existingMemberships: ExistingCrewVolunteerMembership[]
+  },
+): CrewVolunteerSignupPlan {
+  const email = normalizeVolunteerSignupEmail(input.signupEmail)
+  const existingMembership = context.existingMemberships.find(
+    (membership) => normalizeVolunteerSignupEmail(membership.email) === email,
+  )
+
+  if (existingMembership) {
+    if (existingMembership.isActive === false) {
+      return {
+        action: "reject",
+        targetId: existingMembership.id,
+        reason: "inactive_membership",
+        message:
+          "This email is already tied to an inactive volunteer record. Please contact the organizer.",
+      }
+    }
+
+    return {
+      action: "reject",
+      targetId: existingMembership.id,
+      reason: "active_membership",
+      message: "This email is already on the volunteer roster for this event.",
+    }
+  }
+
+  const existingInvitation = context.existingInvitations.find(
+    (invitation) => normalizeVolunteerSignupEmail(invitation.email) === email,
+  )
+
+  if (!existingInvitation) {
+    return { action: "create_invitation", targetId: null }
+  }
+
+  if (
+    existingInvitation.acceptedAt ||
+    existingInvitation.status === INVITATION_STATUS.ACCEPTED
+  ) {
+    return {
+      action: "reject",
+      targetId: existingInvitation.id,
+      reason: "accepted_invitation",
+      message:
+        "This email has already accepted a volunteer invitation for this event.",
+    }
+  }
+
+  return {
+    action: "update_invitation",
+    targetId: existingInvitation.id,
+  }
+}
+
+export function getCrewVolunteerTokenState(
+  record: CrewVolunteerTokenRecord | null | undefined,
+  now = new Date(),
+): CrewVolunteerTokenState {
+  if (!record?.token) return "missing"
+  if (record.status === INVITATION_STATUS.CANCELLED) return "bad"
+  if (!record.expiresAt) return "bad"
+
+  const expiresAt =
+    record.expiresAt instanceof Date
+      ? record.expiresAt
+      : new Date(record.expiresAt)
+  if (Number.isNaN(expiresAt.getTime())) return "bad"
+  if (expiresAt.getTime() <= now.getTime()) return "expired"
+
+  return "valid"
+}
+
+function emptyToUndefined(value: string | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function removeUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -19,7 +19,9 @@ import { Route as EventsEventIdVolunteersRouteImport } from './routes/events/$ev
 import { Route as EventsEventIdSetupRouteImport } from './routes/events/$eventId/setup'
 import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$eventId/schedule'
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
+import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
+import { Route as ESlugScheduleTokenRouteImport } from './routes/e/$slug/schedule/$token'
 
 const EventsRoute = EventsRouteImport.update({
   id: '/events',
@@ -71,9 +73,19 @@ const EventsEventIdImportsRoute = EventsEventIdImportsRouteImport.update({
   path: '/imports',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const ESlugVolunteerRoute = ESlugVolunteerRouteImport.update({
+  id: '/e/$slug/volunteer',
+  path: '/e/$slug/volunteer',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiCrewImportRoute = ApiCrewImportRouteImport.update({
   id: '/api/crew/import',
   path: '/api/crew/import',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ESlugScheduleTokenRoute = ESlugScheduleTokenRouteImport.update({
+  id: '/e/$slug/schedule/$token',
+  path: '/e/$slug/schedule/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
 
@@ -84,11 +96,13 @@ export interface FileRoutesByFullPath {
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
+  '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -96,11 +110,13 @@ export interface FileRoutesByTo {
   '/events': typeof EventsRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId': typeof EventsEventIdIndexRoute
+  '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -110,11 +126,13 @@ export interface FileRoutesById {
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
+  '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -125,11 +143,13 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/events/new'
     | '/api/crew/import'
+    | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
+    | '/e/$slug/schedule/$token'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -137,11 +157,13 @@ export interface FileRouteTypes {
     | '/events'
     | '/events/new'
     | '/api/crew/import'
+    | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
     | '/events/$eventId'
+    | '/e/$slug/schedule/$token'
   id:
     | '__root__'
     | '/'
@@ -150,11 +172,13 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/events/new'
     | '/api/crew/import'
+    | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
+    | '/e/$slug/schedule/$token'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -162,6 +186,8 @@ export interface RootRouteChildren {
   CalculatorRoute: typeof CalculatorRoute
   EventsRoute: typeof EventsRouteWithChildren
   ApiCrewImportRoute: typeof ApiCrewImportRoute
+  ESlugVolunteerRoute: typeof ESlugVolunteerRoute
+  ESlugScheduleTokenRoute: typeof ESlugScheduleTokenRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -236,11 +262,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdImportsRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/e/$slug/volunteer': {
+      id: '/e/$slug/volunteer'
+      path: '/e/$slug/volunteer'
+      fullPath: '/e/$slug/volunteer'
+      preLoaderRoute: typeof ESlugVolunteerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/crew/import': {
       id: '/api/crew/import'
       path: '/api/crew/import'
       fullPath: '/api/crew/import'
       preLoaderRoute: typeof ApiCrewImportRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/e/$slug/schedule/$token': {
+      id: '/e/$slug/schedule/$token'
+      path: '/e/$slug/schedule/$token'
+      fullPath: '/e/$slug/schedule/$token'
+      preLoaderRoute: typeof ESlugScheduleTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
   }
@@ -284,6 +324,8 @@ const rootRouteChildren: RootRouteChildren = {
   CalculatorRoute: CalculatorRoute,
   EventsRoute: EventsRouteWithChildren,
   ApiCrewImportRoute: ApiCrewImportRoute,
+  ESlugVolunteerRoute: ESlugVolunteerRoute,
+  ESlugScheduleTokenRoute: ESlugScheduleTokenRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -1,0 +1,130 @@
+import { createFileRoute, notFound } from "@tanstack/react-router"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_ROLE_LABELS,
+  type VolunteerAvailability,
+  type VolunteerRoleType,
+} from "@/db/schemas/volunteers"
+import { getCrewVolunteerScheduleTokenFn } from "@/server-fns/crew-volunteer-fns"
+
+export const Route = createFileRoute("/e/$slug/schedule/$token")({
+  loader: async ({ params }) => {
+    const result = await getCrewVolunteerScheduleTokenFn({
+      data: { slug: params.slug, token: params.token },
+    })
+
+    if (result.status !== "valid" || !result.event || !result.volunteer) {
+      throw notFound()
+    }
+
+    return result
+  },
+  component: CrewVolunteerScheduleTokenPage,
+  head: ({ loaderData }) => {
+    const event = loaderData?.event
+    if (!event) {
+      return { meta: [{ title: "Volunteer Schedule Not Found" }] }
+    }
+
+    return {
+      meta: [
+        { title: `${event.name} Volunteer Schedule | WODsmith Crew` },
+        {
+          name: "description",
+          content: `Volunteer schedule details for ${event.name}.`,
+        },
+      ],
+    }
+  },
+})
+
+function CrewVolunteerScheduleTokenPage() {
+  const { event, volunteer } = Route.useLoaderData()
+
+  if (!event || !volunteer) {
+    return null
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <p className="text-sm font-medium text-muted-foreground">
+          Volunteer schedule
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold">{event.name}</h1>
+        <p className="mt-2 text-muted-foreground">
+          {event.startDate} to {event.endDate}
+        </p>
+      </section>
+
+      <section className="grid gap-4 sm:grid-cols-2">
+        <InfoBlock label="Volunteer" value={volunteer.name ?? "Not provided"} />
+        <InfoBlock label="Email" value={volunteer.email} />
+        <InfoBlock
+          label="Availability"
+          value={formatAvailability(volunteer.availability)}
+        />
+        <InfoBlock
+          label="Preferred roles"
+          value={formatRoleTypes(volunteer.roleTypes)}
+        />
+      </section>
+
+      {(volunteer.phone ||
+        volunteer.credentials ||
+        volunteer.availabilityNotes) && (
+        <section className="space-y-4 rounded-md border bg-card p-6 shadow-sm">
+          {volunteer.phone && <InfoRow label="Phone" value={volunteer.phone} />}
+          {volunteer.credentials && (
+            <InfoRow label="Credentials" value={volunteer.credentials} />
+          )}
+          {volunteer.availabilityNotes && (
+            <InfoRow
+              label="Availability notes"
+              value={volunteer.availabilityNotes}
+            />
+          )}
+        </section>
+      )}
+
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <h2 className="text-xl font-semibold">Assignments</h2>
+        <p className="mt-2 text-muted-foreground">
+          No volunteer assignments are published for this link yet.
+        </p>
+      </section>
+    </main>
+  )
+}
+
+function InfoBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-card p-5 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-1 font-medium">{value}</p>
+    </div>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-1 whitespace-pre-wrap font-medium">{value}</p>
+    </div>
+  )
+}
+
+function formatRoleTypes(roleTypes: VolunteerRoleType[]) {
+  if (roleTypes.length === 0) return "General"
+  return roleTypes
+    .map((roleType) => VOLUNTEER_ROLE_LABELS[roleType] ?? roleType)
+    .join(", ")
+}
+
+function formatAvailability(availability: VolunteerAvailability | null) {
+  if (availability === VOLUNTEER_AVAILABILITY.MORNING) return "Morning"
+  if (availability === VOLUNTEER_AVAILABILITY.AFTERNOON) return "Afternoon"
+  if (availability === VOLUNTEER_AVAILABILITY.ALL_DAY) return "All day"
+  return "Not provided"
+}

--- a/apps/crew/src/routes/e/$slug/volunteer.tsx
+++ b/apps/crew/src/routes/e/$slug/volunteer.tsx
@@ -1,0 +1,52 @@
+import { createFileRoute, notFound } from "@tanstack/react-router"
+import { CrewVolunteerSignupForm } from "@/components/crew/volunteer-signup-form"
+import { getCrewVolunteerSignupPageFn } from "@/server-fns/crew-volunteer-fns"
+
+export const Route = createFileRoute("/e/$slug/volunteer")({
+  loader: async ({ params }) => {
+    const result = await getCrewVolunteerSignupPageFn({
+      data: { slug: params.slug },
+    })
+
+    if (!result.event) {
+      throw notFound()
+    }
+
+    return result
+  },
+  component: CrewVolunteerSignupPage,
+  head: ({ loaderData }) => {
+    const event = loaderData?.event
+    if (!event) {
+      return { meta: [{ title: "Crew Event Not Found" }] }
+    }
+
+    return {
+      meta: [
+        { title: `Volunteer for ${event.name} | WODsmith Crew` },
+        {
+          name: "description",
+          content: `Sign up to volunteer for ${event.name}.`,
+        },
+      ],
+    }
+  },
+})
+
+function CrewVolunteerSignupPage() {
+  const { event, questions, waivers } = Route.useLoaderData()
+
+  if (!event) {
+    return null
+  }
+
+  return (
+    <main className="mx-auto max-w-2xl px-4 py-8 sm:px-6">
+      <CrewVolunteerSignupForm
+        event={event}
+        questions={questions}
+        waivers={waivers}
+      />
+    </main>
+  )
+}

--- a/apps/crew/src/server-fns/crew-volunteer-fns.ts
+++ b/apps/crew/src/server-fns/crew-volunteer-fns.ts
@@ -1,6 +1,7 @@
+// @lat: [[crew#Import Apply#Confirmed Mutation]]
 import { createId } from "@paralleldrive/cuid2"
 import { createServerFn } from "@tanstack/react-start"
-import { and, asc, eq, ne } from "drizzle-orm"
+import { and, asc, eq, ne, notInArray, sql } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "../db"
 import {
@@ -36,6 +37,8 @@ import {
 import type { QuestionType } from "./registration-questions-fns"
 
 type DbClient = ReturnType<typeof getDb>
+const PUBLIC_DUPLICATE_VOLUNTEER_SIGNUP_ERROR =
+  "This volunteer application could not be submitted. Please contact the organizer if you already signed up."
 
 export interface PublicCrewVolunteerEvent {
   id: string
@@ -132,13 +135,10 @@ export const submitCrewVolunteerSignupFn = createServerFn({ method: "POST" })
       throw new Error("Crew event not found")
     }
 
-    const [questions, waivers, existingInvitations, existingMemberships] =
-      await Promise.all([
-        listVolunteerQuestions(db, event.id, event.groupId),
-        listRequiredVolunteerWaivers(db, event.id),
-        listVolunteerInvitations(db, event.competitionTeamId),
-        listVolunteerMemberships(db, event.competitionTeamId),
-      ])
+    const [questions, waivers] = await Promise.all([
+      listVolunteerQuestions(db, event.id, event.groupId),
+      listRequiredVolunteerWaivers(db, event.id),
+    ])
 
     const validationErrors = validateCrewVolunteerSignupRequirements(data, {
       questions,
@@ -151,84 +151,97 @@ export const submitCrewVolunteerSignupFn = createServerFn({ method: "POST" })
     validateSubmittedQuestionIds(data.answers ?? [], questions)
     validateSubmittedWaiverIds(data.waiverIds ?? [], waivers)
 
-    const plan = planCrewVolunteerSignup(data, {
-      existingInvitations,
-      existingMemberships,
-    })
-    if (plan.action === "reject") {
-      throw new Error(plan.message)
-    }
-
     const timestamp = new Date()
     const expiresAt = new Date(timestamp)
     expiresAt.setFullYear(expiresAt.getFullYear() + 1)
     const signupMetadata = buildCrewVolunteerSignupMetadata(data, timestamp)
-    const existingInvitation =
-      plan.action === "update_invitation"
-        ? existingInvitations.find(
-            (invitation) => invitation.id === plan.targetId,
-          )
-        : null
-    const metadata = mergeCrewVolunteerSignupMetadata(
-      existingInvitation?.metadata,
-      signupMetadata,
-    )
     const email = normalizeVolunteerSignupEmail(data.signupEmail)
-    let invitationId = plan.targetId
+    let invitationId: string | null = null
+    let action: "created" | "updated" = "created"
 
     await db.transaction(async (tx) => {
       const client = tx as unknown as DbClient
-
-      if (plan.action === "create_invitation") {
-        invitationId = createTeamInvitationId()
-        await client.insert(teamInvitationTable).values({
-          id: invitationId,
-          teamId: event.competitionTeamId,
-          email,
-          roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
-          isSystemRole: true,
-          token: createId(),
-          invitedBy: null,
-          expiresAt,
-          status: INVITATION_STATUS.PENDING,
-          metadata,
-          createdAt: timestamp,
-          updatedAt: timestamp,
-        })
-      } else if (plan.action === "update_invitation" && invitationId) {
-        await client
-          .update(teamInvitationTable)
-          .set({
-            email,
-            roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
-            isSystemRole: true,
-            expiresAt,
-            status: INVITATION_STATUS.PENDING,
-            metadata,
-            updatedAt: timestamp,
-          })
-          .where(eq(teamInvitationTable.id, invitationId))
-      }
-
-      if (!invitationId) {
-        throw new Error("Volunteer application could not be saved")
-      }
-
-      await persistVolunteerAnswers(
+      await withVolunteerSignupLock(
         client,
-        invitationId,
-        data.answers ?? [],
-        timestamp,
+        event.competitionTeamId,
+        email,
+        async () => {
+          const [existingInvitations, existingMemberships] = await Promise.all([
+            listVolunteerInvitations(client, event.competitionTeamId),
+            listVolunteerMemberships(client, event.competitionTeamId),
+          ])
+          const plan = planCrewVolunteerSignup(data, {
+            existingInvitations,
+            existingMemberships,
+          })
+
+          if (plan.action === "reject") {
+            throw new Error(PUBLIC_DUPLICATE_VOLUNTEER_SIGNUP_ERROR)
+          }
+
+          const existingInvitation =
+            plan.action === "update_invitation"
+              ? existingInvitations.find(
+                  (invitation) => invitation.id === plan.targetId,
+                )
+              : null
+          const metadata = mergeCrewVolunteerSignupMetadata(
+            existingInvitation?.metadata,
+            signupMetadata,
+          )
+
+          if (plan.action === "create_invitation") {
+            invitationId = createTeamInvitationId()
+            action = "created"
+            await client.insert(teamInvitationTable).values({
+              id: invitationId,
+              teamId: event.competitionTeamId,
+              email,
+              roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+              isSystemRole: true,
+              token: createId(),
+              invitedBy: null,
+              expiresAt,
+              status: INVITATION_STATUS.PENDING,
+              metadata,
+              createdAt: timestamp,
+              updatedAt: timestamp,
+            })
+          } else if (plan.action === "update_invitation" && plan.targetId) {
+            invitationId = plan.targetId
+            action = "updated"
+            await client
+              .update(teamInvitationTable)
+              .set({
+                email,
+                roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+                isSystemRole: true,
+                expiresAt,
+                status: INVITATION_STATUS.PENDING,
+                metadata,
+                updatedAt: timestamp,
+              })
+              .where(eq(teamInvitationTable.id, invitationId))
+          }
+
+          if (!invitationId) {
+            throw new Error("Volunteer application could not be saved")
+          }
+
+          await syncVolunteerAnswers(
+            client,
+            invitationId,
+            data.answers ?? [],
+            timestamp,
+          )
+        },
       )
     })
 
     return {
       success: true,
       applicationId: invitationId,
-      action:
-        plan.action === "create_invitation"
-          ? ("created" as const)
-          : ("updated" as const),
+      action,
     }
   })
 
@@ -489,7 +502,7 @@ function validateSubmittedWaiverIds(
   }
 }
 
-async function persistVolunteerAnswers(
+async function syncVolunteerAnswers(
   db: DbClient,
   invitationId: string,
   answers: Array<{ questionId: string; answer: string }>,
@@ -502,7 +515,22 @@ async function persistVolunteerAnswers(
     }))
     .filter((answer) => answer.answer.length > 0)
 
-  if (cleanedAnswers.length === 0) return
+  if (cleanedAnswers.length === 0) {
+    await db
+      .delete(volunteerRegistrationAnswersTable)
+      .where(eq(volunteerRegistrationAnswersTable.invitationId, invitationId))
+    return
+  }
+
+  await db.delete(volunteerRegistrationAnswersTable).where(
+    and(
+      eq(volunteerRegistrationAnswersTable.invitationId, invitationId),
+      notInArray(
+        volunteerRegistrationAnswersTable.questionId,
+        cleanedAnswers.map((answer) => answer.questionId),
+      ),
+    ),
+  )
 
   for (const answer of cleanedAnswers) {
     await db
@@ -520,6 +548,46 @@ async function persistVolunteerAnswers(
         },
       })
   }
+}
+
+async function withVolunteerSignupLock<T>(
+  db: DbClient,
+  competitionTeamId: string,
+  email: string,
+  callback: () => Promise<T>,
+) {
+  let acquired = false
+  const lockExpression = sql`SHA2(CONCAT('crew-volunteer:', ${competitionTeamId}, ':', ${email}), 256)`
+
+  try {
+    const result = await db.execute<VolunteerSignupLockRow>(
+      sql`SELECT GET_LOCK(${lockExpression}, 5) AS acquired`,
+    )
+    const rows = getExecuteRows<VolunteerSignupLockRow>(result)
+    acquired = Number(rows[0]?.acquired ?? 0) === 1
+    if (!acquired) {
+      throw new Error("Volunteer application could not be saved")
+    }
+
+    return await callback()
+  } finally {
+    if (acquired) {
+      await db.execute(sql`SELECT RELEASE_LOCK(${lockExpression})`)
+    }
+  }
+}
+
+interface VolunteerSignupLockRow {
+  acquired: number | string | null
+}
+
+function getExecuteRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) {
+    if (Array.isArray(result[0])) return result[0] as T[]
+    return result as T[]
+  }
+
+  return ((result as { rows?: T[] })?.rows ?? []) as T[]
 }
 
 function parseQuestionOptions(options: string | null): string[] | null {

--- a/apps/crew/src/server-fns/crew-volunteer-fns.ts
+++ b/apps/crew/src/server-fns/crew-volunteer-fns.ts
@@ -1,0 +1,548 @@
+import { createId } from "@paralleldrive/cuid2"
+import { createServerFn } from "@tanstack/react-start"
+import { and, asc, eq, ne } from "drizzle-orm"
+import { z } from "zod"
+import { getDb } from "../db"
+import {
+  competitionRegistrationQuestionsTable,
+  competitionsTable,
+  volunteerRegistrationAnswersTable,
+} from "../db/schemas/competitions"
+import { createTeamInvitationId } from "../db/schemas/common"
+import {
+  CREW_EVENT_LIFECYCLE,
+  crewEventSettingsTable,
+} from "../db/schemas/crew-event-settings"
+import {
+  INVITATION_STATUS,
+  SYSTEM_ROLES_ENUM,
+  teamInvitationTable,
+  teamMembershipTable,
+} from "../db/schemas/teams"
+import { userTable } from "../db/schemas/users"
+import { waiversTable } from "../db/schemas/waivers"
+import type { VolunteerAvailability } from "../db/schemas/volunteers"
+import {
+  buildCrewVolunteerSignupMetadata,
+  crewVolunteerSignupInputSchema,
+  getCrewVolunteerTokenState,
+  isCrewVolunteerSignupSpam,
+  mergeCrewVolunteerSignupMetadata,
+  normalizeVolunteerSignupEmail,
+  planCrewVolunteerSignup,
+  validateCrewVolunteerSignupRequirements,
+  type CrewVolunteerSignupMetadata,
+} from "../lib/crew/volunteer-signup"
+import type { QuestionType } from "./registration-questions-fns"
+
+type DbClient = ReturnType<typeof getDb>
+
+export interface PublicCrewVolunteerEvent {
+  id: string
+  slug: string
+  name: string
+  description: string | null
+  startDate: string
+  endDate: string
+  timezone: string | null
+  competitionTeamId: string
+}
+
+export interface PublicCrewVolunteerQuestion {
+  id: string
+  competitionId: string | null
+  groupId: string | null
+  type: QuestionType
+  label: string
+  helpText: string | null
+  options: string[] | null
+  required: boolean
+  sortOrder: number
+}
+
+export interface PublicCrewVolunteerWaiver {
+  id: string
+  title: string
+  content: string
+}
+
+export interface CrewVolunteerSignupPageData {
+  event: PublicCrewVolunteerEvent | null
+  questions: PublicCrewVolunteerQuestion[]
+  waivers: PublicCrewVolunteerWaiver[]
+}
+
+export interface CrewVolunteerScheduleTokenData {
+  status: "valid" | "missing" | "expired" | "bad"
+  event: PublicCrewVolunteerEvent | null
+  volunteer: {
+    email: string
+    name: string | null
+    phone: string | null
+    availability: VolunteerAvailability | null
+    availabilityNotes: string | null
+    credentials: string | null
+    roleTypes: CrewVolunteerSignupMetadata["volunteerRoleTypes"]
+    invitationStatus: string
+  } | null
+}
+
+const getCrewVolunteerSignupPageInputSchema = z.object({
+  slug: z.string().trim().min(1, "Event slug is required").max(255),
+})
+
+const getCrewVolunteerScheduleTokenInputSchema = z.object({
+  slug: z.string().trim().min(1, "Event slug is required").max(255),
+  token: z.string().trim().min(1, "Token is required").max(255),
+})
+
+export const getCrewVolunteerSignupPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    getCrewVolunteerSignupPageInputSchema.parse(data),
+  )
+  .handler(async ({ data }): Promise<CrewVolunteerSignupPageData> => {
+    const db = getDb()
+    const event = await getPublicCrewEventBySlug(db, data.slug)
+    if (!event) {
+      return { event: null, questions: [], waivers: [] }
+    }
+
+    const [questions, waivers] = await Promise.all([
+      listVolunteerQuestions(db, event.id, event.groupId),
+      listRequiredVolunteerWaivers(db, event.id),
+    ])
+
+    return {
+      event: toPublicCrewVolunteerEvent(event),
+      questions,
+      waivers,
+    }
+  })
+
+export const submitCrewVolunteerSignupFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => crewVolunteerSignupInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    if (isCrewVolunteerSignupSpam(data)) {
+      return { success: true, applicationId: null, action: "accepted" as const }
+    }
+
+    const db = getDb()
+    const event = await getPublicCrewEventBySlug(db, data.eventSlug)
+    if (!event) {
+      throw new Error("Crew event not found")
+    }
+
+    const [questions, waivers, existingInvitations, existingMemberships] =
+      await Promise.all([
+        listVolunteerQuestions(db, event.id, event.groupId),
+        listRequiredVolunteerWaivers(db, event.id),
+        listVolunteerInvitations(db, event.competitionTeamId),
+        listVolunteerMemberships(db, event.competitionTeamId),
+      ])
+
+    const validationErrors = validateCrewVolunteerSignupRequirements(data, {
+      questions,
+      requiredWaiverIds: waivers.map((waiver) => waiver.id),
+    })
+    if (validationErrors.length > 0) {
+      throw new Error(validationErrors[0])
+    }
+
+    validateSubmittedQuestionIds(data.answers ?? [], questions)
+    validateSubmittedWaiverIds(data.waiverIds ?? [], waivers)
+
+    const plan = planCrewVolunteerSignup(data, {
+      existingInvitations,
+      existingMemberships,
+    })
+    if (plan.action === "reject") {
+      throw new Error(plan.message)
+    }
+
+    const timestamp = new Date()
+    const expiresAt = new Date(timestamp)
+    expiresAt.setFullYear(expiresAt.getFullYear() + 1)
+    const signupMetadata = buildCrewVolunteerSignupMetadata(data, timestamp)
+    const existingInvitation =
+      plan.action === "update_invitation"
+        ? existingInvitations.find(
+            (invitation) => invitation.id === plan.targetId,
+          )
+        : null
+    const metadata = mergeCrewVolunteerSignupMetadata(
+      existingInvitation?.metadata,
+      signupMetadata,
+    )
+    const email = normalizeVolunteerSignupEmail(data.signupEmail)
+    let invitationId = plan.targetId
+
+    await db.transaction(async (tx) => {
+      const client = tx as unknown as DbClient
+
+      if (plan.action === "create_invitation") {
+        invitationId = createTeamInvitationId()
+        await client.insert(teamInvitationTable).values({
+          id: invitationId,
+          teamId: event.competitionTeamId,
+          email,
+          roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+          isSystemRole: true,
+          token: createId(),
+          invitedBy: null,
+          expiresAt,
+          status: INVITATION_STATUS.PENDING,
+          metadata,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        })
+      } else if (plan.action === "update_invitation" && invitationId) {
+        await client
+          .update(teamInvitationTable)
+          .set({
+            email,
+            roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+            isSystemRole: true,
+            expiresAt,
+            status: INVITATION_STATUS.PENDING,
+            metadata,
+            updatedAt: timestamp,
+          })
+          .where(eq(teamInvitationTable.id, invitationId))
+      }
+
+      if (!invitationId) {
+        throw new Error("Volunteer application could not be saved")
+      }
+
+      await persistVolunteerAnswers(
+        client,
+        invitationId,
+        data.answers ?? [],
+        timestamp,
+      )
+    })
+
+    return {
+      success: true,
+      applicationId: invitationId,
+      action:
+        plan.action === "create_invitation"
+          ? ("created" as const)
+          : ("updated" as const),
+    }
+  })
+
+export const getCrewVolunteerScheduleTokenFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) =>
+    getCrewVolunteerScheduleTokenInputSchema.parse(data),
+  )
+  .handler(async ({ data }): Promise<CrewVolunteerScheduleTokenData> => {
+    const db = getDb()
+    const [row] = await db
+      .select({
+        event: publicCrewEventSelect,
+        invitation: {
+          id: teamInvitationTable.id,
+          email: teamInvitationTable.email,
+          token: teamInvitationTable.token,
+          status: teamInvitationTable.status,
+          expiresAt: teamInvitationTable.expiresAt,
+          metadata: teamInvitationTable.metadata,
+        },
+      })
+      .from(teamInvitationTable)
+      .innerJoin(
+        competitionsTable,
+        eq(teamInvitationTable.teamId, competitionsTable.competitionTeamId),
+      )
+      .innerJoin(
+        crewEventSettingsTable,
+        eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+      )
+      .where(
+        and(
+          eq(competitionsTable.slug, data.slug),
+          eq(teamInvitationTable.token, data.token),
+          eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+          eq(teamInvitationTable.isSystemRole, true),
+          eq(crewEventSettingsTable.crewOnly, true),
+          ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
+        ),
+      )
+      .limit(1)
+
+    if (!row) {
+      return { status: "missing", event: null, volunteer: null }
+    }
+
+    const status = getCrewVolunteerTokenState(row.invitation)
+    if (status !== "valid") {
+      return { status, event: null, volunteer: null }
+    }
+
+    const metadata = parseVolunteerMetadata(row.invitation.metadata)
+
+    return {
+      status,
+      event: toPublicCrewVolunteerEvent(row.event),
+      volunteer: {
+        email: row.invitation.email,
+        name: metadata?.signupName ?? null,
+        phone: metadata?.signupPhone ?? null,
+        availability: metadata?.availability ?? null,
+        availabilityNotes: metadata?.availabilityNotes ?? null,
+        credentials: metadata?.credentials ?? null,
+        roleTypes: metadata?.volunteerRoleTypes ?? [],
+        invitationStatus: row.invitation.status,
+      },
+    }
+  })
+
+const publicCrewEventSelect = {
+  id: competitionsTable.id,
+  slug: competitionsTable.slug,
+  name: competitionsTable.name,
+  description: competitionsTable.description,
+  startDate: competitionsTable.startDate,
+  endDate: competitionsTable.endDate,
+  timezone: competitionsTable.timezone,
+  competitionTeamId: competitionsTable.competitionTeamId,
+  groupId: competitionsTable.groupId,
+}
+
+type InternalPublicCrewEvent = PublicCrewVolunteerEvent & {
+  groupId: string | null
+}
+
+async function getPublicCrewEventBySlug(db: DbClient, slug: string) {
+  const [event] = await db
+    .select(publicCrewEventSelect)
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(
+      and(
+        eq(competitionsTable.slug, slug),
+        eq(crewEventSettingsTable.crewOnly, true),
+        ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
+      ),
+    )
+    .limit(1)
+
+  return event ?? null
+}
+
+function toPublicCrewVolunteerEvent(
+  event: InternalPublicCrewEvent,
+): PublicCrewVolunteerEvent {
+  return {
+    id: event.id,
+    slug: event.slug,
+    name: event.name,
+    description: event.description,
+    startDate: event.startDate,
+    endDate: event.endDate,
+    timezone: event.timezone,
+    competitionTeamId: event.competitionTeamId,
+  }
+}
+
+async function listVolunteerQuestions(
+  db: DbClient,
+  competitionId: string,
+  groupId: string | null,
+): Promise<PublicCrewVolunteerQuestion[]> {
+  const competitionQuestions = await db
+    .select()
+    .from(competitionRegistrationQuestionsTable)
+    .where(
+      and(
+        eq(competitionRegistrationQuestionsTable.competitionId, competitionId),
+        eq(competitionRegistrationQuestionsTable.questionTarget, "volunteer"),
+      ),
+    )
+    .orderBy(asc(competitionRegistrationQuestionsTable.sortOrder))
+
+  const seriesQuestions = groupId
+    ? await db
+        .select()
+        .from(competitionRegistrationQuestionsTable)
+        .where(
+          and(
+            eq(competitionRegistrationQuestionsTable.groupId, groupId),
+            eq(
+              competitionRegistrationQuestionsTable.questionTarget,
+              "volunteer",
+            ),
+          ),
+        )
+        .orderBy(asc(competitionRegistrationQuestionsTable.sortOrder))
+    : []
+
+  return [...seriesQuestions, ...competitionQuestions].map((question) => ({
+    id: question.id,
+    competitionId: question.competitionId,
+    groupId: question.groupId,
+    type: question.type as QuestionType,
+    label: question.label,
+    helpText: question.helpText,
+    options: parseQuestionOptions(question.options),
+    required: question.required,
+    sortOrder: question.sortOrder,
+  }))
+}
+
+async function listRequiredVolunteerWaivers(
+  db: DbClient,
+  competitionId: string,
+): Promise<PublicCrewVolunteerWaiver[]> {
+  return await db
+    .select({
+      id: waiversTable.id,
+      title: waiversTable.title,
+      content: waiversTable.content,
+    })
+    .from(waiversTable)
+    .where(
+      and(
+        eq(waiversTable.competitionId, competitionId),
+        eq(waiversTable.requiredForVolunteers, true),
+      ),
+    )
+    .orderBy(asc(waiversTable.position))
+}
+
+async function listVolunteerInvitations(
+  db: DbClient,
+  competitionTeamId: string,
+) {
+  return await db
+    .select({
+      id: teamInvitationTable.id,
+      email: teamInvitationTable.email,
+      acceptedAt: teamInvitationTable.acceptedAt,
+      status: teamInvitationTable.status,
+      metadata: teamInvitationTable.metadata,
+    })
+    .from(teamInvitationTable)
+    .where(
+      and(
+        eq(teamInvitationTable.teamId, competitionTeamId),
+        eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamInvitationTable.isSystemRole, true),
+      ),
+    )
+}
+
+async function listVolunteerMemberships(
+  db: DbClient,
+  competitionTeamId: string,
+) {
+  const rows = await db
+    .select({
+      id: teamMembershipTable.id,
+      email: userTable.email,
+      isActive: teamMembershipTable.isActive,
+    })
+    .from(teamMembershipTable)
+    .innerJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(
+      and(
+        eq(teamMembershipTable.teamId, competitionTeamId),
+        eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamMembershipTable.isSystemRole, true),
+      ),
+    )
+
+  return rows.flatMap((row) =>
+    row.email ? [{ ...row, email: row.email }] : [],
+  )
+}
+
+function validateSubmittedQuestionIds(
+  answers: Array<{ questionId: string; answer: string }>,
+  questions: PublicCrewVolunteerQuestion[],
+) {
+  const questionIds = new Set(questions.map((question) => question.id))
+  const invalidAnswer = answers.find(
+    (answer) => !questionIds.has(answer.questionId),
+  )
+  if (invalidAnswer) {
+    throw new Error("One or more volunteer question answers are invalid")
+  }
+}
+
+function validateSubmittedWaiverIds(
+  waiverIds: string[],
+  waivers: PublicCrewVolunteerWaiver[],
+) {
+  const validWaiverIds = new Set(waivers.map((waiver) => waiver.id))
+  const invalidWaiverId = waiverIds.find(
+    (waiverId) => !validWaiverIds.has(waiverId),
+  )
+  if (invalidWaiverId) {
+    throw new Error("One or more volunteer waiver agreements are invalid")
+  }
+}
+
+async function persistVolunteerAnswers(
+  db: DbClient,
+  invitationId: string,
+  answers: Array<{ questionId: string; answer: string }>,
+  timestamp: Date,
+) {
+  const cleanedAnswers = answers
+    .map((answer) => ({
+      questionId: answer.questionId,
+      answer: answer.answer.trim(),
+    }))
+    .filter((answer) => answer.answer.length > 0)
+
+  if (cleanedAnswers.length === 0) return
+
+  for (const answer of cleanedAnswers) {
+    await db
+      .insert(volunteerRegistrationAnswersTable)
+      .values({
+        ...answer,
+        invitationId,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      .onDuplicateKeyUpdate({
+        set: {
+          answer: answer.answer,
+          updatedAt: timestamp,
+        },
+      })
+  }
+}
+
+function parseQuestionOptions(options: string | null): string[] | null {
+  if (!options) return null
+  try {
+    const parsed = JSON.parse(options)
+    return Array.isArray(parsed) ? parsed.filter(isString) : null
+  } catch {
+    return null
+  }
+}
+
+function parseVolunteerMetadata(
+  metadata: string | null,
+): CrewVolunteerSignupMetadata | null {
+  if (!metadata) return null
+  try {
+    return JSON.parse(metadata) as CrewVolunteerSignupMetadata
+  } catch {
+    return null
+  }
+}
+
+function isString(value: unknown): value is string {
+  return typeof value === "string"
+}

--- a/apps/crew/src/server-fns/crew-volunteer-fns.ts
+++ b/apps/crew/src/server-fns/crew-volunteer-fns.ts
@@ -557,14 +557,13 @@ async function withVolunteerSignupLock<T>(
   callback: () => Promise<T>,
 ) {
   let acquired = false
-  const lockExpression = sql`SHA2(CONCAT('crew-volunteer:', ${competitionTeamId}, ':', ${email}), 256)`
+  const lockName = await createVolunteerSignupLockName(competitionTeamId, email)
 
   try {
-    const result = await db.execute<VolunteerSignupLockRow>(
-      sql`SELECT GET_LOCK(${lockExpression}, 5) AS acquired`,
+    const result = await db.execute(
+      sql`SELECT GET_LOCK(${lockName}, 5) FROM dual`,
     )
-    const rows = getExecuteRows<VolunteerSignupLockRow>(result)
-    acquired = Number(rows[0]?.acquired ?? 0) === 1
+    acquired = Number(getFirstExecuteValue(result) ?? 0) === 1
     if (!acquired) {
       throw new Error("Volunteer application could not be saved")
     }
@@ -572,13 +571,22 @@ async function withVolunteerSignupLock<T>(
     return await callback()
   } finally {
     if (acquired) {
-      await db.execute(sql`SELECT RELEASE_LOCK(${lockExpression})`)
+      await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
     }
   }
 }
 
-interface VolunteerSignupLockRow {
-  acquired: number | string | null
+async function createVolunteerSignupLockName(
+  competitionTeamId: string,
+  email: string,
+) {
+  const encoded = new TextEncoder().encode(
+    `crew-volunteer:${competitionTeamId}:${email}`,
+  )
+  const digest = await crypto.subtle.digest("SHA-256", encoded)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")
 }
 
 function getExecuteRows<T>(result: unknown): T[] {
@@ -588,6 +596,13 @@ function getExecuteRows<T>(result: unknown): T[] {
   }
 
   return ((result as { rows?: T[] })?.rows ?? []) as T[]
+}
+
+function getFirstExecuteValue(result: unknown): unknown {
+  const [row] = getExecuteRows<unknown>(result)
+  if (Array.isArray(row)) return row[0]
+  if (row && typeof row === "object") return Object.values(row)[0]
+  return row
 }
 
 function parseQuestionOptions(options: string | null): string[] | null {

--- a/apps/crew/vite.config.ts
+++ b/apps/crew/vite.config.ts
@@ -67,6 +67,7 @@ const config = defineConfig({
   // Resolve server-only as empty module (Next.js specific, not needed in TanStack Start)
   resolve: {
     alias: {
+      "@": new URL("./src", import.meta.url).pathname,
       "server-only": new URL("./src/lib/server-only-stub.ts", import.meta.url)
         .pathname,
     },

--- a/apps/crew/vite.config.ts
+++ b/apps/crew/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url"
 import { sentryVitePlugin } from "@sentry/vite-plugin"
 import tailwindcss from "@tailwindcss/vite"
 import { devtools } from "@tanstack/devtools-vite"
@@ -67,9 +68,10 @@ const config = defineConfig({
   // Resolve server-only as empty module (Next.js specific, not needed in TanStack Start)
   resolve: {
     alias: {
-      "@": new URL("./src", import.meta.url).pathname,
-      "server-only": new URL("./src/lib/server-only-stub.ts", import.meta.url)
-        .pathname,
+      "@": fileURLToPath(new URL("./src", import.meta.url)),
+      "server-only": fileURLToPath(
+        new URL("./src/lib/server-only-stub.ts", import.meta.url),
+      ),
     },
   },
   // Pre-bundle SSR dependencies to avoid mid-session optimization errors


### PR DESCRIPTION
## Summary
- Add a public Crew volunteer signup route at `/e/$slug/volunteer` with no account or password requirement.
- Store public volunteer applications on existing volunteer `team_invitations` metadata, with case-insensitive email dedupe against pending invitations and volunteer memberships.
- Add required question and volunteer waiver validation, a honeypot guard, focused helper tests, and a minimal read-only token route at `/e/$slug/schedule/$token`.
- Add an explicit Vite `@` alias so existing Crew UI component imports resolve when public UI components enter the bundle.

## Validation
- `pnpm --filter crew test -- src/lib/crew/volunteer-signup.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew build`
- `pnpm --filter crew lint` (exits 0; reports existing warnings in untouched Crew files)
- `pnpm check:schema-ownership`
- `git diff --check`

## Notes / limitations
- Used the established ignored local config workaround for build validation: copied `apps/crew/wrangler.jsonc` to `apps/crew/.alchemy/local/wrangler.jsonc`; the copied file is ignored and not included in this PR.
- This slice intentionally does not send live email or expose a production magic-link copy after signup. Confirmation emails and assignment response flows remain for the follow-up `feat(crew): add confirmation emails and token responses` slice.
- The schedule token page is intentionally read-only and minimal; it validates token presence, match, expiry, and cancellation before showing the volunteer/event summary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public, no‑password volunteer signup flow for Crew and a read‑only volunteer schedule token page. Applications are stored in `team_invitations` with stricter validation, spam protection, case‑insensitive email dedupe, and a Vitess‑compatible advisory lock to prevent duplicates.

- **New Features**
  - Public signup page at `/e/$slug/volunteer` with role preferences, availability, required questions, and required waiver checks.
  - Honeypot field to block bots; no account required.
  - Saves applications to `team_invitations` metadata; updates pending invites or creates new; rejects accepted invites and active members.
  - Read‑only schedule view at `/e/$slug/schedule/$token`; 404s for missing, expired, or cancelled tokens and shows volunteer/event details for valid tokens.
  - Server fns enforce crew‑only, non‑archived events; validate question/waiver IDs; and use a Vitess‑compatible advisory DB lock to prevent duplicate submissions. Focused unit tests for planning/validation/token logic.

- **Dependencies**
  - Adds Vite alias `@` -> `apps/crew/src` so shared Crew UI imports resolve.

<sup>Written for commit 838b6b5f4470dd4f9a1b8f646acbcc43f3f38e83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added volunteer signup form with role type selection, custom event questions, and required waiver agreements.
  * Added volunteer schedule confirmation page displaying submitted signup details, availability, and preferred roles.
  * Implemented email normalization and validation checks for questions and required waivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->