### PR TITLE
feat(crew): add confirmation emails and token responses

### DIFF
--- a/apps/crew/src/lib/crew/assignment-confirmation-display.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmation-display.ts
@@ -1,0 +1,23 @@
+export function getCrewAssignmentConfirmationStatusBadgeClassName(
+  status: string,
+) {
+  if (status === "pending") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+  }
+  if (status === "confirmed") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "declined") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  if (status === "change_requested") {
+    return "border-sky-500/30 bg-sky-500/10 text-sky-700"
+  }
+  if (status === "cancelled") {
+    return "border-muted bg-muted text-muted-foreground"
+  }
+  if (status === "no_show") {
+    return "border-orange-500/30 bg-orange-500/10 text-orange-700"
+  }
+  return "border-muted bg-background text-muted-foreground"
+}

--- a/apps/crew/src/lib/crew/assignment-confirmations.test.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.test.ts
@@ -72,6 +72,7 @@ describe("Crew assignment response state transitions", () => {
       outcome: "updated",
       status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
       responseNote: null,
+      respondedAt: now,
     })
     expect(
       resolveCrewAssignmentConfirmationResponse(base, "decline", null, now),
@@ -79,6 +80,7 @@ describe("Crew assignment response state transitions", () => {
       ok: true,
       outcome: "updated",
       status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+      respondedAt: now,
     })
     expect(
       resolveCrewAssignmentConfirmationResponse(
@@ -92,6 +94,7 @@ describe("Crew assignment response state transitions", () => {
       outcome: "updated",
       status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
       responseNote: "I can do the afternoon.",
+      respondedAt: now,
     })
   })
 
@@ -141,6 +144,24 @@ describe("Crew assignment response state transitions", () => {
     ).toMatchObject({
       ok: false,
       reason: "expired",
+    })
+  })
+
+  it("rejects cancelled confirmations as cancelled", () => {
+    expect(
+      resolveCrewAssignmentConfirmationResponse(
+        {
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+          expiresAt: "2026-06-20T12:00:00.000Z",
+        },
+        "confirm",
+        null,
+        new Date("2026-06-19T12:00:00.000Z"),
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: "cancelled",
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
     })
   })
 })

--- a/apps/crew/src/lib/crew/assignment-confirmations.test.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest"
+import { CREW_ASSIGNMENT_CONFIRMATION_STATUS } from "../../db/schemas/crew-imports"
+import {
+  buildCrewAssignmentConfirmationUrls,
+  generateCrewAssignmentConfirmationToken,
+  getCrewAssignmentConfirmationTokenState,
+  hashCrewAssignmentConfirmationToken,
+  resolveCrewAssignmentConfirmationResponse,
+  summarizeCrewAssignmentConfirmations,
+} from "./assignment-confirmations"
+
+describe("Crew assignment confirmation tokens", () => {
+  it("generates URL-safe random tokens and stable hashes", async () => {
+    const token = generateCrewAssignmentConfirmationToken()
+    const hash = await hashCrewAssignmentConfirmationToken(token)
+
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/)
+    expect(token).toHaveLength(43)
+    expect(hash).toMatch(/^sha256:[0-9a-f]{64}$/)
+    await expect(hashCrewAssignmentConfirmationToken(token)).resolves.toBe(hash)
+  })
+
+  it("classifies missing, invalid, expired, and terminal token rows", () => {
+    const now = new Date("2026-06-19T12:00:00.000Z")
+
+    expect(getCrewAssignmentConfirmationTokenState(null, now)).toBe("missing")
+    expect(
+      getCrewAssignmentConfirmationTokenState(
+        {
+          tokenHash: "sha256:abc",
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+          expiresAt: null,
+        },
+        now,
+      ),
+    ).toBe("bad")
+    expect(
+      getCrewAssignmentConfirmationTokenState(
+        {
+          tokenHash: "sha256:abc",
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+          expiresAt: "2026-06-18T12:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe("expired")
+    expect(
+      getCrewAssignmentConfirmationTokenState(
+        {
+          tokenHash: "sha256:abc",
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+          expiresAt: "2026-06-18T12:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe("valid")
+  })
+})
+
+describe("Crew assignment response state transitions", () => {
+  it("moves pending rows to confirmed, declined, or change requested", () => {
+    const now = new Date("2026-06-19T12:00:00.000Z")
+    const base = {
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+      expiresAt: "2026-06-20T12:00:00.000Z",
+    }
+
+    expect(
+      resolveCrewAssignmentConfirmationResponse(base, "confirm", null, now),
+    ).toMatchObject({
+      ok: true,
+      outcome: "updated",
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+      responseNote: null,
+    })
+    expect(
+      resolveCrewAssignmentConfirmationResponse(base, "decline", null, now),
+    ).toMatchObject({
+      ok: true,
+      outcome: "updated",
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+    })
+    expect(
+      resolveCrewAssignmentConfirmationResponse(
+        base,
+        "request_change",
+        " I can do the afternoon. ",
+        now,
+      ),
+    ).toMatchObject({
+      ok: true,
+      outcome: "updated",
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
+      responseNote: "I can do the afternoon.",
+    })
+  })
+
+  it("makes repeated identical responses idempotent and rejects conflicts", () => {
+    const now = new Date("2026-06-19T12:00:00.000Z")
+    const confirmed = {
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+      expiresAt: "2026-06-20T12:00:00.000Z",
+    }
+
+    expect(
+      resolveCrewAssignmentConfirmationResponse(
+        confirmed,
+        "confirm",
+        null,
+        now,
+      ),
+    ).toMatchObject({
+      ok: true,
+      outcome: "idempotent",
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+    })
+    expect(
+      resolveCrewAssignmentConfirmationResponse(
+        confirmed,
+        "decline",
+        null,
+        now,
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: "already_responded",
+    })
+  })
+
+  it("rejects expired pending tokens", () => {
+    expect(
+      resolveCrewAssignmentConfirmationResponse(
+        {
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+          expiresAt: "2026-06-18T12:00:00.000Z",
+        },
+        "confirm",
+        null,
+        new Date("2026-06-19T12:00:00.000Z"),
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: "expired",
+    })
+  })
+})
+
+describe("Crew assignment confirmation summaries", () => {
+  it("counts missing statuses as pending", () => {
+    expect(
+      summarizeCrewAssignmentConfirmations([
+        CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+        CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+        CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
+        CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+        null,
+      ]),
+    ).toEqual({
+      pending: 1,
+      confirmed: 1,
+      declined: 1,
+      changeRequested: 1,
+      noShow: 0,
+      cancelled: 1,
+    })
+  })
+
+  it("builds public confirmation and schedule URLs", () => {
+    expect(
+      buildCrewAssignmentConfirmationUrls({
+        appUrl: "https://crew.wodsmith.com/",
+        slug: "friday-night-lights",
+        token: "abc_123",
+      }),
+    ).toEqual({
+      confirmUrl:
+        "https://crew.wodsmith.com/e/friday-night-lights/confirm/abc_123",
+      scheduleUrl:
+        "https://crew.wodsmith.com/e/friday-night-lights/schedule/abc_123",
+    })
+  })
+})

--- a/apps/crew/src/lib/crew/assignment-confirmations.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Assignment Confirmation Responses]]
 import {
   CREW_ASSIGNMENT_CONFIRMATION_STATUS,
   type CrewAssignmentConfirmationStatus,

--- a/apps/crew/src/lib/crew/assignment-confirmations.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.ts
@@ -1,0 +1,252 @@
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  type CrewAssignmentConfirmationStatus,
+} from "../../db/schemas/crew-imports"
+
+export type CrewAssignmentTokenState = "valid" | "missing" | "expired" | "bad"
+
+export type CrewAssignmentResponseAction =
+  | "confirm"
+  | "decline"
+  | "request_change"
+
+export interface CrewAssignmentConfirmationTokenRecord {
+  tokenHash?: string | null
+  status?: CrewAssignmentConfirmationStatus | string | null
+  expiresAt?: Date | string | null
+}
+
+export interface CrewAssignmentConfirmationResponseRecord {
+  status: CrewAssignmentConfirmationStatus
+  expiresAt: Date | string | null
+  responseNote?: string | null
+}
+
+export interface CrewAssignmentConfirmationStatusSummary {
+  pending: number
+  confirmed: number
+  declined: number
+  changeRequested: number
+  noShow: number
+  cancelled: number
+}
+
+export const CREW_ASSIGNMENT_CONFIRMATION_TOKEN_BYTES = 32
+export const CREW_ASSIGNMENT_CONFIRMATION_TOKEN_HASH_PREFIX = "sha256:"
+
+export function generateCrewAssignmentConfirmationToken(
+  byteLength = CREW_ASSIGNMENT_CONFIRMATION_TOKEN_BYTES,
+) {
+  const bytes = new Uint8Array(byteLength)
+  crypto.getRandomValues(bytes)
+  return bytesToBase64Url(bytes)
+}
+
+export async function hashCrewAssignmentConfirmationToken(token: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(token),
+  )
+  return `${CREW_ASSIGNMENT_CONFIRMATION_TOKEN_HASH_PREFIX}${bytesToHex(
+    new Uint8Array(digest),
+  )}`
+}
+
+export function getCrewAssignmentConfirmationTokenState(
+  record: CrewAssignmentConfirmationTokenRecord | null | undefined,
+  now = new Date(),
+): CrewAssignmentTokenState {
+  if (!record?.tokenHash) return "missing"
+  if (record.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED) {
+    return "bad"
+  }
+  if (!record.expiresAt) return "bad"
+
+  const expiresAt =
+    record.expiresAt instanceof Date
+      ? record.expiresAt
+      : new Date(record.expiresAt)
+  if (Number.isNaN(expiresAt.getTime())) return "bad"
+  if (
+    expiresAt.getTime() <= now.getTime() &&
+    record.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING
+  ) {
+    return "expired"
+  }
+
+  return "valid"
+}
+
+export function statusForCrewAssignmentResponseAction(
+  action: CrewAssignmentResponseAction,
+): CrewAssignmentConfirmationStatus {
+  if (action === "confirm") {
+    return CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED
+  }
+  if (action === "decline") {
+    return CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED
+  }
+  return CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+}
+
+export type CrewAssignmentConfirmationResponseResolution =
+  | {
+      ok: true
+      outcome: "updated"
+      status: CrewAssignmentConfirmationStatus
+      responseNote: string | null
+      respondedAt: Date
+    }
+  | {
+      ok: true
+      outcome: "idempotent"
+      status: CrewAssignmentConfirmationStatus
+      responseNote: string | null
+      respondedAt: Date | null
+    }
+  | {
+      ok: false
+      reason: "expired" | "cancelled" | "already_responded"
+      status: CrewAssignmentConfirmationStatus
+      message: string
+    }
+
+export function resolveCrewAssignmentConfirmationResponse(
+  record: CrewAssignmentConfirmationResponseRecord,
+  action: CrewAssignmentResponseAction,
+  note: string | null | undefined,
+  now = new Date(),
+): CrewAssignmentConfirmationResponseResolution {
+  const tokenState = getCrewAssignmentConfirmationTokenState(
+    {
+      tokenHash: "validated",
+      status: record.status,
+      expiresAt: record.expiresAt,
+    },
+    now,
+  )
+
+  if (tokenState === "expired") {
+    return {
+      ok: false,
+      reason: "expired",
+      status: record.status,
+      message: "This assignment response link has expired.",
+    }
+  }
+
+  if (record.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED) {
+    return {
+      ok: false,
+      reason: "cancelled",
+      status: record.status,
+      message: "This assignment confirmation has been cancelled.",
+    }
+  }
+
+  const nextStatus = statusForCrewAssignmentResponseAction(action)
+  const responseNote =
+    nextStatus === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+      ? normalizeResponseNote(note)
+      : null
+
+  if (record.status === nextStatus) {
+    const existingNote =
+      nextStatus === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+        ? normalizeResponseNote(record.responseNote)
+        : null
+    return {
+      ok: true,
+      outcome: "idempotent",
+      status: record.status,
+      responseNote: existingNote,
+      respondedAt: null,
+    }
+  }
+
+  if (record.status !== CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING) {
+    return {
+      ok: false,
+      reason: "already_responded",
+      status: record.status,
+      message: "This assignment response has already been submitted.",
+    }
+  }
+
+  return {
+    ok: true,
+    outcome: "updated",
+    status: nextStatus,
+    responseNote,
+    respondedAt: now,
+  }
+}
+
+export function summarizeCrewAssignmentConfirmations(
+  statuses: Array<CrewAssignmentConfirmationStatus | null | undefined>,
+): CrewAssignmentConfirmationStatusSummary {
+  return statuses.reduce<CrewAssignmentConfirmationStatusSummary>(
+    (summary, status) => {
+      if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED) {
+        summary.confirmed += 1
+      } else if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED) {
+        summary.declined += 1
+      } else if (
+        status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+      ) {
+        summary.changeRequested += 1
+      } else if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.NO_SHOW) {
+        summary.noShow += 1
+      } else if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED) {
+        summary.cancelled += 1
+      } else {
+        summary.pending += 1
+      }
+      return summary
+    },
+    {
+      pending: 0,
+      confirmed: 0,
+      declined: 0,
+      changeRequested: 0,
+      noShow: 0,
+      cancelled: 0,
+    },
+  )
+}
+
+export function buildCrewAssignmentConfirmationUrls(params: {
+  appUrl: string
+  slug: string
+  token: string
+}) {
+  const base = params.appUrl.replace(/\/$/, "")
+  const slug = encodeURIComponent(params.slug)
+  const token = encodeURIComponent(params.token)
+  return {
+    confirmUrl: `${base}/e/${slug}/confirm/${token}`,
+    scheduleUrl: `${base}/e/${slug}/schedule/${token}`,
+  }
+}
+
+function normalizeResponseNote(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed.slice(0, 1000) : null
+}
+
+function bytesToBase64Url(bytes: Uint8Array) {
+  let binary = ""
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte)
+  }
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "")
+}
+
+function bytesToHex(bytes: Uint8Array) {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  )
+}

