### PR TITLE
Add multipart docs video uploads

### DIFF
--- a/apps/wodsmith-start/src/lib/docs-video-upload.ts
+++ b/apps/wodsmith-start/src/lib/docs-video-upload.ts
@@ -1,0 +1,156 @@
+import {
+  DOCS_VIDEO_MAX_SIZE_MB,
+  DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES,
+} from "@/lib/upload-limits"
+
+export interface DocsVideoUploadResult {
+  url: string
+  key?: string
+}
+
+export interface DocsVideoMultipartInitiateResponse {
+  uploadId: string
+  uploadToken: string
+  key: string
+  chunkSize: number
+  maxSizeBytes: number
+}
+
+export interface DocsVideoMultipartPartResponse {
+  partNumber: number
+  etag: string
+  size: number
+}
+
+interface ApiErrorBody {
+  error?: string
+}
+
+const SMALL_DOCS_VIDEO_MAX_BYTES = DOCS_VIDEO_MAX_SIZE_MB * 1024 * 1024
+
+export function shouldUseDocsVideoMultipartUpload(file: Pick<File, "size">) {
+  return file.size > SMALL_DOCS_VIDEO_MAX_BYTES
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T | null> {
+  return (await response.json().catch(() => null)) as T | null
+}
+
+function getApiError(data: ApiErrorBody | null, fallback: string) {
+  return data?.error || fallback
+}
+
+async function uploadSmallDocsVideo(
+  file: File,
+): Promise<DocsVideoUploadResult> {
+  const formData = new FormData()
+  formData.append("file", file)
+  formData.append("purpose", "docs-video")
+
+  const response = await fetch("/api/upload", {
+    method: "POST",
+    body: formData,
+  })
+  const data = await readJsonResponse<DocsVideoUploadResult & ApiErrorBody>(
+    response,
+  )
+
+  if (!response.ok || !data?.url) {
+    throw new Error(getApiError(data, "Upload failed"))
+  }
+
+  return data
+}
+
+async function abortMultipartUpload(uploadToken: string) {
+  await fetch("/api/upload/docs-video", {
+    method: "DELETE",
+    headers: { "X-Docs-Video-Upload-Token": uploadToken },
+  }).catch(() => undefined)
+}
+
+export async function uploadMultipartDocsVideo(
+  file: File,
+): Promise<DocsVideoUploadResult> {
+  const initiateResponse = await fetch("/api/upload/docs-video", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      fileName: file.name,
+      fileSize: file.size,
+      contentType: file.type,
+    }),
+  })
+  const initiateData = await readJsonResponse<
+    DocsVideoMultipartInitiateResponse & ApiErrorBody
+  >(initiateResponse)
+
+  if (!initiateResponse.ok || !initiateData?.uploadToken) {
+    throw new Error(getApiError(initiateData, "Upload failed"))
+  }
+
+  const uploadToken = initiateData.uploadToken
+  const chunkSize =
+    initiateData.chunkSize > 0
+      ? initiateData.chunkSize
+      : DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES
+  const uploadedParts: DocsVideoMultipartPartResponse[] = []
+
+  try {
+    for (
+      let start = 0, partNumber = 1;
+      start < file.size;
+      start += chunkSize, partNumber += 1
+    ) {
+      const chunk = file.slice(start, Math.min(start + chunkSize, file.size))
+      const partResponse = await fetch(
+        `/api/upload/docs-video?partNumber=${partNumber}`,
+        {
+          method: "PUT",
+          headers: { "X-Docs-Video-Upload-Token": uploadToken },
+          body: chunk,
+        },
+      )
+      const partData = await readJsonResponse<
+        DocsVideoMultipartPartResponse & ApiErrorBody
+      >(partResponse)
+
+      if (
+        !partResponse.ok ||
+        !partData?.etag ||
+        !Number.isFinite(partData.size)
+      ) {
+        throw new Error(getApiError(partData, "Upload failed"))
+      }
+      uploadedParts.push(partData)
+    }
+
+    const completeResponse = await fetch("/api/upload/docs-video", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ uploadToken, parts: uploadedParts }),
+    })
+    const completeData = await readJsonResponse<
+      DocsVideoUploadResult & ApiErrorBody
+    >(completeResponse)
+
+    if (!completeResponse.ok || !completeData?.url) {
+      throw new Error(getApiError(completeData, "Upload failed"))
+    }
+
+    return completeData
+  } catch (error) {
+    await abortMultipartUpload(uploadToken)
+    throw error
+  }
+}
+
+export async function uploadDocsVideoFile(
+  file: File,
+): Promise<DocsVideoUploadResult> {
+  if (shouldUseDocsVideoMultipartUpload(file)) {
+    return uploadMultipartDocsVideo(file)
+  }
+
+  return uploadSmallDocsVideo(file)
+}

--- a/apps/wodsmith-start/src/lib/upload-limits.ts
+++ b/apps/wodsmith-start/src/lib/upload-limits.ts
@@ -1,1 +1,10 @@
 export const DOCS_VIDEO_MAX_SIZE_MB = 32
+export const DOCS_VIDEO_MULTIPART_MAX_SIZE_MB = 100
+export const DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES = 8 * 1024 * 1024
+export const DOCS_VIDEO_ALLOWED_TYPES = [
+  "video/mp4",
+  "video/webm",
+  "video/quicktime",
+] as const
+export const DOCS_VIDEO_ALLOWED_TYPE_LABEL = "MP4, WebM, MOV"
+export const DOCS_VIDEO_PATH_PREFIX = "docs/videos"

--- a/apps/wodsmith-start/src/routeTree.gen.ts
+++ b/apps/wodsmith-start/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as CompeteCohostInviteRouteImport } from './routes/compete/cohost
 import { Route as CompeteCohostRouteImport } from './routes/compete/cohost'
 import { Route as CompeteSlugRouteImport } from './routes/compete/$slug'
 import { Route as ApiUploadRouteImport } from './routes/api/upload'
+import { Route as ApiUploadDocsVideoRouteImport } from './routes/api/upload/docs-video'
 import { Route as ApiSitemapRouteImport } from './routes/api/sitemap'
 import { Route as ApiGetSessionRouteImport } from './routes/api/get-session'
 import { Route as ProtectedSettingsRouteImport } from './routes/_protected/settings'
