### PR TITLE
[codex] Mitigate docs-video upload buffering

### DIFF
--- a/apps/wodsmith-start/src/lib/upload-limits.ts
+++ b/apps/wodsmith-start/src/lib/upload-limits.ts
@@ -1,0 +1,1 @@
+export const DOCS_VIDEO_MAX_SIZE_MB = 32

--- a/apps/wodsmith-start/src/routes/admin/docs/-components/route-doc-form.tsx
+++ b/apps/wodsmith-start/src/routes/admin/docs/-components/route-doc-form.tsx
@@ -48,6 +48,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { ROUTE_DOC_TYPES } from "@/db/schemas/route-docs"
+import { DOCS_VIDEO_MAX_SIZE_MB } from "@/lib/upload-limits"
 import { ORGANIZER_ROUTE_PREFIX } from "@/utils/route-docs"
 
 function isValidUrl(value: string): boolean {
@@ -502,8 +503,8 @@ function VideoField({
         </Button>
       </div>
       <p className="text-xs text-muted-foreground">
-        Paste a YouTube/Vimeo URL, or upload an MP4/WebM/MOV (max 100MB, stored
-        on R2).
+        Paste a YouTube/Vimeo URL, or upload an MP4/WebM/MOV (max{" "}
+        {DOCS_VIDEO_MAX_SIZE_MB}MB, stored on R2).
       </p>
     </div>
   )
@@ -529,7 +530,11 @@ function RoutePicker({
     return ids
       .filter(
         (routeId) =>
-          !(routeId.length > 1 && routeId.endsWith("/") && idSet.has(routeId.slice(0, -1))),
+          !(
+            routeId.length > 1 &&
+            routeId.endsWith("/") &&
+            idSet.has(routeId.slice(0, -1))
+          ),
       )
       .sort()
   }, [router])

--- a/apps/wodsmith-start/src/routes/api/upload.ts
+++ b/apps/wodsmith-start/src/routes/api/upload.ts
@@ -28,6 +28,7 @@ import {
   logWarning,
   updateRequestContext,
 } from "@/lib/logging"
+import { DOCS_VIDEO_MAX_SIZE_MB } from "@/lib/upload-limits"
 import { checkUploadAuthorization } from "@/server/upload-authorization"
 import { getSessionFromCookie } from "@/utils/auth"
 
@@ -76,10 +77,17 @@ const PURPOSE_CONFIG: Record<
   },
   // Documentation drawer videos (site admin only, see upload-authorization)
   "docs-video": {
-    maxSizeMb: 100,
+    maxSizeMb: DOCS_VIDEO_MAX_SIZE_MB,
     pathPrefix: "docs/videos",
     allowedTypes: VIDEO_TYPES,
   },
+}
+
+async function getR2UploadBody(file: File, purpose: string) {
+  if (purpose === "docs-video") {
+    return file.stream()
+  }
+  return await file.arrayBuffer()
 }
 
 export const Route = createFileRoute("/api/upload")({
@@ -198,7 +206,7 @@ export const Route = createFileRoute("/api/upload")({
           : `${config.pathPrefix}/${session.user.id}/${filename}`
 
         try {
-          await env.R2_BUCKET.put(key, await file.arrayBuffer(), {
+          await env.R2_BUCKET.put(key, await getR2UploadBody(file, purpose), {
             httpMetadata: {
               contentType: file.type,
             },

--- a/apps/wodsmith-start/test/routes/api/upload.test.ts
+++ b/apps/wodsmith-start/test/routes/api/upload.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockR2Put = vi.hoisted(() => vi.fn())
+const mockGetSessionFromCookie = vi.hoisted(() => vi.fn())
+const mockCheckUploadAuthorization = vi.hoisted(() => vi.fn())
+
+vi.mock("cloudflare:workers", () => ({
+  env: {
+    R2_BUCKET: {
+      put: (...args: unknown[]) => mockR2Put(...args),
+    },
+    R2_PUBLIC_URL: "https://uploads.wodsmith.test",
+  },
+}))
+
+vi.mock("@/utils/auth", () => ({
+  getSessionFromCookie: (...args: unknown[]) =>
+    mockGetSessionFromCookie(...args),
+}))
+
+vi.mock("@/server/upload-authorization", () => ({
+  checkUploadAuthorization: (...args: unknown[]) =>
+    mockCheckUploadAuthorization(...args),
+}))
+
+vi.mock("@/lib/logging", () => ({
+  addRequestContextAttribute: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+  logWarning: vi.fn(),
+  updateRequestContext: vi.fn(),
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: unknown) => config,
+}))
+
+vi.mock("@tanstack/react-start", () => ({
+  json: (data: unknown, init?: { status?: number }) =>
+    new Response(JSON.stringify(data), {
+      status: init?.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+}))
+
+import { DOCS_VIDEO_MAX_SIZE_MB } from "@/lib/upload-limits"
+import { Route } from "@/routes/api/upload"
+
+const routeConfig = Route as unknown as {
+  server: {
+    handlers: {
+      POST: (args: { request: Request }) => Promise<Response>
+    }
+  }
+}
+
+function buildUploadRequest(file: File, purpose: string) {
+  return {
+    formData: vi.fn(async () => ({
+      get: (name: string) => {
+        if (name === "file") return file
+        if (name === "purpose") return purpose
+        if (name === "entityId") return null
+        return null
+      },
+    })),
+  } as unknown as Request
+}
+
+async function callUpload(file: File, purpose: string) {
+  return routeConfig.server.handlers.POST({
+    request: buildUploadRequest(file, purpose),
+  })
+}
+
+function createFileLike({
+  name,
+  size,
+  type,
+}: {
+  name: string
+  size: number
+  type: string
+}) {
+  return {
+    name,
+    size,
+    type,
+    arrayBuffer: vi.fn(),
+    stream: vi.fn(),
+  } as unknown as File
+}
+
+describe("upload API route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSessionFromCookie.mockResolvedValue({
+      user: { id: "user-admin", role: "admin" },
+    })
+    mockCheckUploadAuthorization.mockResolvedValue({ authorized: true })
+    mockR2Put.mockResolvedValue(undefined)
+  })
+
+  it("streams docs-video uploads to R2 without a second arrayBuffer copy", async () => {
+    // @lat: [[route-docs#Video storage#Streams docs-video without second buffer]]
+    const file = createFileLike({
+      name: "training.mp4",
+      size: 1024,
+      type: "video/mp4",
+    })
+    const uploadStream = { stream: true }
+    const arrayBufferSpy = vi
+      .mocked(file.arrayBuffer)
+      .mockRejectedValue(new Error("docs-video should not buffer"))
+    const streamSpy = vi
+      .mocked(file.stream)
+      .mockReturnValue(uploadStream as never)
+
+    const response = await callUpload(file, "docs-video")
+
+    expect(response.status).toBe(200)
+    expect(arrayBufferSpy).not.toHaveBeenCalled()
+    expect(streamSpy).toHaveBeenCalledTimes(1)
+    expect(mockR2Put).toHaveBeenCalledTimes(1)
+    expect(mockR2Put.mock.calls[0][0]).toMatch(
+      /^docs\/videos\/user-admin\/\d+\.mp4$/,
+    )
+    expect(mockR2Put.mock.calls[0][1]).toBe(uploadStream)
+  })
+
+  it("keeps non-video upload purposes on the existing buffered R2 path", async () => {
+    // @lat: [[route-docs#Video storage#Preserves non-video buffered uploads]]
+    const file = createFileLike({
+      name: "profile.png",
+      size: 1024,
+      type: "image/png",
+    })
+    const expectedBody = new ArrayBuffer(5)
+    const arrayBufferSpy = vi
+      .mocked(file.arrayBuffer)
+      .mockResolvedValue(expectedBody)
+    const streamSpy = vi.mocked(file.stream)
+
+    const response = await callUpload(file, "competition-profile")
+
+    expect(response.status).toBe(200)
+    expect(arrayBufferSpy).toHaveBeenCalledTimes(1)
+    expect(streamSpy).not.toHaveBeenCalled()
+    expect(mockR2Put).toHaveBeenCalledTimes(1)
+    expect(mockR2Put.mock.calls[0][1]).toBe(expectedBody)
+  })
+
+  it("rejects docs-video uploads above the demo-safe cap before R2 writes", async () => {
+    // @lat: [[route-docs#Video storage#Rejects docs-video above demo-safe cap]]
+    const file = createFileLike({
+      name: "oversized.mp4",
+      size: (DOCS_VIDEO_MAX_SIZE_MB + 1) * 1024 * 1024,
+      type: "video/mp4",
+    })
+
+    const response = await callUpload(file, "docs-video")
+    const data = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe(
+      `File too large. Maximum size is ${DOCS_VIDEO_MAX_SIZE_MB}MB`,
+    )
+    expect(mockR2Put).not.toHaveBeenCalled()
+  })
+})

--- a/lat.md/route-docs.md
+++ b/lat.md/route-docs.md
@@ -72,9 +72,27 @@ Dev environments get starter content from the `22-route-docs` seeder: a markdown
 
 ## Video storage
 
-Documentation videos upload to R2 through the existing `/api/upload` route using the `docs-video` purpose (MP4/WebM/MOV, 100MB max, stored under `docs/videos/`).
+Documentation videos upload to R2 through the existing `/api/upload` route using the `docs-video` purpose (MP4/WebM/MOV, 32MB max, stored under `docs/videos/`).
 
 Authorization in [[apps/wodsmith-start/src/server/upload-authorization.ts#checkUploadAuthorization]] restricts the purpose to site admins. Files are served from `R2_PUBLIC_URL` like other uploads; admins can alternatively paste YouTube/Vimeo URLs instead of uploading.
+
+### PR-1 upload mitigation
+
+Docs-video upload is capped at 32MB and sends `file.stream()` to R2 so the Worker avoids the extra `file.arrayBuffer()` copy that exhausted memory on larger videos.
+
+The route still parses the multipart body with `request.formData()`, so this is not the final large-video architecture. Larger training videos should use YouTube/Vimeo until PR-2 adds a signed direct-to-R2 upload protocol.
+
+### Streams docs-video without second buffer
+
+Verifies the `/api/upload` handler passes a docs-video file stream to R2 without calling `file.arrayBuffer()`, avoiding the extra memory copy that failed large demo uploads.
+
+### Preserves non-video buffered uploads
+
+Verifies generic upload purposes still pass `file.arrayBuffer()` results to R2, keeping image and PDF upload behavior unchanged while docs-video receives the targeted mitigation.
+
+### Rejects docs-video above demo-safe cap
+
+Verifies docs-video uploads above 32MB return the configured size error before R2 writes, keeping admin UI copy, route validation, and docs aligned around the proven-safe cap.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

This is PR-1: an immediate mitigation for demo docs-video upload failures, not the final direct-to-R2 solution.

- Lowers the `docs-video` upload cap from 100MB to the proven-safe 32MB limit and shares that value between the API route and admin UI copy.
- Changes only `docs-video` R2 writes to pass `file.stream()` into `R2_BUCKET.put()` instead of calling `file.arrayBuffer()` and creating a second full-file buffer.
- Keeps non-video upload purposes on the existing `file.arrayBuffer()` path.
- Updates `lat.md/route-docs.md` with the new behavior, tests, and residual follow-up.

## Root Cause

The deployed admin docs-video upload route advertised up to 100MB, but `/api/upload` parsed multipart form data with `request.formData()` and then called `file.arrayBuffer()` before `env.R2_BUCKET.put()`. A 96MiB docs-video file therefore created an additional full-file buffer inside the Worker and exceeded the Worker memory limit (`outcome=exceededMemory`, `status=503`).

This PR removes the second explicit buffer for docs-video uploads and caps that multipart path to 32MB. It does not remove the `request.formData()` buffering risk, which is why it intentionally lowers the cap instead of continuing to advertise 100MB.

## Verification

- `pnpm --dir apps/wodsmith-start test test/routes/api/upload.test.ts`
- `pnpm --dir apps/wodsmith-start type-check`
- `pnpm --dir apps/wodsmith-start exec biome check src/lib/upload-limits.ts src/routes/api/upload.ts src/routes/admin/docs/-components/route-doc-form.tsx test/routes/api/upload.test.ts`
- `git diff --cached --check`
- `lat check` was run and still fails on pre-existing unrelated broken links/refs in `lat.md/competition-invites.md`, `lat.md/domain.md`, `lat.md/organizer-dashboard.md`, and Crew import `@lat` refs; the new route-doc anchors are not reported.
- GitNexus impact and staged `detect_changes` were run. The staged diff is marked high risk because it touches the upload route `POST` entrypoint, but symbol-level impacts for `POST`, `PURPOSE_CONFIG`, `getR2UploadBody`, `DOCS_VIDEO_MAX_SIZE_MB`, `VideoField`, and `RoutePicker` were low.
- Pre-push hook ran full repo `pnpm lint` and `pnpm type-check`; type-check passed, lint completed with existing warnings in unrelated files.

## PR-2 Follow-up

Build the final large-video path as a direct-to-R2/signed upload protocol for docs videos:

- Add an authenticated admin endpoint that issues a short-lived signed upload target/key for `docs-video`.
- Upload the video body from the browser directly to R2 instead of through the Worker multipart parser.
- Finalize/validate metadata server-side and return the public route-doc video URL.
- Revisit the docs-video size limit after the Worker is no longer in the large-file data path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mitigates docs-video upload failures by streaming video bodies to R2 and lowering the size cap to 32MB to avoid Worker memory limits. Non-video uploads are unchanged; this is an interim step before a direct-to-R2 path.

- **Bug Fixes**
  - Introduced `DOCS_VIDEO_MAX_SIZE_MB = 32` and used it in the API and admin UI.
  - For `docs-video`, send `file.stream()` to `R2_BUCKET.put()`; keep other purposes on `file.arrayBuffer()`.
  - Reject docs-video files above the cap before writing to R2.
  - Added tests for the streaming path, cap enforcement, and non-video behavior.
  - Updated `lat.md/route-docs.md` with the mitigation details and new limit.

<sup>Written for commit 4d6915a3d4c47c40c4255e6cafcdab60ae9385a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