--- a/apps/crew/src/react-email/crew-assignment-confirmation.tsx
+++ b/apps/crew/src/react-email/crew-assignment-confirmation.tsx
@@ -1,0 +1,187 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Html,
+  Link,
+  Section,
+  Text,
+} from "@react-email/components"
+
+export interface CrewAssignmentConfirmationEmailProps {
+  eventName: string
+  volunteerName: string
+  shiftName: string
+  roleLabel: string
+  startsAtLabel: string
+  endsAtLabel: string
+  location?: string | null
+  confirmUrl: string
+  scheduleUrl: string
+}
+
+export const CrewAssignmentConfirmationEmail = ({
+  eventName,
+  volunteerName,
+  shiftName,
+  roleLabel,
+  startsAtLabel,
+  endsAtLabel,
+  location,
+  confirmUrl,
+  scheduleUrl,
+}: CrewAssignmentConfirmationEmailProps) => {
+  return (
+    <Html>
+      <Head />
+      <Body style={main}>
+        <Container style={container}>
+          <Text style={fromLine}>WODsmith Crew</Text>
+          <Heading style={heading}>Confirm your assignment</Heading>
+          <Text style={paragraph}>Hi {volunteerName},</Text>
+          <Text style={paragraph}>
+            You are assigned to help with {eventName}. Please confirm that this
+            shift still works for you, or request a change if something needs
+            attention.
+          </Text>
+
+          <Section style={detailSection}>
+            <Text style={detailRow}>
+              <strong>Shift:</strong> {shiftName}
+            </Text>
+            <Text style={detailRow}>
+              <strong>Role:</strong> {roleLabel}
+            </Text>
+            <Text style={detailRow}>
+              <strong>Time:</strong> {startsAtLabel} to {endsAtLabel}
+            </Text>
+            {location ? (
+              <Text style={detailRow}>
+                <strong>Location:</strong> {location}
+              </Text>
+            ) : null}
+          </Section>
+
+          <Section style={buttonContainer}>
+            <Link style={button} href={confirmUrl}>
+              Review and respond
+            </Link>
+          </Section>
+
+          <Text style={paragraph}>
+            You can also view your schedule at{" "}
+            <Link href={scheduleUrl} style={textLink}>
+              this private schedule link
+            </Link>
+            .
+          </Text>
+        </Container>
+        <Text style={footer}>
+          This assignment link is private to you. No WODsmith account is
+          required to respond.
+        </Text>
+      </Body>
+    </Html>
+  )
+}
+
+CrewAssignmentConfirmationEmail.PreviewProps = {
+  eventName: "Mountain West Throwdown",
+  volunteerName: "Ada",
+  shiftName: "Lane judging block 1",
+  roleLabel: "Judge",
+  startsAtLabel: "Sat, Jun 27 9:00 AM",
+  endsAtLabel: "11:00 AM",
+  location: "Floor 1",
+  confirmUrl:
+    "https://crew.wodsmith.com/e/mountain-west-throwdown/confirm/example",
+  scheduleUrl:
+    "https://crew.wodsmith.com/e/mountain-west-throwdown/schedule/example",
+} as CrewAssignmentConfirmationEmailProps
+
+export default CrewAssignmentConfirmationEmail
+
+const main = {
+  backgroundColor: "#f6f9fc",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+  marginTop: "30px",
+}
+
+const container = {
+  backgroundColor: "#ffffff",
+  border: "1px solid #f0f0f0",
+  borderRadius: "5px",
+  boxShadow: "0 5px 10px rgba(20,50,70,.2)",
+  margin: "20px auto",
+  maxWidth: "600px",
+  padding: "40px",
+}
+
+const fromLine = {
+  color: "#64748b",
+  fontSize: "13px",
+  lineHeight: "20px",
+  marginBottom: "8px",
+}
+
+const heading = {
+  color: "#1e293b",
+  fontSize: "22px",
+  lineHeight: "30px",
+  marginBottom: "24px",
+}
+
+const paragraph = {
+  color: "#334155",
+  fontSize: "15px",
+  lineHeight: "24px",
+  marginBottom: "14px",
+}
+
+const detailSection = {
+  backgroundColor: "#f8fafc",
+  border: "1px solid #e2e8f0",
+  borderRadius: "5px",
+  marginBottom: "16px",
+  padding: "18px",
+}
+
+const detailRow = {
+  color: "#334155",
+  fontSize: "14px",
+  lineHeight: "22px",
+  margin: "0 0 8px 0",
+}
+
+const buttonContainer = {
+  margin: "28px 0",
+  textAlign: "center" as const,
+}
+
+const button = {
+  backgroundColor: "#0f766e",
+  borderRadius: "5px",
+  color: "#fff",
+  display: "inline-block",
+  fontSize: "16px",
+  fontWeight: "bold",
+  margin: "0 auto",
+  padding: "13px 32px",
+  textAlign: "center" as const,
+  textDecoration: "none",
+}
+
+const textLink = {
+  color: "#0f766e",
+  textDecoration: "underline",
+}
+
+const footer = {
+  color: "#8898aa",
+  fontSize: "12px",
+  lineHeight: "16px",
+  margin: "20px 0",
+  textAlign: "center" as const,
+}

--- a/apps/crew/src/react-email/crew-assignment-confirmation.tsx
+++ b/apps/crew/src/react-email/crew-assignment-confirmation.tsx
@@ -1,3 +1,4 @@
+// @lat: [[crew#Assignment Confirmation Responses]]
 import {
   Body,
   Container,

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as EventsEventIdImportsRouteImport } from './routes/events/$event
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
 import { Route as ESlugScheduleTokenRouteImport } from './routes/e/$slug/schedule/$token'
