### PR TITLE
feat(crew): add roster, shifts, and assignments

### DIFF
--- a/apps/crew/src/lib/crew/roster-shifts.test.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.test.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Roster Shifts Assignments]]
 import { describe, expect, it } from "vitest"
 import {
   buildCrewRoster,
@@ -5,6 +6,7 @@ import {
   normalizeCrewShiftTimes,
   summarizeCrewRoster,
   validateShiftAssignment,
+  validateShiftCapacityUpdate,
 } from "./roster-shifts"
 
 describe("Crew roster helpers", () => {
@@ -130,6 +132,45 @@ describe("Crew roster helpers", () => {
       }),
     ).toEqual({ ok: true })
   })
+
+  it("falls back to invitation email when metadata signup email is blank", () => {
+    const roster = buildCrewRoster(
+      [
+        {
+          id: "tinv_blank_email",
+          email: "invite@example.com",
+          status: "pending",
+          metadata: JSON.stringify({
+            signupEmail: "   ",
+            signupName: "Invite Person",
+          }),
+        },
+      ],
+      [],
+    )
+
+    expect(roster[0]?.email).toBe("invite@example.com")
+  })
+
+  it("falls back to membership user email when metadata signup email is blank", () => {
+    const roster = buildCrewRoster(
+      [],
+      [
+        {
+          id: "tmem_blank_email",
+          isActive: true,
+          user: {
+            firstName: "Member",
+            lastName: "Person",
+            email: "member@example.com",
+          },
+          metadata: JSON.stringify({ signupEmail: " " }),
+        },
+      ],
+    )
+
+    expect(roster[0]?.email).toBe("member@example.com")
+  })
 })
 
 describe("Crew shift helpers", () => {
@@ -221,5 +262,14 @@ describe("Crew shift helpers", () => {
         timezone: "America/Denver",
       }),
     ).toThrow("Shift end time must be after the start time.")
+  })
+
+  it("rejects capacity updates below current assignment count", () => {
+    expect(validateShiftCapacityUpdate(2, 3)).toMatchObject({
+      ok: false,
+      reason: "below_assigned_count",
+    })
+    expect(validateShiftCapacityUpdate(3, 3)).toEqual({ ok: true })
+    expect(validateShiftCapacityUpdate(4, 3)).toEqual({ ok: true })
   })
 })

--- a/apps/crew/src/lib/crew/roster-shifts.test.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   buildCrewRoster,
+  getCrewRosterRoleTypes,
   normalizeCrewShiftTimes,
   summarizeCrewRoster,
   validateShiftAssignment,
@@ -110,6 +111,24 @@ describe("Crew roster helpers", () => {
     expect(roster).toHaveLength(1)
     expect(roster[0]?.source).toBe("team_membership")
     expect(roster[0]?.status).toBe("active")
+  })
+
+  it("defaults missing volunteer role metadata to general for roster and assignment paths", () => {
+    expect(getCrewRosterRoleTypes(undefined)).toEqual(["general"])
+    expect(getCrewRosterRoleTypes([])).toEqual(["general"])
+
+    expect(
+      validateShiftAssignment({
+        shiftRoleType: "general",
+        capacity: 1,
+        currentAssignmentMembershipIds: [],
+        volunteer: {
+          membershipId: "tmem_missing_roles",
+          roleTypes: getCrewRosterRoleTypes(undefined),
+          isActive: true,
+        },
+      }),
+    ).toEqual({ ok: true })
   })
 })
 

--- a/apps/crew/src/lib/crew/roster-shifts.test.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildCrewRoster,
+  normalizeCrewShiftTimes,
+  summarizeCrewRoster,
+  validateShiftAssignment,
+} from "./roster-shifts"
+
+describe("Crew roster helpers", () => {
+  it("maps volunteer invitations and memberships to roster statuses", () => {
+    const now = new Date("2026-06-19T12:00:00.000Z")
+    const roster = buildCrewRoster(
+      [
+        {
+          id: "tinv_pending",
+          email: "pending@example.com",
+          expiresAt: "2026-06-20T12:00:00.000Z",
+          status: "pending",
+          metadata: JSON.stringify({
+            signupName: "Pending Person",
+            volunteerRoleTypes: ["judge"],
+          }),
+        },
+        {
+          id: "tinv_accepted",
+          email: "accepted@example.com",
+          status: "accepted",
+          metadata: JSON.stringify({
+            signupName: "Accepted Person",
+            volunteerRoleTypes: ["medical"],
+          }),
+        },
+        {
+          id: "tinv_expired",
+          email: "expired@example.com",
+          expiresAt: "2026-06-18T12:00:00.000Z",
+          status: "pending",
+          metadata: null,
+        },
+      ],
+      [
+        {
+          id: "tmem_active",
+          isActive: true,
+          user: {
+            firstName: "Active",
+            lastName: "Person",
+            email: "active@example.com",
+          },
+          metadata: JSON.stringify({ volunteerRoleTypes: ["staff"] }),
+        },
+        {
+          id: "tmem_inactive",
+          isActive: false,
+          user: {
+            firstName: "Inactive",
+            lastName: "Person",
+            email: "inactive@example.com",
+          },
+          metadata: JSON.stringify({ volunteerRoleTypes: ["check_in"] }),
+        },
+      ],
+      now,
+    )
+
+    expect(
+      roster.map((volunteer) => [volunteer.email, volunteer.status]),
+    ).toEqual([
+      ["active@example.com", "active"],
+      ["accepted@example.com", "accepted"],
+      ["pending@example.com", "pending"],
+      ["inactive@example.com", "inactive"],
+      ["expired@example.com", "expired"],
+    ])
+    expect(summarizeCrewRoster(roster)).toMatchObject({
+      total: 5,
+      active: 1,
+      accepted: 1,
+      pending: 1,
+      inactive: 1,
+      expired: 1,
+      assignable: 1,
+    })
+  })
+
+  it("deduplicates invitation rows when an active membership exists for the email", () => {
+    const roster = buildCrewRoster(
+      [
+        {
+          id: "tinv_duplicate",
+          email: "same@example.com",
+          status: "accepted",
+          metadata: JSON.stringify({ signupName: "Old Invite" }),
+        },
+      ],
+      [
+        {
+          id: "tmem_same",
+          isActive: true,
+          user: {
+            firstName: "Roster",
+            lastName: "Member",
+            email: "same@example.com",
+          },
+          metadata: JSON.stringify({ volunteerRoleTypes: ["general"] }),
+        },
+      ],
+    )
+
+    expect(roster).toHaveLength(1)
+    expect(roster[0]?.source).toBe("team_membership")
+    expect(roster[0]?.status).toBe("active")
+  })
+})
+
+describe("Crew shift helpers", () => {
+  it("validates duplicate, capacity, role, and active assignment cases", () => {
+    expect(
+      validateShiftAssignment({
+        shiftRoleType: "medical",
+        capacity: 2,
+        currentAssignmentMembershipIds: [],
+        volunteer: {
+          membershipId: "tmem_1",
+          roleTypes: ["general"],
+          isActive: true,
+        },
+      }),
+    ).toEqual({ ok: true })
+
+    expect(
+      validateShiftAssignment({
+        shiftRoleType: "medical",
+        capacity: 2,
+        currentAssignmentMembershipIds: ["tmem_1"],
+        volunteer: {
+          membershipId: "tmem_1",
+          roleTypes: ["medical"],
+          isActive: true,
+        },
+      }),
+    ).toMatchObject({ ok: false, reason: "duplicate" })
+
+    expect(
+      validateShiftAssignment({
+        shiftRoleType: "medical",
+        capacity: 1,
+        currentAssignmentMembershipIds: ["tmem_other"],
+        volunteer: {
+          membershipId: "tmem_1",
+          roleTypes: ["medical"],
+          isActive: true,
+        },
+      }),
+    ).toMatchObject({ ok: false, reason: "capacity" })
+
+    expect(
+      validateShiftAssignment({
+        shiftRoleType: "medical",
+        capacity: 2,
+        currentAssignmentMembershipIds: [],
+        volunteer: {
+          membershipId: "tmem_1",
+          roleTypes: ["judge"],
+          isActive: true,
+        },
+      }),
+    ).toMatchObject({ ok: false, reason: "role_mismatch" })
+
+    expect(
+      validateShiftAssignment({
+        shiftRoleType: "medical",
+        capacity: 2,
+        currentAssignmentMembershipIds: [],
+        volunteer: {
+          membershipId: "tmem_1",
+          roleTypes: ["medical"],
+          isActive: false,
+        },
+      }),
+    ).toMatchObject({ ok: false, reason: "inactive_volunteer" })
+  })
+
+  it("normalizes shift date and time in the event timezone", () => {
+    const normalized = normalizeCrewShiftTimes({
+      date: "2026-07-04",
+      startTime: "09:00",
+      endTime: "11:30",
+      timezone: "America/Denver",
+    })
+
+    expect(normalized.startTime.toISOString()).toBe("2026-07-04T15:00:00.000Z")
+    expect(normalized.endTime.toISOString()).toBe("2026-07-04T17:30:00.000Z")
+  })
+
+  it("rejects shifts that end before they start", () => {
+    expect(() =>
+      normalizeCrewShiftTimes({
+        date: "2026-07-04",
+        startTime: "12:00",
+        endTime: "11:30",
+        timezone: "America/Denver",
+      }),
+    ).toThrow("Shift end time must be after the start time.")
+  })
+})

--- a/apps/crew/src/lib/crew/roster-shifts.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Roster Shifts Assignments]]
 import {
   INVITATION_STATUS,
   type InvitationStatus,
@@ -109,6 +110,10 @@ export type ShiftAssignmentValidationResult =
         | "role_mismatch"
       message: string
     }