@@ -297,6 +298,11 @@ const ApiUploadRoute = ApiUploadRouteImport.update({
   id: '/api/upload',
   path: '/api/upload',
   getParentRoute: () => rootRouteImport,
+} as any)
+const ApiUploadDocsVideoRoute = ApiUploadDocsVideoRouteImport.update({
+  id: '/docs-video',
+  path: '/docs-video',
+  getParentRoute: () => ApiUploadRoute,
 } as any)
 const ApiSitemapRoute = ApiSitemapRouteImport.update({
   id: '/api/sitemap',
@@ -1431,7 +1437,8 @@ export interface FileRoutesByFullPath {
   '/settings': typeof ProtectedSettingsRouteWithChildren
   '/api/get-session': typeof ApiGetSessionRoute
   '/api/sitemap': typeof ApiSitemapRoute
-  '/api/upload': typeof ApiUploadRoute
+  '/api/upload': typeof ApiUploadRouteWithChildren
+  '/api/upload/docs-video': typeof ApiUploadDocsVideoRoute
   '/compete/$slug': typeof CompeteSlugRouteWithChildren
   '/compete/cohost': typeof CompeteCohostRouteWithChildren
   '/compete/cohost-invite': typeof CompeteCohostInviteRouteWithChildren
@@ -1637,7 +1644,8 @@ export interface FileRoutesByTo {
   '/dashboard': typeof ProtectedDashboardRoute
   '/api/get-session': typeof ApiGetSessionRoute
   '/api/sitemap': typeof ApiSitemapRoute
-  '/api/upload': typeof ApiUploadRoute
+  '/api/upload': typeof ApiUploadRouteWithChildren
+  '/api/upload/docs-video': typeof ApiUploadDocsVideoRoute
   '/compete/cohost': typeof CompeteCohostRouteWithChildren
   '/compete/cohost-invite': typeof CompeteCohostInviteRouteWithChildren
   '/compete/organizer': typeof CompeteOrganizerDashboardIndexRoute
@@ -1837,7 +1845,8 @@ export interface FileRoutesById {
   '/_protected/settings': typeof ProtectedSettingsRouteWithChildren
   '/api/get-session': typeof ApiGetSessionRoute
   '/api/sitemap': typeof ApiSitemapRoute
-  '/api/upload': typeof ApiUploadRoute
+  '/api/upload': typeof ApiUploadRouteWithChildren
+  '/api/upload/docs-video': typeof ApiUploadDocsVideoRoute
   '/compete/$slug': typeof CompeteSlugRouteWithChildren
   '/compete/cohost': typeof CompeteCohostRouteWithChildren
   '/compete/cohost-invite': typeof CompeteCohostInviteRouteWithChildren
@@ -2050,6 +2059,7 @@ export interface FileRouteTypes {
     | '/api/get-session'
     | '/api/sitemap'
     | '/api/upload'
+    | '/api/upload/docs-video'
     | '/compete/$slug'
     | '/compete/cohost'
     | '/compete/cohost-invite'
@@ -2256,6 +2266,7 @@ export interface FileRouteTypes {
     | '/api/get-session'
     | '/api/sitemap'
     | '/api/upload'
+    | '/api/upload/docs-video'
     | '/compete/cohost'
     | '/compete/cohost-invite'
     | '/compete/organizer'
@@ -2455,6 +2466,7 @@ export interface FileRouteTypes {
     | '/api/get-session'
     | '/api/sitemap'
     | '/api/upload'
+    | '/api/upload/docs-video'
     | '/compete/$slug'
     | '/compete/cohost'
     | '/compete/cohost-invite'
@@ -2659,7 +2671,7 @@ export interface RootRouteChildren {
   TermsRoute: typeof TermsRoute
   ApiGetSessionRoute: typeof ApiGetSessionRoute
   ApiSitemapRoute: typeof ApiSitemapRoute
-  ApiUploadRoute: typeof ApiUploadRoute
+  ApiUploadRoute: typeof ApiUploadRouteWithChildren
   TransferTransferIdRoute: typeof TransferTransferIdRoute
   ApiAuthTokenRoute: typeof ApiAuthTokenRouteWithChildren
   ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute
@@ -2798,6 +2810,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/upload'
       preLoaderRoute: typeof ApiUploadRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/api/upload/docs-video': {
+      id: '/api/upload/docs-video'
+      path: '/docs-video'
+      fullPath: '/api/upload/docs-video'
+      preLoaderRoute: typeof ApiUploadDocsVideoRouteImport
+      parentRoute: typeof ApiUploadRoute
     }
     '/api/sitemap': {
       id: '/api/sitemap'
@@ -4842,6 +4861,17 @@ const CompeteRouteChildren: CompeteRouteChildren = {
 const CompeteRouteWithChildren =
   CompeteRoute._addFileChildren(CompeteRouteChildren)
 
+interface ApiUploadRouteChildren {
+  ApiUploadDocsVideoRoute: typeof ApiUploadDocsVideoRoute
+}
+
+const ApiUploadRouteChildren: ApiUploadRouteChildren = {
+  ApiUploadDocsVideoRoute: ApiUploadDocsVideoRoute,
+}
+
+const ApiUploadRouteWithChildren =
+  ApiUploadRoute._addFileChildren(ApiUploadRouteChildren)
+
 interface ApiAuthTokenRouteChildren {
   ApiAuthTokenRefreshRoute: typeof ApiAuthTokenRefreshRoute
 }
@@ -4865,7 +4895,7 @@ const rootRouteChildren: RootRouteChildren = {
   TermsRoute: TermsRoute,
   ApiGetSessionRoute: ApiGetSessionRoute,
   ApiSitemapRoute: ApiSitemapRoute,
-  ApiUploadRoute: ApiUploadRoute,
+  ApiUploadRoute: ApiUploadRouteWithChildren,
   TransferTransferIdRoute: TransferTransferIdRoute,
   ApiAuthTokenRoute: ApiAuthTokenRouteWithChildren,
   ApiWebhooksStripeRoute: ApiWebhooksStripeRoute,

--- a/apps/wodsmith-start/src/routes/admin/docs/-components/route-doc-form.tsx
+++ b/apps/wodsmith-start/src/routes/admin/docs/-components/route-doc-form.tsx
@@ -48,7 +48,11 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import { ROUTE_DOC_TYPES } from "@/db/schemas/route-docs"
-import { DOCS_VIDEO_MAX_SIZE_MB } from "@/lib/upload-limits"
+import { uploadDocsVideoFile } from "@/lib/docs-video-upload"
+import {
+  DOCS_VIDEO_MAX_SIZE_MB,
+  DOCS_VIDEO_MULTIPART_MAX_SIZE_MB,
+} from "@/lib/upload-limits"
 import { ORGANIZER_ROUTE_PREFIX } from "@/utils/route-docs"
 
 function isValidUrl(value: string): boolean {
@@ -443,24 +447,8 @@ function VideoField({
 
     setIsUploading(true)
     try {
-      const formData = new FormData()
-      formData.append("file", file)
-      formData.append("purpose", "docs-video")
-
-      const res = await fetch("/api/upload", {
-        method: "POST",
-        body: formData,
-      })
-      const data = (await res.json().catch(() => null)) as {
-        url?: string
-        error?: string
-      } | null
-
-      if (!res.ok || !data?.url) {
-        throw new Error(data?.error || "Upload failed")
-      }
-
-      onChange(data.url)
+      const result = await uploadDocsVideoFile(file)
+      onChange(result.url)
       toast.success("Video uploaded")
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Upload failed")
@@ -504,7 +492,8 @@ function VideoField({
       </div>
       <p className="text-xs text-muted-foreground">
         Paste a YouTube/Vimeo URL, or upload an MP4/WebM/MOV (max{" "}
-        {DOCS_VIDEO_MAX_SIZE_MB}MB, stored on R2).
+        {DOCS_VIDEO_MULTIPART_MAX_SIZE_MB}MB; files up to{" "}
+        {DOCS_VIDEO_MAX_SIZE_MB}MB use the compatibility uploader).
       </p>
     </div>
   )

--- a/apps/wodsmith-start/src/routes/api/upload.ts
+++ b/apps/wodsmith-start/src/routes/api/upload.ts
@@ -28,14 +28,17 @@ import {
   logWarning,
   updateRequestContext,
 } from "@/lib/logging"
-import { DOCS_VIDEO_MAX_SIZE_MB } from "@/lib/upload-limits"
+import {
+  DOCS_VIDEO_ALLOWED_TYPE_LABEL,
+  DOCS_VIDEO_ALLOWED_TYPES,
+  DOCS_VIDEO_MAX_SIZE_MB,
+  DOCS_VIDEO_PATH_PREFIX,
+} from "@/lib/upload-limits"
 import { checkUploadAuthorization } from "@/server/upload-authorization"
 import { getSessionFromCookie } from "@/utils/auth"
 
 const IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"]
 const DOCUMENT_TYPES = ["application/pdf"]
-const VIDEO_TYPES = ["video/mp4", "video/webm", "video/quicktime"]
-
 const PURPOSE_CONFIG: Record<
   string,
   { maxSizeMb: number; pathPrefix: string; allowedTypes: string[] }
@@ -78,8 +81,8 @@ const PURPOSE_CONFIG: Record<
   // Documentation drawer videos (site admin only, see upload-authorization)
   "docs-video": {
     maxSizeMb: DOCS_VIDEO_MAX_SIZE_MB,
-    pathPrefix: "docs/videos",
-    allowedTypes: VIDEO_TYPES,
+    pathPrefix: DOCS_VIDEO_PATH_PREFIX,
+    allowedTypes: [...DOCS_VIDEO_ALLOWED_TYPES],
   },
 }
 
@@ -190,7 +193,7 @@ export const Route = createFileRoute("/api/upload")({
             purpose === "judging-sheet"
               ? "PDF"
               : purpose === "docs-video"
-                ? "MP4, WebM, MOV"
+                ? DOCS_VIDEO_ALLOWED_TYPE_LABEL
                 : "JPEG, PNG, WebP, GIF"
           return json(
             { error: `Invalid file type. Allowed: ${allowedTypeNames}` },

--- a/apps/wodsmith-start/src/routes/api/upload/docs-video.ts
+++ b/apps/wodsmith-start/src/routes/api/upload/docs-video.ts
@@ -1,0 +1,535 @@
+import { env } from "cloudflare:workers"
+import { createFileRoute } from "@tanstack/react-router"
+import { json } from "@tanstack/react-start"
+import {
+  addRequestContextAttribute,
+  logError,
+  logInfo,
+  logWarning,
+  updateRequestContext,
+} from "@/lib/logging"
+import {
+  DOCS_VIDEO_ALLOWED_TYPE_LABEL,
+  DOCS_VIDEO_ALLOWED_TYPES,
+  DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES,
+  DOCS_VIDEO_MULTIPART_MAX_SIZE_MB,
+  DOCS_VIDEO_PATH_PREFIX,
+} from "@/lib/upload-limits"
+import { checkUploadAuthorization } from "@/server/upload-authorization"
+import { getSessionFromCookie } from "@/utils/auth"
+
+const DOCS_VIDEO_UPLOAD_TOKEN_TTL_MS = 60 * 60 * 1000
+const UPLOAD_TOKEN_HEADER = "X-Docs-Video-Upload-Token"
+
+interface DocsVideoUploadedPart extends R2UploadedPart {
+  size: number
+}
+
+interface DocsVideoUploadTokenPayload {
+  uploadId: string
+  key: string
+  userId: string
+  originalFilename: string
+  fileSize: number
+  contentType: string
+  createdAt: number
+  expiresAt: number
+}
+
+interface InitiateBody {
+  fileName?: string
+  fileSize?: number
+  contentType?: string
+}
+
+interface ValidInitiateBody {
+  fileName: string
+  fileSize: number
+  contentType: string
+}
+
+interface CompleteBody {
+  uploadToken?: string
+  parts?: DocsVideoUploadedPart[]
+}
+
+type UploadSession = NonNullable<
+  Awaited<ReturnType<typeof getSessionFromCookie>>
+>
+
+type AuthenticatedUpload =
+  | { ok: true; session: UploadSession }
+  | { ok: false; response: Response }
+
+async function readJsonBody<T>(request: Request): Promise<T | null> {
+  return (await request.json().catch(() => null)) as T | null
+}
+
+async function requireDocsVideoUploadAuth(): Promise<AuthenticatedUpload> {
+  const session = await getSessionFromCookie()
+  if (!session) {
+    logWarning({ message: "[DocsVideoUpload] Unauthorized upload attempt" })
+    return {
+      ok: false,
+      response: json({ error: "Unauthorized" }, { status: 401 }),
+    }
+  }
+
+  updateRequestContext({ userId: session.user.id })
+  addRequestContextAttribute("uploadPurpose", "docs-video")
+
+  const authCheck = await checkUploadAuthorization(
+    "docs-video",
+    null,
+    session.user.id,
+  )
+  if (!authCheck.authorized) {
+    logWarning({
+      message: "[DocsVideoUpload] Authorization denied",
+      attributes: { reason: authCheck.error },
+    })
+    return {
+      ok: false,
+      response: json(
+        { error: authCheck.error || "Forbidden" },
+        { status: 403 },
+      ),
+    }
+  }
+
+  return { ok: true, session }
+}
+
+function validateInitiateBody(body: InitiateBody | null) {
+  if (!body?.fileName || !body.fileSize || !body.contentType) {
+    return "fileName, fileSize, and contentType are required"
+  }
+
+  if (!Number.isFinite(body.fileSize) || body.fileSize <= 0) {
+    return "Invalid file size"
+  }
+
+  const maxSizeBytes = DOCS_VIDEO_MULTIPART_MAX_SIZE_MB * 1024 * 1024
+  if (body.fileSize > maxSizeBytes) {
+    return `File too large. Maximum size is ${DOCS_VIDEO_MULTIPART_MAX_SIZE_MB}MB`
+  }
+
+  if (!DOCS_VIDEO_ALLOWED_TYPES.some((type) => type === body.contentType)) {
+    return `Invalid file type. Allowed: ${DOCS_VIDEO_ALLOWED_TYPE_LABEL}`
+  }
+
+  return null
+}
+
+function parseValidInitiateBody(body: InitiateBody | null) {
+  const error = validateInitiateBody(body)
+  if (error || !body?.fileName || !body.fileSize || !body.contentType) {
+    return { ok: false as const, error: error || "Invalid request" }
+  }
+
+  return {
+    ok: true as const,
+    body: {
+      fileName: body.fileName,
+      fileSize: body.fileSize,
+      contentType: body.contentType,
+    } satisfies ValidInitiateBody,
+  }
+}
+
+function getExtension(fileName: string, contentType: string) {
+  const fileExtension = fileName.split(".").pop()?.toLowerCase()
+  if (fileExtension && ["mp4", "webm", "mov", "qt"].includes(fileExtension)) {
+    return fileExtension === "qt" ? "mov" : fileExtension
+  }
+
+  if (contentType === "video/webm") return "webm"
+  if (contentType === "video/quicktime") return "mov"
+  return "mp4"
+}
+
+function buildPublicUrl(key: string) {
+  return env.R2_PUBLIC_URL ? `${env.R2_PUBLIC_URL}/${key}` : key
+}
+
+function base64UrlEncodeBytes(bytes: Uint8Array) {
+  let binary = ""
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "")
+}
+
+function base64UrlDecodeBytes(value: string) {
+  const base64 = value.replaceAll("-", "+").replaceAll("_", "/")
+  const paddingLength = (4 - (base64.length % 4)) % 4
+  const binary = atob(base64 + "=".repeat(paddingLength))
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0))
+}
+
+function encodePayload(payload: DocsVideoUploadTokenPayload) {
+  return base64UrlEncodeBytes(new TextEncoder().encode(JSON.stringify(payload)))
+}
+
+function decodePayload(value: string) {
+  return JSON.parse(
+    new TextDecoder().decode(base64UrlDecodeBytes(value)),
+  ) as DocsVideoUploadTokenPayload
+}
+
+async function getUploadTokenSigningKey(session: UploadSession) {
+  return await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(
+      `docs-video-upload:${session.id}:${session.user.id}`,
+    ),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign", "verify"],
+  )
+}
+
+async function signUploadPayload(
+  payload: DocsVideoUploadTokenPayload,
+  session: UploadSession,
+) {
+  const encodedPayload = encodePayload(payload)
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    await getUploadTokenSigningKey(session),
+    new TextEncoder().encode(encodedPayload),
+  )
+
+  return `${encodedPayload}.${base64UrlEncodeBytes(new Uint8Array(signature))}`
+}
+
+async function verifyUploadToken(
+  uploadToken: string | null | undefined,
+  session: UploadSession,
+) {
+  if (!uploadToken) return null
+
+  try {
+    const tokenParts = uploadToken.split(".")
+    if (tokenParts.length !== 2) return null
+
+    const [encodedPayload, encodedSignature] = tokenParts
+    if (!encodedPayload || !encodedSignature) return null
+
+    const isValid = await crypto.subtle.verify(
+      "HMAC",
+      await getUploadTokenSigningKey(session),
+      base64UrlDecodeBytes(encodedSignature),
+      new TextEncoder().encode(encodedPayload),
+    )
+    if (!isValid) return null
+
+    const payload = decodePayload(encodedPayload)
+    if (payload.userId !== session.user.id || payload.expiresAt < Date.now()) {
+      return null
+    }
+
+    return payload
+  } catch {
+    return null
+  }
+}
+
+function getExpectedPartCount(fileSize: number) {
+  return Math.ceil(fileSize / DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES)
+}
+
+function getExpectedPartSize(fileSize: number, partNumber: number) {
+  const expectedPartCount = getExpectedPartCount(fileSize)
+  if (partNumber < 1 || partNumber > expectedPartCount) return null
+  if (partNumber < expectedPartCount) {
+    return DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES
+  }
+
+  const finalPartSize = fileSize % DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES
+  return finalPartSize === 0
+    ? DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES
+    : finalPartSize
+}
+
+function toR2UploadedParts(parts: DocsVideoUploadedPart[]): R2UploadedPart[] {
+  return parts.map(({ partNumber, etag }) => ({ partNumber, etag }))
+}
+
+function validateUploadedParts(
+  parts: DocsVideoUploadedPart[] | undefined,
+  payload: DocsVideoUploadTokenPayload,
+) {
+  if (!Array.isArray(parts) || parts.length === 0) {
+    return { ok: false as const, error: "No uploaded parts to complete" }
+  }
+
+  const expectedPartCount = getExpectedPartCount(payload.fileSize)
+  if (parts.length !== expectedPartCount) {
+    return {
+      ok: false as const,
+      error: "Uploaded parts do not match declared file size",
+    }
+  }
+
+  const sortedParts = [...parts].sort((a, b) => a.partNumber - b.partNumber)
+  let uploadedByteCount = 0
+  for (let index = 0; index < expectedPartCount; index += 1) {
+    const expectedPartNumber = index + 1
+    const part = sortedParts[index]
+    const expectedPartSize = getExpectedPartSize(
+      payload.fileSize,
+      expectedPartNumber,
+    )
+    if (
+      !part ||
+      part.partNumber !== expectedPartNumber ||
+      typeof part.etag !== "string" ||
+      part.etag.length === 0 ||
+      !Number.isFinite(part.size) ||
+      part.size !== expectedPartSize
+    ) {
+      return {
+        ok: false as const,
+        error: "Uploaded parts do not match declared file size",
+      }
+    }
+    uploadedByteCount += part.size
+  }
+
+  if (uploadedByteCount !== payload.fileSize) {
+    return {
+      ok: false as const,
+      error: "Uploaded parts do not match declared file size",
+    }
+  }
+
+  return { ok: true as const, parts: sortedParts }
+}
+
+export const Route = createFileRoute("/api/upload/docs-video")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        const auth = await requireDocsVideoUploadAuth()
+        if (!auth.ok) return auth.response
+
+        const parsedBody = parseValidInitiateBody(
+          await readJsonBody<InitiateBody>(request),
+        )
+        if (!parsedBody.ok) {
+          return json({ error: parsedBody.error }, { status: 400 })
+        }
+        const { body } = parsedBody
+
+        const extension = getExtension(body.fileName, body.contentType)
+        const key = `${DOCS_VIDEO_PATH_PREFIX}/${auth.session.user.id}/${Date.now()}-${crypto.randomUUID()}.${extension}`
+
+        try {
+          const multipartUpload = await env.R2_BUCKET.createMultipartUpload(
+            key,
+            {
+              httpMetadata: {
+                contentType: body.contentType,
+              },
+              customMetadata: {
+                uploadedBy: auth.session.user.id,
+                purpose: "docs-video",
+                originalFilename: body.fileName,
+              },
+            },
+          )
+
+          const now = Date.now()
+          const uploadToken = await signUploadPayload(
+            {
+              uploadId: multipartUpload.uploadId,
+              key,
+              userId: auth.session.user.id,
+              originalFilename: body.fileName,
+              fileSize: body.fileSize,
+              contentType: body.contentType,
+              createdAt: now,
+              expiresAt: now + DOCS_VIDEO_UPLOAD_TOKEN_TTL_MS,
+            },
+            auth.session,
+          )
+
+          logInfo({
+            message: "[DocsVideoUpload] Multipart upload initiated",
+            attributes: {
+              key,
+              fileSize: body.fileSize,
+              mimeType: body.contentType,
+            },
+          })
+
+          return json({
+            uploadId: multipartUpload.uploadId,
+            uploadToken,
+            key,
+            chunkSize: DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES,
+            maxSizeBytes: DOCS_VIDEO_MULTIPART_MAX_SIZE_MB * 1024 * 1024,
+          })
+        } catch (err) {
+          logError({
+            message: "[DocsVideoUpload] Failed to initiate multipart upload",
+            error: err,
+            attributes: { fileName: body.fileName },
+          })
+          return json({ error: "Upload failed" }, { status: 500 })
+        }
+      },
+      PUT: async ({ request }) => {
+        const auth = await requireDocsVideoUploadAuth()
+        if (!auth.ok) return auth.response
+
+        const partNumber = Number(
+          new URL(request.url).searchParams.get("partNumber"),
+        )
+        if (!Number.isInteger(partNumber) || partNumber < 1) {
+          return json({ error: "partNumber is required" }, { status: 400 })
+        }
+
+        if (!request.body) {
+          return json({ error: "No upload body provided" }, { status: 400 })
+        }
+
+        const uploadPayload = await verifyUploadToken(
+          request.headers.get(UPLOAD_TOKEN_HEADER),
+          auth.session,
+        )
+        if (!uploadPayload) {
+          return json({ error: "Invalid upload token" }, { status: 400 })
+        }
+
+        const expectedPartSize = getExpectedPartSize(
+          uploadPayload.fileSize,
+          partNumber,
+        )
+        if (!expectedPartSize) {
+          return json({ error: "Invalid part number" }, { status: 400 })
+        }
+
+        const contentLength = Number(request.headers.get("Content-Length"))
+        if (!Number.isFinite(contentLength) || contentLength <= 0) {
+          return json(
+            { error: "Upload part size is required" },
+            { status: 400 },
+          )
+        }
+
+        if (contentLength !== expectedPartSize) {
+          return json(
+            { error: "Upload part size does not match expected size" },
+            { status: 400 },
+          )
+        }
+
+        try {
+          const multipartUpload = env.R2_BUCKET.resumeMultipartUpload(
+            uploadPayload.key,
+            uploadPayload.uploadId,
+          )
+          const uploadedPart = await multipartUpload.uploadPart(
+            partNumber,
+            request.body,
+          )
+
+          return json({ ...uploadedPart, size: contentLength })
+        } catch (err) {
+          logError({
+            message: "[DocsVideoUpload] Multipart part upload failed",
+            error: err,
+            attributes: { uploadId: uploadPayload.uploadId, partNumber },
+          })
+          return json({ error: "Upload failed" }, { status: 500 })
+        }
+      },
+      PATCH: async ({ request }) => {
+        const auth = await requireDocsVideoUploadAuth()
+        if (!auth.ok) return auth.response
+
+        const body = await readJsonBody<CompleteBody>(request)
+        const uploadPayload = await verifyUploadToken(
+          body?.uploadToken,
+          auth.session,
+        )
+        if (!uploadPayload) {
+          return json({ error: "Invalid upload token" }, { status: 400 })
+        }
+
+        const uploadedParts = validateUploadedParts(body?.parts, uploadPayload)
+        if (!uploadedParts.ok) {
+          return json({ error: uploadedParts.error }, { status: 400 })
+        }
+
+        try {
+          const multipartUpload = env.R2_BUCKET.resumeMultipartUpload(
+            uploadPayload.key,
+            uploadPayload.uploadId,
+          )
+          await multipartUpload.complete(toR2UploadedParts(uploadedParts.parts))
+
+          addRequestContextAttribute("uploadKey", uploadPayload.key)
+          logInfo({
+            message: "[DocsVideoUpload] Multipart upload completed",
+            attributes: {
+              key: uploadPayload.key,
+              fileSize: uploadPayload.fileSize,
+            },
+          })
+
+          return json({
+            url: buildPublicUrl(uploadPayload.key),
+            key: uploadPayload.key,
+            originalFilename: uploadPayload.originalFilename,
+            fileSize: uploadPayload.fileSize,
+            mimeType: uploadPayload.contentType,
+          })
+        } catch (err) {
+          logError({
+            message: "[DocsVideoUpload] Multipart completion failed",
+            error: err,
+            attributes: { uploadId: uploadPayload.uploadId },
+          })
+          return json({ error: "Upload failed" }, { status: 500 })
+        }
+      },
+      DELETE: async ({ request }) => {
+        const auth = await requireDocsVideoUploadAuth()
+        if (!auth.ok) return auth.response
+
+        const uploadPayload = await verifyUploadToken(
+          request.headers.get(UPLOAD_TOKEN_HEADER),
+          auth.session,
+        )
+        if (!uploadPayload) {
+          return json({ ok: true })
+        }
+
+        try {
+          const multipartUpload = env.R2_BUCKET.resumeMultipartUpload(
+            uploadPayload.key,
+            uploadPayload.uploadId,
+          )
+          await multipartUpload.abort()
+        } catch (err) {
+          logWarning({
+            message: "[DocsVideoUpload] Multipart abort failed",
+            attributes: {
+              uploadId: uploadPayload.uploadId,
+              error: String(err),
+            },
+          })
+        }
+
+        return json({ ok: true })
+      },
+    },
+  },
+})

--- a/apps/wodsmith-start/test/lib/docs-video-upload.test.ts
+++ b/apps/wodsmith-start/test/lib/docs-video-upload.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  shouldUseDocsVideoMultipartUpload,
+  uploadDocsVideoFile,
+} from "@/lib/docs-video-upload"
+import { DOCS_VIDEO_MAX_SIZE_MB } from "@/lib/upload-limits"
+
+function jsonResponse(data: unknown, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function createFileLike(size: number) {
+  return {
+    name: "training.mp4",
+    size,
+    type: "video/mp4",
+    slice: vi.fn(() => new Blob(["chunk"], { type: "video/mp4" })),
+  } as unknown as File
+}
+
+describe("docs video upload client", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("keeps docs videos up to the fallback cap on the compatibility upload route", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse({ url: "https://uploads/video.mp4" }))
+    const file = createFileLike(DOCS_VIDEO_MAX_SIZE_MB * 1024 * 1024)
+
+    const result = await uploadDocsVideoFile(file)
+
+    expect(result.url).toBe("https://uploads/video.mp4")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/upload")
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: "POST" })
+    expect(fetchMock.mock.calls[0][1]?.body).toBeInstanceOf(FormData)
+  })
+
+  it("uses multipart route calls for docs videos above the fallback cap", async () => {
+    const file = createFileLike(DOCS_VIDEO_MAX_SIZE_MB * 1024 * 1024 + 1)
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          uploadId: "upload-123",
+          uploadToken: "signed-token",
+          key: "docs/videos/user/video.mp4",
+          chunkSize: 64 * 1024 * 1024,
+          maxSizeBytes: 100 * 1024 * 1024,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({ partNumber: 1, etag: "etag-1", size: file.size }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ url: "https://uploads/video.mp4" }))
+
+    const result = await uploadDocsVideoFile(file)
+
+    expect(result.url).toBe("https://uploads/video.mp4")
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/upload/docs-video")
+    expect(fetchMock.mock.calls[0][1]).toMatchObject({ method: "POST" })
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "/api/upload/docs-video?partNumber=1",
+    )
+    expect(fetchMock.mock.calls[1][1]).toMatchObject({
+      method: "PUT",
+      headers: { "X-Docs-Video-Upload-Token": "signed-token" },
+    })
+    expect(fetchMock.mock.calls[1][1]?.body).toBeInstanceOf(Blob)
+    expect(fetchMock.mock.calls[2][0]).toBe("/api/upload/docs-video")
+    expect(fetchMock.mock.calls[2][1]).toMatchObject({ method: "PATCH" })
+    expect(JSON.parse(String(fetchMock.mock.calls[2][1]?.body))).toEqual({
+      uploadToken: "signed-token",
+      parts: [{ partNumber: 1, etag: "etag-1", size: file.size }],
+    })
+  })
+
+  it("aborts the multipart upload when a part fails", async () => {
+    const file = createFileLike(DOCS_VIDEO_MAX_SIZE_MB * 1024 * 1024 + 1)
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({
+          uploadId: "upload-123",
+          uploadToken: "signed-token",
+          key: "docs/videos/user/video.mp4",
+          chunkSize: 64 * 1024 * 1024,
+          maxSizeBytes: 100 * 1024 * 1024,
+        }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: "part failed" }, 500))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+
+    await expect(uploadDocsVideoFile(file)).rejects.toThrow("part failed")
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[2][0]).toBe("/api/upload/docs-video")
+    expect(fetchMock.mock.calls[2][1]).toMatchObject({
+      method: "DELETE",
+      headers: { "X-Docs-Video-Upload-Token": "signed-token" },
+    })
+  })
+
+  it("selects multipart only above the fallback cap", () => {
+    expect(
+      shouldUseDocsVideoMultipartUpload({
+        size: DOCS_VIDEO_MAX_SIZE_MB * 1024 * 1024,
+      } as File),
+    ).toBe(false)
+    expect(
+      shouldUseDocsVideoMultipartUpload({
+        size: DOCS_VIDEO_MAX_SIZE_MB * 1024 * 1024 + 1,
+      } as File),
+    ).toBe(true)
+  })
+})