+import { Route as ESlugConfirmTokenRouteImport } from './routes/e/$slug/confirm/$token'
 
 const EventsRoute = EventsRouteImport.update({
   id: '/events',
@@ -94,6 +95,11 @@ const ESlugScheduleTokenRoute = ESlugScheduleTokenRouteImport.update({
   path: '/e/$slug/schedule/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ESlugConfirmTokenRoute = ESlugConfirmTokenRouteImport.update({
+  id: '/e/$slug/confirm/$token',
+  path: '/e/$slug/confirm/$token',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -109,6 +115,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
+  '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRoutesByTo {
@@ -124,6 +131,7 @@ export interface FileRoutesByTo {
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId': typeof EventsEventIdIndexRoute
+  '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRoutesById {
@@ -141,6 +149,7 @@ export interface FileRoutesById {
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
+  '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRouteTypes {
@@ -159,6 +168,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/shifts'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
+    | '/e/$slug/confirm/$token'
     | '/e/$slug/schedule/$token'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -174,6 +184,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/shifts'
     | '/events/$eventId/volunteers'
     | '/events/$eventId'
+    | '/e/$slug/confirm/$token'
     | '/e/$slug/schedule/$token'
   id:
     | '__root__'
@@ -190,6 +201,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/shifts'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
+    | '/e/$slug/confirm/$token'
     | '/e/$slug/schedule/$token'
   fileRoutesById: FileRoutesById
 }
@@ -199,6 +211,7 @@ export interface RootRouteChildren {
   EventsRoute: typeof EventsRouteWithChildren
   ApiCrewImportRoute: typeof ApiCrewImportRoute
   ESlugVolunteerRoute: typeof ESlugVolunteerRoute
+  ESlugConfirmTokenRoute: typeof ESlugConfirmTokenRoute
   ESlugScheduleTokenRoute: typeof ESlugScheduleTokenRoute
 }
 
@@ -302,6 +315,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ESlugScheduleTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/e/$slug/confirm/$token': {
+      id: '/e/$slug/confirm/$token'
+      path: '/e/$slug/confirm/$token'
+      fullPath: '/e/$slug/confirm/$token'
+      preLoaderRoute: typeof ESlugConfirmTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -346,6 +366,7 @@ const rootRouteChildren: RootRouteChildren = {
   EventsRoute: EventsRouteWithChildren,
   ApiCrewImportRoute: ApiCrewImportRoute,
   ESlugVolunteerRoute: ESlugVolunteerRoute,
+  ESlugConfirmTokenRoute: ESlugConfirmTokenRoute,
   ESlugScheduleTokenRoute: ESlugScheduleTokenRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/crew/src/routes/e/$slug/confirm/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/confirm/$token.tsx
@@ -1,3 +1,4 @@
+// @lat: [[crew#Assignment Confirmation Responses]]
 import type { FormEvent } from "react"
 import { createFileRoute, notFound, useRouter } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
@@ -242,14 +243,7 @@ function Fact({ label, value }: { label: string; value: string }) {
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const className =
-    status === "confirmed"
-      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
-      : status === "declined"
-        ? "border-destructive/30 bg-destructive/10 text-destructive"
-        : status === "change_requested"
-          ? "border-sky-500/30 bg-sky-500/10 text-sky-700"
-          : "border-amber-500/30 bg-amber-500/10 text-amber-700"
+  const className = getStatusBadgeClassName(status)
 
   return (
     <span
@@ -258,6 +252,28 @@ function StatusBadge({ status }: { status: string }) {
       {formatCrewValue(status)}
     </span>
   )
+}
+
+function getStatusBadgeClassName(status: string) {
+  if (status === "pending") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+  }
+  if (status === "confirmed") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "declined") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  if (status === "change_requested") {
+    return "border-sky-500/30 bg-sky-500/10 text-sky-700"
+  }
+  if (status === "cancelled") {
+    return "border-muted bg-muted text-muted-foreground"
+  }
+  if (status === "no_show") {
+    return "border-orange-500/30 bg-orange-500/10 text-orange-700"
+  }
+  return "border-muted bg-background text-muted-foreground"
 }
 
 function getFormString(formData: FormData, name: string) {

--- a/apps/crew/src/routes/e/$slug/confirm/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/confirm/$token.tsx
@@ -1,0 +1,266 @@
+import type { FormEvent } from "react"
+import { createFileRoute, notFound, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { Loader2 } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+import { formatCrewValue } from "@/lib/crew-event-display"
+import {
+  getCrewAssignmentConfirmationTokenFn,
+  respondCrewAssignmentConfirmationTokenFn,
+} from "@/server-fns/crew-confirmation-fns"
+import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
+
+export const Route = createFileRoute("/e/$slug/confirm/$token")({
+  loader: async ({ params }) => {
+    const result = await getCrewAssignmentConfirmationTokenFn({
+      data: { slug: params.slug, token: params.token },
+    })
+
+    if (result.status === "missing") {
+      throw notFound()
+    }
+
+    return result
+  },
+  component: CrewAssignmentConfirmationPage,
+  head: ({ loaderData }) => {
+    const event = loaderData?.event
+    return {
+      meta: [
+        {
+          title: event
+            ? `${event.name} Assignment Confirmation | WODsmith Crew`
+            : "Assignment Confirmation | WODsmith Crew",
+        },
+      ],
+    }
+  },
+})
+
+function CrewAssignmentConfirmationPage() {
+  const data = Route.useLoaderData()
+  const { slug, token } = Route.useParams()
+  const router = useRouter()
+  const respond = useServerFn(respondCrewAssignmentConfirmationTokenFn)
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+
+  if (data.status !== "valid" || !data.event || !data.assignment) {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-10 sm:px-6">
+        <section className="rounded-md border bg-card p-6 shadow-sm">
+          <p className="text-sm font-medium text-muted-foreground">
+            Assignment confirmation
+          </p>
+          <h1 className="mt-2 text-2xl font-semibold">
+            {data.status === "expired"
+              ? "This link has expired"
+              : "This link is no longer valid"}
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Please contact the event organizer for a fresh assignment link.
+          </p>
+        </section>
+      </main>
+    )
+  }
+
+  const timezone = data.event.timezone ?? "America/Denver"
+  const confirmationStatus = data.confirmation?.status ?? "pending"
+  const canRespond = confirmationStatus === "pending"
+
+  async function submitResponse(
+    action: "confirm" | "decline" | "request_change",
+    responseNote?: string,
+  ) {
+    setPendingAction(action)
+    try {
+      const result = await respond({
+        data: { slug, token, action, responseNote },
+      })
+      if (result.success) {
+        toast.success(result.message)
+      } else {
+        toast.error(result.message)
+      }
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Assignment response failed",
+      )
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  async function handleChangeRequest(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const responseNote = getFormString(formData, "responseNote")
+    await submitResponse("request_change", responseNote)
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <p className="text-sm font-medium text-muted-foreground">
+          Assignment confirmation
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold">{data.event.name}</h1>
+        <p className="mt-2 text-muted-foreground">
+          {data.volunteer?.name ?? "Volunteer"} ·{" "}
+          {data.volunteer?.email ?? "No email"}
+        </p>
+      </section>
+
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">{data.assignment.name}</h2>
+            <p className="mt-2 text-muted-foreground">
+              {data.assignment.roleLabel}
+            </p>
+          </div>
+          <StatusBadge status={confirmationStatus} />
+        </div>
+
+        <dl className="mt-6 grid gap-4 text-sm sm:grid-cols-2">
+          <Fact
+            label="Start"
+            value={formatDateTimeInTimezone(
+              data.assignment.startTime,
+              timezone,
+              "EEE, MMM d h:mm a",
+            )}
+          />
+          <Fact
+            label="End"
+            value={formatDateTimeInTimezone(
+              data.assignment.endTime,
+              timezone,
+              "EEE, MMM d h:mm a",
+            )}
+          />
+          <Fact
+            label="Location"
+            value={data.assignment.location ?? "Not set"}
+          />
+          <Fact
+            label="Respond by"
+            value={
+              data.confirmation?.expiresAt
+                ? formatDateTimeInTimezone(
+                    data.confirmation.expiresAt,
+                    timezone,
+                    "MMM d h:mm a",
+                  )
+                : "Not set"
+            }
+          />
+        </dl>
+
+        {data.assignment.notes ? (
+          <p className="mt-5 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
+            {data.assignment.notes}
+          </p>
+        ) : null}
+      </section>
+
+      {canRespond ? (
+        <section className="space-y-4 rounded-md border bg-card p-6 shadow-sm">
+          <div className="flex flex-wrap gap-3">
+            <button
+              type="button"
+              disabled={pendingAction !== null}
+              onClick={() => submitResponse("confirm")}
+              className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {pendingAction === "confirm" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
+              Confirm
+            </button>
+            <button
+              type="button"
+              disabled={pendingAction !== null}
+              onClick={() => submitResponse("decline")}
+              className="inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {pendingAction === "decline" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
+              Decline
+            </button>
+          </div>
+
+          <form onSubmit={handleChangeRequest} className="space-y-3">
+            <label className="grid gap-2 text-sm">
+              <span className="font-medium">Request a change</span>
+              <textarea
+                name="responseNote"
+                rows={4}
+                className="rounded-md border bg-background px-3 py-2"
+                placeholder="Share what needs to change"
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={pendingAction !== null}
+              className="inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {pendingAction === "request_change" ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : null}
+              Send request
+            </button>
+          </form>
+        </section>
+      ) : (
+        <section className="rounded-md border bg-card p-6 shadow-sm">
+          <h2 className="text-xl font-semibold">Response recorded</h2>
+          <p className="mt-2 text-muted-foreground">
+            Your current response is {formatCrewValue(confirmationStatus)}.
+          </p>
+          {data.confirmation?.responseNote ? (
+            <p className="mt-4 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm">
+              {data.confirmation.responseNote}
+            </p>
+          ) : null}
+        </section>
+      )}
+    </main>
+  )
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const className =
+    status === "confirmed"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+      : status === "declined"
+        ? "border-destructive/30 bg-destructive/10 text-destructive"
+        : status === "change_requested"
+          ? "border-sky-500/30 bg-sky-500/10 text-sky-700"
+          : "border-amber-500/30 bg-amber-500/10 text-amber-700"
+
+  return (
+    <span
+      className={`inline-flex w-fit rounded-md border px-2 py-1 text-xs font-medium ${className}`}
+    >
+      {formatCrewValue(status)}
+    </span>
+  )
+}
+
+function getFormString(formData: FormData, name: string) {
+  const value = formData.get(name)
+  return typeof value === "string" ? value.trim() : ""
+}

--- a/apps/crew/src/routes/e/$slug/confirm/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/confirm/$token.tsx
@@ -5,6 +5,7 @@ import { useServerFn } from "@tanstack/react-start"
 import { Loader2 } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
+import { getCrewAssignmentConfirmationStatusBadgeClassName } from "@/lib/crew/assignment-confirmation-display"
 import { formatCrewValue } from "@/lib/crew-event-display"
 import {
   getCrewAssignmentConfirmationTokenFn,
@@ -243,7 +244,7 @@ function Fact({ label, value }: { label: string; value: string }) {
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const className = getStatusBadgeClassName(status)
+  const className = getCrewAssignmentConfirmationStatusBadgeClassName(status)
 
   return (
     <span
@@ -252,28 +253,6 @@ function StatusBadge({ status }: { status: string }) {
       {formatCrewValue(status)}
     </span>
   )
-}
-
-function getStatusBadgeClassName(status: string) {
-  if (status === "pending") {
-    return "border-amber-500/30 bg-amber-500/10 text-amber-700"
-  }
-  if (status === "confirmed") {
-    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
-  }
-  if (status === "declined") {
-    return "border-destructive/30 bg-destructive/10 text-destructive"
-  }
-  if (status === "change_requested") {
-    return "border-sky-500/30 bg-sky-500/10 text-sky-700"
-  }
-  if (status === "cancelled") {
-    return "border-muted bg-muted text-muted-foreground"
-  }
-  if (status === "no_show") {
-    return "border-orange-500/30 bg-orange-500/10 text-orange-700"
-  }
-  return "border-muted bg-background text-muted-foreground"
 }
 
 function getFormString(formData: FormData, name: string) {

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -1,3 +1,4 @@
+// @lat: [[crew#Assignment Confirmation Responses]]
 import { createFileRoute, notFound } from "@tanstack/react-router"
 import {
   VOLUNTEER_AVAILABILITY,

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -5,10 +5,23 @@ import {
   type VolunteerAvailability,
   type VolunteerRoleType,
 } from "@/db/schemas/volunteers"
+import { formatCrewValue } from "@/lib/crew-event-display"
+import {
+  getCrewAssignmentConfirmationTokenFn,
+  type CrewAssignmentConfirmationTokenData,
+} from "@/server-fns/crew-confirmation-fns"
 import { getCrewVolunteerScheduleTokenFn } from "@/server-fns/crew-volunteer-fns"
+import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
 export const Route = createFileRoute("/e/$slug/schedule/$token")({
   loader: async ({ params }) => {
+    const assignmentResult = await getCrewAssignmentConfirmationTokenFn({
+      data: { slug: params.slug, token: params.token },
+    })
+    if (assignmentResult.status !== "missing") {
+      return { mode: "assignment" as const, assignmentResult }
+    }
+
     const result = await getCrewVolunteerScheduleTokenFn({
       data: { slug: params.slug, token: params.token },
     })
@@ -17,11 +30,14 @@ export const Route = createFileRoute("/e/$slug/schedule/$token")({
       throw notFound()
     }
 
-    return result
+    return { mode: "volunteer" as const, volunteerResult: result }
   },
   component: CrewVolunteerScheduleTokenPage,
   head: ({ loaderData }) => {
-    const event = loaderData?.event
+    const event =
+      loaderData?.mode === "assignment"
+        ? loaderData.assignmentResult.event
+        : loaderData?.volunteerResult.event
     if (!event) {
       return { meta: [{ title: "Volunteer Schedule Not Found" }] }
     }
@@ -39,7 +55,13 @@ export const Route = createFileRoute("/e/$slug/schedule/$token")({
 })
 
 function CrewVolunteerScheduleTokenPage() {
-  const { event, volunteer } = Route.useLoaderData()
+  const loaderData = Route.useLoaderData()
+
+  if (loaderData.mode === "assignment") {
+    return <CrewAssignmentSchedule data={loaderData.assignmentResult} />
+  }
+
+  const { event, volunteer } = loaderData.volunteerResult
 
   if (!event || !volunteer) {
     return null
@@ -92,6 +114,96 @@ function CrewVolunteerScheduleTokenPage() {
         <p className="mt-2 text-muted-foreground">
           No volunteer assignments are published for this link yet.
         </p>
+      </section>
+    </main>
+  )
+}
+
+function CrewAssignmentSchedule({
+  data,
+}: {
+  data: CrewAssignmentConfirmationTokenData
+}) {
+  if (data.status !== "valid" || !data.event || !data.assignment) {
+    return (
+      <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6">
+        <section className="rounded-md border bg-card p-6 shadow-sm">
+          <p className="text-sm font-medium text-muted-foreground">
+            Volunteer schedule
+          </p>
+          <h1 className="mt-2 text-2xl font-semibold">
+            {data.status === "expired"
+              ? "This schedule link has expired"
+              : "This schedule link is no longer valid"}
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            Please contact the event organizer for a fresh link.
+          </p>
+        </section>
+      </main>
+    )
+  }
+
+  const timezone = data.event.timezone ?? "America/Denver"
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <p className="text-sm font-medium text-muted-foreground">
+          Volunteer schedule
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold">{data.event.name}</h1>
+        <p className="mt-2 text-muted-foreground">
+          {data.volunteer?.name ?? "Volunteer"} ·{" "}
+          {data.volunteer?.email ?? "No email"}
+        </p>
+      </section>
+
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">{data.assignment.name}</h2>
+            <p className="mt-2 text-muted-foreground">
+              {data.assignment.roleLabel}
+            </p>
+          </div>
+          <span className="inline-flex w-fit rounded-md border bg-background px-2 py-1 text-xs font-medium">
+            {formatCrewValue(data.confirmation?.status ?? "pending")}
+          </span>
+        </div>
+
+        <dl className="mt-6 grid gap-4 text-sm sm:grid-cols-2">
+          <InfoRow
+            label="Start"
+            value={formatDateTimeInTimezone(
+              data.assignment.startTime,
+              timezone,
+              "EEE, MMM d h:mm a",
+            )}
+          />
+          <InfoRow
+            label="End"
+            value={formatDateTimeInTimezone(
+              data.assignment.endTime,
+              timezone,
+              "EEE, MMM d h:mm a",
+            )}
+          />
+          <InfoRow
+            label="Location"
+            value={data.assignment.location ?? "Not set"}
+          />
+          <InfoRow
+            label="Event dates"
+            value={`${data.event.startDate} to ${data.event.endDate}`}
+          />
+        </dl>
+
+        {data.assignment.notes ? (
+          <p className="mt-5 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
+            {data.assignment.notes}
+          </p>
+        ) : null}
       </section>
     </main>
   )

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -26,7 +26,7 @@ function EventOverviewPage() {
 
   return (
     <section className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-6">
+      <div className="grid gap-4 md:grid-cols-7">
         <StatusPanel
           label="Lifecycle"
           value={formatCrewValue(event.settings.lifecycle)}
@@ -47,6 +47,10 @@ function EventOverviewPage() {
         <StatusPanel
           label="Shift slots"
           value={`${shiftSummary.assignedSlots}/${shiftSummary.capacity}`}
+        />
+        <StatusPanel
+          label="Confirmed"
+          value={`${shiftSummary.confirmationSummary.confirmed}/${shiftSummary.assignedSlots}`}
         />
       </div>
 

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -4,6 +4,7 @@ import { useServerFn } from "@tanstack/react-start"
 import { Loader2, Plus, Trash2 } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
+import { getCrewAssignmentConfirmationStatusBadgeClassName } from "@/lib/crew/assignment-confirmation-display"
 import { formatCrewValue } from "@/lib/crew-event-display"
 import {
   isVolunteerCompatibleWithShift,
@@ -465,7 +466,7 @@ function ShiftCard({
 }
 
 function ConfirmationBadge({ status }: { status: string }) {
-  const className = getConfirmationBadgeClassName(status)
+  const className = getCrewAssignmentConfirmationStatusBadgeClassName(status)
 
   return (
     <span
@@ -474,28 +475,6 @@ function ConfirmationBadge({ status }: { status: string }) {
       {formatCrewValue(status)}
     </span>
   )
-}
-
-function getConfirmationBadgeClassName(status: string) {
-  if (status === "pending") {
-    return "border-amber-500/30 bg-amber-500/10 text-amber-700"
-  }
-  if (status === "confirmed") {
-    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
-  }
-  if (status === "declined") {
-    return "border-destructive/30 bg-destructive/10 text-destructive"
-  }
-  if (status === "change_requested") {
-    return "border-sky-500/30 bg-sky-500/10 text-sky-700"
-  }
-  if (status === "cancelled") {
-    return "border-muted bg-muted text-muted-foreground"
-  }
-  if (status === "no_show") {
-    return "border-orange-500/30 bg-orange-500/10 text-orange-700"
-  }
-  return "border-muted bg-background text-muted-foreground"
 }
 
 function ShiftFields({

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -4,6 +4,7 @@ import { useServerFn } from "@tanstack/react-start"
 import { Loader2, Plus, Trash2 } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
+import { formatCrewValue } from "@/lib/crew-event-display"
 import {
   isVolunteerCompatibleWithShift,
   type CrewRosterVolunteer,
@@ -52,14 +53,25 @@ function EventShiftsPage() {
         </div>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-5">
         <StatusPanel label="Active volunteers" value={rosterSummary.active} />
         <StatusPanel label="Assignable" value={rosterSummary.assignable} />
         <StatusPanel
           label="Assigned slots"
           value={shiftSummary.assignedSlots}
         />
-        <StatusPanel label="Capacity" value={shiftSummary.capacity} />
+        <StatusPanel
+          label="Confirmed"
+          value={shiftSummary.confirmationSummary.confirmed}
+        />
+        <StatusPanel
+          label="Needs response"
+          value={
+            shiftSummary.confirmationSummary.pending +
+            shiftSummary.confirmationSummary.changeRequested +
+            shiftSummary.confirmationSummary.declined
+          }
+        />
       </div>
 
       <CreateShiftForm
@@ -347,12 +359,22 @@ function ShiftCard({
                   className="flex flex-col gap-3 rounded-md border bg-background p-3 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div>
-                    <div className="font-medium">
-                      {assignment.volunteer.name}
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="font-medium">
+                        {assignment.volunteer.name}
+                      </span>
+                      <ConfirmationBadge
+                        status={assignment.confirmation?.status ?? "pending"}
+                      />
                     </div>
                     <div className="text-sm text-muted-foreground">
                       {assignment.volunteer.email}
                     </div>
+                    {assignment.confirmation?.responseNote ? (
+                      <div className="mt-1 max-w-md text-sm text-muted-foreground">
+                        {assignment.confirmation.responseNote}
+                      </div>
+                    ) : null}
                   </div>
                   <button
                     type="button"
@@ -439,6 +461,25 @@ function ShiftCard({
         </form>
       </details>
     </section>
+  )
+}
+
+function ConfirmationBadge({ status }: { status: string }) {
+  const className =
+    status === "confirmed"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+      : status === "declined"
+        ? "border-destructive/30 bg-destructive/10 text-destructive"
+        : status === "change_requested"
+          ? "border-sky-500/30 bg-sky-500/10 text-sky-700"
+          : "border-amber-500/30 bg-amber-500/10 text-amber-700"
+
+  return (
+    <span
+      className={`inline-flex rounded-md border px-2 py-1 text-xs font-medium ${className}`}
+    >
+      {formatCrewValue(status)}
+    </span>
   )
 }
 

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -465,14 +465,7 @@ function ShiftCard({
 }
 
 function ConfirmationBadge({ status }: { status: string }) {
-  const className =
-    status === "confirmed"
-      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
-      : status === "declined"
-        ? "border-destructive/30 bg-destructive/10 text-destructive"
-        : status === "change_requested"
-          ? "border-sky-500/30 bg-sky-500/10 text-sky-700"
-          : "border-amber-500/30 bg-amber-500/10 text-amber-700"
+  const className = getConfirmationBadgeClassName(status)
 
   return (
     <span
@@ -481,6 +474,28 @@ function ConfirmationBadge({ status }: { status: string }) {
       {formatCrewValue(status)}
     </span>
   )
+}
+
+function getConfirmationBadgeClassName(status: string) {
+  if (status === "pending") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+  }
+  if (status === "confirmed") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "declined") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  if (status === "change_requested") {
+    return "border-sky-500/30 bg-sky-500/10 text-sky-700"
+  }
+  if (status === "cancelled") {
+    return "border-muted bg-muted text-muted-foreground"
+  }
+  if (status === "no_show") {
+    return "border-orange-500/30 bg-orange-500/10 text-orange-700"
+  }
+  return "border-muted bg-background text-muted-foreground"
 }
 
 function ShiftFields({

--- a/apps/crew/src/routes/events/$eventId/volunteers.tsx
+++ b/apps/crew/src/routes/events/$eventId/volunteers.tsx
@@ -38,13 +38,17 @@ function VolunteersPage() {
         </Link>
       </div>
 
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-5">
         <StatusPanel label="Pending" value={summary.pending} />
         <StatusPanel label="Accepted" value={summary.accepted} />
         <StatusPanel label="Active" value={summary.active} />
         <StatusPanel
           label="Shift coverage"
           value={`${shiftSummary.assignedSlots}/${shiftSummary.capacity}`}
+        />
+        <StatusPanel
+          label="Confirmed"
+          value={shiftSummary.confirmationSummary.confirmed}
         />
       </div>
 

--- a/apps/crew/src/server-fns/crew-confirmation-fns.ts
+++ b/apps/crew/src/server-fns/crew-confirmation-fns.ts
@@ -1,6 +1,7 @@
 import { render } from "@react-email/render"
 import { createServerFn } from "@tanstack/react-start"
-import { and, desc, eq, inArray, ne } from "drizzle-orm"
+// @lat: [[crew#Assignment Confirmation Responses]]
+import { and, desc, eq, inArray, ne, sql } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "../db"
 import { competitionsTable, type Competition } from "../db/schemas/competitions"
@@ -115,6 +116,18 @@ export interface CrewAssignmentConfirmationEmailMessage {
   bodyHtml: string
   replyTo?: string
 }
+
+export type EnsureCrewShiftAssignmentConfirmationResult =
+  | {
+      id: string
+      action: "existing"
+      token: null
+    }
+  | {
+      id: string
+      action: "created"
+      token: string
+    }
 
 const publicTokenInputSchema = z.object({
   slug: z.string().trim().min(1, "Event slug is required").max(255),
@@ -250,52 +263,61 @@ export async function ensureCrewShiftAssignmentConfirmation(params: {
   email: string | null
   expiresAt: Date
   now?: Date
-}) {
+}): Promise<EnsureCrewShiftAssignmentConfirmationResult> {
   const now = params.now ?? new Date()
-  const [existing] = await params.db
-    .select({
-      id: crewAssignmentConfirmationsTable.id,
-      status: crewAssignmentConfirmationsTable.status,
-    })
-    .from(crewAssignmentConfirmationsTable)
-    .where(
-      and(
-        eq(
-          crewAssignmentConfirmationsTable.assignmentType,
-          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
-        ),
-        eq(crewAssignmentConfirmationsTable.assignmentId, params.assignmentId),
-        ne(
-          crewAssignmentConfirmationsTable.status,
-          CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
-        ),
-      ),
-    )
-    .limit(1)
+  return await withCrewAssignmentConfirmationLock(
+    params.db,
+    params.assignmentId,
+    async () => {
+      const [existing] = await params.db
+        .select({
+          id: crewAssignmentConfirmationsTable.id,
+          status: crewAssignmentConfirmationsTable.status,
+        })
+        .from(crewAssignmentConfirmationsTable)
+        .where(
+          and(
+            eq(
+              crewAssignmentConfirmationsTable.assignmentType,
+              CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+            ),
+            eq(
+              crewAssignmentConfirmationsTable.assignmentId,
+              params.assignmentId,
+            ),
+            ne(
+              crewAssignmentConfirmationsTable.status,
+              CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+            ),
+          ),
+        )
+        .limit(1)
 
-  if (existing) {
-    return { id: existing.id, action: "existing" as const }
-  }
+      if (existing) {
+        return { id: existing.id, action: "existing", token: null }
+      }
 
-  const token = generateCrewAssignmentConfirmationToken()
-  const tokenHash = await hashCrewAssignmentConfirmationToken(token)
-  const confirmationId = createCrewAssignmentConfirmationId()
+      const token = generateCrewAssignmentConfirmationToken()
+      const tokenHash = await hashCrewAssignmentConfirmationToken(token)
+      const confirmationId = createCrewAssignmentConfirmationId()
 
-  await params.db.insert(crewAssignmentConfirmationsTable).values({
-    id: confirmationId,
-    competitionId: params.competitionId,
-    assignmentType: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
-    assignmentId: params.assignmentId,
-    membershipId: params.membershipId,
-    email: params.email,
-    tokenHash,
-    status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
-    expiresAt: params.expiresAt,
-    createdAt: now,
-    updatedAt: now,
-  })
+      await params.db.insert(crewAssignmentConfirmationsTable).values({
+        id: confirmationId,
+        competitionId: params.competitionId,
+        assignmentType: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        assignmentId: params.assignmentId,
+        membershipId: params.membershipId,
+        email: params.email,
+        tokenHash,
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+        expiresAt: params.expiresAt,
+        createdAt: now,
+        updatedAt: now,
+      })
 
-  return { id: confirmationId, action: "created" as const }
+      return { id: confirmationId, action: "created", token }
+    },
+  )
 }
 
 export async function cancelCrewShiftAssignmentConfirmations(params: {
@@ -493,24 +515,18 @@ async function getCrewAssignmentConfirmationByToken({
       crewEventSettingsTable,
       eq(crewEventSettingsTable.competitionId, competitionsTable.id),
     )
-    .innerJoin(
+    .leftJoin(
       volunteerShiftAssignmentsTable,
-      and(
-        eq(
-          crewAssignmentConfirmationsTable.assignmentId,
-          volunteerShiftAssignmentsTable.id,
-        ),
-        eq(
-          crewAssignmentConfirmationsTable.assignmentType,
-          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
-        ),
+      eq(
+        crewAssignmentConfirmationsTable.assignmentId,
+        volunteerShiftAssignmentsTable.id,
       ),
     )
-    .innerJoin(
+    .leftJoin(
       volunteerShiftsTable,
       eq(volunteerShiftAssignmentsTable.shiftId, volunteerShiftsTable.id),
     )
-    .innerJoin(
+    .leftJoin(
       teamMembershipTable,
       eq(volunteerShiftAssignmentsTable.membershipId, teamMembershipTable.id),
     )
@@ -518,6 +534,10 @@ async function getCrewAssignmentConfirmationByToken({
     .where(
       and(
         eq(crewAssignmentConfirmationsTable.tokenHash, tokenHash),
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        ),
         eq(competitionsTable.slug, slug),
         eq(crewEventSettingsTable.crewOnly, true),
         ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
@@ -529,7 +549,11 @@ async function getCrewAssignmentConfirmationByToken({
     return emptyTokenData("missing")
   }
 
-  const status = getCrewAssignmentConfirmationTokenState(row.confirmation)
+  const tokenState = getCrewAssignmentConfirmationTokenState(row.confirmation)
+  const status =
+    tokenState === "valid" && (!row.assignment?.id || !row.shift?.id)
+      ? "bad"
+      : tokenState
   if (status !== "valid") {
     return {
       status,
@@ -540,7 +564,19 @@ async function getCrewAssignmentConfirmationByToken({
     }
   }
 
-  const metadata = parseCrewRosterMetadata(row.membership.metadata)
+  const assignment = row.assignment
+  const shift = row.shift
+  if (!assignment || !shift) {
+    return {
+      status: "bad",
+      event: row.event,
+      volunteer: null,
+      assignment: null,
+      confirmation: toConfirmationDisplay(row.confirmation),
+    }
+  }
+
+  const metadata = parseCrewRosterMetadata(row.membership?.metadata)
   const name =
     metadata.signupName ||
     [row.user?.firstName, row.user?.lastName].filter(Boolean).join(" ") ||
@@ -559,15 +595,15 @@ async function getCrewAssignmentConfirmationByToken({
       roleTypes: getCrewRosterRoleTypes(metadata.volunteerRoleTypes),
     },
     assignment: {
-      id: row.assignment.id,
-      shiftId: row.shift.id,
-      name: row.shift.name,
-      roleType: row.shift.roleType,
-      roleLabel: formatVolunteerRole(row.shift.roleType),
-      startTime: row.shift.startTime,
-      endTime: row.shift.endTime,
-      location: row.shift.location,
-      notes: row.shift.notes,
+      id: assignment.id,
+      shiftId: shift.id,
+      name: shift.name,
+      roleType: shift.roleType,
+      roleLabel: formatVolunteerRole(shift.roleType),
+      startTime: shift.startTime,
+      endTime: shift.endTime,
+      location: shift.location,
+      notes: shift.notes,
     },
     confirmation: toConfirmationDisplay(row.confirmation),
   }
@@ -612,4 +648,55 @@ function getResponseSuccessMessage(action: CrewAssignmentResponseAction) {
     return "Assignment declined. The organizer will see your response."
   }
   return "Change request sent. The organizer will see your note."
+}
+
+async function withCrewAssignmentConfirmationLock<T>(
+  db: DbClient,
+  assignmentId: string,
+  callback: () => Promise<T>,
+) {
+  let acquired = false
+  const lockName = await createCrewAssignmentConfirmationLockName(assignmentId)
+
+  try {
+    const result = await db.execute(
+      sql`SELECT GET_LOCK(${lockName}, 5) FROM dual`,
+    )
+    acquired = Number(getFirstExecuteValue(result) ?? 0) === 1
+    if (!acquired) {
+      throw new Error("Assignment confirmation could not be saved")
+    }
+
+    return await callback()
+  } finally {
+    if (acquired) {
+      await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
+    }
+  }
+}
+
+async function createCrewAssignmentConfirmationLockName(assignmentId: string) {
+  const encoded = new TextEncoder().encode(
+    `crew-assignment-confirmation:${assignmentId}`,
+  )
+  const digest = await crypto.subtle.digest("SHA-256", encoded)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")
+}
+
+function getExecuteRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) {
+    if (Array.isArray(result[0])) return result[0] as T[]
+    return result as T[]
+  }
+
+  return ((result as { rows?: T[] })?.rows ?? []) as T[]
+}
+
+function getFirstExecuteValue(result: unknown): unknown {
+  const [row] = getExecuteRows<unknown>(result)
+  if (Array.isArray(row)) return row[0]
+  if (row && typeof row === "object") return Object.values(row)[0]
+  return row
 }

--- a/apps/crew/src/server-fns/crew-confirmation-fns.ts
+++ b/apps/crew/src/server-fns/crew-confirmation-fns.ts
@@ -46,6 +46,7 @@ import {
   DEFAULT_TIMEZONE,
   formatDateTimeInTimezone,
 } from "../utils/timezone-utils"
+import { getFirstExecuteValue } from "./db-execute"
 
 type DbClient = ReturnType<typeof getDb>
 
@@ -683,20 +684,4 @@ async function createCrewAssignmentConfirmationLockName(assignmentId: string) {
   return Array.from(new Uint8Array(digest), (byte) =>
     byte.toString(16).padStart(2, "0"),
   ).join("")
-}
-
-function getExecuteRows<T>(result: unknown): T[] {
-  if (Array.isArray(result)) {
-    if (Array.isArray(result[0])) return result[0] as T[]
-    return result as T[]
-  }
-
-  return ((result as { rows?: T[] })?.rows ?? []) as T[]
-}
-
-function getFirstExecuteValue(result: unknown): unknown {
-  const [row] = getExecuteRows<unknown>(result)
-  if (Array.isArray(row)) return row[0]
-  if (row && typeof row === "object") return Object.values(row)[0]
-  return row
 }

--- a/apps/crew/src/server-fns/crew-confirmation-fns.ts
+++ b/apps/crew/src/server-fns/crew-confirmation-fns.ts
@@ -1,0 +1,615 @@
+import { render } from "@react-email/render"
+import { createServerFn } from "@tanstack/react-start"
+import { and, desc, eq, inArray, ne } from "drizzle-orm"
+import { z } from "zod"
+import { getDb } from "../db"
+import { competitionsTable, type Competition } from "../db/schemas/competitions"
+import { createCrewAssignmentConfirmationId } from "../db/schemas/common"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+  crewAssignmentConfirmationsTable,
+  type CrewAssignmentConfirmationStatus,
+} from "../db/schemas/crew-imports"
+import {
+  CREW_EVENT_LIFECYCLE,
+  crewEventSettingsTable,
+} from "../db/schemas/crew-event-settings"
+import { teamMembershipTable } from "../db/schemas/teams"
+import { userTable } from "../db/schemas/users"
+import {
+  volunteerShiftAssignmentsTable,
+  volunteerShiftsTable,
+  type VolunteerRoleType,
+} from "../db/schemas/volunteers"
+import {
+  buildCrewAssignmentConfirmationUrls,
+  generateCrewAssignmentConfirmationToken,
+  getCrewAssignmentConfirmationTokenState,
+  hashCrewAssignmentConfirmationToken,
+  resolveCrewAssignmentConfirmationResponse,
+  statusForCrewAssignmentResponseAction,
+  summarizeCrewAssignmentConfirmations,
+  type CrewAssignmentConfirmationStatusSummary,
+  type CrewAssignmentResponseAction,
+  type CrewAssignmentTokenState,
+} from "../lib/crew/assignment-confirmations"
+import {
+  formatVolunteerRole,
+  getCrewRosterRoleTypes,
+  parseCrewRosterMetadata,
+} from "../lib/crew/roster-shifts"
+import { getAppUrl } from "../lib/env"
+import { CrewAssignmentConfirmationEmail } from "../react-email/crew-assignment-confirmation"
+import {
+  DEFAULT_TIMEZONE,
+  formatDateTimeInTimezone,
+} from "../utils/timezone-utils"
+
+type DbClient = ReturnType<typeof getDb>
+
+type CrewConfirmationCompetition = Pick<
+  Competition,
+  "id" | "slug" | "name" | "timezone" | "startDate" | "endDate"
+>
+
+export interface CrewAssignmentConfirmationDisplay {
+  id: string
+  status: CrewAssignmentConfirmationStatus
+  sentAt: Date | null
+  respondedAt: Date | null
+  expiresAt: Date | null
+  responseNote: string | null
+}
+
+export interface CrewAssignmentConfirmationTokenData {
+  status: CrewAssignmentTokenState
+  event: CrewConfirmationCompetition | null
+  volunteer: {
+    name: string
+    email: string
+    roleTypes: VolunteerRoleType[]
+  } | null
+  assignment: {
+    id: string
+    shiftId: string
+    name: string
+    roleType: VolunteerRoleType
+    roleLabel: string
+    startTime: Date
+    endTime: Date
+    location: string | null
+    notes: string | null
+  } | null
+  confirmation: CrewAssignmentConfirmationDisplay | null
+}
+
+export interface CrewAssignmentConfirmationResponseResult
+  extends CrewAssignmentConfirmationTokenData {
+  success: boolean
+  outcome:
+    | "updated"
+    | "idempotent"
+    | "expired"
+    | "cancelled"
+    | "already_responded"
+    | "missing"
+    | "bad"
+  message: string
+}
+
+export interface CrewShiftAssignmentConfirmationStatus {
+  id: string
+  status: CrewAssignmentConfirmationStatus
+  respondedAt: Date | null
+  responseNote: string | null
+}
+
+export interface CrewAssignmentConfirmationEmailMessage {
+  kind: "crew-assignment-confirmation"
+  confirmationId: string
+  assignmentId: string
+  competitionId: string
+  email: string
+  subject: string
+  bodyHtml: string
+  replyTo?: string
+}
+
+const publicTokenInputSchema = z.object({
+  slug: z.string().trim().min(1, "Event slug is required").max(255),
+  token: z.string().trim().min(1, "Token is required").max(255),
+})
+
+const publicTokenResponseInputSchema = publicTokenInputSchema.extend({
+  action: z.enum(["confirm", "decline", "request_change"]),
+  responseNote: z.string().trim().max(1000).optional(),
+})
+
+export const getCrewAssignmentConfirmationTokenFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) => publicTokenInputSchema.parse(data))
+  .handler(async ({ data }): Promise<CrewAssignmentConfirmationTokenData> => {
+    return await getCrewAssignmentConfirmationByToken(data)
+  })
+
+export const respondCrewAssignmentConfirmationTokenFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) => publicTokenResponseInputSchema.parse(data))
+  .handler(
+    async ({ data }): Promise<CrewAssignmentConfirmationResponseResult> => {
+      const db = getDb()
+      const tokenHash = await hashCrewAssignmentConfirmationToken(data.token)
+      const responseState: {
+        outcome: CrewAssignmentConfirmationResponseResult["outcome"]
+        message: string
+      } = {
+        outcome: "missing",
+        message: "Assignment confirmation link was not found.",
+      }
+
+      await db.transaction(async (tx) => {
+        const [row] = await tx
+          .select({
+            confirmation: crewAssignmentConfirmationsTable,
+          })
+          .from(crewAssignmentConfirmationsTable)
+          .innerJoin(
+            competitionsTable,
+            eq(
+              crewAssignmentConfirmationsTable.competitionId,
+              competitionsTable.id,
+            ),
+          )
+          .innerJoin(
+            crewEventSettingsTable,
+            eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+          )
+          .where(
+            and(
+              eq(crewAssignmentConfirmationsTable.tokenHash, tokenHash),
+              eq(competitionsTable.slug, data.slug),
+              eq(crewEventSettingsTable.crewOnly, true),
+              ne(
+                crewEventSettingsTable.lifecycle,
+                CREW_EVENT_LIFECYCLE.ARCHIVED,
+              ),
+            ),
+          )
+          .for("update")
+          .limit(1)
+
+        if (!row) {
+          responseState.outcome = "missing"
+          return
+        }
+
+        const tokenState = getCrewAssignmentConfirmationTokenState(
+          row.confirmation,
+        )
+        if (tokenState !== "valid") {
+          responseState.outcome = tokenState
+          responseState.message =
+            tokenState === "expired"
+              ? "This assignment response link has expired."
+              : "This assignment response link is no longer valid."
+          return
+        }
+
+        const resolution = resolveCrewAssignmentConfirmationResponse(
+          row.confirmation,
+          data.action,
+          data.responseNote,
+        )
+
+        if (!resolution.ok) {
+          responseState.outcome = resolution.reason
+          responseState.message = resolution.message
+          return
+        }
+
+        responseState.outcome = resolution.outcome
+        responseState.message =
+          resolution.outcome === "idempotent"
+            ? "Your assignment response was already recorded."
+            : getResponseSuccessMessage(data.action)
+
+        if (resolution.outcome === "updated") {
+          await tx
+            .update(crewAssignmentConfirmationsTable)
+            .set({
+              status: resolution.status,
+              responseNote: resolution.responseNote,
+              respondedAt: resolution.respondedAt,
+              updatedAt: resolution.respondedAt,
+            })
+            .where(eq(crewAssignmentConfirmationsTable.id, row.confirmation.id))
+        }
+      })
+
+      const freshData = await getCrewAssignmentConfirmationByToken(data)
+
+      return {
+        ...freshData,
+        success:
+          responseState.outcome === "updated" ||
+          responseState.outcome === "idempotent",
+        outcome: responseState.outcome,
+        message: responseState.message,
+      }
+    },
+  )
+
+export async function ensureCrewShiftAssignmentConfirmation(params: {
+  db: DbClient
+  competitionId: string
+  assignmentId: string
+  membershipId: string
+  email: string | null
+  expiresAt: Date
+  now?: Date
+}) {
+  const now = params.now ?? new Date()
+  const [existing] = await params.db
+    .select({
+      id: crewAssignmentConfirmationsTable.id,
+      status: crewAssignmentConfirmationsTable.status,
+    })
+    .from(crewAssignmentConfirmationsTable)
+    .where(
+      and(
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        ),
+        eq(crewAssignmentConfirmationsTable.assignmentId, params.assignmentId),
+        ne(
+          crewAssignmentConfirmationsTable.status,
+          CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+        ),
+      ),
+    )
+    .limit(1)
+
+  if (existing) {
+    return { id: existing.id, action: "existing" as const }
+  }
+
+  const token = generateCrewAssignmentConfirmationToken()
+  const tokenHash = await hashCrewAssignmentConfirmationToken(token)
+  const confirmationId = createCrewAssignmentConfirmationId()
+
+  await params.db.insert(crewAssignmentConfirmationsTable).values({
+    id: confirmationId,
+    competitionId: params.competitionId,
+    assignmentType: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+    assignmentId: params.assignmentId,
+    membershipId: params.membershipId,
+    email: params.email,
+    tokenHash,
+    status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+    expiresAt: params.expiresAt,
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  return { id: confirmationId, action: "created" as const }
+}
+
+export async function cancelCrewShiftAssignmentConfirmations(params: {
+  db: DbClient
+  assignmentIds: string[]
+  now?: Date
+}) {
+  if (params.assignmentIds.length === 0) return
+
+  const now = params.now ?? new Date()
+  await params.db
+    .update(crewAssignmentConfirmationsTable)
+    .set({
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        ),
+        inArray(
+          crewAssignmentConfirmationsTable.assignmentId,
+          params.assignmentIds,
+        ),
+        eq(
+          crewAssignmentConfirmationsTable.status,
+          CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+        ),
+      ),
+    )
+}
+
+export async function loadCrewShiftAssignmentConfirmationMap(
+  db: DbClient,
+  assignmentIds: string[],
+) {
+  if (assignmentIds.length === 0) {
+    return new Map<string, CrewShiftAssignmentConfirmationStatus>()
+  }
+
+  const rows = await db
+    .select({
+      assignmentId: crewAssignmentConfirmationsTable.assignmentId,
+      id: crewAssignmentConfirmationsTable.id,
+      status: crewAssignmentConfirmationsTable.status,
+      respondedAt: crewAssignmentConfirmationsTable.respondedAt,
+      responseNote: crewAssignmentConfirmationsTable.responseNote,
+      updatedAt: crewAssignmentConfirmationsTable.updatedAt,
+    })
+    .from(crewAssignmentConfirmationsTable)
+    .where(
+      and(
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        ),
+        inArray(crewAssignmentConfirmationsTable.assignmentId, assignmentIds),
+      ),
+    )
+    .orderBy(desc(crewAssignmentConfirmationsTable.updatedAt))
+
+  const byAssignment = new Map<string, CrewShiftAssignmentConfirmationStatus>()
+  for (const row of rows) {
+    if (byAssignment.has(row.assignmentId)) continue
+    byAssignment.set(row.assignmentId, {
+      id: row.id,
+      status: row.status,
+      respondedAt: row.respondedAt,
+      responseNote: row.responseNote,
+    })
+  }
+  return byAssignment
+}
+
+export function summarizeCrewShiftAssignmentConfirmations(
+  confirmations: Array<CrewShiftAssignmentConfirmationStatus | null>,
+): CrewAssignmentConfirmationStatusSummary {
+  return summarizeCrewAssignmentConfirmations(
+    confirmations.map((confirmation) => confirmation?.status),
+  )
+}
+
+export async function buildCrewAssignmentConfirmationEmailMessage(params: {
+  confirmationId: string
+  event: CrewConfirmationCompetition
+  volunteer: { name: string; email: string }
+  assignment: {
+    id: string
+    shiftName: string
+    roleLabel: string
+    startTime: Date
+    endTime: Date
+    location: string | null
+  }
+  token: string
+}) {
+  const urls = buildCrewAssignmentConfirmationUrls({
+    appUrl: getAppUrl(),
+    slug: params.event.slug,
+    token: params.token,
+  })
+  const timezone = params.event.timezone ?? DEFAULT_TIMEZONE
+  const subject = `${params.event.name}: confirm ${params.assignment.shiftName}`
+  const bodyHtml = await render(
+    CrewAssignmentConfirmationEmail({
+      eventName: params.event.name,
+      volunteerName: params.volunteer.name,
+      shiftName: params.assignment.shiftName,
+      roleLabel: params.assignment.roleLabel,
+      startsAtLabel: formatDateTimeInTimezone(
+        params.assignment.startTime,
+        timezone,
+        "EEE, MMM d h:mm a",
+      ),
+      endsAtLabel: formatDateTimeInTimezone(
+        params.assignment.endTime,
+        timezone,
+        "h:mm a",
+      ),
+      location: params.assignment.location,
+      confirmUrl: urls.confirmUrl,
+      scheduleUrl: urls.scheduleUrl,
+    }),
+  )
+
+  return {
+    kind: "crew-assignment-confirmation",
+    confirmationId: params.confirmationId,
+    assignmentId: params.assignment.id,
+    competitionId: params.event.id,
+    email: params.volunteer.email,
+    subject,
+    bodyHtml,
+  } satisfies CrewAssignmentConfirmationEmailMessage
+}
+
+async function getCrewAssignmentConfirmationByToken({
+  slug,
+  token,
+}: {
+  slug: string
+  token: string
+}): Promise<CrewAssignmentConfirmationTokenData> {
+  const db = getDb()
+  const tokenHash = await hashCrewAssignmentConfirmationToken(token)
+  const [row] = await db
+    .select({
+      event: {
+        id: competitionsTable.id,
+        slug: competitionsTable.slug,
+        name: competitionsTable.name,
+        timezone: competitionsTable.timezone,
+        startDate: competitionsTable.startDate,
+        endDate: competitionsTable.endDate,
+      },
+      confirmation: {
+        id: crewAssignmentConfirmationsTable.id,
+        status: crewAssignmentConfirmationsTable.status,
+        sentAt: crewAssignmentConfirmationsTable.sentAt,
+        respondedAt: crewAssignmentConfirmationsTable.respondedAt,
+        expiresAt: crewAssignmentConfirmationsTable.expiresAt,
+        responseNote: crewAssignmentConfirmationsTable.responseNote,
+        tokenHash: crewAssignmentConfirmationsTable.tokenHash,
+      },
+      shift: {
+        id: volunteerShiftsTable.id,
+        name: volunteerShiftsTable.name,
+        roleType: volunteerShiftsTable.roleType,
+        startTime: volunteerShiftsTable.startTime,
+        endTime: volunteerShiftsTable.endTime,
+        location: volunteerShiftsTable.location,
+        notes: volunteerShiftsTable.notes,
+      },
+      assignment: {
+        id: volunteerShiftAssignmentsTable.id,
+      },
+      confirmationEmail: crewAssignmentConfirmationsTable.email,
+      membership: {
+        metadata: teamMembershipTable.metadata,
+      },
+      user: {
+        firstName: userTable.firstName,
+        lastName: userTable.lastName,
+        email: userTable.email,
+      },
+    })
+    .from(crewAssignmentConfirmationsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewAssignmentConfirmationsTable.competitionId, competitionsTable.id),
+    )
+    .innerJoin(
+      crewEventSettingsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .innerJoin(
+      volunteerShiftAssignmentsTable,
+      and(
+        eq(
+          crewAssignmentConfirmationsTable.assignmentId,
+          volunteerShiftAssignmentsTable.id,
+        ),
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        ),
+      ),
+    )
+    .innerJoin(
+      volunteerShiftsTable,
+      eq(volunteerShiftAssignmentsTable.shiftId, volunteerShiftsTable.id),
+    )
+    .innerJoin(
+      teamMembershipTable,
+      eq(volunteerShiftAssignmentsTable.membershipId, teamMembershipTable.id),
+    )
+    .leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(
+      and(
+        eq(crewAssignmentConfirmationsTable.tokenHash, tokenHash),
+        eq(competitionsTable.slug, slug),
+        eq(crewEventSettingsTable.crewOnly, true),
+        ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
+      ),
+    )
+    .limit(1)
+
+  if (!row) {
+    return emptyTokenData("missing")
+  }
+
+  const status = getCrewAssignmentConfirmationTokenState(row.confirmation)
+  if (status !== "valid") {
+    return {
+      status,
+      event: row.event,
+      volunteer: null,
+      assignment: null,
+      confirmation: toConfirmationDisplay(row.confirmation),
+    }
+  }
+
+  const metadata = parseCrewRosterMetadata(row.membership.metadata)
+  const name =
+    metadata.signupName ||
+    [row.user?.firstName, row.user?.lastName].filter(Boolean).join(" ") ||
+    row.user?.email ||
+    row.confirmationEmail ||
+    "Volunteer"
+  const email =
+    row.confirmationEmail ?? metadata.signupEmail ?? row.user?.email ?? ""
+
+  return {
+    status,
+    event: row.event,
+    volunteer: {
+      name,
+      email,
+      roleTypes: getCrewRosterRoleTypes(metadata.volunteerRoleTypes),
+    },
+    assignment: {
+      id: row.assignment.id,
+      shiftId: row.shift.id,
+      name: row.shift.name,
+      roleType: row.shift.roleType,
+      roleLabel: formatVolunteerRole(row.shift.roleType),
+      startTime: row.shift.startTime,
+      endTime: row.shift.endTime,
+      location: row.shift.location,
+      notes: row.shift.notes,
+    },
+    confirmation: toConfirmationDisplay(row.confirmation),
+  }
+}
+
+function emptyTokenData(
+  status: CrewAssignmentTokenState,
+): CrewAssignmentConfirmationTokenData {
+  return {
+    status,
+    event: null,
+    volunteer: null,
+    assignment: null,
+    confirmation: null,
+  }
+}
+
+function toConfirmationDisplay(confirmation: {
+  id: string
+  status: CrewAssignmentConfirmationStatus
+  sentAt: Date | null
+  respondedAt: Date | null
+  expiresAt: Date | null
+  responseNote: string | null
+}): CrewAssignmentConfirmationDisplay {
+  return {
+    id: confirmation.id,
+    status: confirmation.status,
+    sentAt: confirmation.sentAt,
+    respondedAt: confirmation.respondedAt,
+    expiresAt: confirmation.expiresAt,
+    responseNote: confirmation.responseNote,
+  }
+}
+
+function getResponseSuccessMessage(action: CrewAssignmentResponseAction) {
+  const status = statusForCrewAssignmentResponseAction(action)
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED) {
+    return "Assignment confirmed. Thank you."
+  }
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED) {
+    return "Assignment declined. The organizer will see your response."
+  }
+  return "Change request sent. The organizer will see your note."
+}

--- a/apps/crew/src/server-fns/crew-roster-shift-fns.ts
+++ b/apps/crew/src/server-fns/crew-roster-shift-fns.ts
@@ -1,6 +1,6 @@
 // @lat: [[crew#Roster Shifts Assignments]]
 import { createServerFn } from "@tanstack/react-start"
-import { and, asc, eq } from "drizzle-orm"
+import { and, asc, eq, inArray } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "../db"
 import { createVolunteerShiftAssignmentId } from "../db/schemas/common"
@@ -356,18 +356,32 @@ export const deleteCrewShiftFn = createServerFn({ method: "POST" })
     const db = getDb()
 
     await db.transaction(async (tx) => {
+      const [lockedShift] = await tx
+        .select({ id: volunteerShiftsTable.id })
+        .from(volunteerShiftsTable)
+        .where(eq(volunteerShiftsTable.id, data.shiftId))
+        .for("update")
+        .limit(1)
+      if (!lockedShift) {
+        throw new Error("Volunteer shift not found")
+      }
+
       const assignments = await tx
         .select({ id: volunteerShiftAssignmentsTable.id })
         .from(volunteerShiftAssignmentsTable)
         .where(eq(volunteerShiftAssignmentsTable.shiftId, data.shiftId))
+        .for("update")
+      const assignmentIds = assignments.map((assignment) => assignment.id)
 
       await cancelCrewShiftAssignmentConfirmations({
         db: tx as unknown as DbClient,
-        assignmentIds: assignments.map((assignment) => assignment.id),
+        assignmentIds,
       })
-      await tx
-        .delete(volunteerShiftAssignmentsTable)
-        .where(eq(volunteerShiftAssignmentsTable.shiftId, data.shiftId))
+      if (assignmentIds.length > 0) {
+        await tx
+          .delete(volunteerShiftAssignmentsTable)
+          .where(inArray(volunteerShiftAssignmentsTable.id, assignmentIds))
+      }
       await tx
         .delete(volunteerShiftsTable)
         .where(eq(volunteerShiftsTable.id, data.shiftId))
@@ -482,7 +496,8 @@ export const assignCrewVolunteerToShiftFn = createServerFn({ method: "POST" })
         competitionId: event.id,
         assignmentId,
         membershipId: membership.id,
-        email: metadata.signupEmail ?? membership.email ?? null,
+        email:
+          emptyToNull(metadata.signupEmail) ?? emptyToNull(membership.email),
         expiresAt: getAssignmentConfirmationExpiry(now),
         now,
       })
@@ -512,19 +527,18 @@ export const removeCrewVolunteerShiftAssignmentFn = createServerFn({
             eq(volunteerShiftAssignmentsTable.membershipId, data.membershipId),
           ),
         )
+        .for("update")
+      const assignmentIds = assignments.map((assignment) => assignment.id)
 
       await cancelCrewShiftAssignmentConfirmations({
         db: tx as unknown as DbClient,
-        assignmentIds: assignments.map((assignment) => assignment.id),
+        assignmentIds,
       })
-      await tx
-        .delete(volunteerShiftAssignmentsTable)
-        .where(
-          and(
-            eq(volunteerShiftAssignmentsTable.shiftId, shift.id),
-            eq(volunteerShiftAssignmentsTable.membershipId, data.membershipId),
-          ),
-        )
+      if (assignmentIds.length > 0) {
+        await tx
+          .delete(volunteerShiftAssignmentsTable)
+          .where(inArray(volunteerShiftAssignmentsTable.id, assignmentIds))
+      }
     })
 
     return { success: true }

--- a/apps/crew/src/server-fns/crew-roster-shift-fns.ts
+++ b/apps/crew/src/server-fns/crew-roster-shift-fns.ts
@@ -11,6 +11,7 @@ import {
   teamInvitationTable,
   teamMembershipTable,
 } from "../db/schemas/teams"
+import { userTable } from "../db/schemas/users"
 import {
   VOLUNTEER_ROLE_TYPE_VALUES,
   volunteerShiftAssignmentsTable,
@@ -31,9 +32,18 @@ import {
 } from "../lib/crew/roster-shifts"
 import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
 import {
+  cancelCrewShiftAssignmentConfirmations,
+  ensureCrewShiftAssignmentConfirmation,
+  loadCrewShiftAssignmentConfirmationMap,
+  summarizeCrewShiftAssignmentConfirmations,
+  type CrewShiftAssignmentConfirmationStatus,
+} from "./crew-confirmation-fns"
+import {
   DEFAULT_TIMEZONE,
   formatDateTimeInTimezone,
 } from "../utils/timezone-utils"
+
+type DbClient = ReturnType<typeof getDb>
 
 type CrewRosterCompetition = Pick<
   Competition,
@@ -57,6 +67,7 @@ export interface CrewShiftAssignmentItem {
   id: string
   membershipId: string
   notes: string | null
+  confirmation: CrewShiftAssignmentConfirmationStatus | null
   volunteer: CrewShiftAssignmentVolunteer
 }
 
@@ -96,6 +107,9 @@ export interface CrewShiftSummary {
   assignedSlots: number
   capacity: number
   openSlots: number
+  confirmationSummary: ReturnType<
+    typeof summarizeCrewShiftAssignmentConfirmations
+  >
 }
 
 const eventIdSchema = z.string().min(1, "Event ID is required")
@@ -342,6 +356,15 @@ export const deleteCrewShiftFn = createServerFn({ method: "POST" })
     const db = getDb()
 
     await db.transaction(async (tx) => {
+      const assignments = await tx
+        .select({ id: volunteerShiftAssignmentsTable.id })
+        .from(volunteerShiftAssignmentsTable)
+        .where(eq(volunteerShiftAssignmentsTable.shiftId, data.shiftId))
+
+      await cancelCrewShiftAssignmentConfirmations({
+        db: tx as unknown as DbClient,
+        assignmentIds: assignments.map((assignment) => assignment.id),
+      })
       await tx
         .delete(volunteerShiftAssignmentsTable)
         .where(eq(volunteerShiftAssignmentsTable.shiftId, data.shiftId))
@@ -391,8 +414,10 @@ export const assignCrewVolunteerToShiftFn = createServerFn({ method: "POST" })
             id: teamMembershipTable.id,
             isActive: teamMembershipTable.isActive,
             metadata: teamMembershipTable.metadata,
+            email: userTable.email,
           })
           .from(teamMembershipTable)
+          .leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
           .where(
             and(
               eq(teamMembershipTable.id, data.membershipId),
@@ -441,11 +466,25 @@ export const assignCrewVolunteerToShiftFn = createServerFn({ method: "POST" })
       }
 
       const assignmentId = createVolunteerShiftAssignmentId()
+      const now = new Date()
       await tx.insert(volunteerShiftAssignmentsTable).values({
         id: assignmentId,
         shiftId: shift.id,
         membershipId: membership.id,
         notes: emptyToNull(data.notes),
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      const metadata = parseCrewRosterMetadata(membership.metadata)
+      await ensureCrewShiftAssignmentConfirmation({
+        db: tx as unknown as DbClient,
+        competitionId: event.id,
+        assignmentId,
+        membershipId: membership.id,
+        email: metadata.signupEmail ?? membership.email ?? null,
+        expiresAt: getAssignmentConfirmationExpiry(now),
+        now,
       })
 
       return { success: true, action: "assigned" as const, assignmentId }
@@ -463,14 +502,30 @@ export const removeCrewVolunteerShiftAssignmentFn = createServerFn({
     const shift = await requireCrewShift(event.id, data.shiftId)
     const db = getDb()
 
-    await db
-      .delete(volunteerShiftAssignmentsTable)
-      .where(
-        and(
-          eq(volunteerShiftAssignmentsTable.shiftId, shift.id),
-          eq(volunteerShiftAssignmentsTable.membershipId, data.membershipId),
-        ),
-      )
+    await db.transaction(async (tx) => {
+      const assignments = await tx
+        .select({ id: volunteerShiftAssignmentsTable.id })
+        .from(volunteerShiftAssignmentsTable)
+        .where(
+          and(
+            eq(volunteerShiftAssignmentsTable.shiftId, shift.id),
+            eq(volunteerShiftAssignmentsTable.membershipId, data.membershipId),
+          ),
+        )
+
+      await cancelCrewShiftAssignmentConfirmations({
+        db: tx as unknown as DbClient,
+        assignmentIds: assignments.map((assignment) => assignment.id),
+      })
+      await tx
+        .delete(volunteerShiftAssignmentsTable)
+        .where(
+          and(
+            eq(volunteerShiftAssignmentsTable.shiftId, shift.id),
+            eq(volunteerShiftAssignmentsTable.membershipId, data.membershipId),
+          ),
+        )
+    })
 
     return { success: true }
   })
@@ -549,6 +604,13 @@ async function loadCrewShifts(
       },
     },
   })
+  const assignmentIds = shifts.flatMap((shift) =>
+    shift.assignments.map((assignment) => assignment.id),
+  )
+  const confirmationMap = await loadCrewShiftAssignmentConfirmationMap(
+    db,
+    assignmentIds,
+  )
 
   return shifts.map((shift) => {
     const assignments = shift.assignments.map((assignment) => {
@@ -569,6 +631,7 @@ async function loadCrewShifts(
         id: assignment.id,
         membershipId: assignment.membershipId,
         notes: assignment.notes,
+        confirmation: confirmationMap.get(assignment.id) ?? null,
         volunteer: {
           membershipId: assignment.membershipId,
           name,
@@ -598,16 +661,35 @@ async function loadCrewShifts(
 }
 
 function summarizeCrewShifts(shifts: CrewShiftBoardItem[]): CrewShiftSummary {
-  return shifts.reduce<CrewShiftSummary>(
-    (summary, shift) => {
-      summary.totalShifts += 1
-      summary.assignedSlots += shift.assignedCount
-      summary.capacity += shift.capacity
-      summary.openSlots += shift.openSlots
-      return summary
+  const summary = shifts.reduce(
+    (nextSummary, shift) => {
+      nextSummary.totalShifts += 1
+      nextSummary.assignedSlots += shift.assignedCount
+      nextSummary.capacity += shift.capacity
+      nextSummary.openSlots += shift.openSlots
+      nextSummary.confirmations.push(
+        ...shift.assignments.map((assignment) => assignment.confirmation),
+      )
+      return nextSummary
     },
-    { totalShifts: 0, assignedSlots: 0, capacity: 0, openSlots: 0 },
+    {
+      totalShifts: 0,
+      assignedSlots: 0,
+      capacity: 0,
+      openSlots: 0,
+      confirmations: [] as Array<CrewShiftAssignmentConfirmationStatus | null>,
+    },
   )
+
+  return {
+    totalShifts: summary.totalShifts,
+    assignedSlots: summary.assignedSlots,
+    capacity: summary.capacity,
+    openSlots: summary.openSlots,
+    confirmationSummary: summarizeCrewShiftAssignmentConfirmations(
+      summary.confirmations,
+    ),
+  }
 }
 
 async function requireCrewShift(competitionId: string, shiftId: string) {
@@ -629,4 +711,10 @@ async function requireCrewShift(competitionId: string, shiftId: string) {
 function emptyToNull(value: string | null | undefined) {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
+}
+
+function getAssignmentConfirmationExpiry(now: Date) {
+  const expiresAt = new Date(now)
+  expiresAt.setDate(expiresAt.getDate() + 30)
+  return expiresAt
 }

--- a/apps/crew/src/server-fns/crew-volunteer-fns.ts
+++ b/apps/crew/src/server-fns/crew-volunteer-fns.ts
@@ -34,6 +34,7 @@ import {
   validateCrewVolunteerSignupRequirements,
   type CrewVolunteerSignupMetadata,
 } from "../lib/crew/volunteer-signup"
+import { getFirstExecuteValue } from "./db-execute"
 import type { QuestionType } from "./registration-questions-fns"
 
 type DbClient = ReturnType<typeof getDb>
@@ -587,22 +588,6 @@ async function createVolunteerSignupLockName(
   return Array.from(new Uint8Array(digest), (byte) =>
     byte.toString(16).padStart(2, "0"),
   ).join("")
-}
-
-function getExecuteRows<T>(result: unknown): T[] {
-  if (Array.isArray(result)) {
-    if (Array.isArray(result[0])) return result[0] as T[]
-    return result as T[]
-  }
-
-  return ((result as { rows?: T[] })?.rows ?? []) as T[]
-}
-
-function getFirstExecuteValue(result: unknown): unknown {
-  const [row] = getExecuteRows<unknown>(result)
-  if (Array.isArray(row)) return row[0]
-  if (row && typeof row === "object") return Object.values(row)[0]
-  return row
 }
 
 function parseQuestionOptions(options: string | null): string[] | null {

--- a/apps/crew/src/server-fns/db-execute.ts
+++ b/apps/crew/src/server-fns/db-execute.ts
@@ -1,0 +1,15 @@
+export function getExecuteRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) {
+    if (Array.isArray(result[0])) return result[0] as T[]
+    return result as T[]
+  }
+
+  return ((result as { rows?: T[] })?.rows ?? []) as T[]
+}
+
+export function getFirstExecuteValue(result: unknown): unknown {
+  const [row] = getExecuteRows<unknown>(result)
+  if (Array.isArray(row)) return row[0]
+  if (row && typeof row === "object") return Object.values(row)[0]
+  return row
+}

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -89,3 +89,9 @@ IDs use the `cimpr_` prefix.
 One row per volunteer or judge assignment confirmation. It tracks the assignment target, optional membership or invitation identity, confirmation status, response timing, reminder state, and only a token hash.
 
 Raw confirmation tokens are generated later for links and must not be persisted. IDs use the `caconf_` prefix.
+
+## Assignment Confirmation Responses
+
+Crew assignment confirmation links are token-only volunteer surfaces. Raw tokens are generated only while creating links, stored only as hashes, and used by [[apps/crew/src/routes/e/$slug/confirm/$token.tsx]] and [[apps/crew/src/routes/e/$slug/schedule/$token.tsx]] to show safe confirm, decline, and change-request flows without requiring a session.
+
+[[apps/crew/src/server-fns/crew-confirmation-fns.ts]] owns token lookup, transient email payload construction, and deterministic response transitions. [[apps/crew/src/lib/crew/assignment-confirmations.ts]] keeps the pure token and status helpers testable outside the server function layer.


### PR DESCRIPTION
## Summary
- add hashed Crew assignment confirmation token helpers, response state transitions, and focused tests
- add public token-only assignment confirmation and schedule views for confirm, decline, and change-request notes
- create/cancel confirmation rows from Crew shift assignment changes and surface confirmation summaries in overview, roster, and shifts
- add a React Email assignment confirmation template and local queue-message construction helper without wiring live sends or queue mutations

## Validation
- pnpm --filter crew test -- src/lib/crew/assignment-confirmations.test.ts
- pnpm --filter crew type-check
- pnpm --filter crew build
- pnpm --filter crew lint (passes with existing unrelated warnings)
- pnpm check:schema-ownership
- git diff --check

## Notes
- Build required the established ignored local config workaround: copied apps/crew/wrangler.jsonc to apps/crew/.alchemy/local/wrangler.jsonc for validation only.
- This PR renders/builds the assignment confirmation email payload shape but does not enqueue live jobs or send production email. Live queue/email wiring remains for a later infrastructure-safe slice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full crew shift assignment confirmation flow with hashed tokens, public confirm/schedule pages, response handling, and UI summaries. Includes a React Email template and message builder for confirmations (no live sending).

- **New Features**
  - Token generation, hashing, validation, and deterministic, idempotent response transitions with focused tests.
  - Public routes: `/e/$slug/confirm/$token` (confirm/decline/request change) and `/e/$slug/schedule/$token` (supports assignment or volunteer tokens; shows assignment details).
  - Server functions to load token data, process responses with idempotency, build email payloads, create confirmation rows on assignment create, cancel them on assignment removal/shift delete, and prevent duplicates with locks; shared helpers centralized in `assignment-confirmations.ts` and `server-fns/db-execute.ts`.
  - UI: confirmation badges and notes on assignments; “Confirmed” counts in Event Overview, Shifts, and Volunteers; “Needs response” on Shifts.

- **Migration**
  - Emails are not sent yet; only render and payload construction are included.
  - Assignment confirmation tokens default to a 30-day expiry; only valid for `crewOnly` events that are not archived.
  - Ensure `getAppUrl()` returns the correct base URL for links in emails.

<sup>Written for commit 2ed431b04125dbd1aad146b1aacd6a6492df27b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crew assignment confirmation workflow: volunteers can confirm, decline, or request changes for shift assignments
  * Confirmation status tracking displayed across event overview, shifts, and volunteers pages
  * Confirmation email notifications with secure action links for responding
  * Response timestamps and optional notes for declined assignments or change requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->