+
+export type ShiftCapacityValidationResult =
+  | { ok: true }
+  | { ok: false; reason: "below_assigned_count"; message: string }
 
 export interface NormalizedShiftTimeInput {
   date: string
@@ -286,6 +291,21 @@ export function validateShiftAssignment(
   return { ok: true }
 }
 
+export function validateShiftCapacityUpdate(
+  capacity: number,
+  assignedCount: number,
+): ShiftCapacityValidationResult {
+  if (capacity < assignedCount) {
+    return {
+      ok: false,
+      reason: "below_assigned_count",
+      message: `Shift capacity cannot be lower than the ${assignedCount} assigned volunteer${assignedCount === 1 ? "" : "s"}.`,
+    }
+  }
+
+  return { ok: true }
+}
+
 export function isVolunteerCompatibleWithShift(
   shiftRoleType: VolunteerRoleType,
   volunteerRoleTypes: VolunteerRoleType[],
@@ -343,7 +363,7 @@ function toInvitationRosterRow(
     sourceId: invitation.id,
     membershipId: null,
     invitationId: invitation.id,
-    email: metadata.signupEmail ?? invitation.email,
+    email: nonBlankText(metadata.signupEmail) ?? invitation.email,
     name: getMetadataName(metadata) || invitation.email,
     phone: metadata.signupPhone ?? null,
     status: getCrewRosterStatus(
@@ -370,7 +390,10 @@ function toMembershipRosterRow(
   const userName = [membership.user?.firstName, membership.user?.lastName]
     .filter(Boolean)
     .join(" ")
-  const email = metadata.signupEmail ?? membership.user?.email ?? ""
+  const email =
+    nonBlankText(metadata.signupEmail) ??
+    nonBlankText(membership.user?.email) ??
+    ""
 
   return {
     id: `membership:${membership.id}`,
@@ -398,6 +421,11 @@ function toMembershipRosterRow(
 
 function getMetadataName(metadata: CrewRosterMetadata) {
   return metadata.signupName?.trim() || metadata.inviteName?.trim() || ""
+}
+
+function nonBlankText(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
 }
 
 function compareCrewRosterRows(

--- a/apps/crew/src/lib/crew/roster-shifts.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.ts
@@ -1,0 +1,416 @@
+import {
+  INVITATION_STATUS,
+  type InvitationStatus,
+} from "../../db/schemas/teams"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_ROLE_LABELS,
+  VOLUNTEER_ROLE_TYPES,
+  VOLUNTEER_ROLE_TYPE_VALUES,
+  type VolunteerAvailability,
+  type VolunteerMembershipMetadata,
+  type VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+import { parseTimeInTimezone } from "../../utils/timezone-utils"
+
+export type CrewRosterStatus =
+  | "pending"
+  | "accepted"
+  | "active"
+  | "inactive"
+  | "expired"
+
+export interface CrewRosterMetadata
+  extends Partial<VolunteerMembershipMetadata> {
+  signupName?: string
+  signupEmail?: string
+  signupPhone?: string
+  inviteName?: string
+  crewImportId?: string
+  crewSignupSource?: string
+}
+
+export interface CrewVolunteerInvitationRecord {
+  id: string
+  email: string
+  acceptedAt?: Date | string | null
+  expiresAt?: Date | string | null
+  status?: InvitationStatus | string | null
+  metadata?: string | null
+  createdAt?: Date | string | null
+  updatedAt?: Date | string | null
+}
+
+export interface CrewVolunteerMembershipRecord {
+  id: string
+  isActive?: boolean | null
+  metadata?: string | null
+  user?: {
+    firstName?: string | null
+    lastName?: string | null
+    email?: string | null
+  } | null
+  createdAt?: Date | string | null
+  updatedAt?: Date | string | null
+}
+
+export interface CrewRosterVolunteer {
+  id: string
+  source: "team_invitation" | "team_membership"
+  sourceId: string
+  membershipId: string | null
+  invitationId: string | null
+  email: string
+  name: string
+  phone: string | null
+  status: CrewRosterStatus
+  roleTypes: VolunteerRoleType[]
+  availability: VolunteerAvailability | null
+  availabilityNotes: string | null
+  credentials: string | null
+  imported: boolean
+  signupSource: string | null
+  createdAt: Date | null
+  updatedAt: Date | null
+}
+
+export interface CrewRosterSummary {
+  total: number
+  pending: number
+  accepted: number
+  active: number
+  inactive: number
+  expired: number
+  assignable: number
+}
+
+export interface ShiftAssignmentCandidate {
+  membershipId: string
+  roleTypes: VolunteerRoleType[]
+  isActive: boolean
+}
+
+export interface ShiftAssignmentValidationInput {
+  shiftRoleType: VolunteerRoleType
+  capacity: number
+  currentAssignmentMembershipIds: string[]
+  volunteer: ShiftAssignmentCandidate | null
+}
+
+export type ShiftAssignmentValidationResult =
+  | { ok: true }
+  | {
+      ok: false
+      reason:
+        | "missing_volunteer"
+        | "inactive_volunteer"
+        | "duplicate"
+        | "capacity"
+        | "role_mismatch"
+      message: string
+    }
+
+export interface NormalizedShiftTimeInput {
+  date: string
+  startTime: string
+  endTime: string
+  timezone: string
+}
+
+export interface NormalizedShiftTimes {
+  startTime: Date
+  endTime: Date
+}
+
+const statusWeight: Record<CrewRosterStatus, number> = {
+  active: 0,
+  accepted: 1,
+  pending: 2,
+  inactive: 3,
+  expired: 4,
+}
+
+export function parseCrewRosterMetadata(
+  metadata: string | null | undefined,
+): CrewRosterMetadata {
+  if (!metadata) return {}
+
+  try {
+    const parsed = JSON.parse(metadata) as CrewRosterMetadata
+    return parsed && typeof parsed === "object" ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function normalizeCrewRosterRoleTypes(
+  roleTypes: unknown,
+): VolunteerRoleType[] {
+  if (!Array.isArray(roleTypes)) return []
+
+  return [...new Set(roleTypes)].filter(
+    (roleType): roleType is VolunteerRoleType =>
+      typeof roleType === "string" &&
+      VOLUNTEER_ROLE_TYPE_VALUES.includes(roleType as VolunteerRoleType),
+  )
+}
+
+export function getCrewRosterStatus(
+  record:
+    | ({ source: "team_membership" } & Pick<
+        CrewVolunteerMembershipRecord,
+        "isActive"
+      >)
+    | ({ source: "team_invitation" } & Pick<
+        CrewVolunteerInvitationRecord,
+        "acceptedAt" | "expiresAt" | "status"
+      >),
+  now = new Date(),
+): CrewRosterStatus {
+  if (record.source === "team_membership") {
+    return record.isActive === false ? "inactive" : "active"
+  }
+
+  if (record.acceptedAt || record.status === INVITATION_STATUS.ACCEPTED) {
+    return "accepted"
+  }
+
+  if (isPast(record.expiresAt, now)) {
+    return "expired"
+  }
+
+  return "pending"
+}
+
+export function buildCrewRoster(
+  invitations: CrewVolunteerInvitationRecord[],
+  memberships: CrewVolunteerMembershipRecord[],
+  now = new Date(),
+): CrewRosterVolunteer[] {
+  const invitationRows = invitations.map((invitation) =>
+    toInvitationRosterRow(invitation, now),
+  )
+  const membershipRows = memberships.map((membership) =>
+    toMembershipRosterRow(membership, now),
+  )
+  const membershipEmails = new Set(
+    membershipRows.map((row) => row.email.toLowerCase()).filter(Boolean),
+  )
+
+  return [
+    ...membershipRows,
+    ...invitationRows.filter(
+      (row) => !membershipEmails.has(row.email.toLowerCase()),
+    ),
+  ].sort(compareCrewRosterRows)
+}
+
+export function summarizeCrewRoster(
+  roster: CrewRosterVolunteer[],
+): CrewRosterSummary {
+  return roster.reduce<CrewRosterSummary>(
+    (summary, volunteer) => {
+      summary.total += 1
+      summary[volunteer.status] += 1
+      if (volunteer.membershipId && volunteer.status === "active") {
+        summary.assignable += 1
+      }
+      return summary
+    },
+    {
+      total: 0,
+      pending: 0,
+      accepted: 0,
+      active: 0,
+      inactive: 0,
+      expired: 0,
+      assignable: 0,
+    },
+  )
+}
+
+export function validateShiftAssignment(
+  input: ShiftAssignmentValidationInput,
+): ShiftAssignmentValidationResult {
+  const { volunteer } = input
+
+  if (!volunteer) {
+    return {
+      ok: false,
+      reason: "missing_volunteer",
+      message: "Volunteer record was not found for this event.",
+    }
+  }
+
+  if (!volunteer.isActive) {
+    return {
+      ok: false,
+      reason: "inactive_volunteer",
+      message: "Only active volunteers can be assigned to shifts.",
+    }
+  }
+
+  if (input.currentAssignmentMembershipIds.includes(volunteer.membershipId)) {
+    return {
+      ok: false,
+      reason: "duplicate",
+      message: "Volunteer is already assigned to this shift.",
+    }
+  }
+
+  if (input.currentAssignmentMembershipIds.length >= input.capacity) {
+    return {
+      ok: false,
+      reason: "capacity",
+      message: `Shift capacity (${input.capacity}) has been reached.`,
+    }
+  }
+
+  if (
+    !isVolunteerCompatibleWithShift(input.shiftRoleType, volunteer.roleTypes)
+  ) {
+    return {
+      ok: false,
+      reason: "role_mismatch",
+      message: `Volunteer is not tagged for ${formatVolunteerRole(input.shiftRoleType)}.`,
+    }
+  }
+
+  return { ok: true }
+}
+
+export function isVolunteerCompatibleWithShift(
+  shiftRoleType: VolunteerRoleType,
+  volunteerRoleTypes: VolunteerRoleType[],
+) {
+  return (
+    volunteerRoleTypes.includes(shiftRoleType) ||
+    volunteerRoleTypes.includes(VOLUNTEER_ROLE_TYPES.GENERAL)
+  )
+}
+
+export function normalizeCrewShiftTimes(
+  input: NormalizedShiftTimeInput,
+): NormalizedShiftTimes {
+  const startTime = parseTimeInTimezone(
+    input.startTime,
+    input.date,
+    input.timezone,
+  )
+  const endTime = parseTimeInTimezone(input.endTime, input.date, input.timezone)
+
+  if (!startTime || !endTime) {
+    throw new Error("Enter a valid shift date and time.")
+  }
+
+  if (endTime <= startTime) {
+    throw new Error("Shift end time must be after the start time.")
+  }
+
+  return { startTime, endTime }
+}
+
+export function formatVolunteerRole(roleType: VolunteerRoleType) {
+  return VOLUNTEER_ROLE_LABELS[roleType] ?? roleType
+}
+
+export function formatVolunteerAvailability(
+  availability: VolunteerAvailability | null,
+) {
+  if (availability === VOLUNTEER_AVAILABILITY.MORNING) return "Morning"
+  if (availability === VOLUNTEER_AVAILABILITY.AFTERNOON) return "Afternoon"
+  if (availability === VOLUNTEER_AVAILABILITY.ALL_DAY) return "All day"
+  return "Not set"
+}
+
+function toInvitationRosterRow(
+  invitation: CrewVolunteerInvitationRecord,
+  now: Date,
+): CrewRosterVolunteer {
+  const metadata = parseCrewRosterMetadata(invitation.metadata)
+  const roleTypes = normalizeCrewRosterRoleTypes(metadata.volunteerRoleTypes)
+
+  return {
+    id: `invitation:${invitation.id}`,
+    source: "team_invitation",
+    sourceId: invitation.id,
+    membershipId: null,
+    invitationId: invitation.id,
+    email: metadata.signupEmail ?? invitation.email,
+    name: getMetadataName(metadata) || invitation.email,
+    phone: metadata.signupPhone ?? null,
+    status: getCrewRosterStatus(
+      { source: "team_invitation", ...invitation },
+      now,
+    ),
+    roleTypes:
+      roleTypes.length > 0 ? roleTypes : [VOLUNTEER_ROLE_TYPES.GENERAL],
+    availability: metadata.availability ?? null,
+    availabilityNotes: metadata.availabilityNotes ?? null,
+    credentials: metadata.credentials ?? null,
+    imported: Boolean(metadata.crewImportId),
+    signupSource: metadata.crewSignupSource ?? metadata.inviteSource ?? null,
+    createdAt: toNullableDate(invitation.createdAt),
+    updatedAt: toNullableDate(invitation.updatedAt),
+  }
+}
+
+function toMembershipRosterRow(
+  membership: CrewVolunteerMembershipRecord,
+  now: Date,
+): CrewRosterVolunteer {
+  const metadata = parseCrewRosterMetadata(membership.metadata)
+  const roleTypes = normalizeCrewRosterRoleTypes(metadata.volunteerRoleTypes)
+  const userName = [membership.user?.firstName, membership.user?.lastName]
+    .filter(Boolean)
+    .join(" ")
+  const email = metadata.signupEmail ?? membership.user?.email ?? ""
+
+  return {
+    id: `membership:${membership.id}`,
+    source: "team_membership",
+    sourceId: membership.id,
+    membershipId: membership.id,
+    invitationId: null,
+    email,
+    name: getMetadataName(metadata) || userName || email || "Unknown",
+    phone: metadata.signupPhone ?? null,
+    status: getCrewRosterStatus(
+      { source: "team_membership", ...membership },
+      now,
+    ),
+    roleTypes:
+      roleTypes.length > 0 ? roleTypes : [VOLUNTEER_ROLE_TYPES.GENERAL],
+    availability: metadata.availability ?? null,
+    availabilityNotes: metadata.availabilityNotes ?? null,
+    credentials: metadata.credentials ?? null,
+    imported: Boolean(metadata.crewImportId),
+    signupSource: metadata.crewSignupSource ?? metadata.inviteSource ?? null,
+    createdAt: toNullableDate(membership.createdAt),
+    updatedAt: toNullableDate(membership.updatedAt),
+  }
+}
+
+function getMetadataName(metadata: CrewRosterMetadata) {
+  return metadata.signupName?.trim() || metadata.inviteName?.trim() || ""
+}
+
+function compareCrewRosterRows(
+  left: CrewRosterVolunteer,
+  right: CrewRosterVolunteer,
+) {
+  const statusDelta = statusWeight[left.status] - statusWeight[right.status]
+  if (statusDelta !== 0) return statusDelta
+  return (left.name || left.email).localeCompare(right.name || right.email)
+}
+
+function isPast(value: Date | string | null | undefined, now: Date) {
+  const date = toNullableDate(value)
+  return date ? date < now : false
+}
+
+function toNullableDate(value: Date | string | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}

--- a/apps/crew/src/lib/crew/roster-shifts.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.ts
@@ -155,6 +155,13 @@ export function normalizeCrewRosterRoleTypes(
   )
 }
 
+export function getCrewRosterRoleTypes(
+  roleTypes: unknown,
+): VolunteerRoleType[] {
+  const normalized = normalizeCrewRosterRoleTypes(roleTypes)
+  return normalized.length > 0 ? normalized : [VOLUNTEER_ROLE_TYPES.GENERAL]
+}
+
 export function getCrewRosterStatus(
   record:
     | ({ source: "team_membership" } & Pick<
@@ -328,7 +335,7 @@ function toInvitationRosterRow(
   now: Date,
 ): CrewRosterVolunteer {
   const metadata = parseCrewRosterMetadata(invitation.metadata)
-  const roleTypes = normalizeCrewRosterRoleTypes(metadata.volunteerRoleTypes)
+  const roleTypes = getCrewRosterRoleTypes(metadata.volunteerRoleTypes)
 
   return {
     id: `invitation:${invitation.id}`,
@@ -343,8 +350,7 @@ function toInvitationRosterRow(
       { source: "team_invitation", ...invitation },
       now,
     ),
-    roleTypes:
-      roleTypes.length > 0 ? roleTypes : [VOLUNTEER_ROLE_TYPES.GENERAL],
+    roleTypes,
     availability: metadata.availability ?? null,
     availabilityNotes: metadata.availabilityNotes ?? null,
     credentials: metadata.credentials ?? null,
@@ -360,7 +366,7 @@ function toMembershipRosterRow(
   now: Date,
 ): CrewRosterVolunteer {
   const metadata = parseCrewRosterMetadata(membership.metadata)
-  const roleTypes = normalizeCrewRosterRoleTypes(metadata.volunteerRoleTypes)
+  const roleTypes = getCrewRosterRoleTypes(metadata.volunteerRoleTypes)
   const userName = [membership.user?.firstName, membership.user?.lastName]
     .filter(Boolean)
     .join(" ")
@@ -379,8 +385,7 @@ function toMembershipRosterRow(
       { source: "team_membership", ...membership },
       now,
     ),
-    roleTypes:
-      roleTypes.length > 0 ? roleTypes : [VOLUNTEER_ROLE_TYPES.GENERAL],
+    roleTypes,
     availability: metadata.availability ?? null,
     availabilityNotes: metadata.availabilityNotes ?? null,
     credentials: metadata.credentials ?? null,

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as EventsNewRouteImport } from './routes/events/new'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
 import { Route as EventsEventIdIndexRouteImport } from './routes/events/$eventId/index'
 import { Route as EventsEventIdVolunteersRouteImport } from './routes/events/$eventId/volunteers'
+import { Route as EventsEventIdShiftsRouteImport } from './routes/events/$eventId/shifts'
 import { Route as EventsEventIdSetupRouteImport } from './routes/events/$eventId/setup'
 import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$eventId/schedule'
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
@@ -56,6 +57,11 @@ const EventsEventIdIndexRoute = EventsEventIdIndexRouteImport.update({
 const EventsEventIdVolunteersRoute = EventsEventIdVolunteersRouteImport.update({
   id: '/volunteers',
   path: '/volunteers',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
+const EventsEventIdShiftsRoute = EventsEventIdShiftsRouteImport.update({
+  id: '/shifts',
+  path: '/shifts',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
 const EventsEventIdSetupRoute = EventsEventIdSetupRouteImport.update({
@@ -100,6 +106,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
+  '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
@@ -114,6 +121,7 @@ export interface FileRoutesByTo {
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
+  '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId': typeof EventsEventIdIndexRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
@@ -130,6 +138,7 @@ export interface FileRoutesById {
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
+  '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
@@ -147,6 +156,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
+    | '/events/$eventId/shifts'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
     | '/e/$slug/schedule/$token'
@@ -161,6 +171,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
+    | '/events/$eventId/shifts'
     | '/events/$eventId/volunteers'
     | '/events/$eventId'
     | '/e/$slug/schedule/$token'
@@ -176,6 +187,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/imports'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
+    | '/events/$eventId/shifts'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
     | '/e/$slug/schedule/$token'
@@ -241,6 +253,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdVolunteersRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/shifts': {
+      id: '/events/$eventId/shifts'
+      path: '/shifts'
+      fullPath: '/events/$eventId/shifts'
+      preLoaderRoute: typeof EventsEventIdShiftsRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/events/$eventId/setup': {
       id: '/events/$eventId/setup'
       path: '/setup'
@@ -290,6 +309,7 @@ interface EventsEventIdRouteChildren {
   EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
   EventsEventIdScheduleRoute: typeof EventsEventIdScheduleRoute
   EventsEventIdSetupRoute: typeof EventsEventIdSetupRoute
+  EventsEventIdShiftsRoute: typeof EventsEventIdShiftsRoute
   EventsEventIdVolunteersRoute: typeof EventsEventIdVolunteersRoute
   EventsEventIdIndexRoute: typeof EventsEventIdIndexRoute
 }
@@ -298,6 +318,7 @@ const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdImportsRoute: EventsEventIdImportsRoute,
   EventsEventIdScheduleRoute: EventsEventIdScheduleRoute,
   EventsEventIdSetupRoute: EventsEventIdSetupRoute,
+  EventsEventIdShiftsRoute: EventsEventIdShiftsRoute,
   EventsEventIdVolunteersRoute: EventsEventIdVolunteersRoute,
   EventsEventIdIndexRoute: EventsEventIdIndexRoute,
 }

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -61,6 +61,14 @@ function EventShell() {
             Volunteers
           </Link>
           <Link
+            to="/events/$eventId/shifts"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Shifts
+          </Link>
+          <Link
             to="/events/$eventId/schedule"
             params={{ eventId }}
             activeProps={{ className: "bg-muted text-foreground" }}

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -5,8 +5,13 @@ import {
   crewSetupChecklistItems,
   parseCrewSettings,
 } from "@/lib/crew-event-setup"
+import { getCrewEventRosterShiftSummaryFn } from "@/server-fns/crew-roster-shift-fns"
 
 export const Route = createFileRoute("/events/$eventId/")({
+  loader: async ({ params }) =>
+    await getCrewEventRosterShiftSummaryFn({
+      data: { eventId: params.eventId },
+    }),
   component: EventOverviewPage,
 })
 
@@ -15,12 +20,13 @@ const parentRoute = getRouteApi("/events/$eventId")
 function EventOverviewPage() {
   const { eventId } = parentRoute.useParams()
   const { event } = parentRoute.useLoaderData()
+  const { rosterSummary, shiftSummary } = Route.useLoaderData()
   const parsedSettings = parseCrewSettings(event.settings.settings)
   const setupProgress = calculateSetupProgress(parsedSettings.setup)
 
   return (
     <section className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-6">
         <StatusPanel
           label="Lifecycle"
           value={formatCrewValue(event.settings.lifecycle)}
@@ -36,6 +42,11 @@ function EventOverviewPage() {
         <StatusPanel
           label="Setup"
           value={`${setupProgress.completed}/${setupProgress.total}`}
+        />
+        <StatusPanel label="Roster" value={rosterSummary.total.toString()} />
+        <StatusPanel
+          label="Shift slots"
+          value={`${shiftSummary.assignedSlots}/${shiftSummary.capacity}`}
         />
       </div>
 

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -1,0 +1,569 @@
+import type { FormEvent } from "react"
+import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { Loader2, Plus, Trash2 } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+import {
+  isVolunteerCompatibleWithShift,
+  type CrewRosterVolunteer,
+} from "@/lib/crew/roster-shifts"
+import {
+  assignCrewVolunteerToShiftFn,
+  createCrewShiftFn,
+  deleteCrewShiftFn,
+  getCrewShiftBoardFn,
+  removeCrewVolunteerShiftAssignmentFn,
+  updateCrewShiftFn,
+  type CrewShiftBoardItem,
+} from "@/server-fns/crew-roster-shift-fns"
+import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
+import {
+  VOLUNTEER_ROLE_OPTIONS,
+  type VolunteerRoleType,
+} from "@/db/schemas/volunteers"
+
+export const Route = createFileRoute("/events/$eventId/shifts")({
+  loader: async ({ params }) =>
+    await getCrewShiftBoardFn({ data: { eventId: params.eventId } }),
+  component: EventShiftsPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+function EventShiftsPage() {
+  const { eventId } = parentRoute.useParams()
+  const { event, roster, rosterSummary, shifts, shiftSummary } =
+    Route.useLoaderData()
+  const timezone = event.timezone ?? "America/Denver"
+  const assignableVolunteers = roster.filter(
+    (volunteer) => volunteer.membershipId && volunteer.status === "active",
+  )
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Shifts</h2>
+          <p className="text-sm text-muted-foreground">
+            {shiftSummary.totalShifts} shifts, {shiftSummary.openSlots} open
+            slots
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <StatusPanel label="Active volunteers" value={rosterSummary.active} />
+        <StatusPanel label="Assignable" value={rosterSummary.assignable} />
+        <StatusPanel
+          label="Assigned slots"
+          value={shiftSummary.assignedSlots}
+        />
+        <StatusPanel label="Capacity" value={shiftSummary.capacity} />
+      </div>
+
+      <CreateShiftForm
+        eventId={eventId}
+        eventStartDate={event.startDate}
+        timezone={timezone}
+      />
+
+      <div className="space-y-4">
+        {shifts.length > 0 ? (
+          shifts.map((shift) => (
+            <ShiftCard
+              key={shift.id}
+              eventId={eventId}
+              shift={shift}
+              volunteers={assignableVolunteers}
+              timezone={timezone}
+            />
+          ))
+        ) : (
+          <section className="rounded-md border bg-card p-8 text-center shadow-sm">
+            <h3 className="font-semibold">No shifts yet</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Create the first event shift to start assigning volunteers.
+            </p>
+          </section>
+        )}
+      </div>
+    </section>
+  )
+}
+
+function CreateShiftForm({
+  eventId,
+  eventStartDate,
+  timezone,
+}: {
+  eventId: string
+  eventStartDate: string
+  timezone: string
+}) {
+  const router = useRouter()
+  const createShift = useServerFn(createCrewShiftFn)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    setIsSubmitting(true)
+
+    try {
+      await createShift({
+        data: {
+          eventId,
+          name: getFormString(formData, "name"),
+          roleType: getFormString(formData, "roleType") as VolunteerRoleType,
+          date: getFormString(formData, "date"),
+          startTime: getFormString(formData, "startTime"),
+          endTime: getFormString(formData, "endTime"),
+          location: getFormString(formData, "location"),
+          capacity: Number(getFormString(formData, "capacity")),
+          notes: getFormString(formData, "notes"),
+        },
+      })
+      toast.success("Shift created")
+      form.reset()
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to create shift",
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="rounded-md border bg-card p-5 shadow-sm"
+    >
+      <div className="flex items-center gap-3">
+        <div className="flex size-10 items-center justify-center rounded-md bg-muted">
+          <Plus className="size-5 text-muted-foreground" />
+        </div>
+        <div>
+          <h3 className="font-semibold">New shift</h3>
+          <p className="text-sm text-muted-foreground">{timezone}</p>
+        </div>
+      </div>
+
+      <ShiftFields
+        defaultDate={eventStartDate}
+        defaultStartTime="09:00"
+        defaultEndTime="12:00"
+      />
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="mt-5 inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isSubmitting ? <Loader2 className="size-4 animate-spin" /> : null}
+        Create shift
+      </button>
+    </form>
+  )
+}
+
+function ShiftCard({
+  eventId,
+  shift,
+  volunteers,
+  timezone,
+}: {
+  eventId: string
+  shift: CrewShiftBoardItem
+  volunteers: CrewRosterVolunteer[]
+  timezone: string
+}) {
+  const router = useRouter()
+  const assignVolunteer = useServerFn(assignCrewVolunteerToShiftFn)
+  const removeAssignment = useServerFn(removeCrewVolunteerShiftAssignmentFn)
+  const deleteShift = useServerFn(deleteCrewShiftFn)
+  const updateShift = useServerFn(updateCrewShiftFn)
+  const [isAssigning, setIsAssigning] = useState(false)
+  const [isUpdating, setIsUpdating] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const assignedMembershipIds = new Set(
+    shift.assignments.map((assignment) => assignment.membershipId),
+  )
+  const availableVolunteers = volunteers.filter(
+    (volunteer) =>
+      volunteer.membershipId &&
+      !assignedMembershipIds.has(volunteer.membershipId) &&
+      isVolunteerCompatibleWithShift(shift.roleType, volunteer.roleTypes),
+  )
+
+  async function handleAssign(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    const membershipId = getFormString(formData, "membershipId")
+    if (!membershipId) {
+      toast.error("Choose a volunteer")
+      return
+    }
+
+    setIsAssigning(true)
+    try {
+      const result = await assignVolunteer({
+        data: { eventId, shiftId: shift.id, membershipId },
+      })
+      toast.success(
+        result.action === "skipped_duplicate"
+          ? "Volunteer already assigned"
+          : "Volunteer assigned",
+      )
+      form.reset()
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to assign volunteer",
+      )
+    } finally {
+      setIsAssigning(false)
+    }
+  }
+
+  async function handleRemove(membershipId: string) {
+    try {
+      await removeAssignment({
+        data: { eventId, shiftId: shift.id, membershipId },
+      })
+      toast.success("Volunteer removed")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remove volunteer",
+      )
+    }
+  }
+
+  async function handleDelete() {
+    if (!confirm(`Delete ${shift.name}?`)) return
+
+    setIsDeleting(true)
+    try {
+      await deleteShift({ data: { eventId, shiftId: shift.id } })
+      toast.success("Shift deleted")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to delete shift",
+      )
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  async function handleUpdate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    setIsUpdating(true)
+
+    try {
+      await updateShift({
+        data: {
+          eventId,
+          shiftId: shift.id,
+          name: getFormString(formData, "name"),
+          roleType: getFormString(formData, "roleType") as VolunteerRoleType,
+          date: getFormString(formData, "date"),
+          startTime: getFormString(formData, "startTime"),
+          endTime: getFormString(formData, "endTime"),
+          location: getFormString(formData, "location"),
+          capacity: Number(getFormString(formData, "capacity")),
+          notes: getFormString(formData, "notes"),
+        },
+      })
+      toast.success("Shift updated")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to update shift",
+      )
+    } finally {
+      setIsUpdating(false)
+    }
+  }
+
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-lg font-semibold">{shift.name}</h3>
+            <span className="rounded-md border bg-background px-2 py-1 text-xs">
+              {shift.roleLabel}
+            </span>
+            <span className="rounded-md border bg-background px-2 py-1 text-xs">
+              {shift.assignedCount}/{shift.capacity}
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-muted-foreground">
+            {formatDateTimeInTimezone(
+              shift.startTime,
+              timezone,
+              "EEE, MMM d h:mm a",
+            )}{" "}
+            to {formatDateTimeInTimezone(shift.endTime, timezone, "h:mm a")}
+          </p>
+          {shift.location ? (
+            <p className="mt-1 text-sm text-muted-foreground">
+              {shift.location}
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="inline-flex h-10 w-fit items-center gap-2 rounded-md border px-3 text-sm font-medium text-destructive hover:bg-destructive/10 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <Trash2 className="size-4" />
+          Delete
+        </button>
+      </div>
+
+      {shift.notes ? (
+        <p className="mt-4 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
+          {shift.notes}
+        </p>
+      ) : null}
+
+      <div className="mt-5 grid gap-5 lg:grid-cols-[1fr_22rem]">
+        <div className="space-y-3">
+          <h4 className="text-sm font-semibold">Assignments</h4>
+          {shift.assignments.length > 0 ? (
+            <div className="space-y-2">
+              {shift.assignments.map((assignment) => (
+                <div
+                  key={assignment.id}
+                  className="flex flex-col gap-3 rounded-md border bg-background p-3 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div>
+                    <div className="font-medium">
+                      {assignment.volunteer.name}
+                    </div>
+                    <div className="text-sm text-muted-foreground">
+                      {assignment.volunteer.email}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(assignment.membershipId)}
+                    className="h-9 w-fit rounded-md border px-3 text-sm hover:bg-muted"
+                  >
+                    Remove
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="rounded-md border bg-background p-3 text-sm text-muted-foreground">
+              No assignments yet
+            </p>
+          )}
+        </div>
+
+        <form onSubmit={handleAssign} className="space-y-3">
+          <label className="grid gap-1 text-sm">
+            <span className="font-medium">Add volunteer</span>
+            <select
+              name="membershipId"
+              className="h-10 rounded-md border bg-background px-3"
+              disabled={
+                availableVolunteers.length === 0 || shift.openSlots === 0
+              }
+            >
+              <option value="">Choose volunteer</option>
+              {availableVolunteers.map((volunteer) => (
+                <option key={volunteer.id} value={volunteer.membershipId ?? ""}>
+                  {volunteer.name} · {volunteer.email}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="submit"
+            disabled={
+              isAssigning ||
+              availableVolunteers.length === 0 ||
+              shift.openSlots === 0
+            }
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isAssigning ? <Loader2 className="size-4 animate-spin" /> : null}
+            Assign
+          </button>
+        </form>
+      </div>
+
+      <details className="mt-5 rounded-md border bg-background p-3">
+        <summary className="cursor-pointer text-sm font-medium">
+          Edit shift
+        </summary>
+        <form onSubmit={handleUpdate} className="mt-4">
+          <ShiftFields
+            shift={shift}
+            timezone={timezone}
+            defaultDate={formatDateTimeInTimezone(
+              shift.startTime,
+              timezone,
+              "yyyy-MM-dd",
+            )}
+            defaultStartTime={formatDateTimeInTimezone(
+              shift.startTime,
+              timezone,
+              "HH:mm",
+            )}
+            defaultEndTime={formatDateTimeInTimezone(
+              shift.endTime,
+              timezone,
+              "HH:mm",
+            )}
+          />
+          <button
+            type="submit"
+            disabled={isUpdating}
+            className="mt-5 inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isUpdating ? <Loader2 className="size-4 animate-spin" /> : null}
+            Save shift
+          </button>
+        </form>
+      </details>
+    </section>
+  )
+}
+
+function ShiftFields({
+  shift,
+  defaultDate,
+  defaultStartTime,
+  defaultEndTime,
+}: {
+  shift?: CrewShiftBoardItem
+  timezone?: string
+  defaultDate: string
+  defaultStartTime: string
+  defaultEndTime: string
+}) {
+  return (
+    <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <Field label="Name">
+        <input
+          name="name"
+          defaultValue={shift?.name ?? ""}
+          required
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        />
+      </Field>
+      <Field label="Role">
+        <select
+          name="roleType"
+          defaultValue={shift?.roleType ?? "general"}
+          required
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        >
+          {VOLUNTEER_ROLE_OPTIONS.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </Field>
+      <Field label="Date">
+        <input
+          type="date"
+          name="date"
+          defaultValue={defaultDate}
+          required
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        />
+      </Field>
+      <Field label="Capacity">
+        <input
+          type="number"
+          name="capacity"
+          min={1}
+          defaultValue={shift?.capacity ?? 1}
+          required
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        />
+      </Field>
+      <Field label="Start">
+        <input
+          type="time"
+          name="startTime"
+          defaultValue={defaultStartTime}
+          required
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        />
+      </Field>
+      <Field label="End">
+        <input
+          type="time"
+          name="endTime"
+          defaultValue={defaultEndTime}
+          required
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        />
+      </Field>
+      <Field label="Location">
+        <input
+          name="location"
+          defaultValue={shift?.location ?? ""}
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        />
+      </Field>
+      <Field label="Notes">
+        <input
+          name="notes"
+          defaultValue={shift?.notes ?? ""}
+          className="h-10 rounded-md border bg-background px-3 text-sm"
+        />
+      </Field>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="grid gap-1 text-sm">
+      <span className="font-medium">{label}</span>
+      {children}
+    </div>
+  )
+}
+
+function StatusPanel({
+  label,
+  value,
+}: {
+  label: string
+  value: number | string
+}) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function getFormString(formData: FormData, name: string) {
+  const value = formData.get(name)
+  return typeof value === "string" ? value.trim() : ""
+}

--- a/apps/crew/src/routes/events/$eventId/volunteers.tsx
+++ b/apps/crew/src/routes/events/$eventId/volunteers.tsx
@@ -1,17 +1,162 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import { formatCrewValue } from "@/lib/crew-event-display"
+import {
+  formatVolunteerAvailability,
+  formatVolunteerRole,
+  type CrewRosterStatus,
+  type CrewRosterVolunteer,
+} from "@/lib/crew/roster-shifts"
+import { getCrewRosterPageFn } from "@/server-fns/crew-roster-shift-fns"
 
 export const Route = createFileRoute("/events/$eventId/volunteers")({
+  loader: async ({ params }) =>
+    await getCrewRosterPageFn({ data: { eventId: params.eventId } }),
   component: VolunteersPage,
 })
 
+const parentRoute = getRouteApi("/events/$eventId")
+
 function VolunteersPage() {
+  const { eventId } = parentRoute.useParams()
+  const { roster, summary, shiftSummary } = Route.useLoaderData()
+
   return (
-    <section className="rounded-md border bg-card p-5 shadow-sm">
-      <h2 className="text-xl font-semibold">Volunteers</h2>
-      <p className="mt-2 text-muted-foreground">
-        Volunteer signup, invitations, confirmations, and crew roster tools are
-        intentionally placeholder-only in this route trim.
-      </p>
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Roster</h2>
+          <p className="text-sm text-muted-foreground">
+            {summary.total} volunteers, {summary.assignable} assignable
+          </p>
+        </div>
+        <Link
+          to="/events/$eventId/shifts"
+          params={{ eventId }}
+          className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          Manage shifts
+        </Link>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <StatusPanel label="Pending" value={summary.pending} />
+        <StatusPanel label="Accepted" value={summary.accepted} />
+        <StatusPanel label="Active" value={summary.active} />
+        <StatusPanel
+          label="Shift coverage"
+          value={`${shiftSummary.assignedSlots}/${shiftSummary.capacity}`}
+        />
+      </div>
+
+      <section className="overflow-hidden rounded-md border bg-card shadow-sm">
+        {roster.length > 0 ? (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[760px] text-sm">
+              <thead className="border-b bg-muted/50 text-left text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Volunteer</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium">Roles</th>
+                  <th className="px-4 py-3 font-medium">Availability</th>
+                  <th className="px-4 py-3 font-medium">Source</th>
+                </tr>
+              </thead>
+              <tbody>
+                {roster.map((volunteer) => (
+                  <VolunteerRow key={volunteer.id} volunteer={volunteer} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <div className="p-8 text-center">
+            <h3 className="font-semibold">No volunteers yet</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Import volunteers or share the public signup link to build the
+              roster.
+            </p>
+          </div>
+        )}
+      </section>
     </section>
+  )
+}
+
+function VolunteerRow({ volunteer }: { volunteer: CrewRosterVolunteer }) {
+  return (
+    <tr className="border-b last:border-0">
+      <td className="px-4 py-3 align-top">
+        <div className="font-medium">{volunteer.name}</div>
+        <div className="text-muted-foreground">{volunteer.email}</div>
+        {volunteer.phone ? (
+          <div className="text-muted-foreground">{volunteer.phone}</div>
+        ) : null}
+      </td>
+      <td className="px-4 py-3 align-top">
+        <StatusBadge status={volunteer.status} />
+      </td>
+      <td className="px-4 py-3 align-top">
+        <div className="flex flex-wrap gap-1">
+          {volunteer.roleTypes.map((roleType) => (
+            <span
+              key={roleType}
+              className="rounded-md border bg-background px-2 py-1 text-xs"
+            >
+              {formatVolunteerRole(roleType)}
+            </span>
+          ))}
+        </div>
+      </td>
+      <td className="px-4 py-3 align-top">
+        <div>{formatVolunteerAvailability(volunteer.availability)}</div>
+        {volunteer.availabilityNotes ? (
+          <div className="mt-1 max-w-xs text-muted-foreground">
+            {volunteer.availabilityNotes}
+          </div>
+        ) : null}
+      </td>
+      <td className="px-4 py-3 align-top text-muted-foreground">
+        <div>
+          {volunteer.imported ? "Imported" : formatCrewValue(volunteer.source)}
+        </div>
+        {volunteer.signupSource ? (
+          <div className="mt-1">{formatCrewValue(volunteer.signupSource)}</div>
+        ) : null}
+      </td>
+    </tr>
+  )
+}
+
+function StatusPanel({
+  label,
+  value,
+}: {
+  label: string
+  value: number | string
+}) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function StatusBadge({ status }: { status: CrewRosterStatus }) {
+  const className =
+    status === "active"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+      : status === "accepted"
+        ? "border-sky-500/30 bg-sky-500/10 text-sky-700"
+        : status === "pending"
+          ? "border-amber-500/30 bg-amber-500/10 text-amber-700"
+          : "border-muted bg-muted text-muted-foreground"
+
+  return (
+    <span
+      className={`inline-flex rounded-md border px-2 py-1 text-xs font-medium ${className}`}
+    >
+      {formatCrewValue(status)}
+    </span>
   )
 }

--- a/apps/crew/src/server-fns/crew-roster-shift-fns.ts
+++ b/apps/crew/src/server-fns/crew-roster-shift-fns.ts
@@ -1,0 +1,576 @@
+// @lat: [[crew#Roster Shifts Assignments]]
+import { createServerFn } from "@tanstack/react-start"
+import { and, asc, eq } from "drizzle-orm"
+import { z } from "zod"
+import { getDb } from "../db"
+import { createVolunteerShiftAssignmentId } from "../db/schemas/common"
+import { competitionsTable, type Competition } from "../db/schemas/competitions"
+import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import {
+  SYSTEM_ROLES_ENUM,
+  teamInvitationTable,
+  teamMembershipTable,
+} from "../db/schemas/teams"
+import {
+  VOLUNTEER_ROLE_TYPE_VALUES,
+  volunteerShiftAssignmentsTable,
+  volunteerShiftsTable,
+  type VolunteerRoleType,
+} from "../db/schemas/volunteers"
+import {
+  buildCrewRoster,
+  formatVolunteerRole,
+  normalizeCrewRosterRoleTypes,
+  normalizeCrewShiftTimes,
+  parseCrewRosterMetadata,
+  summarizeCrewRoster,
+  validateShiftAssignment,
+  type CrewRosterSummary,
+  type CrewRosterVolunteer,
+} from "../lib/crew/roster-shifts"
+import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
+import {
+  DEFAULT_TIMEZONE,
+  formatDateTimeInTimezone,
+} from "../utils/timezone-utils"
+
+type DbClient = ReturnType<typeof getDb>
+
+type CrewRosterCompetition = Pick<
+  Competition,
+  | "id"
+  | "name"
+  | "slug"
+  | "competitionTeamId"
+  | "timezone"
+  | "startDate"
+  | "endDate"
+>
+
+export interface CrewShiftAssignmentVolunteer {
+  membershipId: string
+  name: string
+  email: string
+  roleTypes: VolunteerRoleType[]
+}
+
+export interface CrewShiftAssignmentItem {
+  id: string
+  membershipId: string
+  notes: string | null
+  volunteer: CrewShiftAssignmentVolunteer
+}
+
+export interface CrewShiftBoardItem {
+  id: string
+  competitionId: string
+  name: string
+  roleType: VolunteerRoleType
+  roleLabel: string
+  startTime: Date
+  endTime: Date
+  location: string | null
+  capacity: number
+  notes: string | null
+  assignments: CrewShiftAssignmentItem[]
+  assignedCount: number
+  openSlots: number
+}
+
+export interface CrewRosterPageData {
+  event: CrewRosterCompetition
+  roster: CrewRosterVolunteer[]
+  summary: CrewRosterSummary
+  shiftSummary: CrewShiftSummary
+}
+
+export interface CrewShiftBoardData {
+  event: CrewRosterCompetition
+  roster: CrewRosterVolunteer[]
+  rosterSummary: CrewRosterSummary
+  shifts: CrewShiftBoardItem[]
+  shiftSummary: CrewShiftSummary
+}
+
+export interface CrewShiftSummary {
+  totalShifts: number
+  assignedSlots: number
+  capacity: number
+  openSlots: number
+}
+
+const eventIdSchema = z.string().min(1, "Event ID is required")
+const shiftIdSchema = z.string().startsWith("vshf_", "Invalid shift ID")
+const membershipIdSchema = z
+  .string()
+  .startsWith("tmem_", "Invalid membership ID")
+const roleTypeSchema = z.enum(VOLUNTEER_ROLE_TYPE_VALUES)
+const shiftTextSchema = z.string().trim().max(1000).optional()
+const shiftDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date must be YYYY-MM-DD")
+const shiftTimeSchema = z
+  .string()
+  .regex(/^([01]?\d|2[0-3]):([0-5]\d)$/, "Time must be HH:mm")
+
+const shiftInputSchema = z.object({
+  eventId: eventIdSchema,
+  name: z.string().trim().min(1, "Name is required").max(200),
+  roleType: roleTypeSchema,
+  date: shiftDateSchema,
+  startTime: shiftTimeSchema,
+  endTime: shiftTimeSchema,
+  location: z.string().trim().max(200).optional(),
+  capacity: z.coerce.number().int().min(1).max(500),
+  notes: shiftTextSchema,
+})
+
+const updateShiftInputSchema = shiftInputSchema
+  .extend({
+    shiftId: shiftIdSchema,
+  })
+  .partial({
+    name: true,
+    roleType: true,
+    date: true,
+    startTime: true,
+    endTime: true,
+    location: true,
+    capacity: true,
+    notes: true,
+  })
+  .required({
+    eventId: true,
+    shiftId: true,
+  })
+
+const shiftAssignmentInputSchema = z.object({
+  eventId: eventIdSchema,
+  shiftId: shiftIdSchema,
+  membershipId: membershipIdSchema,
+  notes: z.string().trim().max(500).optional(),
+})
+
+const deleteShiftInputSchema = z.object({
+  eventId: eventIdSchema,
+  shiftId: shiftIdSchema,
+})
+
+export const getCrewRosterPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    z.object({ eventId: eventIdSchema }).parse(data),
+  )
+  .handler(async ({ data }): Promise<CrewRosterPageData> => {
+    requireLocalCrewOperatorAccess("Crew roster")
+
+    const event = await requireCrewRosterEvent(data.eventId)
+    const [roster, shifts] = await Promise.all([
+      loadCrewRoster(event.competitionTeamId),
+      loadCrewShifts(event.id),
+    ])
+
+    return {
+      event,
+      roster,
+      summary: summarizeCrewRoster(roster),
+      shiftSummary: summarizeCrewShifts(shifts),
+    }
+  })
+
+export const getCrewShiftBoardFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    z.object({ eventId: eventIdSchema }).parse(data),
+  )
+  .handler(async ({ data }): Promise<CrewShiftBoardData> => {
+    requireLocalCrewOperatorAccess("Crew shifts")
+
+    const event = await requireCrewRosterEvent(data.eventId)
+    const [roster, shifts] = await Promise.all([
+      loadCrewRoster(event.competitionTeamId),
+      loadCrewShifts(event.id),
+    ])
+
+    return {
+      event,
+      roster,
+      rosterSummary: summarizeCrewRoster(roster),
+      shifts,
+      shiftSummary: summarizeCrewShifts(shifts),
+    }
+  })
+
+export const getCrewEventRosterShiftSummaryFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) =>
+    z.object({ eventId: eventIdSchema }).parse(data),
+  )
+  .handler(async ({ data }) => {
+    requireLocalCrewOperatorAccess("Crew dashboard")
+
+    const event = await requireCrewRosterEvent(data.eventId)
+    const [roster, shifts] = await Promise.all([
+      loadCrewRoster(event.competitionTeamId),
+      loadCrewShifts(event.id),
+    ])
+
+    return {
+      rosterSummary: summarizeCrewRoster(roster),
+      shiftSummary: summarizeCrewShifts(shifts),
+    }
+  })
+
+export const createCrewShiftFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => shiftInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    requireLocalCrewOperatorAccess("Crew shifts")
+
+    const event = await requireCrewRosterEvent(data.eventId)
+    const { startTime, endTime } = normalizeCrewShiftTimes({
+      date: data.date,
+      startTime: data.startTime,
+      endTime: data.endTime,
+      timezone: event.timezone ?? DEFAULT_TIMEZONE,
+    })
+    const db = getDb()
+
+    await db.insert(volunteerShiftsTable).values({
+      competitionId: event.id,
+      name: data.name,
+      roleType: data.roleType,
+      startTime,
+      endTime,
+      location: emptyToNull(data.location),
+      capacity: data.capacity,
+      notes: emptyToNull(data.notes),
+    })
+
+    return { success: true }
+  })
+
+export const updateCrewShiftFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => updateShiftInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    requireLocalCrewOperatorAccess("Crew shifts")
+
+    const event = await requireCrewRosterEvent(data.eventId)
+    const existingShift = await requireCrewShift(event.id, data.shiftId)
+    const updateValues: Partial<typeof volunteerShiftsTable.$inferInsert> = {}
+    const timezone = event.timezone ?? DEFAULT_TIMEZONE
+    const date =
+      data.date ??
+      formatDateTimeInTimezone(existingShift.startTime, timezone, "yyyy-MM-dd")
+    const startInput =
+      data.startTime ??
+      formatDateTimeInTimezone(existingShift.startTime, timezone, "HH:mm")
+    const endInput =
+      data.endTime ??
+      formatDateTimeInTimezone(existingShift.endTime, timezone, "HH:mm")
+
+    if (data.date || data.startTime || data.endTime) {
+      const { startTime, endTime } = normalizeCrewShiftTimes({
+        date,
+        startTime: startInput,
+        endTime: endInput,
+        timezone,
+      })
+      updateValues.startTime = startTime
+      updateValues.endTime = endTime
+    }
+
+    if (data.name !== undefined) updateValues.name = data.name
+    if (data.roleType !== undefined) updateValues.roleType = data.roleType
+    if (data.location !== undefined)
+      updateValues.location = emptyToNull(data.location)
+    if (data.capacity !== undefined) updateValues.capacity = data.capacity
+    if (data.notes !== undefined) updateValues.notes = emptyToNull(data.notes)
+
+    if (Object.keys(updateValues).length === 0) return { success: true }
+
+    updateValues.updatedAt = new Date()
+    const db = getDb()
+    await db
+      .update(volunteerShiftsTable)
+      .set(updateValues)
+      .where(eq(volunteerShiftsTable.id, data.shiftId))
+
+    return { success: true }
+  })
+
+export const deleteCrewShiftFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => deleteShiftInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    requireLocalCrewOperatorAccess("Crew shifts")
+
+    await requireCrewRosterEvent(data.eventId)
+    await requireCrewShift(data.eventId, data.shiftId)
+    const db = getDb()
+
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(volunteerShiftAssignmentsTable)
+        .where(eq(volunteerShiftAssignmentsTable.shiftId, data.shiftId))
+      await tx
+        .delete(volunteerShiftsTable)
+        .where(eq(volunteerShiftsTable.id, data.shiftId))
+    })
+
+    return { success: true }
+  })
+
+export const assignCrewVolunteerToShiftFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => shiftAssignmentInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    requireLocalCrewOperatorAccess("Crew shifts")
+
+    const event = await requireCrewRosterEvent(data.eventId)
+    const shift = await requireCrewShift(event.id, data.shiftId)
+    const db = getDb()
+    const [assignments, membership] = await Promise.all([
+      db.query.volunteerShiftAssignmentsTable.findMany({
+        where: eq(volunteerShiftAssignmentsTable.shiftId, shift.id),
+      }),
+      getAssignableVolunteer(db, event.competitionTeamId, data.membershipId),
+    ])
+
+    const existingAssignment = assignments.find(
+      (assignment) => assignment.membershipId === data.membershipId,
+    )
+    if (existingAssignment) {
+      return {
+        success: true,
+        action: "skipped_duplicate" as const,
+        assignmentId: existingAssignment.id,
+      }
+    }
+
+    const validation = validateShiftAssignment({
+      shiftRoleType: shift.roleType,
+      capacity: shift.capacity,
+      currentAssignmentMembershipIds: assignments.map(
+        (assignment) => assignment.membershipId,
+      ),
+      volunteer: membership
+        ? {
+            membershipId: membership.id,
+            isActive: membership.isActive,
+            roleTypes: normalizeCrewRosterRoleTypes(
+              parseCrewRosterMetadata(membership.metadata).volunteerRoleTypes,
+            ),
+          }
+        : null,
+    })
+
+    if (!validation.ok) {
+      throw new Error(validation.message)
+    }
+    if (!membership) {
+      throw new Error("Volunteer record was not found for this event.")
+    }
+
+    const assignmentId = createVolunteerShiftAssignmentId()
+    await db.insert(volunteerShiftAssignmentsTable).values({
+      id: assignmentId,
+      shiftId: shift.id,
+      membershipId: membership.id,
+      notes: emptyToNull(data.notes),
+    })
+
+    return { success: true, action: "assigned" as const, assignmentId }
+  })
+
+export const removeCrewVolunteerShiftAssignmentFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) => shiftAssignmentInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    requireLocalCrewOperatorAccess("Crew shifts")
+
+    const event = await requireCrewRosterEvent(data.eventId)
+    const shift = await requireCrewShift(event.id, data.shiftId)
+    const db = getDb()
+
+    await db
+      .delete(volunteerShiftAssignmentsTable)
+      .where(
+        and(
+          eq(volunteerShiftAssignmentsTable.shiftId, shift.id),
+          eq(volunteerShiftAssignmentsTable.membershipId, data.membershipId),
+        ),
+      )
+
+    return { success: true }
+  })
+
+async function requireCrewRosterEvent(
+  eventId: string,
+): Promise<CrewRosterCompetition> {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      name: competitionsTable.name,
+      slug: competitionsTable.slug,
+      competitionTeamId: competitionsTable.competitionTeamId,
+      timezone: competitionsTable.timezone,
+      startDate: competitionsTable.startDate,
+      endDate: competitionsTable.endDate,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  return event
+}
+
+async function loadCrewRoster(competitionTeamId: string) {
+  const db = getDb()
+  const [invitations, memberships] = await Promise.all([
+    db.query.teamInvitationTable.findMany({
+      where: and(
+        eq(teamInvitationTable.teamId, competitionTeamId),
+        eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamInvitationTable.isSystemRole, true),
+      ),
+      orderBy: [asc(teamInvitationTable.email)],
+    }),
+    db.query.teamMembershipTable.findMany({
+      where: and(
+        eq(teamMembershipTable.teamId, competitionTeamId),
+        eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamMembershipTable.isSystemRole, true),
+      ),
+      with: {
+        user: true,
+      },
+    }),
+  ])
+
+  return buildCrewRoster(invitations, memberships)
+}
+
+async function loadCrewShifts(
+  competitionId: string,
+): Promise<CrewShiftBoardItem[]> {
+  const db = getDb()
+  const shifts = await db.query.volunteerShiftsTable.findMany({
+    where: eq(volunteerShiftsTable.competitionId, competitionId),
+    orderBy: [asc(volunteerShiftsTable.startTime)],
+    with: {
+      assignments: {
+        with: {
+          membership: {
+            with: {
+              user: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  return shifts.map((shift) => {
+    const assignments = shift.assignments.map((assignment) => {
+      const metadata = parseCrewRosterMetadata(assignment.membership.metadata)
+      const roleTypes = normalizeCrewRosterRoleTypes(
+        metadata.volunteerRoleTypes,
+      )
+      const name =
+        metadata.signupName ||
+        [
+          assignment.membership.user?.firstName,
+          assignment.membership.user?.lastName,
+        ]
+          .filter(Boolean)
+          .join(" ") ||
+        assignment.membership.user?.email ||
+        "Unknown"
+
+      return {
+        id: assignment.id,
+        membershipId: assignment.membershipId,
+        notes: assignment.notes,
+        volunteer: {
+          membershipId: assignment.membershipId,
+          name,
+          email:
+            metadata.signupEmail ?? assignment.membership.user?.email ?? "",
+          roleTypes,
+        },
+      }
+    })
+
+    return {
+      id: shift.id,
+      competitionId: shift.competitionId,
+      name: shift.name,
+      roleType: shift.roleType,
+      roleLabel: formatVolunteerRole(shift.roleType),
+      startTime: shift.startTime,
+      endTime: shift.endTime,
+      location: shift.location,
+      capacity: shift.capacity,
+      notes: shift.notes,
+      assignments,
+      assignedCount: assignments.length,
+      openSlots: Math.max(shift.capacity - assignments.length, 0),
+    }
+  })
+}
+
+function summarizeCrewShifts(shifts: CrewShiftBoardItem[]): CrewShiftSummary {
+  return shifts.reduce<CrewShiftSummary>(
+    (summary, shift) => {
+      summary.totalShifts += 1
+      summary.assignedSlots += shift.assignedCount
+      summary.capacity += shift.capacity
+      summary.openSlots += shift.openSlots
+      return summary
+    },
+    { totalShifts: 0, assignedSlots: 0, capacity: 0, openSlots: 0 },
+  )
+}
+
+async function requireCrewShift(competitionId: string, shiftId: string) {
+  const db = getDb()
+  const shift = await db.query.volunteerShiftsTable.findFirst({
+    where: and(
+      eq(volunteerShiftsTable.id, shiftId),
+      eq(volunteerShiftsTable.competitionId, competitionId),
+    ),
+  })
+
+  if (!shift) {
+    throw new Error("Volunteer shift not found")
+  }
+
+  return shift
+}
+
+async function getAssignableVolunteer(
+  db: DbClient,
+  competitionTeamId: string,
+  membershipId: string,
+) {
+  return await db.query.teamMembershipTable.findFirst({
+    where: and(
+      eq(teamMembershipTable.id, membershipId),
+      eq(teamMembershipTable.teamId, competitionTeamId),
+      eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+      eq(teamMembershipTable.isSystemRole, true),
+    ),
+  })
+}
+
+function emptyToNull(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}

--- a/apps/crew/src/server-fns/crew-roster-shift-fns.ts
+++ b/apps/crew/src/server-fns/crew-roster-shift-fns.ts
@@ -20,7 +20,7 @@ import {
 import {
   buildCrewRoster,
   formatVolunteerRole,
-  normalizeCrewRosterRoleTypes,
+  getCrewRosterRoleTypes,
   normalizeCrewShiftTimes,
   parseCrewRosterMetadata,
   summarizeCrewRoster,
@@ -354,7 +354,7 @@ export const assignCrewVolunteerToShiftFn = createServerFn({ method: "POST" })
         ? {
             membershipId: membership.id,
             isActive: membership.isActive,
-            roleTypes: normalizeCrewRosterRoleTypes(
+            roleTypes: getCrewRosterRoleTypes(
               parseCrewRosterMetadata(membership.metadata).volunteerRoleTypes,
             ),
           }
@@ -480,9 +480,7 @@ async function loadCrewShifts(
   return shifts.map((shift) => {
     const assignments = shift.assignments.map((assignment) => {
       const metadata = parseCrewRosterMetadata(assignment.membership.metadata)
-      const roleTypes = normalizeCrewRosterRoleTypes(
-        metadata.volunteerRoleTypes,
-      )
+      const roleTypes = getCrewRosterRoleTypes(metadata.volunteerRoleTypes)
       const name =
         metadata.signupName ||
         [

--- a/apps/crew/src/server-fns/crew-roster-shift-fns.ts
+++ b/apps/crew/src/server-fns/crew-roster-shift-fns.ts
@@ -25,6 +25,7 @@ import {
   parseCrewRosterMetadata,
   summarizeCrewRoster,
   validateShiftAssignment,
+  validateShiftCapacityUpdate,
   type CrewRosterSummary,
   type CrewRosterVolunteer,
 } from "../lib/crew/roster-shifts"
@@ -33,8 +34,6 @@ import {
   DEFAULT_TIMEZONE,
   formatDateTimeInTimezone,
 } from "../utils/timezone-utils"
-
-type DbClient = ReturnType<typeof getDb>
 
 type CrewRosterCompetition = Pick<
   Competition,
@@ -254,45 +253,81 @@ export const updateCrewShiftFn = createServerFn({ method: "POST" })
     requireLocalCrewOperatorAccess("Crew shifts")
 
     const event = await requireCrewRosterEvent(data.eventId)
-    const existingShift = await requireCrewShift(event.id, data.shiftId)
-    const updateValues: Partial<typeof volunteerShiftsTable.$inferInsert> = {}
-    const timezone = event.timezone ?? DEFAULT_TIMEZONE
-    const date =
-      data.date ??
-      formatDateTimeInTimezone(existingShift.startTime, timezone, "yyyy-MM-dd")
-    const startInput =
-      data.startTime ??
-      formatDateTimeInTimezone(existingShift.startTime, timezone, "HH:mm")
-    const endInput =
-      data.endTime ??
-      formatDateTimeInTimezone(existingShift.endTime, timezone, "HH:mm")
-
-    if (data.date || data.startTime || data.endTime) {
-      const { startTime, endTime } = normalizeCrewShiftTimes({
-        date,
-        startTime: startInput,
-        endTime: endInput,
-        timezone,
-      })
-      updateValues.startTime = startTime
-      updateValues.endTime = endTime
-    }
-
-    if (data.name !== undefined) updateValues.name = data.name
-    if (data.roleType !== undefined) updateValues.roleType = data.roleType
-    if (data.location !== undefined)
-      updateValues.location = emptyToNull(data.location)
-    if (data.capacity !== undefined) updateValues.capacity = data.capacity
-    if (data.notes !== undefined) updateValues.notes = emptyToNull(data.notes)
-
-    if (Object.keys(updateValues).length === 0) return { success: true }
-
-    updateValues.updatedAt = new Date()
     const db = getDb()
-    await db
-      .update(volunteerShiftsTable)
-      .set(updateValues)
-      .where(eq(volunteerShiftsTable.id, data.shiftId))
+    await db.transaction(async (tx) => {
+      const [existingShift] = await tx
+        .select()
+        .from(volunteerShiftsTable)
+        .where(
+          and(
+            eq(volunteerShiftsTable.id, data.shiftId),
+            eq(volunteerShiftsTable.competitionId, event.id),
+          ),
+        )
+        .for("update")
+        .limit(1)
+
+      if (!existingShift) {
+        throw new Error("Volunteer shift not found")
+      }
+
+      const updateValues: Partial<typeof volunteerShiftsTable.$inferInsert> = {}
+      const timezone = event.timezone ?? DEFAULT_TIMEZONE
+      const date =
+        data.date ??
+        formatDateTimeInTimezone(
+          existingShift.startTime,
+          timezone,
+          "yyyy-MM-dd",
+        )
+      const startInput =
+        data.startTime ??
+        formatDateTimeInTimezone(existingShift.startTime, timezone, "HH:mm")
+      const endInput =
+        data.endTime ??
+        formatDateTimeInTimezone(existingShift.endTime, timezone, "HH:mm")
+
+      if (data.date || data.startTime || data.endTime) {
+        const { startTime, endTime } = normalizeCrewShiftTimes({
+          date,
+          startTime: startInput,
+          endTime: endInput,
+          timezone,
+        })
+        updateValues.startTime = startTime
+        updateValues.endTime = endTime
+      }
+
+      if (data.name !== undefined) updateValues.name = data.name
+      if (data.roleType !== undefined) updateValues.roleType = data.roleType
+      if (data.location !== undefined)
+        updateValues.location = emptyToNull(data.location)
+      if (data.capacity !== undefined) {
+        const currentAssignments = await tx
+          .select({ id: volunteerShiftAssignmentsTable.id })
+          .from(volunteerShiftAssignmentsTable)
+          .where(eq(volunteerShiftAssignmentsTable.shiftId, existingShift.id))
+
+        const capacityValidation = validateShiftCapacityUpdate(
+          data.capacity,
+          currentAssignments.length,
+        )
+        if (!capacityValidation.ok) {
+          throw new Error(capacityValidation.message)
+        }
+
+        updateValues.capacity = data.capacity
+      }
+      if (data.notes !== undefined) updateValues.notes = emptyToNull(data.notes)
+
+      if (Object.keys(updateValues).length === 0) return
+
+      updateValues.updatedAt = new Date()
+      await tx
+        .update(volunteerShiftsTable)
+        .set(updateValues)
+        .where(eq(volunteerShiftsTable.id, data.shiftId))
+    })
 
     return { success: true }
   })
@@ -323,60 +358,98 @@ export const assignCrewVolunteerToShiftFn = createServerFn({ method: "POST" })
   .handler(async ({ data }) => {
     requireLocalCrewOperatorAccess("Crew shifts")
 
-    const event = await requireCrewRosterEvent(data.eventId)
-    const shift = await requireCrewShift(event.id, data.shiftId)
     const db = getDb()
-    const [assignments, membership] = await Promise.all([
-      db.query.volunteerShiftAssignmentsTable.findMany({
-        where: eq(volunteerShiftAssignmentsTable.shiftId, shift.id),
-      }),
-      getAssignableVolunteer(db, event.competitionTeamId, data.membershipId),
-    ])
+    const event = await requireCrewRosterEvent(data.eventId)
 
-    const existingAssignment = assignments.find(
-      (assignment) => assignment.membershipId === data.membershipId,
-    )
-    if (existingAssignment) {
-      return {
-        success: true,
-        action: "skipped_duplicate" as const,
-        assignmentId: existingAssignment.id,
+    return await db.transaction(async (tx) => {
+      const [shift] = await tx
+        .select()
+        .from(volunteerShiftsTable)
+        .where(
+          and(
+            eq(volunteerShiftsTable.id, data.shiftId),
+            eq(volunteerShiftsTable.competitionId, event.id),
+          ),
+        )
+        .for("update")
+        .limit(1)
+
+      if (!shift) {
+        throw new Error("Volunteer shift not found")
       }
-    }
 
-    const validation = validateShiftAssignment({
-      shiftRoleType: shift.roleType,
-      capacity: shift.capacity,
-      currentAssignmentMembershipIds: assignments.map(
-        (assignment) => assignment.membershipId,
-      ),
-      volunteer: membership
-        ? {
-            membershipId: membership.id,
-            isActive: membership.isActive,
-            roleTypes: getCrewRosterRoleTypes(
-              parseCrewRosterMetadata(membership.metadata).volunteerRoleTypes,
+      const [assignments, membershipRows] = await Promise.all([
+        tx
+          .select({
+            id: volunteerShiftAssignmentsTable.id,
+            membershipId: volunteerShiftAssignmentsTable.membershipId,
+          })
+          .from(volunteerShiftAssignmentsTable)
+          .where(eq(volunteerShiftAssignmentsTable.shiftId, shift.id)),
+        tx
+          .select({
+            id: teamMembershipTable.id,
+            isActive: teamMembershipTable.isActive,
+            metadata: teamMembershipTable.metadata,
+          })
+          .from(teamMembershipTable)
+          .where(
+            and(
+              eq(teamMembershipTable.id, data.membershipId),
+              eq(teamMembershipTable.teamId, event.competitionTeamId),
+              eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+              eq(teamMembershipTable.isSystemRole, true),
             ),
-          }
-        : null,
+          )
+          .limit(1),
+      ])
+      const membership = membershipRows[0] ?? null
+
+      const existingAssignment = assignments.find(
+        (assignment) => assignment.membershipId === data.membershipId,
+      )
+      if (existingAssignment) {
+        return {
+          success: true,
+          action: "skipped_duplicate" as const,
+          assignmentId: existingAssignment.id,
+        }
+      }
+
+      const validation = validateShiftAssignment({
+        shiftRoleType: shift.roleType,
+        capacity: shift.capacity,
+        currentAssignmentMembershipIds: assignments.map(
+          (assignment) => assignment.membershipId,
+        ),
+        volunteer: membership
+          ? {
+              membershipId: membership.id,
+              isActive: membership.isActive,
+              roleTypes: getCrewRosterRoleTypes(
+                parseCrewRosterMetadata(membership.metadata).volunteerRoleTypes,
+              ),
+            }
+          : null,
+      })
+
+      if (!validation.ok) {
+        throw new Error(validation.message)
+      }
+      if (!membership) {
+        throw new Error("Volunteer record was not found for this event.")
+      }
+
+      const assignmentId = createVolunteerShiftAssignmentId()
+      await tx.insert(volunteerShiftAssignmentsTable).values({
+        id: assignmentId,
+        shiftId: shift.id,
+        membershipId: membership.id,
+        notes: emptyToNull(data.notes),
+      })
+
+      return { success: true, action: "assigned" as const, assignmentId }
     })
-
-    if (!validation.ok) {
-      throw new Error(validation.message)
-    }
-    if (!membership) {
-      throw new Error("Volunteer record was not found for this event.")
-    }
-
-    const assignmentId = createVolunteerShiftAssignmentId()
-    await db.insert(volunteerShiftAssignmentsTable).values({
-      id: assignmentId,
-      shiftId: shift.id,
-      membershipId: membership.id,
-      notes: emptyToNull(data.notes),
-    })
-
-    return { success: true, action: "assigned" as const, assignmentId }
   })
 
 export const removeCrewVolunteerShiftAssignmentFn = createServerFn({
@@ -551,21 +624,6 @@ async function requireCrewShift(competitionId: string, shiftId: string) {
   }
 
   return shift
-}
-
-async function getAssignableVolunteer(
-  db: DbClient,
-  competitionTeamId: string,
-  membershipId: string,
-) {
-  return await db.query.teamMembershipTable.findFirst({
-    where: and(
-      eq(teamMembershipTable.id, membershipId),
-      eq(teamMembershipTable.teamId, competitionTeamId),
-      eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
-      eq(teamMembershipTable.isSystemRole, true),
-    ),
-  })
 }
 
 function emptyToNull(value: string | null | undefined) {


### PR DESCRIPTION
## Summary
- add Crew roster helpers and route data for pending, accepted, active, inactive, and expired volunteer rows from team invitations and memberships
- add operator-side Crew shift board with create/edit/delete shift flows plus assign/remove volunteer actions backed by volunteer_shifts and volunteer_shift_assignments
- add dashboard roster/shift summaries, event nav link, generated route metadata, and focused helper tests for roster status, duplicate handling, assignment validation, and timezone shift normalization

## Validation
- pnpm --filter crew test -- src/lib/crew/roster-shifts.test.ts
- pnpm --filter crew type-check
- pnpm --filter crew build
- pnpm --filter crew lint (passes; existing warning-only diagnostics remain in unrelated files)
- pnpm check:schema-ownership
- git diff --check

## Notes
- Build validation used the established ignored local config workaround: copied apps/crew/wrangler.jsonc to apps/crew/.alchemy/local/wrangler.jsonc. The generated .alchemy and dist outputs are ignored and not committed.
- This slice intentionally keeps confirmation emails, public token responses, reminders, and notification wiring out of scope.
- Assignment validation is operator-side only and requires an active volunteer membership with a compatible role tag, allowing general volunteers as fallbacks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds operator-side crew roster and shift management for events, including CRUD shifts, volunteer assignments, and dashboard/volunteer views. Strengthens assignment and capacity validations (skips duplicates, blocks over-capacity, and prevents capacity edits below the number assigned).

- New Features
  - Roster helpers: map invitations/memberships into pending/accepted/active/inactive/expired, dedupe by email, and summarize.
  - Shifts: new board at /events/$eventId/shifts with create/edit/delete and assign/remove; server fns for page/board/dashboard; normalize shift times in the event timezone; guard capacity updates below current assignments.
  - Event UI: overview shows roster total and shift coverage; Volunteers lists roster with roles/availability and links to Shifts; “Shifts” nav and route added. Tests cover roster status/deduplication, assignment rules, capacity update guard, and timezone normalization.

- Bug Fixes
  - Hardened assignment validation with clear errors for missing/inactive volunteers; duplicate assignment is now a no-op. Volunteers without role tags default to `general` for validation.

<sup>Written for commit 181cbab68b26ac58627b54aae24781e9a73725ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift management capability: create, edit, delete shifts, and assign volunteers with role/capacity validation
  * Volunteer roster view displaying status breakdowns and availability details
  * New "Shifts" tab in event navigation for shift board access
  * Event overview now displays roster count and shift slot metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->