--- a/apps/wodsmith-start/test/routes/api/upload-docs-video.test.ts
+++ b/apps/wodsmith-start/test/routes/api/upload-docs-video.test.ts
@@ -1,0 +1,345 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockKvGet = vi.hoisted(() => vi.fn())
+const mockKvPut = vi.hoisted(() => vi.fn())
+const mockKvDelete = vi.hoisted(() => vi.fn())
+const mockCreateMultipartUpload = vi.hoisted(() => vi.fn())
+const mockResumeMultipartUpload = vi.hoisted(() => vi.fn())
+const mockUploadPart = vi.hoisted(() => vi.fn())
+const mockComplete = vi.hoisted(() => vi.fn())
+const mockAbort = vi.hoisted(() => vi.fn())
+const mockGetSessionFromCookie = vi.hoisted(() => vi.fn())
+const mockCheckUploadAuthorization = vi.hoisted(() => vi.fn())
+
+vi.mock("cloudflare:workers", () => ({
+  env: {
+    KV_SESSION: {
+      get: (...args: unknown[]) => mockKvGet(...args),
+      put: (...args: unknown[]) => mockKvPut(...args),
+      delete: (...args: unknown[]) => mockKvDelete(...args),
+    },
+    R2_BUCKET: {
+      createMultipartUpload: (...args: unknown[]) =>
+        mockCreateMultipartUpload(...args),
+      resumeMultipartUpload: (...args: unknown[]) =>
+        mockResumeMultipartUpload(...args),
+    },
+    R2_PUBLIC_URL: "https://uploads.wodsmith.test",
+  },
+}))
+
+vi.mock("@/utils/auth", () => ({
+  getSessionFromCookie: (...args: unknown[]) =>
+    mockGetSessionFromCookie(...args),
+}))
+
+vi.mock("@/server/upload-authorization", () => ({
+  checkUploadAuthorization: (...args: unknown[]) =>
+    mockCheckUploadAuthorization(...args),
+}))
+
+vi.mock("@/lib/logging", () => ({
+  addRequestContextAttribute: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+  logWarning: vi.fn(),
+  updateRequestContext: vi.fn(),
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: unknown) => config,
+}))
+
+vi.mock("@tanstack/react-start", () => ({
+  json: (data: unknown, init?: { status?: number }) =>
+    new Response(JSON.stringify(data), {
+      status: init?.status ?? 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+}))
+
+import {
+  DOCS_VIDEO_ALLOWED_TYPE_LABEL,
+  DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES,
+  DOCS_VIDEO_MULTIPART_MAX_SIZE_MB,
+} from "@/lib/upload-limits"
+import { Route } from "@/routes/api/upload/docs-video"
+
+const routeConfig = Route as unknown as {
+  server: {
+    handlers: {
+      POST: (args: { request: Request }) => Promise<Response>
+      PUT: (args: { request: Request }) => Promise<Response>
+      PATCH: (args: { request: Request }) => Promise<Response>
+      DELETE: (args: { request: Request }) => Promise<Response>
+    }
+  }
+}
+
+interface InitiateResponse {
+  uploadId: string
+  uploadToken: string
+  key: string
+  chunkSize: number
+}
+
+function jsonRequest(method: string, body: unknown) {
+  return new Request("https://wodsmith.test/api/upload/docs-video", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+async function initiateUpload({
+  fileName = "training.mp4",
+  fileSize = 64 * 1024 * 1024,
+  contentType = "video/mp4",
+}: {
+  fileName?: string
+  fileSize?: number
+  contentType?: string
+} = {}) {
+  const response = await routeConfig.server.handlers.POST({
+    request: jsonRequest("POST", { fileName, fileSize, contentType }),
+  })
+
+  return {
+    response,
+    data: (await response.json()) as InitiateResponse & { error?: string },
+  }
+}
+
+function partRequest(uploadToken: string, partNumber: number, size: number) {
+  return new Request(
+    `https://wodsmith.test/api/upload/docs-video?partNumber=${partNumber}`,
+    {
+      method: "PUT",
+      body: new Blob(["chunk"], { type: "video/mp4" }),
+      headers: {
+        "Content-Length": String(size),
+        "X-Docs-Video-Upload-Token": uploadToken,
+      },
+    },
+  )
+}
+
+describe("docs video multipart upload route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetSessionFromCookie.mockResolvedValue({
+      id: "session-123",
+      userId: "user-admin",
+      user: { id: "user-admin", role: "admin" },
+    })
+    mockCheckUploadAuthorization.mockResolvedValue({ authorized: true })
+    mockCreateMultipartUpload.mockResolvedValue({
+      key: "docs/videos/user-admin/video.mp4",
+      uploadId: "upload-123",
+    })
+    mockResumeMultipartUpload.mockReturnValue({
+      uploadPart: mockUploadPart,
+      complete: mockComplete,
+      abort: mockAbort,
+    })
+    mockUploadPart.mockResolvedValue({ partNumber: 1, etag: "etag-1" })
+    mockComplete.mockResolvedValue({ key: "docs/videos/user-admin/video.mp4" })
+    mockAbort.mockResolvedValue(undefined)
+  })
+
+  it("initiates an authenticated multipart docs-video upload without reading formData", async () => {
+    // @lat: [[route-docs#Video storage#Initiates large multipart docs-video uploads]]
+    const request = jsonRequest("POST", {
+      fileName: "training.mp4",
+      fileSize: 64 * 1024 * 1024,
+      contentType: "video/mp4",
+    }) as Request & { formData: ReturnType<typeof vi.fn> }
+    request.formData = vi.fn()
+
+    const response = await routeConfig.server.handlers.POST({ request })
+    const data = (await response.json()) as InitiateResponse
+
+    expect(response.status).toBe(200)
+    expect(request.formData).not.toHaveBeenCalled()
+    expect(mockCreateMultipartUpload).toHaveBeenCalledTimes(1)
+    expect(mockCreateMultipartUpload.mock.calls[0][0]).toMatch(
+      /^docs\/videos\/user-admin\/\d+-[a-f0-9-]+\.mp4$/,
+    )
+    expect(mockCreateMultipartUpload.mock.calls[0][1]).toMatchObject({
+      httpMetadata: { contentType: "video/mp4" },
+      customMetadata: {
+        uploadedBy: "user-admin",
+        purpose: "docs-video",
+        originalFilename: "training.mp4",
+      },
+    })
+    expect(mockKvPut).not.toHaveBeenCalled()
+    expect(data.uploadId).toBe("upload-123")
+    expect(data.uploadToken).toEqual(expect.any(String))
+    expect(data.key).toMatch(/^docs\/videos\/user-admin\//)
+    expect(data.chunkSize).toBe(DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES)
+  })
+
+  it("streams raw PUT request bodies into R2 multipart parts", async () => {
+    // @lat: [[route-docs#Video storage#Streams raw multipart parts to R2]]
+    const { data: initiateData } = await initiateUpload({ fileSize: 5 })
+    const request = partRequest(initiateData.uploadToken, 1, 5)
+    const expectedBody = request.body
+
+    const response = await routeConfig.server.handlers.PUT({ request })
+    const data = (await response.json()) as {
+      partNumber: number
+      etag: string
+      size: number
+    }
+
+    expect(response.status).toBe(200)
+    expect(mockResumeMultipartUpload).toHaveBeenCalledWith(
+      initiateData.key,
+      "upload-123",
+    )
+    expect(mockUploadPart).toHaveBeenCalledWith(1, expectedBody)
+    expect(data).toEqual({ partNumber: 1, etag: "etag-1", size: 5 })
+    expect(mockKvGet).not.toHaveBeenCalled()
+    expect(mockKvPut).not.toHaveBeenCalled()
+  })
+
+  it("rejects part uploads whose size does not match the initiated chunk plan", async () => {
+    const { data: initiateData } = await initiateUpload({ fileSize: 5 })
+
+    const response = await routeConfig.server.handlers.PUT({
+      request: partRequest(initiateData.uploadToken, 1, 8),
+    })
+    const data = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe("Upload part size does not match expected size")
+    expect(mockUploadPart).not.toHaveBeenCalled()
+  })
+
+  it("rejects oversized docs-video initiation before creating R2 uploads", async () => {
+    const { response, data } = await initiateUpload({
+      fileName: "huge.mp4",
+      fileSize: (DOCS_VIDEO_MULTIPART_MAX_SIZE_MB + 1) * 1024 * 1024,
+      contentType: "video/mp4",
+    })
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe(
+      `File too large. Maximum size is ${DOCS_VIDEO_MULTIPART_MAX_SIZE_MB}MB`,
+    )
+    expect(mockCreateMultipartUpload).not.toHaveBeenCalled()
+  })
+
+  it("rejects invalid video types before creating R2 uploads", async () => {
+    const { response, data } = await initiateUpload({
+      fileName: "training.avi",
+      contentType: "video/x-msvideo",
+    })
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe(
+      `Invalid file type. Allowed: ${DOCS_VIDEO_ALLOWED_TYPE_LABEL}`,
+    )
+    expect(mockCreateMultipartUpload).not.toHaveBeenCalled()
+  })
+
+  it("completes uploaded parts and returns the public video URL", async () => {
+    // @lat: [[route-docs#Video storage#Completes multipart docs-video uploads]]
+    const fileSize = DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES + 5
+    const { data: initiateData } = await initiateUpload({ fileSize })
+
+    const response = await routeConfig.server.handlers.PATCH({
+      request: jsonRequest("PATCH", {
+        uploadToken: initiateData.uploadToken,
+        parts: [
+          { partNumber: 2, etag: "etag-2", size: 5 },
+          {
+            partNumber: 1,
+            etag: "etag-1",
+            size: DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES,
+          },
+        ],
+      }),
+    })
+    const data = (await response.json()) as { url: string; key: string }
+
+    expect(response.status).toBe(200)
+    expect(mockComplete).toHaveBeenCalledWith([
+      { partNumber: 1, etag: "etag-1" },
+      { partNumber: 2, etag: "etag-2" },
+    ])
+    expect(mockKvDelete).not.toHaveBeenCalled()
+    expect(data).toMatchObject({
+      url: `https://uploads.wodsmith.test/${initiateData.key}`,
+      key: initiateData.key,
+    })
+  })
+
+  it("rejects incomplete multipart uploads before completing R2", async () => {
+    // @lat: [[route-docs#Video storage#Rejects incomplete multipart docs-video uploads]]
+    const fileSize = DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES * 2
+    const { data: initiateData } = await initiateUpload({ fileSize })
+
+    const response = await routeConfig.server.handlers.PATCH({
+      request: jsonRequest("PATCH", {
+        uploadToken: initiateData.uploadToken,
+        parts: [
+          {
+            partNumber: 1,
+            etag: "etag-1",
+            size: DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES,
+          },
+          {
+            partNumber: 3,
+            etag: "etag-3",
+            size: DOCS_VIDEO_MULTIPART_CHUNK_SIZE_BYTES,
+          },
+        ],
+      }),
+    })
+    const data = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(400)
+    expect(data.error).toBe("Uploaded parts do not match declared file size")
+    expect(mockComplete).not.toHaveBeenCalled()
+    expect(mockKvDelete).not.toHaveBeenCalled()
+  })
+
+  it("aborts multipart uploads without reading mutable KV metadata", async () => {
+    // @lat: [[route-docs#Video storage#Aborts multipart docs-video uploads]]
+    const { data: initiateData } = await initiateUpload()
+
+    const response = await routeConfig.server.handlers.DELETE({
+      request: new Request("https://wodsmith.test/api/upload/docs-video", {
+        method: "DELETE",
+        headers: { "X-Docs-Video-Upload-Token": initiateData.uploadToken },
+      }),
+    })
+    const data = (await response.json()) as { ok: boolean }
+
+    expect(response.status).toBe(200)
+    expect(data.ok).toBe(true)
+    expect(mockAbort).toHaveBeenCalledTimes(1)
+    expect(mockKvGet).not.toHaveBeenCalled()
+    expect(mockKvDelete).not.toHaveBeenCalled()
+  })
+
+  it("requires docs-video upload authorization for every multipart request", async () => {
+    mockCheckUploadAuthorization.mockResolvedValue({
+      authorized: false,
+      error: "Not authorized to upload documentation videos",
+    })
+
+    const response = await routeConfig.server.handlers.POST({
+      request: jsonRequest("POST", {
+        fileName: "training.mp4",
+        fileSize: 64 * 1024 * 1024,
+        contentType: "video/mp4",
+      }),
+    })
+
+    expect(response.status).toBe(403)
+    expect(mockCreateMultipartUpload).not.toHaveBeenCalled()
+  })
+})

