### PR TITLE
[codex] Route competition type picker through registry

### DIFF
--- a/apps/wodsmith-start/src/components/compete/scoring-config-form.tsx
+++ b/apps/wodsmith-start/src/components/compete/scoring-config-form.tsx
@@ -58,6 +58,7 @@ function EditablePointsPreview({
     )
   }
 
+  // scoringAlgorithm axis, not competitionType.
   // Online scoring - static display, no customization
   if (algorithm === "online" || baseTemplate === "online") {
     return (
@@ -651,6 +652,7 @@ export function ScoringConfigForm({
                   <RadioGroupItem value="online" id="algo-online" />
                   <Label htmlFor="algo-online">Online</Label>
                 </div>
+                {/* scoringAlgorithm axis, not competitionType. */}
                 {displayAlgorithm === "online" && (
                   <div className="ml-6 space-y-3">
                     <p className="text-xs text-muted-foreground">

--- a/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/competition-leaderboard-table.tsx
@@ -129,6 +129,7 @@ function RankCell({ rank, points }: { rank: number; points?: number }) {
  */
 function formatPoints(points: number, algorithm: ScoringAlgorithm): string {
   // Online and p_score show raw points
+  // scoringAlgorithm axis, not competitionType.
   if (algorithm === "online" || algorithm === "p_score") {
     return String(points)
   }

--- a/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
+++ b/apps/wodsmith-start/src/components/online-competition-leaderboard-table.tsx
@@ -171,6 +171,7 @@ function RankCell({ rank, points }: { rank: number; points?: number }) {
 }
 
 function formatPoints(points: number, algorithm: ScoringAlgorithm): string {
+  // scoringAlgorithm axis, not competitionType.
   if (algorithm === "online" || algorithm === "p_score") {
     return String(points)
   }

--- a/apps/wodsmith-start/src/components/organizer-competition-form.tsx
+++ b/apps/wodsmith-start/src/components/organizer-competition-form.tsx
@@ -27,7 +27,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import type { Competition, CompetitionGroup } from "@/db/schemas/competitions"
-import { selectableCompetitionTypes } from "@/lib/competitions/capabilities"
+import { selectableCompetitionTypeOptions } from "@/lib/competitions/capabilities"
 import { trackEvent } from "@/lib/posthog"
 import { initializeCompetitionDivisionsFn } from "@/server-fns/competition-divisions-fns"
 import {
@@ -453,12 +453,9 @@ export function OrganizerCompetitionForm({
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {selectableCompetitionTypes().map((type) => (
-                    <SelectItem key={type.id} value={type.id}>
-                      {type.label}
-                      {type.id === "online"
-                        ? " - Virtual competition with video submissions"
-                        : " - Traditional venue-based competition"}
+                  {selectableCompetitionTypeOptions().map((option) => (
+                    <SelectItem key={option.id} value={option.id}>
+                      {option.displayLabel}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/apps/wodsmith-start/src/components/organizer-competition-form.tsx
+++ b/apps/wodsmith-start/src/components/organizer-competition-form.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import type { Competition, CompetitionGroup } from "@/db/schemas/competitions"
+import { selectableCompetitionTypes } from "@/lib/competitions/capabilities"
 import { trackEvent } from "@/lib/posthog"
 import { initializeCompetitionDivisionsFn } from "@/server-fns/competition-divisions-fns"
 import {
@@ -452,12 +453,14 @@ export function OrganizerCompetitionForm({
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  <SelectItem value="in-person">
-                    In-Person - Traditional venue-based competition
-                  </SelectItem>
-                  <SelectItem value="online">
-                    Online - Virtual competition with video submissions
-                  </SelectItem>
+                  {selectableCompetitionTypes().map((type) => (
+                    <SelectItem key={type.id} value={type.id}>
+                      {type.label}
+                      {type.id === "online"
+                        ? " - Virtual competition with video submissions"
+                        : " - Traditional venue-based competition"}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               <FormDescription>

--- a/apps/wodsmith-start/src/components/organizer-competition-form.tsx
+++ b/apps/wodsmith-start/src/components/organizer-competition-form.tsx
@@ -27,7 +27,11 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import type { Competition, CompetitionGroup } from "@/db/schemas/competitions"
-import { selectableCompetitionTypeOptions } from "@/lib/competitions/capabilities"
+import {
+  type CompetitionTypeId,
+  isSelectableCompetitionTypeValue,
+  selectableCompetitionTypeOptions,
+} from "@/lib/competitions/capabilities"
 import { trackEvent } from "@/lib/posthog"
 import { initializeCompetitionDivisionsFn } from "@/server-fns/competition-divisions-fns"
 import {
@@ -52,7 +56,10 @@ const formSchema = z
         /^[a-z0-9-]+$/,
         "Slug must be lowercase letters, numbers, and hyphens only",
       ),
-    competitionType: z.enum(["in-person", "online"]),
+    competitionType: z.custom<CompetitionTypeId>(
+      isSelectableCompetitionTypeValue,
+      "Select a supported competition type",
+    ),
     isMultiDay: z.boolean(),
     startDate: z.string().min(1, "Start date is required"),
     endDate: z.string().optional(),

--- a/apps/wodsmith-start/src/lib/competitions/capabilities.ts
+++ b/apps/wodsmith-start/src/lib/competitions/capabilities.ts
@@ -62,6 +62,8 @@ export const COMPETITION_TYPE_REGISTRY: Readonly<
   },
 }
 
+export type CompetitionTypeId = keyof typeof COMPETITION_TYPE_REGISTRY
+
 export function competitionCan(
   type: string,
   capability: CompetitionCapability,
@@ -79,11 +81,17 @@ export function leaderboardVariant(type: string): LeaderboardVariant {
   )
 }
 
-export function isSelectableType(type: string): boolean {
+export function isSelectableType(type: string): type is CompetitionTypeId {
   return (
     COMPETITION_TYPE_REGISTRY[type as keyof typeof COMPETITION_TYPE_REGISTRY]
       ?.selectableOnCreate ?? false
   )
+}
+
+export function isSelectableCompetitionTypeValue(
+  value: unknown,
+): value is CompetitionTypeId {
+  return typeof value === "string" && isSelectableType(value)
 }
 
 export function selectableCompetitionTypes(): CompetitionTypeDef[] {

--- a/apps/wodsmith-start/src/lib/competitions/capabilities.ts
+++ b/apps/wodsmith-start/src/lib/competitions/capabilities.ts
@@ -16,9 +16,17 @@ export type ResultsNavLabel = "Results" | "Submissions"
 export interface CompetitionTypeDef {
   id: string
   label: string
+  createPickerDescription: string
   capabilities: ReadonlySet<CompetitionCapability>
   leaderboardVariant: LeaderboardVariant
   selectableOnCreate: boolean
+}
+
+export interface CompetitionTypePickerOption {
+  id: string
+  label: string
+  description: string
+  displayLabel: string
 }
 
 const EMPTY_CAPABILITIES: ReadonlySet<CompetitionCapability> = new Set()
@@ -29,6 +37,7 @@ export const COMPETITION_TYPE_REGISTRY: Readonly<
   "in-person": {
     id: "in-person",
     label: "In-Person",
+    createPickerDescription: "Traditional venue-based competition",
     leaderboardVariant: "standard",
     selectableOnCreate: true,
     capabilities: new Set([
@@ -42,6 +51,7 @@ export const COMPETITION_TYPE_REGISTRY: Readonly<
   online: {
     id: "online",
     label: "Online",
+    createPickerDescription: "Virtual competition with video submissions",
     leaderboardVariant: "online",
     selectableOnCreate: true,
     capabilities: new Set([
@@ -80,6 +90,15 @@ export function selectableCompetitionTypes(): CompetitionTypeDef[] {
   return Object.values(COMPETITION_TYPE_REGISTRY).filter((definition) =>
     isSelectableType(definition.id),
   )
+}
+
+export function selectableCompetitionTypeOptions(): CompetitionTypePickerOption[] {
+  return selectableCompetitionTypes().map((definition) => ({
+    id: definition.id,
+    label: definition.label,
+    description: definition.createPickerDescription,
+    displayLabel: `${definition.label} - ${definition.createPickerDescription}`,
+  }))
 }
 
 export function canOrganizerEnterResults(type: string): boolean {

--- a/apps/wodsmith-start/src/lib/competitions/capabilities.ts
+++ b/apps/wodsmith-start/src/lib/competitions/capabilities.ts
@@ -76,6 +76,12 @@ export function isSelectableType(type: string): boolean {
   )
 }
 
+export function selectableCompetitionTypes(): CompetitionTypeDef[] {
+  return Object.values(COMPETITION_TYPE_REGISTRY).filter((definition) =>
+    isSelectableType(definition.id),
+  )
+}
+
 export function canOrganizerEnterResults(type: string): boolean {
   return competitionCan(type, "organizerEntersResults")
 }

--- a/apps/wodsmith-start/src/lib/scoring/tiebreakers.ts
+++ b/apps/wodsmith-start/src/lib/scoring/tiebreakers.ts
@@ -73,6 +73,7 @@ export function applyTiebreakers(input: TiebreakerInput): RankedAthlete[] {
     return []
   }
 
+  // scoringAlgorithm axis, not competitionType.
   // For online scoring, lower points = better (ascending sort)
   // For all other algorithms, higher points = better (descending sort)
   const lowerIsBetter = scoringAlgorithm === "online"

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/organizer-competition-edit-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/organizer-competition-edit-form.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import type { Competition, CompetitionGroup } from "@/db/schemas/competitions"
+import { selectableCompetitionTypes } from "@/lib/competitions/capabilities"
 import { updateCompetitionFn } from "@/server-fns/competition-fns"
 import { COMMON_US_TIMEZONES, DEFAULT_TIMEZONE } from "@/utils/timezone-utils"
 
@@ -343,12 +344,14 @@ export function OrganizerCompetitionEditForm({
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  <SelectItem value="in-person">
-                    In-Person - Traditional venue-based competition
-                  </SelectItem>
-                  <SelectItem value="online">
-                    Online - Virtual competition with video submissions
-                  </SelectItem>
+                  {selectableCompetitionTypes().map((type) => (
+                    <SelectItem key={type.id} value={type.id}>
+                      {type.label}
+                      {type.id === "online"
+                        ? " - Virtual competition with video submissions"
+                        : " - Traditional venue-based competition"}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
               <FormDescription>

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/organizer-competition-edit-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/organizer-competition-edit-form.tsx
@@ -37,7 +37,7 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import type { Competition, CompetitionGroup } from "@/db/schemas/competitions"
-import { selectableCompetitionTypes } from "@/lib/competitions/capabilities"
+import { selectableCompetitionTypeOptions } from "@/lib/competitions/capabilities"
 import { updateCompetitionFn } from "@/server-fns/competition-fns"
 import { COMMON_US_TIMEZONES, DEFAULT_TIMEZONE } from "@/utils/timezone-utils"
 
@@ -344,12 +344,9 @@ export function OrganizerCompetitionEditForm({
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>
-                  {selectableCompetitionTypes().map((type) => (
-                    <SelectItem key={type.id} value={type.id}>
-                      {type.label}
-                      {type.id === "online"
-                        ? " - Virtual competition with video submissions"
-                        : " - Traditional venue-based competition"}
+                  {selectableCompetitionTypeOptions().map((option) => (
+                    <SelectItem key={option.id} value={option.id}>
+                      {option.displayLabel}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/organizer-competition-edit-form.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/organizer-competition-edit-form.tsx
@@ -37,7 +37,11 @@ import {
 } from "@/components/ui/select"
 import { Textarea } from "@/components/ui/textarea"
 import type { Competition, CompetitionGroup } from "@/db/schemas/competitions"
-import { selectableCompetitionTypeOptions } from "@/lib/competitions/capabilities"
+import {
+  type CompetitionTypeId,
+  isSelectableCompetitionTypeValue,
+  selectableCompetitionTypeOptions,
+} from "@/lib/competitions/capabilities"
 import { updateCompetitionFn } from "@/server-fns/competition-fns"
 import { COMMON_US_TIMEZONES, DEFAULT_TIMEZONE } from "@/utils/timezone-utils"
 
@@ -76,7 +80,10 @@ const formSchema = z
         /^[a-z0-9-]+$/,
         "Slug must be lowercase letters, numbers, and hyphens only",
       ),
-    competitionType: z.enum(["in-person", "online"]),
+    competitionType: z.custom<CompetitionTypeId>(
+      isSelectableCompetitionTypeValue,
+      "Select a supported competition type",
+    ),
     isMultiDay: z.boolean(),
     startDate: z.string().min(1, "Start date is required"),
     endDate: z.string().optional(),

--- a/apps/wodsmith-start/src/server-fns/competition-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/competition-fns.ts
@@ -19,6 +19,10 @@ import {
 } from "@/db/schemas/competitions"
 import { TEAM_PERMISSIONS, type Team, teamTable } from "@/db/schemas/teams"
 import { ROLES_ENUM } from "@/db/schemas/users"
+import {
+  type CompetitionTypeId,
+  isSelectableCompetitionTypeValue,
+} from "@/lib/competitions/capabilities"
 import { getEvlog } from "@/lib/evlog"
 import {
   addRequestContextAttribute,
@@ -92,7 +96,12 @@ const createCompetitionInputSchema = z.object({
   groupId: z.string().optional(),
   settings: z.string().optional(),
   timezone: z.string().optional(),
-  competitionType: z.enum(["in-person", "online"]).optional(),
+  competitionType: z
+    .custom<CompetitionTypeId>(
+      isSelectableCompetitionTypeValue,
+      "Select a supported competition type",
+    )
+    .optional(),
 })
 
 const updateCompetitionInputSchema = z.object({
@@ -108,7 +117,12 @@ const updateCompetitionInputSchema = z.object({
   settings: z.string().nullable().optional(),
   visibility: z.enum(["public", "private"]).optional(),
   status: z.enum(["draft", "published"]).optional(),
-  competitionType: z.enum(["in-person", "online"]).optional(),
+  competitionType: z
+    .custom<CompetitionTypeId>(
+      isSelectableCompetitionTypeValue,
+      "Select a supported competition type",
+    )
+    .optional(),
   profileImageUrl: z.string().nullable().optional(),
   bannerImageUrl: z.string().nullable().optional(),
   timezone: z.string().optional(),

--- a/apps/wodsmith-start/test/lib/competitions/capabilities.test.ts
+++ b/apps/wodsmith-start/test/lib/competitions/capabilities.test.ts
@@ -3,6 +3,7 @@ import {
 	COMPETITION_TYPE_REGISTRY,
 	type CompetitionCapability,
 	competitionCan,
+	isSelectableCompetitionTypeValue,
 	resultsEntryMode,
 	resultsNavLabel,
 	isSelectableType,
@@ -97,7 +98,10 @@ describe("competition type capabilities", () => {
 		])
 		for (const type of selectableTypes) {
 			expect(isSelectableType(type.id)).toBe(true)
+			expect(isSelectableCompetitionTypeValue(type.id)).toBe(true)
 		}
+		expect(isSelectableCompetitionTypeValue("benchmark")).toBe(false)
+		expect(isSelectableCompetitionTypeValue(null)).toBe(false)
 
 		expect(pickerOptions).toEqual([
 			{

--- a/apps/wodsmith-start/test/lib/competitions/capabilities.test.ts
+++ b/apps/wodsmith-start/test/lib/competitions/capabilities.test.ts
@@ -7,6 +7,7 @@ import {
 	resultsNavLabel,
 	isSelectableType,
 	leaderboardVariant,
+	selectableCompetitionTypes,
 } from "@/lib/competitions/capabilities"
 
 const CAPABILITIES: CompetitionCapability[] = [
@@ -82,6 +83,19 @@ describe("competition type capabilities", () => {
 
 		expect(leaderboardVariant("benchmark")).toBe("standard")
 		expect(isSelectableType("benchmark")).toBe(false)
+	})
+
+	// @lat: [[competition-type-capabilities#Create Picker Selectability Test]]
+	it("derives create-picker type options from selectable registry entries only", () => {
+		const selectableTypes = selectableCompetitionTypes()
+
+		expect(selectableTypes.map((type) => type.id)).toEqual([
+			"in-person",
+			"online",
+		])
+		for (const type of selectableTypes) {
+			expect(isSelectableType(type.id)).toBe(true)
+		}
 	})
 
 	// @lat: [[competition-type-capabilities#Results Entry and Sidebar Gates Test]]

--- a/apps/wodsmith-start/test/lib/competitions/capabilities.test.ts
+++ b/apps/wodsmith-start/test/lib/competitions/capabilities.test.ts
@@ -7,6 +7,7 @@ import {
 	resultsNavLabel,
 	isSelectableType,
 	leaderboardVariant,
+	selectableCompetitionTypeOptions,
 	selectableCompetitionTypes,
 } from "@/lib/competitions/capabilities"
 
@@ -88,6 +89,7 @@ describe("competition type capabilities", () => {
 	// @lat: [[competition-type-capabilities#Create Picker Selectability Test]]
 	it("derives create-picker type options from selectable registry entries only", () => {
 		const selectableTypes = selectableCompetitionTypes()
+		const pickerOptions = selectableCompetitionTypeOptions()
 
 		expect(selectableTypes.map((type) => type.id)).toEqual([
 			"in-person",
@@ -96,6 +98,21 @@ describe("competition type capabilities", () => {
 		for (const type of selectableTypes) {
 			expect(isSelectableType(type.id)).toBe(true)
 		}
+
+		expect(pickerOptions).toEqual([
+			{
+				id: "in-person",
+				label: "In-Person",
+				description: "Traditional venue-based competition",
+				displayLabel: "In-Person - Traditional venue-based competition",
+			},
+			{
+				id: "online",
+				label: "Online",
+				description: "Virtual competition with video submissions",
+				displayLabel: "Online - Virtual competition with video submissions",
+			},
+		])
 	})
 
 	// @lat: [[competition-type-capabilities#Results Entry and Sidebar Gates Test]]

--- a/lat.md/competition-type-capabilities.md
+++ b/lat.md/competition-type-capabilities.md
@@ -28,7 +28,7 @@ Focused PR-2 server-function tests pin that in-person score saves pass the submi
 
 The create-picker test pins that selectable competition type options are derived from registry selectability while exposing only current types.
 
-[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypes]] returns only in-person and online type definitions, with each entry passing [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]]. [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypeOptions]] provides the registry-backed label and description text that the generic organizer create and edit form pickers render.
+[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypes]] returns only in-person and online type definitions, with each entry passing [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]] and [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableCompetitionTypeValue]]. [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypeOptions]] provides the registry-backed label and description text that the generic organizer create and edit form pickers render, while the form and server schemas use the same selectable-value guard.
 
 ## Results Entry and Sidebar Gates Test
 

--- a/lat.md/competition-type-capabilities.md
+++ b/lat.md/competition-type-capabilities.md
@@ -28,7 +28,7 @@ Focused PR-2 server-function tests pin that in-person score saves pass the submi
 
 The create-picker test pins that selectable competition type options are derived from registry selectability while exposing only current types.
 
-[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypes]] returns only in-person and online type definitions, with each entry passing [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]]. The generic organizer create and edit form pickers render those registry-derived options instead of hard-coded type rows.
+[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypes]] returns only in-person and online type definitions, with each entry passing [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]]. [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypeOptions]] provides the registry-backed label and description text that the generic organizer create and edit form pickers render.
 
 ## Results Entry and Sidebar Gates Test
 

--- a/lat.md/competition-type-capabilities.md
+++ b/lat.md/competition-type-capabilities.md
@@ -24,6 +24,12 @@ The truth-table test pins every capability and leaderboard variant for in-person
 
 Focused PR-2 server-function tests pin that in-person score saves pass the submission-window gate, online score saves still honor closed windows, and in-person video submissions still reject before writes. PR-3 adds [[apps/wodsmith-start/test/components/leaderboard-page-content.test.tsx]] coverage for standard versus online leaderboard table selection plus [[apps/wodsmith-start/test/server/competition-leaderboard-capability-gates.test.ts]] coverage for opt-in result publishing defaults and the leaderboard video-submission fetch gate. PR-4 adds [[apps/wodsmith-start/test/lib/competitions/scheduling-check-in-gates.test.ts]] coverage for the heat scheduling and day-of check-in gates used by the public schedule, judge rotations, check-in routes, and check-in server functions. PR-5 adds [[apps/wodsmith-start/test/lib/competitions/venue-volunteer-gates.test.ts]] and [[apps/wodsmith-start/test/components/competition-location-card.test.tsx]] coverage for physical venue display and volunteer schedule-tab gates.
 
+## Create Picker Selectability Test
+
+The create-picker test pins that selectable competition type options are derived from registry selectability while exposing only current types.
+
+[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypes]] returns only in-person and online type definitions, with each entry passing [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]]. The generic organizer create and edit form pickers render those registry-derived options instead of hard-coded type rows.
+
 ## Results Entry and Sidebar Gates Test
 
 PR-6 tests pin that result-entry labels and sidebar tabs come from capabilities rather than direct competition-type checks.


### PR DESCRIPTION
## Summary

- Add `selectableCompetitionTypes()` so create/edit competition type pickers render registry-selectable types via `isSelectableType`.
- Pin the selectable create-picker path in `capabilities.test.ts` while preserving only the existing `in-person` and `online` options.
- Add local comments at the existing `scoringAlgorithm === "online"` checks to distinguish scoring algorithm from competition type, without changing scoring behavior.
- Update `lat.md/competition-type-capabilities.md` with the PR-7 create-picker selectability test section.

## Verification

- `pnpm --dir apps/wodsmith-start test test/lib/competitions/capabilities.test.ts` passed: 1 file, 5 tests.
- `pnpm --dir apps/wodsmith-start type-check` passed.
- `lat check` passed.
- `git diff --check` passed.
- `pnpm --dir apps/wodsmith-start exec biome check src/components/compete/scoring-config-form.tsx src/components/organizer-competition-form.tsx src/lib/competitions/capabilities.ts src/lib/scoring/tiebreakers.ts 'src/routes/compete/organizer/$competitionId/-components/organizer-competition-edit-form.tsx' test/lib/competitions/capabilities.test.ts` passed.
- Full `pnpm --dir apps/wodsmith-start check` is blocked by existing unrelated diagnostics across the app; the touched leaderboard table files also have pre-existing Biome diagnostics unrelated to the added comments.
- Pre-push hook completed `pnpm lint` with existing warnings and `pnpm type-check` successfully.

## GitNexus

- Refreshed the GitNexus index for this worktree before impact checks.
- Pre-edit impact: `isSelectableType` LOW; `OrganizerCompetitionForm` LOW; `OrganizerCompetitionEditForm` LOW; `ScoringConfigForm` LOW; leaderboard table components LOW; `COMPETITION_TYPE_REGISTRY` LOW.
- Pre-edit impact: `applyTiebreakers` HIGH because it feeds leaderboard/series leaderboard paths; this PR only adds a comment at the existing scoring-algorithm check.
- `gitnexus detect_changes` reported medium risk, with affected scope centered on organizer create/edit form flows plus comment-only scoring/tiebreaker touches.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the create/edit competition type pickers and validation through the registry so only supported types are shown and accepted. Options remain in-person and online; no scoring behavior changes.

- **Refactors**
  - Organizer create/edit pickers render registry-backed options via `selectableCompetitionTypeOptions()` with display labels from `createPickerDescription`.
  - Form and server schemas validate against the registry using `CompetitionTypeId` and `isSelectableCompetitionTypeValue`.
  - Selectable types come from `selectableCompetitionTypes()`/`isSelectableType()`; tests and `lat.md` updated. Added clarifying comments where `scoringAlgorithm === "online"` is used.

<sup>Written for commit 760d345a7356cc0cbb05b4f7b0c8c109cdfe2306. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

- `main` <!-- branch-stack -->
  - \#513
    - **\[codex] Route competition type picker through registry** :point\_left:
