### PR TITLE
[codex] Use capability registry for server submission gates

### DIFF
--- a/apps/wodsmith-start/src/routes/api/compete/scores/judge.ts
+++ b/apps/wodsmith-start/src/routes/api/compete/scores/judge.ts
@@ -40,6 +40,7 @@ import {
   type TiebreakScheme,
   workouts,
 } from "@/db/schemas/workouts"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import {
   computeSortKey,
   encodeRounds,
@@ -81,15 +82,22 @@ const judgeScoreSchema = z.object({
   workout: workoutInfoSchema.optional(),
 })
 
-function mapToNewStatus(status: ScoreStatus): "scored" | "cap" | "dq" | "withdrawn" {
+function mapToNewStatus(
+  status: ScoreStatus,
+): "scored" | "cap" | "dq" | "withdrawn" {
   switch (status) {
-    case "scored": return "scored"
-    case "cap": return "cap"
-    case "dq": return "dq"
+    case "scored":
+      return "scored"
+    case "cap":
+      return "cap"
+    case "dq":
+      return "dq"
     case "withdrawn":
     case "dns":
-    case "dnf": return "withdrawn"
-    default: return "scored"
+    case "dnf":
+      return "withdrawn"
+    default:
+      return "scored"
   }
 }
 
@@ -106,7 +114,10 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
 
       POST: async ({ request }: { request: Request }) => {
         const origin = request.headers.get("Origin")
-        const headers = { "Content-Type": "application/json", ...corsHeaders(origin) }
+        const headers = {
+          "Content-Type": "application/json",
+          ...corsHeaders(origin),
+        }
 
         const session = await getSessionFromBearerOrCookie(request)
         if (!session?.userId) {
@@ -131,11 +142,16 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
         const data = parsed.data
 
         // Check organizer team membership from parsed data
-        const isTeamMember = session.teams?.some((t) => t.id === data.organizingTeamId)
+        const isTeamMember = session.teams?.some(
+          (t) => t.id === data.organizingTeamId,
+        )
         const isSiteAdmin = session.user?.role === "admin"
 
         if (!isTeamMember && !isSiteAdmin) {
-          return json({ error: "Not authorized for this team" }, { status: 403, headers })
+          return json(
+            { error: "Not authorized for this team" },
+            { status: 403, headers },
+          )
         }
 
         const db = getDb()
@@ -158,7 +174,10 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
               .limit(1)
 
             if (!workoutRow) {
-              return json({ error: "Workout not found" }, { status: 404, headers })
+              return json(
+                { error: "Workout not found" },
+                { status: 404, headers },
+              )
             }
             workoutInfo = workoutRow
           }
@@ -170,7 +189,10 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
             .where(eq(competitionsTable.id, data.competitionId))
             .limit(1)
 
-          if (competition?.competitionType === "online") {
+          if (
+            competition &&
+            competitionCan(competition.competitionType, "submissionWindows")
+          ) {
             const [event] = await db
               .select({
                 submissionOpensAt: competitionEventsTable.submissionOpensAt,
@@ -180,7 +202,10 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
               .where(
                 and(
                   eq(competitionEventsTable.competitionId, data.competitionId),
-                  eq(competitionEventsTable.trackWorkoutId, data.trackWorkoutId),
+                  eq(
+                    competitionEventsTable.trackWorkoutId,
+                    data.trackWorkoutId,
+                  ),
                 ),
               )
               .limit(1)
@@ -197,8 +222,10 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
           }
 
           const scheme = workoutInfo.scheme as ScoringWorkoutScheme
-          const scoreType = (workoutInfo.scoreType as ScoreType) || getDefaultScoreType(scheme)
-          const workoutTiebreakScheme = (workoutInfo.tiebreakScheme as TiebreakScheme) ?? null
+          const scoreType =
+            (workoutInfo.scoreType as ScoreType) || getDefaultScoreType(scheme)
+          const workoutTiebreakScheme =
+            (workoutInfo.tiebreakScheme as TiebreakScheme) ?? null
 
           let encodedValue: number | null = null
           let encodedRounds: number[] = []
@@ -207,7 +234,9 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
           )
 
           if (data.roundScores && data.roundScores.length > 0) {
-            const roundInputs = data.roundScores.map((rs) => ({ raw: rs.score }))
+            const roundInputs = data.roundScores.map((rs) => ({
+              raw: rs.score,
+            }))
             const result = encodeRounds(roundInputs, scheme, scoreType)
             // Reject partial rounds so roundStatuses aligns with the rows
             // we insert below (encodeRounds silently drops null encodes).
@@ -264,13 +293,18 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
           let tiebreakValue: number | null = null
           if (data.tieBreakScore && workoutInfo.tiebreakScheme) {
             try {
-              tiebreakValue = encodeScore(data.tieBreakScore, workoutInfo.tiebreakScheme as ScoringWorkoutScheme)
+              tiebreakValue = encodeScore(
+                data.tieBreakScore,
+                workoutInfo.tiebreakScheme as ScoringWorkoutScheme,
+              )
             } catch {
               // ignore tiebreak encoding errors
             }
           }
 
-          const timeCapMs = workoutInfo.timeCap ? workoutInfo.timeCap * 1000 : null
+          const timeCapMs = workoutInfo.timeCap
+            ? workoutInfo.timeCap * 1000
+            : null
 
           const sortKey =
             encodedValue !== null
@@ -286,7 +320,10 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
                       : undefined,
                   tiebreak:
                     tiebreakValue !== null && workoutInfo.tiebreakScheme
-                      ? { scheme: workoutInfo.tiebreakScheme as "time" | "reps", value: tiebreakValue }
+                      ? {
+                          scheme: workoutInfo.tiebreakScheme as "time" | "reps",
+                          value: tiebreakValue,
+                        }
                       : undefined,
                 })
               : null
@@ -341,18 +378,22 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
               .where(and(...finalScoreConditions))
               .limit(1)
 
-            if (!finalScore) throw new Error("Failed to retrieve score after upsert")
+            if (!finalScore)
+              throw new Error("Failed to retrieve score after upsert")
 
             const id = finalScore.id
 
             if (data.roundScores && data.roundScores.length > 0) {
-              await tx.delete(scoreRoundsTable).where(eq(scoreRoundsTable.scoreId, id))
+              await tx
+                .delete(scoreRoundsTable)
+                .where(eq(scoreRoundsTable.scoreId, id))
 
               const roundsToInsert = data.roundScores.map((round, index) => {
                 let roundValue: number
 
                 if (scheme === "rounds-reps") {
-                  const roundsNum = Number.parseInt(round.parts?.[0] ?? round.score, 10) || 0
+                  const roundsNum =
+                    Number.parseInt(round.parts?.[0] ?? round.score, 10) || 0
                   const reps = Number.parseInt(round.parts?.[1] ?? "0", 10) || 0
                   roundValue = roundsNum * 100000 + reps
                 } else {
@@ -373,10 +414,16 @@ export const Route = createFileRoute("/api/compete/scores/judge")({
             return id
           })
 
-          return json({ success: true, data: { resultId: scoreId, isNew: true } }, { headers })
+          return json(
+            { success: true, data: { resultId: scoreId, isNew: true } },
+            { headers },
+          )
         } catch (err) {
           console.error("[API] /api/compete/scores/judge error:", err)
-          return json({ error: "Internal server error" }, { status: 500, headers })
+          return json(
+            { error: "Internal server error" },
+            { status: 500, headers },
+          )
         }
       },
     },

--- a/apps/wodsmith-start/src/routes/api/compete/scores/submit.ts
+++ b/apps/wodsmith-start/src/routes/api/compete/scores/submit.ts
@@ -33,6 +33,7 @@ import {
 import { scoresTable } from "@/db/schemas/scores"
 import type { TiebreakScheme } from "@/db/schemas/workouts"
 import { workouts } from "@/db/schemas/workouts"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import {
   computeSortKey,
   encodeScore,
@@ -67,7 +68,10 @@ async function checkSubmissionWindow(
     .where(eq(competitionsTable.id, competitionId))
     .limit(1)
 
-  if (!competition || competition.competitionType !== "online") {
+  if (
+    !competition ||
+    !competitionCan(competition.competitionType, "submissionWindows")
+  ) {
     return { isOpen: false, reason: "Not an online competition" }
   }
 

--- a/apps/wodsmith-start/src/routes/api/compete/scores/window-status.ts
+++ b/apps/wodsmith-start/src/routes/api/compete/scores/window-status.ts
@@ -14,6 +14,7 @@ import {
   competitionEventsTable,
   competitionsTable,
 } from "@/db/schemas/competitions"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import { corsHeaders } from "@/utils/bearer-auth"
 
 async function getSubmissionWindowStatus(
@@ -29,10 +30,15 @@ async function getSubmissionWindowStatus(
     .limit(1)
 
   if (!competition) {
-    return { isOpen: false, opensAt: null, closesAt: null, reason: "Competition not found" }
+    return {
+      isOpen: false,
+      opensAt: null,
+      closesAt: null,
+      reason: "Competition not found",
+    }
   }
 
-  if (competition.competitionType !== "online") {
+  if (!competitionCan(competition.competitionType, "submissionWindows")) {
     return {
       isOpen: false,
       opensAt: null,
@@ -56,7 +62,12 @@ async function getSubmissionWindowStatus(
     .limit(1)
 
   if (!event || !event.submissionOpensAt || !event.submissionClosesAt) {
-    return { isOpen: false, opensAt: null, closesAt: null, reason: "Submission window not configured" }
+    return {
+      isOpen: false,
+      opensAt: null,
+      closesAt: null,
+      reason: "Submission window not configured",
+    }
   }
 
   const now = new Date()
@@ -81,7 +92,11 @@ async function getSubmissionWindowStatus(
     }
   }
 
-  return { isOpen: true, opensAt: event.submissionOpensAt, closesAt: event.submissionClosesAt }
+  return {
+    isOpen: true,
+    opensAt: event.submissionOpensAt,
+    closesAt: event.submissionClosesAt,
+  }
 }
 
 export const Route = createFileRoute("/api/compete/scores/window-status")({
@@ -111,11 +126,17 @@ export const Route = createFileRoute("/api/compete/scores/window-status")({
         }
 
         try {
-          const status = await getSubmissionWindowStatus(competitionId, trackWorkoutId)
+          const status = await getSubmissionWindowStatus(
+            competitionId,
+            trackWorkoutId,
+          )
           return json(status, { headers })
         } catch (err) {
           console.error("[API] /api/compete/scores/window-status error:", err)
-          return json({ error: "Internal server error" }, { status: 500, headers })
+          return json(
+            { error: "Internal server error" },
+            { status: 500, headers },
+          )
         }
       },
     },

--- a/apps/wodsmith-start/src/routes/api/compete/video/submit.ts
+++ b/apps/wodsmith-start/src/routes/api/compete/video/submit.ts
@@ -28,11 +28,18 @@ import {
   competitionsTable,
   REGISTRATION_STATUS,
 } from "@/db/schemas/competitions"
-import { programmingTracksTable, trackWorkoutsTable } from "@/db/schemas/programming"
+import {
+  programmingTracksTable,
+  trackWorkoutsTable,
+} from "@/db/schemas/programming"
 import { scoresTable } from "@/db/schemas/scores"
+import {
+  createVideoSubmissionId,
+  videoSubmissionsTable,
+} from "@/db/schemas/video-submissions"
 import type { TiebreakScheme } from "@/db/schemas/workouts"
 import { workouts } from "@/db/schemas/workouts"
-import { createVideoSubmissionId, videoSubmissionsTable } from "@/db/schemas/video-submissions"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import {
   computeSortKey,
   encodeScore,
@@ -57,7 +64,10 @@ const submitVideoSchema = z.object({
   tiebreakScore: z.string().optional(),
 })
 
-async function checkVideoSubmissionWindow(competitionId: string, trackWorkoutId: string) {
+async function checkVideoSubmissionWindow(
+  competitionId: string,
+  trackWorkoutId: string,
+) {
   const db = getDb()
 
   const [competition] = await db
@@ -68,8 +78,11 @@ async function checkVideoSubmissionWindow(competitionId: string, trackWorkoutId:
 
   if (!competition) return { allowed: false, reason: "Competition not found" }
 
-  if (competition.competitionType !== "online") {
-    return { allowed: false, reason: "Video submissions are only for online competitions" }
+  if (!competitionCan(competition.competitionType, "videoSubmissions")) {
+    return {
+      allowed: false,
+      reason: "Video submissions are only for online competitions",
+    }
   }
 
   const [event] = await db
@@ -114,7 +127,10 @@ export const Route = createFileRoute("/api/compete/video/submit")({
 
       POST: async ({ request }: { request: Request }) => {
         const origin = request.headers.get("Origin")
-        const headers = { "Content-Type": "application/json", ...corsHeaders(origin) }
+        const headers = {
+          "Content-Type": "application/json",
+          ...corsHeaders(origin),
+        }
 
         const session = await getSessionFromBearerOrCookie(request)
         if (!session?.userId) {
@@ -147,7 +163,10 @@ export const Route = createFileRoute("/api/compete/video/submit")({
           const regConditions = [
             eq(competitionRegistrationsTable.eventId, data.competitionId),
             eq(competitionRegistrationsTable.userId, userId),
-            ne(competitionRegistrationsTable.status, REGISTRATION_STATUS.REMOVED),
+            ne(
+              competitionRegistrationsTable.status,
+              REGISTRATION_STATUS.REMOVED,
+            ),
           ]
           if (data.divisionId) {
             regConditions.push(
@@ -178,7 +197,10 @@ export const Route = createFileRoute("/api/compete/video/submit")({
 
           if (!registration) {
             return json(
-              { error: "You must be registered for this competition to submit a video" },
+              {
+                error:
+                  "You must be registered for this competition to submit a video",
+              },
               { status: 403, headers },
             )
           }
@@ -190,7 +212,9 @@ export const Route = createFileRoute("/api/compete/video/submit")({
           )
           if (!windowCheck.allowed) {
             return json(
-              { error: windowCheck.reason ?? "Cannot submit video at this time" },
+              {
+                error: windowCheck.reason ?? "Cannot submit video at this time",
+              },
               { status: 422, headers },
             )
           }
@@ -213,7 +237,12 @@ export const Route = createFileRoute("/api/compete/video/submit")({
           if (existingSubmission) {
             await db
               .update(videoSubmissionsTable)
-              .set({ videoUrl: data.videoUrl, notes: data.notes ?? null, submittedAt: now, updatedAt: now })
+              .set({
+                videoUrl: data.videoUrl,
+                notes: data.notes ?? null,
+                submittedAt: now,
+                updatedAt: now,
+              })
               .where(eq(videoSubmissionsTable.id, existingSubmission.id))
             submissionId = existingSubmission.id
           } else {
@@ -242,21 +271,30 @@ export const Route = createFileRoute("/api/compete/video/submit")({
                 trackId: trackWorkoutsTable.trackId,
               })
               .from(trackWorkoutsTable)
-              .innerJoin(workouts, eq(trackWorkoutsTable.workoutId, workouts.id))
+              .innerJoin(
+                workouts,
+                eq(trackWorkoutsTable.workoutId, workouts.id),
+              )
               .where(eq(trackWorkoutsTable.id, data.trackWorkoutId))
               .limit(1)
 
             if (!workoutRow) {
-              return json({ error: "Workout not found" }, { status: 404, headers })
+              return json(
+                { error: "Workout not found" },
+                { status: 404, headers },
+              )
             }
 
             const scheme = workoutRow.scheme as WorkoutScheme
-            const scoreType = (workoutRow.scoreType as ScoreType) || getDefaultScoreType(scheme)
+            const scoreType =
+              (workoutRow.scoreType as ScoreType) || getDefaultScoreType(scheme)
 
             const parseResult = parseScore(data.score, scheme)
             if (!parseResult.isValid) {
               return json(
-                { error: `Invalid score format: ${parseResult.error || "Please check your entry"}` },
+                {
+                  error: `Invalid score format: ${parseResult.error || "Please check your entry"}`,
+                },
                 { status: 422, headers },
               )
             }
@@ -265,7 +303,11 @@ export const Route = createFileRoute("/api/compete/video/submit")({
             let status: "scored" | "cap" = data.scoreStatus ?? "scored"
             let secondaryValue: number | null = null
 
-            if (scheme === "time-with-cap" && workoutRow.timeCap && encodedValue !== null) {
+            if (
+              scheme === "time-with-cap" &&
+              workoutRow.timeCap &&
+              encodedValue !== null
+            ) {
               const capMs = workoutRow.timeCap * 1000
               if (encodedValue >= capMs) {
                 status = "cap"
@@ -282,10 +324,15 @@ export const Route = createFileRoute("/api/compete/video/submit")({
 
             let tiebreakValue: number | null = null
             if (data.tiebreakScore && workoutRow.tiebreakScheme) {
-              tiebreakValue = encodeScore(data.tiebreakScore, workoutRow.tiebreakScheme as WorkoutScheme)
+              tiebreakValue = encodeScore(
+                data.tiebreakScore,
+                workoutRow.tiebreakScheme as WorkoutScheme,
+              )
             }
 
-            const timeCapMs = workoutRow.timeCap ? workoutRow.timeCap * 1000 : null
+            const timeCapMs = workoutRow.timeCap
+              ? workoutRow.timeCap * 1000
+              : null
 
             const sortKey =
               encodedValue !== null
@@ -300,7 +347,12 @@ export const Route = createFileRoute("/api/compete/video/submit")({
                         : undefined,
                     tiebreak:
                       tiebreakValue !== null && workoutRow.tiebreakScheme
-                        ? { scheme: workoutRow.tiebreakScheme as "time" | "reps", value: tiebreakValue }
+                        ? {
+                            scheme: workoutRow.tiebreakScheme as
+                              | "time"
+                              | "reps",
+                            value: tiebreakValue,
+                          }
                         : undefined,
                   })
                 : null
@@ -312,10 +364,14 @@ export const Route = createFileRoute("/api/compete/video/submit")({
               .limit(1)
 
             if (!track?.ownerTeamId) {
-              return json({ error: "Could not determine team ownership" }, { status: 500, headers })
+              return json(
+                { error: "Could not determine team ownership" },
+                { status: 500, headers },
+              )
             }
 
-            const statusOrder = status === "cap" ? STATUS_ORDER.cap : STATUS_ORDER.scored
+            const statusOrder =
+              status === "cap" ? STATUS_ORDER.cap : STATUS_ORDER.scored
 
             await db
               .insert(scoresTable)
@@ -330,7 +386,8 @@ export const Route = createFileRoute("/api/compete/video/submit")({
                 status,
                 statusOrder,
                 sortKey: sortKey ? sortKeyToString(sortKey) : null,
-                tiebreakScheme: (workoutRow.tiebreakScheme as TiebreakScheme) ?? null,
+                tiebreakScheme:
+                  (workoutRow.tiebreakScheme as TiebreakScheme) ?? null,
                 tiebreakValue,
                 timeCapMs,
                 secondaryValue,
@@ -344,7 +401,8 @@ export const Route = createFileRoute("/api/compete/video/submit")({
                   status,
                   statusOrder,
                   sortKey: sortKey ? sortKeyToString(sortKey) : null,
-                  tiebreakScheme: (workoutRow.tiebreakScheme as TiebreakScheme) ?? null,
+                  tiebreakScheme:
+                    (workoutRow.tiebreakScheme as TiebreakScheme) ?? null,
                   tiebreakValue,
                   timeCapMs,
                   secondaryValue,
@@ -360,7 +418,10 @@ export const Route = createFileRoute("/api/compete/video/submit")({
           )
         } catch (err) {
           console.error("[API] /api/compete/video/submit error:", err)
-          return json({ error: "Internal server error" }, { status: 500, headers })
+          return json(
+            { error: "Internal server error" },
+            { status: 500, headers },
+          )
         }
       },
     },

--- a/apps/wodsmith-start/src/server-fns/athlete-score-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/athlete-score-fns.ts
@@ -15,14 +15,6 @@ import { and, eq, isNull, ne, type SQL } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import {
-  addRequestContextAttribute,
-  logEntityUpdated,
-  logError,
-  logInfo,
-  logWarning,
-  updateRequestContext,
-} from "@/lib/logging"
-import {
   competitionEventsTable,
   competitionRegistrationsTable,
   competitionsTable,
@@ -35,6 +27,15 @@ import {
 import { scoresTable } from "@/db/schemas/scores"
 import type { TiebreakScheme } from "@/db/schemas/workouts"
 import { workouts } from "@/db/schemas/workouts"
+import { competitionCan } from "@/lib/competitions/capabilities"
+import {
+  addRequestContextAttribute,
+  logEntityUpdated,
+  logError,
+  logInfo,
+  logWarning,
+  updateRequestContext,
+} from "@/lib/logging"
 import {
   computeSortKey,
   encodeScore,
@@ -148,8 +149,7 @@ async function checkSubmissionWindow(
     }
   }
 
-  // Only check submission windows for online competitions
-  if (competition.competitionType !== "online") {
+  if (!competitionCan(competition.competitionType, "submissionWindows")) {
     return {
       isOpen: false,
       opensAt: null,
@@ -278,9 +278,7 @@ async function resolveAthleteDivisionId({
   if (regs.length === 0) return { kind: "notFound" }
   if (regs.length > 1) return { kind: "ambiguous" }
   const divisionId = regs[0].divisionId
-  return divisionId
-    ? { kind: "specific", divisionId }
-    : { kind: "open" }
+  return divisionId ? { kind: "specific", divisionId } : { kind: "open" }
 }
 
 /**

--- a/apps/wodsmith-start/src/server-fns/competition-score-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-score-fns.ts
@@ -15,16 +15,6 @@ import { and, eq, gt, inArray, isNull, ne, or } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import {
-  addRequestContextAttribute,
-  logEntityDeleted,
-  logEntityUpdated,
-  logError,
-  logInfo,
-  logWarning,
-  updateRequestContext,
-} from "@/lib/logging"
-import { getEvlog } from "@/lib/evlog"
-import {
   type CompetitionHeat,
   competitionEventsTable,
   competitionHeatAssignmentsTable,
@@ -41,7 +31,7 @@ import {
 } from "@/db/schemas/programming"
 import { scalingLevelsTable } from "@/db/schemas/scaling"
 import { scoreRoundsTable, scoresTable } from "@/db/schemas/scores"
-import { teamMembershipTable } from "@/db/schemas/teams"
+import { TEAM_PERMISSIONS, teamMembershipTable } from "@/db/schemas/teams"
 import { userTable } from "@/db/schemas/users"
 import {
   SCORE_STATUS_VALUES,
@@ -51,7 +41,19 @@ import {
   type WorkoutScheme,
   workouts,
 } from "@/db/schemas/workouts"
+import { competitionCan } from "@/lib/competitions/capabilities"
+import { getEvlog } from "@/lib/evlog"
 import {
+  addRequestContextAttribute,
+  logEntityDeleted,
+  logEntityUpdated,
+  logError,
+  logInfo,
+  logWarning,
+  updateRequestContext,
+} from "@/lib/logging"
+import {
+  aggregateValues,
   computeSortKey,
   decodeScore,
   encodeRounds,
@@ -63,8 +65,6 @@ import {
 } from "@/lib/scoring"
 import { getSessionFromCookie } from "@/utils/auth"
 import { requireTeamPermission } from "@/utils/team-auth"
-import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
-import { aggregateValues } from "@/lib/scoring"
 
 // ============================================================================
 // Types
@@ -163,7 +163,7 @@ export interface EventScoreEntryDataWithHeats extends EventScoreEntryData {
 
 /**
  * Check if current time is within the event's submission window.
- * Only applies to online competitions.
+ * Only applies to competitions with submission windows.
  */
 async function isWithinSubmissionWindow(
   competitionId: string,
@@ -184,8 +184,7 @@ async function isWithinSubmissionWindow(
     return { allowed: false, reason: "Competition not found" }
   }
 
-  // Only check submission windows for online competitions
-  if (competition.competitionType !== "online") {
+  if (!competitionCan(competition.competitionType, "submissionWindows")) {
     return { allowed: true }
   }
 
@@ -926,9 +925,7 @@ export const getEventScoreEntryDataWithHeatsBatchFn = createServerFn({
     getEventScoreEntryDataBatchInputSchema.parse(data),
   )
   .handler(
-    async ({
-      data,
-    }): Promise<Record<string, EventScoreEntryDataWithHeats>> => {
+    async ({ data }): Promise<Record<string, EventScoreEntryDataWithHeats>> => {
       const db = getDb()
       if (data.trackWorkoutIds.length === 0) {
         return {}
@@ -1136,7 +1133,8 @@ export const getEventScoreEntryDataWithHeatsBatchFn = createServerFn({
               description: row.workoutDescription,
               scheme: row.workoutScheme as WorkoutScheme,
               scoreType: row.workoutScoreType as ScoreType | null,
-              tiebreakScheme: row.workoutTiebreakScheme as TiebreakScheme | null,
+              tiebreakScheme:
+                row.workoutTiebreakScheme as TiebreakScheme | null,
               timeCap: row.workoutTimeCap,
               repsPerRound: row.workoutRepsPerRound,
               roundsToScore: row.workoutRoundsToScore,

--- a/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
@@ -38,6 +38,7 @@ import {
 import { videoVotesTable } from "@/db/schemas/video-votes"
 import type { TiebreakScheme } from "@/db/schemas/workouts"
 import { workouts } from "@/db/schemas/workouts"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import {
   computeSortKey,
   decodeScore,
@@ -109,7 +110,7 @@ function getStatusOrder(status: "scored" | "cap"): number {
 
 /**
  * Check if current time is within the event's submission window.
- * Only applies to online competitions.
+ * Only applies to competitions with video submissions.
  */
 async function checkSubmissionWindow(
   competitionId: string,
@@ -135,8 +136,7 @@ async function checkSubmissionWindow(
     return { allowed: false, reason: "Competition not found" }
   }
 
-  // Only check submission windows for online competitions
-  if (competition.competitionType !== "online") {
+  if (!competitionCan(competition.competitionType, "videoSubmissions")) {
     return {
       allowed: false,
       reason: "Video submissions are only for online competitions",
@@ -933,8 +933,7 @@ export const submitVideoFn = createServerFn({ method: "POST" })
     // the score is only sent with the first slot (videoIndex 0) and shared
     // across the team's submission, so subsequent slots intentionally arrive
     // without a score and must not be rejected here.
-    const hasRoundScores =
-      data.roundScores && data.roundScores.length > 0
+    const hasRoundScores = data.roundScores && data.roundScores.length > 0
     const hasScore = data.score || hasRoundScores
 
     if (data.videoIndex === 0 && !hasScore) {
@@ -1253,10 +1252,7 @@ export const getOrganizerSubmissionsFn = createServerFn({ method: "GET" })
       .where(
         and(
           eq(videoSubmissionsTable.trackWorkoutId, data.trackWorkoutId),
-          ne(
-            competitionRegistrationsTable.status,
-            REGISTRATION_STATUS.REMOVED,
-          ),
+          ne(competitionRegistrationsTable.status, REGISTRATION_STATUS.REMOVED),
         ),
       )
       .orderBy(asc(videoSubmissionsTable.videoIndex))

--- a/apps/wodsmith-start/test/server-fns/competition-score-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/competition-score-fns.test.ts
@@ -428,6 +428,65 @@ describe('Competition Score Server Functions (TanStack)', () => {
       ).rejects.toThrow('Workout info is required to save competition score')
     })
 
+    it('continues in-person score saves past the submission-window gate', async () => {
+      mockDbInstance = createDbMock({
+        withSubmissionWindowCheck: true,
+        competition: {competitionType: 'in-person'},
+      })
+
+      await expect(
+        saveCompetitionScoreFn({
+          data: {
+            competitionId: 'comp-1',
+            organizingTeamId: 'team-1',
+            trackWorkoutId: 'tw-1',
+            workoutId: 'wod-1',
+            registrationId: 'reg-1',
+            userId: 'user-1',
+            divisionId: 'div-1',
+            score: '5:00',
+            scoreStatus: 'scored',
+          },
+        }),
+      ).rejects.toThrow('Workout info is required to save competition score')
+    })
+
+    it('blocks online score saves after the submission window closes', async () => {
+      const now = new Date()
+      mockDbInstance = createDbMock({
+        withSubmissionWindowCheck: true,
+        competition: {competitionType: 'online'},
+        competitionEvent: {
+          submissionOpensAt: new Date(now.getTime() - 7200000),
+          submissionClosesAt: new Date(now.getTime() - 3600000),
+        },
+      })
+
+      await expect(
+        saveCompetitionScoreFn({
+          data: {
+            competitionId: 'comp-1',
+            organizingTeamId: 'team-1',
+            trackWorkoutId: 'tw-1',
+            workoutId: 'wod-1',
+            registrationId: 'reg-1',
+            userId: 'user-1',
+            divisionId: 'div-1',
+            score: '5:00',
+            scoreStatus: 'scored',
+            workout: {
+              scheme: 'time',
+              scoreType: 'min',
+              repsPerRound: null,
+              roundsToScore: 1,
+              timeCap: null,
+              tiebreakScheme: null,
+            },
+          },
+        }),
+      ).rejects.toThrow(/Submission window closed at/)
+    })
+
     it('saves a time score correctly', async () => {
       const teamResult = {ownerTeamId: 'team-1'}
       const finalScore = {id: 'score-new'}

--- a/apps/wodsmith-start/test/server-fns/video-submission-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/video-submission-fns.test.ts
@@ -78,7 +78,7 @@ const setMockSession = (session: unknown) => {
 function createTestCompetition(
 	overrides?: Partial<{
 		id: string
-		competitionType: "in_person" | "online"
+		competitionType: "in-person" | "online"
 	}>,
 ) {
 	return {
@@ -267,7 +267,7 @@ describe("Video Submission Server Functions (TanStack)", () => {
 
 		it("returns canSubmit false for in-person competitions", async () => {
 			const registration = createTestRegistration()
-			const competition = createTestCompetition({ competitionType: "in_person" })
+			const competition = createTestCompetition({ competitionType: "in-person" })
 
 			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
 			const orderByMock = mockDb.getChainMock().orderBy as ReturnType<typeof vi.fn>
@@ -561,6 +561,28 @@ describe("Video Submission Server Functions (TanStack)", () => {
 					},
 				}),
 			).rejects.toThrow("Submission window has closed")
+		})
+
+		it("throws for in-person competitions before writing video submissions", async () => {
+			const registration = createTestRegistration()
+			const competition = createTestCompetition({ competitionType: "in-person" })
+
+			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
+			limitMock
+				.mockResolvedValueOnce([registration])
+				.mockResolvedValueOnce([competition])
+
+			await expect(
+				submitVideoFn({
+					data: {
+						trackWorkoutId: "tw-1",
+						competitionId: "comp-1",
+						videoUrl: "https://youtube.com/watch?v=test",
+					},
+				}),
+			).rejects.toThrow("Video submissions are only for online competitions")
+
+			expect(mockDb.insert).not.toHaveBeenCalled()
 		})
 
 		it("creates new video submission successfully", async () => {

--- a/lat.md/competition-type-capabilities.md
+++ b/lat.md/competition-type-capabilities.md
@@ -12,6 +12,8 @@ The registry maps each competition type to named capabilities, its leaderboard v
 
 [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#COMPETITION_TYPE_REGISTRY]] keeps `competitionType` as the stored discriminator and exposes [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#competitionCan]], [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#leaderboardVariant]], and [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]] for later call-site refactors. In-person competitions retain heat scheduling, day-of check-in, physical venue, volunteer scheduling, and organizer-entered results. Online competitions retain video submissions, submission windows, opt-in result publishing, and the online leaderboard variant.
 
+Server submission gates now consume the registry for the low-risk API and server-function paths: score-window checks use `submissionWindows`, while video submission checks use `videoSubmissions`. The leaderboard video-submission fetch gate remains deferred because GitNexus reported a HIGH blast radius for [[apps/wodsmith-start/src/server/competition-leaderboard.ts#getCompetitionLeaderboard]].
+
 The `scoringAlgorithm === "online"` axis remains separate from `competitionType === "online"`. Capability checks must not replace scoring-algorithm branches.
 
 ## Capability Truth Table Test
@@ -19,3 +21,5 @@ The `scoringAlgorithm === "online"` axis remains separate from `competitionType 
 The truth-table test pins every capability and leaderboard variant for in-person and online competitions before call sites are refactored.
 
 [[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies each capability for both current types, confirms registry metadata matches type identity, and covers the unknown-type fallback. This is the PR-1 safety net for the M0 competition-type capability registry.
+
+Focused PR-2 server-function tests pin that in-person score saves pass the submission-window gate, online score saves still honor closed windows, and in-person video submissions still reject before writes. Route-level API gates remain covered by the shared helper intent rather than brittle full router units.


### PR DESCRIPTION
## Summary

- Refactors LOW-risk server/API submission-window gates to use `competitionCan(type, "submissionWindows")`.
- Refactors video-submission server/API gates to use `competitionCan(type, "videoSubmissions")`.
- Adds focused server-function characterization tests for in-person/online behavior before and after the swap, and updates lat.md with the PR-2 scope.

## Deferred

- `apps/wodsmith-start/src/server/competition-leaderboard.ts` video-submission fetch gate is intentionally deferred. GitNexus reported HIGH blast radius for `getCompetitionLeaderboard`: 4 direct callers and 9 upstream affected symbols across leaderboard API, leaderboard server-fn, event leaderboard, and invite roster flows.
- Route-level API units are not added here because the file-route handlers are coupled to TanStack/router and DB plumbing; the same gate intent is covered through focused server-function tests and the registry truth-table test.

## Validation

- `lat search "competition type capability registry server submission axis video submissions submission windows"`
- `lat expand "Implement plan §8 PR-2 Server submission axis..."`
- `PATH=/Users/zacjones/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm --dir apps/wodsmith-start exec vitest run test/lib/competitions/capabilities.test.ts test/server-fns/video-submission-fns.test.ts test/server-fns/competition-score-fns.test.ts` (76 tests)
- `PATH=/Users/zacjones/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm --dir apps/wodsmith-start exec biome check --write ...changed files...`
- `PATH=/Users/zacjones/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH corepack pnpm --dir apps/wodsmith-start run type-check`
- `lat check`
- pre-push hook: `pnpm lint` and `pnpm type-check` passed repo-wide; lint emitted existing warnings in unrelated files.

## GitNexus

- Refreshed index with `npx gitnexus analyze`.
- LOW impact: score submit `checkSubmissionWindow`, video submit `checkVideoSubmissionWindow`, window-status `getSubmissionWindowStatus`, athlete-score `checkSubmissionWindow`, competition-score `isWithinSubmissionWindow`, video-submission `checkSubmissionWindow`, judge route `POST`.
- HIGH impact found and deferred: `getCompetitionLeaderboard`.
- Staged `gitnexus_detect_changes` reported CRITICAL because staged API `POST` handlers/server fns are entry points; changed files are limited to the expected PR-2 server/API targets, tests, and lat docs.

## Reviewer notes

- Messages remain backward-compatible: current in-person/online behavior is preserved while predicates now express capability intent.
- Biome reflowed some touched API files while applying changed-file formatting.

* `main` <!-- branch-stack -->
  - \#513
    - **\[codex] Use capability registry for server submission gates** :point\_left:


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored server/API submission gates to use the capability registry via `competitionCan(...)` for `submissionWindows` and `videoSubmissions`, preserving current in‑person vs online behavior and clarifying intent.

- **Refactors**
  - Swapped competition-type checks for `competitionCan` in `scores/judge`, `scores/submit`, `scores/window-status`, `video/submit`, and related server fns.
  - Added focused server-function tests covering in‑person pass/online block cases for score and video submissions.
  - Deferred leaderboard video-submission gate in `getCompetitionLeaderboard` due to high blast radius.
  - Updated `lat.md` to document the PR-2 scope.

<sup>Written for commit cb41647ce5c0f4ea093e90e6316973ec9acf05bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