--- a/lat.md/route-docs.md
+++ b/lat.md/route-docs.md
@@ -72,15 +72,21 @@ Dev environments get starter content from the `22-route-docs` seeder: a markdown
 
 ## Video storage
 
-Documentation videos upload to R2 through the existing `/api/upload` route using the `docs-video` purpose (MP4/WebM/MOV, 32MB max, stored under `docs/videos/`).
+Documentation videos upload to R2 under `docs/videos/`; small files keep the `/api/upload` compatibility path while large files use a raw-body multipart route.
 
 Authorization in [[apps/wodsmith-start/src/server/upload-authorization.ts#checkUploadAuthorization]] restricts the purpose to site admins. Files are served from `R2_PUBLIC_URL` like other uploads; admins can alternatively paste YouTube/Vimeo URLs instead of uploading.
 
 ### PR-1 upload mitigation
 
-Docs-video upload is capped at 32MB and sends `file.stream()` to R2 so the Worker avoids the extra `file.arrayBuffer()` copy that exhausted memory on larger videos.
+Docs-video fallback upload is capped at 32MB and sends `file.stream()` to R2 so the Worker avoids the extra `file.arrayBuffer()` copy that exhausted memory on larger videos.
 
-The route still parses the multipart body with `request.formData()`, so this is not the final large-video architecture. Larger training videos should use YouTube/Vimeo until PR-2 adds a signed direct-to-R2 upload protocol.
+This remains the compatibility path for small files. Because `/api/upload` still parses multipart requests with `request.formData()`, the admin docs form sends larger local video files through the multipart route below instead of this fallback.
+
+### Multipart large-video upload
+
+Large admin docs videos upload through `/api/upload/docs-video`, which streams raw chunks to R2 multipart uploads and authorizes each step with a signed upload token.
+
+The route uses the existing `docs-video` authorization check for every initiate, part, complete, and abort request. It accepts MP4/WebM/MOV files up to 100MB, creates R2 multipart uploads under `docs/videos/{userId}/`, streams `PUT` request bodies directly into `uploadPart`, and completes only a validated contiguous part list returned by the client. This avoids sending the full video through `request.formData()` and avoids mutable multipart state in eventually consistent KV while preserving the small-file `/api/upload` fallback.
 
 ### Streams docs-video without second buffer
 
@@ -93,6 +99,26 @@ Verifies generic upload purposes still pass `file.arrayBuffer()` results to R2, 
 ### Rejects docs-video above demo-safe cap
 
 Verifies docs-video uploads above 32MB return the configured size error before R2 writes, keeping admin UI copy, route validation, and docs aligned around the proven-safe cap.
+
+### Initiates large multipart docs-video uploads
+
+Verifies the multipart route validates admin docs-video metadata, creates an R2 multipart upload, returns a signed upload token, and never reads multipart form data.
+
+### Streams raw multipart parts to R2
+
+Verifies each large docs-video part request passes the raw `Request.body` stream to R2 multipart upload, avoiding Worker-side full-file buffering.
+
+### Completes multipart docs-video uploads
+
+Verifies the multipart route completes a validated R2 part list and returns the public docs-video URL used by the admin form.
+
+### Rejects incomplete multipart docs-video uploads
+
+Verifies completion refuses provided part sets whose contiguous part numbers or byte total do not match the initiated file size, preventing truncated videos from being saved as successful uploads.
+
+### Aborts multipart docs-video uploads
+
+Verifies failed or canceled multipart uploads abort the R2 multipart session using the signed upload token without reading mutable KV metadata.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- add `/api/upload/docs-video` for admin docs-video multipart uploads directly into R2 using JSON initiation, raw `PUT` chunk streams, `PATCH` completion, and `DELETE` abort
- avoid mutable multipart state in Workers KV: initiation returns a short-lived session-bound signed upload token, and completion validates the client-returned R2 part list for contiguous part numbers and expected byte sizes
- keep the 32MB `/api/upload` compatibility path for smaller docs videos while sending larger files through the multipart client helper
- document the upload split in `lat.md/route-docs.md` and add route/client tests around the multipart flow

## Verification
- `pnpm --dir apps/wodsmith-start test test/routes/api/upload.test.ts test/routes/api/upload-docs-video.test.ts test/lib/docs-video-upload.test.ts` — 16 tests passing
- `pnpm --dir apps/wodsmith-start type-check`
- `pnpm --dir apps/wodsmith-start exec biome check --write src/lib/docs-video-upload.ts src/routes/api/upload/docs-video.ts test/lib/docs-video-upload.test.ts test/routes/api/upload-docs-video.test.ts`
- `git diff --cached --check`
- `npx gitnexus detect-changes --scope staged --repo /Users/zacjones/.codex/worktrees/manual-docs-video-pr2/thewodapp` reported CRITICAL risk because the new route participates in auth/session/R2 upload flows; that is the intended blast radius.

## Known ambient failures
- `lat check` still fails on pre-existing broken refs in `lat.md/competition-invites.md`, `lat.md/domain.md`, `lat.md/organizer-dashboard.md`, and Crew `@lat` refs. No failures are from the new `route-docs` sections.
- `pnpm --dir apps/wodsmith-start check` still fails on existing repo-wide Biome lint/format diagnostics outside this change set.
- The pre-push hook ran monorepo `pnpm lint` and `pnpm type-check`; type-check passed, lint emitted existing warning diagnostics and did not block the push.
- CodeRabbit is currently rate-limited for this PR; the independent Codex review thread is re-checking the addressed findings.