### PR TITLE
feat(crew): add pilot readiness checklist

### DIFF
--- a/apps/crew/src/lib/crew/readiness.test.ts
+++ b/apps/crew/src/lib/crew/readiness.test.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Pilot Readiness Checklist]]
 import { describe, expect, it } from "vitest"
 import { buildCrewReadinessChecklist } from "./readiness"
 import type { CrewReadinessInput } from "./readiness"
@@ -97,6 +98,23 @@ describe("Crew readiness checklist", () => {
       status: "needs_attention",
       summary: "3/7 assignments confirmed",
       details: ["2 no response.", "1 declined.", "1 change requested."],
+    })
+  })
+
+  it("keeps workout and heat readiness attention-worthy until workouts are published", () => {
+    const checklist = buildCrewReadinessChecklist({
+      ...readyInput,
+      schedule: {
+        ...readyInput.schedule,
+        publishedWorkoutCount: 3,
+      },
+    })
+
+    expect(
+      checklist.items.find((item) => item.category === "workouts_heats"),
+    ).toMatchObject({
+      status: "needs_attention",
+      summary: "3/4 workouts published, 20 heats",
     })
   })
 })

--- a/apps/crew/src/lib/crew/readiness.test.ts
+++ b/apps/crew/src/lib/crew/readiness.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest"
+import { buildCrewReadinessChecklist } from "./readiness"
+import type { CrewReadinessInput } from "./readiness"
+
+describe("Crew readiness checklist", () => {
+  it("marks a fully prepared pilot event ready except the manual judge checkpoint", () => {
+    const checklist = buildCrewReadinessChecklist({
+      ...readyInput,
+      judge: {
+        rotationCount: 0,
+        assignmentCount: 0,
+        activeVersionCount: 0,
+      },
+    })
+
+    expect(checklist.summary).toMatchObject({
+      total: 7,
+      ready: 6,
+      needsAttention: 1,
+      blocked: 0,
+      highestStatus: "needs_attention",
+    })
+    expect(
+      checklist.items.find((item) => item.category === "judge_publishing"),
+    ).toMatchObject({
+      status: "needs_attention",
+      summary: "Judge rotation publishing is not ready in Crew yet.",
+    })
+  })
+
+  it("blocks readiness when core event, venue, heat, roster, or shift data is missing", () => {
+    const checklist = buildCrewReadinessChecklist({
+      ...readyInput,
+      event: { startDate: "", endDate: "", timezone: null },
+      venues: { venueCount: 0, totalLaneCount: 0 },
+      schedule: {
+        workoutCount: 1,
+        publishedWorkoutCount: 1,
+        heatCount: 0,
+        scheduledHeatCount: 0,
+        publishedHeatCount: 0,
+      },
+      roster: {
+        total: 0,
+        pending: 0,
+        accepted: 0,
+        active: 0,
+        inactive: 0,
+        expired: 0,
+        assignable: 0,
+      },
+      shifts: {
+        ...readyInput.shifts,
+        totalShifts: 0,
+        assignedSlots: 0,
+        capacity: 0,
+        openSlots: 0,
+      },
+    })
+
+    expect(checklist.summary.blocked).toBe(5)
+    expect(checklist.summary.highestStatus).toBe("blocked")
+    expect(
+      checklist.items
+        .filter((item) => item.status === "blocked")
+        .map((item) => item.category),
+    ).toEqual([
+      "event_basics",
+      "venues_lanes",
+      "workouts_heats",
+      "volunteers",
+      "shifts_assignments",
+    ])
+  })
+
+  it("surfaces no-response, decline, and change-request confirmation counts", () => {
+    const checklist = buildCrewReadinessChecklist({
+      ...readyInput,
+      shifts: {
+        ...readyInput.shifts,
+        confirmationSummary: {
+          pending: 2,
+          confirmed: 3,
+          declined: 1,
+          changeRequested: 1,
+          noShow: 0,
+          cancelled: 0,
+        },
+      },
+    })
+
+    expect(
+      checklist.items.find(
+        (item) => item.category === "assignment_confirmations",
+      ),
+    ).toMatchObject({
+      status: "needs_attention",
+      summary: "3/7 assignments confirmed",
+      details: ["2 no response.", "1 declined.", "1 change requested."],
+    })
+  })
+})
+
+const readyInput: CrewReadinessInput = {
+  event: {
+    startDate: "2026-07-10",
+    endDate: "2026-07-11",
+    timezone: "America/Denver",
+  },
+  setup: {
+    completed: 5,
+    total: 5,
+  },
+  venues: {
+    venueCount: 2,
+    totalLaneCount: 14,
+  },
+  schedule: {
+    workoutCount: 4,
+    publishedWorkoutCount: 4,
+    heatCount: 20,
+    scheduledHeatCount: 20,
+    publishedHeatCount: 20,
+  },
+  imports: {
+    volunteerImportCount: 1,
+    appliedVolunteerImportCount: 1,
+    heatScheduleImportCount: 1,
+    appliedHeatScheduleImportCount: 1,
+  },
+  roster: {
+    total: 16,
+    pending: 2,
+    accepted: 0,
+    active: 14,
+    inactive: 0,
+    expired: 0,
+    assignable: 14,
+  },
+  shifts: {
+    totalShifts: 5,
+    assignedSlots: 7,
+    capacity: 7,
+    openSlots: 0,
+    confirmationSummary: {
+      pending: 0,
+      confirmed: 7,
+      declined: 0,
+      changeRequested: 0,
+      noShow: 0,
+      cancelled: 0,
+    },
+  },
+  judge: {
+    rotationCount: 4,
+    assignmentCount: 28,
+    activeVersionCount: 1,
+  },
+}

--- a/apps/crew/src/lib/crew/readiness.ts
+++ b/apps/crew/src/lib/crew/readiness.ts
@@ -1,0 +1,339 @@
+import type { CrewAssignmentConfirmationStatusSummary } from "./assignment-confirmations"
+import type { CrewRosterSummary } from "./roster-shifts"
+
+export type CrewReadinessStatus = "ready" | "needs_attention" | "blocked"
+
+export type CrewReadinessCategory =
+  | "event_basics"
+  | "venues_lanes"
+  | "workouts_heats"
+  | "volunteers"
+  | "shifts_assignments"
+  | "judge_publishing"
+  | "assignment_confirmations"
+
+export type CrewReadinessActionTo =
+  | "/events/$eventId/setup"
+  | "/events/$eventId/imports"
+  | "/events/$eventId/volunteers"
+  | "/events/$eventId/shifts"
+  | "/events/$eventId/schedule"
+
+export interface CrewReadinessAction {
+  label: string
+  to: CrewReadinessActionTo
+}
+
+export interface CrewReadinessChecklistItem {
+  category: CrewReadinessCategory
+  label: string
+  status: CrewReadinessStatus
+  summary: string
+  details: string[]
+  action: CrewReadinessAction
+}
+
+export interface CrewReadinessSummary {
+  total: number
+  ready: number
+  needsAttention: number
+  blocked: number
+  progressPercent: number
+  highestStatus: CrewReadinessStatus
+}
+
+export interface CrewReadinessEventInput {
+  startDate: string | null
+  endDate: string | null
+  timezone: string | null
+}
+
+export interface CrewReadinessSetupInput {
+  completed: number
+  total: number
+}
+
+export interface CrewReadinessVenueInput {
+  venueCount: number
+  totalLaneCount: number
+}
+
+export interface CrewReadinessScheduleInput {
+  workoutCount: number
+  publishedWorkoutCount: number
+  heatCount: number
+  scheduledHeatCount: number
+  publishedHeatCount: number
+}
+
+export interface CrewReadinessImportInput {
+  volunteerImportCount: number
+  appliedVolunteerImportCount: number
+  heatScheduleImportCount: number
+  appliedHeatScheduleImportCount: number
+}
+
+export interface CrewReadinessShiftInput {
+  totalShifts: number
+  assignedSlots: number
+  capacity: number
+  openSlots: number
+  confirmationSummary: CrewAssignmentConfirmationStatusSummary
+}
+
+export interface CrewReadinessJudgeInput {
+  rotationCount: number
+  assignmentCount: number
+  activeVersionCount: number
+}
+
+export interface CrewReadinessInput {
+  event: CrewReadinessEventInput
+  setup: CrewReadinessSetupInput
+  venues: CrewReadinessVenueInput
+  schedule: CrewReadinessScheduleInput
+  imports: CrewReadinessImportInput
+  roster: CrewRosterSummary
+  shifts: CrewReadinessShiftInput
+  judge: CrewReadinessJudgeInput
+}
+
+export interface CrewReadinessChecklist {
+  items: CrewReadinessChecklistItem[]
+  summary: CrewReadinessSummary
+}
+
+export const crewReadinessStatusLabels: Record<CrewReadinessStatus, string> = {
+  ready: "Ready",
+  needs_attention: "Needs attention",
+  blocked: "Blocked",
+}
+
+export function buildCrewReadinessChecklist(
+  input: CrewReadinessInput,
+): CrewReadinessChecklist {
+  const items = [
+    buildEventBasicsItem(input),
+    buildVenuesLanesItem(input),
+    buildWorkoutsHeatsItem(input),
+    buildVolunteersItem(input),
+    buildShiftsAssignmentsItem(input),
+    buildJudgePublishingItem(input),
+    buildAssignmentConfirmationsItem(input),
+  ]
+
+  return {
+    items,
+    summary: summarizeCrewReadiness(items),
+  }
+}
+
+export function summarizeCrewReadiness(
+  items: CrewReadinessChecklistItem[],
+): CrewReadinessSummary {
+  const ready = items.filter((item) => item.status === "ready").length
+  const needsAttention = items.filter(
+    (item) => item.status === "needs_attention",
+  ).length
+  const blocked = items.filter((item) => item.status === "blocked").length
+  const total = items.length
+
+  return {
+    total,
+    ready,
+    needsAttention,
+    blocked,
+    progressPercent: total === 0 ? 0 : Math.round((ready / total) * 100),
+    highestStatus:
+      blocked > 0
+        ? "blocked"
+        : needsAttention > 0
+          ? "needs_attention"
+          : "ready",
+  }
+}
+
+function buildEventBasicsItem(
+  input: CrewReadinessInput,
+): CrewReadinessChecklistItem {
+  const hasDates = Boolean(input.event.startDate && input.event.endDate)
+  const hasTimezone = Boolean(input.event.timezone)
+  const setupComplete =
+    input.setup.total > 0 && input.setup.completed === input.setup.total
+  const status = !hasDates
+    ? "blocked"
+    : hasTimezone && setupComplete
+      ? "ready"
+      : "needs_attention"
+
+  return {
+    category: "event_basics",
+    label: "Event dates and timezone",
+    status,
+    summary: hasDates
+      ? `${input.event.startDate} to ${input.event.endDate}`
+      : "Event dates are missing.",
+    details: [
+      hasTimezone
+        ? `Timezone: ${input.event.timezone}`
+        : "Timezone is not set.",
+      `${input.setup.completed}/${input.setup.total} operator setup checks complete.`,
+    ],
+    action: { label: "Review setup", to: "/events/$eventId/setup" },
+  }
+}
+
+function buildVenuesLanesItem(
+  input: CrewReadinessInput,
+): CrewReadinessChecklistItem {
+  const status =
+    input.venues.venueCount === 0 || input.venues.totalLaneCount === 0
+      ? "blocked"
+      : "ready"
+
+  return {
+    category: "venues_lanes",
+    label: "Venues, floors, and lanes",
+    status,
+    summary:
+      input.venues.venueCount > 0
+        ? `${input.venues.venueCount} venue${plural(input.venues.venueCount)}, ${input.venues.totalLaneCount} total lane${plural(input.venues.totalLaneCount)}`
+        : "No venues are configured.",
+    details: [
+      input.venues.totalLaneCount > 0
+        ? "Lane counts are available for schedule planning."
+        : "Add at least one floor or venue with lanes.",
+    ],
+    action: { label: "Open schedule", to: "/events/$eventId/schedule" },
+  }
+}
+
+function buildWorkoutsHeatsItem(
+  input: CrewReadinessInput,
+): CrewReadinessChecklistItem {
+  const { schedule } = input
+  const status =
+    schedule.workoutCount === 0 || schedule.heatCount === 0
+      ? "blocked"
+      : schedule.scheduledHeatCount < schedule.heatCount ||
+          schedule.publishedHeatCount < schedule.heatCount
+        ? "needs_attention"
+        : "ready"
+
+  return {
+    category: "workouts_heats",
+    label: "Workouts and heats",
+    status,
+    summary: `${schedule.workoutCount} workout${plural(schedule.workoutCount)}, ${schedule.heatCount} heat${plural(schedule.heatCount)}`,
+    details: [
+      `${schedule.publishedWorkoutCount}/${schedule.workoutCount} workouts published.`,
+      `${schedule.scheduledHeatCount}/${schedule.heatCount} heats scheduled.`,
+      `${schedule.publishedHeatCount}/${schedule.heatCount} heat schedules published.`,
+      `${input.imports.appliedHeatScheduleImportCount}/${input.imports.heatScheduleImportCount} heat schedule imports applied.`,
+    ],
+    action: { label: "Review imports", to: "/events/$eventId/imports" },
+  }
+}
+
+function buildVolunteersItem(
+  input: CrewReadinessInput,
+): CrewReadinessChecklistItem {
+  const status =
+    input.roster.total === 0
+      ? "blocked"
+      : input.roster.assignable === 0
+        ? "needs_attention"
+        : "ready"
+
+  return {
+    category: "volunteers",
+    label: "Volunteer roster",
+    status,
+    summary: `${input.roster.total} volunteer${plural(input.roster.total)}, ${input.roster.assignable} assignable`,
+    details: [
+      `${input.roster.active} active, ${input.roster.pending} pending, ${input.roster.accepted} accepted.`,
+      `${input.imports.appliedVolunteerImportCount}/${input.imports.volunteerImportCount} volunteer imports applied.`,
+    ],
+    action: { label: "Open volunteers", to: "/events/$eventId/volunteers" },
+  }
+}
+
+function buildShiftsAssignmentsItem(
+  input: CrewReadinessInput,
+): CrewReadinessChecklistItem {
+  const status =
+    input.shifts.totalShifts === 0 || input.shifts.assignedSlots === 0
+      ? "blocked"
+      : input.shifts.openSlots > 0
+        ? "needs_attention"
+        : "ready"
+
+  return {
+    category: "shifts_assignments",
+    label: "Shifts and assignments",
+    status,
+    summary: `${input.shifts.assignedSlots}/${input.shifts.capacity} shift slots assigned`,
+    details: [
+      `${input.shifts.totalShifts} shift${plural(input.shifts.totalShifts)} configured.`,
+      `${input.shifts.openSlots} open slot${plural(input.shifts.openSlots)} remaining.`,
+    ],
+    action: { label: "Manage shifts", to: "/events/$eventId/shifts" },
+  }
+}
+
+function buildJudgePublishingItem(
+  input: CrewReadinessInput,
+): CrewReadinessChecklistItem {
+  const status =
+    input.judge.activeVersionCount > 0 ? "ready" : "needs_attention"
+  const summary =
+    input.judge.activeVersionCount > 0
+      ? `${input.judge.activeVersionCount} active judge assignment version${plural(input.judge.activeVersionCount)}`
+      : "Judge rotation publishing is not ready in Crew yet."
+
+  return {
+    category: "judge_publishing",
+    label: "Judge rotation publishing",
+    status,
+    summary,
+    details: [
+      `${input.judge.rotationCount} rotation${plural(input.judge.rotationCount)} drafted.`,
+      `${input.judge.assignmentCount} judge assignment${plural(input.judge.assignmentCount)} found.`,
+      "Use this as a manual pilot checkpoint until the Crew judge rotation UI lands.",
+    ],
+    action: { label: "Open schedule", to: "/events/$eventId/schedule" },
+  }
+}
+
+function buildAssignmentConfirmationsItem(
+  input: CrewReadinessInput,
+): CrewReadinessChecklistItem {
+  const confirmations = input.shifts.confirmationSummary
+  const responseIssues =
+    confirmations.pending +
+    confirmations.declined +
+    confirmations.changeRequested
+  const status =
+    input.shifts.assignedSlots === 0
+      ? "needs_attention"
+      : responseIssues > 0
+        ? "needs_attention"
+        : "ready"
+
+  return {
+    category: "assignment_confirmations",
+    label: "Assignment confirmations",
+    status,
+    summary: `${confirmations.confirmed}/${input.shifts.assignedSlots} assignments confirmed`,
+    details: [
+      `${confirmations.pending} no response.`,
+      `${confirmations.declined} declined.`,
+      `${confirmations.changeRequested} change requested.`,
+    ],
+    action: { label: "Review shifts", to: "/events/$eventId/shifts" },
+  }
+}
+
+function plural(count: number) {
+  return count === 1 ? "" : "s"
+}

--- a/apps/crew/src/lib/crew/readiness.ts
+++ b/apps/crew/src/lib/crew/readiness.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Pilot Readiness Checklist]]
 import type { CrewAssignmentConfirmationStatusSummary } from "./assignment-confirmations"
 import type { CrewRosterSummary } from "./roster-shifts"
 
@@ -215,18 +216,22 @@ function buildWorkoutsHeatsItem(
   const status =
     schedule.workoutCount === 0 || schedule.heatCount === 0
       ? "blocked"
-      : schedule.scheduledHeatCount < schedule.heatCount ||
+      : schedule.publishedWorkoutCount < schedule.workoutCount ||
+          schedule.scheduledHeatCount < schedule.heatCount ||
           schedule.publishedHeatCount < schedule.heatCount
         ? "needs_attention"
         : "ready"
+  const unpublishedWorkoutCount =
+    schedule.workoutCount - schedule.publishedWorkoutCount
 
   return {
     category: "workouts_heats",
     label: "Workouts and heats",
     status,
-    summary: `${schedule.workoutCount} workout${plural(schedule.workoutCount)}, ${schedule.heatCount} heat${plural(schedule.heatCount)}`,
+    summary: `${schedule.publishedWorkoutCount}/${schedule.workoutCount} workouts published, ${schedule.heatCount} heat${plural(schedule.heatCount)}`,
     details: [
       `${schedule.publishedWorkoutCount}/${schedule.workoutCount} workouts published.`,
+      `${unpublishedWorkoutCount} unpublished workout${plural(unpublishedWorkoutCount)} remaining.`,
       `${schedule.scheduledHeatCount}/${schedule.heatCount} heats scheduled.`,
       `${schedule.publishedHeatCount}/${schedule.heatCount} heat schedules published.`,
       `${input.imports.appliedHeatScheduleImportCount}/${input.imports.heatScheduleImportCount} heat schedule imports applied.`,

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as EventsEventIdVolunteersRouteImport } from './routes/events/$ev
 import { Route as EventsEventIdShiftsRouteImport } from './routes/events/$eventId/shifts'
 import { Route as EventsEventIdSetupRouteImport } from './routes/events/$eventId/setup'
 import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$eventId/schedule'
+import { Route as EventsEventIdReadinessRouteImport } from './routes/events/$eventId/readiness'
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
@@ -75,6 +76,11 @@ const EventsEventIdScheduleRoute = EventsEventIdScheduleRouteImport.update({
   path: '/schedule',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdReadinessRoute = EventsEventIdReadinessRouteImport.update({
+  id: '/readiness',
+  path: '/readiness',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const EventsEventIdImportsRoute = EventsEventIdImportsRouteImport.update({
   id: '/imports',
   path: '/imports',
@@ -110,6 +116,7 @@ export interface FileRoutesByFullPath {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
+  '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
@@ -126,6 +133,7 @@ export interface FileRoutesByTo {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
+  '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
@@ -144,6 +152,7 @@ export interface FileRoutesById {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
+  '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
@@ -163,6 +172,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
+    | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/shifts'
@@ -179,6 +189,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
+    | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/shifts'
@@ -196,6 +207,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
+    | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/shifts'
@@ -287,6 +299,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdScheduleRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/readiness': {
+      id: '/events/$eventId/readiness'
+      path: '/readiness'
+      fullPath: '/events/$eventId/readiness'
+      preLoaderRoute: typeof EventsEventIdReadinessRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/events/$eventId/imports': {
       id: '/events/$eventId/imports'
       path: '/imports'
@@ -327,6 +346,7 @@ declare module '@tanstack/react-router' {
 
 interface EventsEventIdRouteChildren {
   EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
+  EventsEventIdReadinessRoute: typeof EventsEventIdReadinessRoute
   EventsEventIdScheduleRoute: typeof EventsEventIdScheduleRoute
   EventsEventIdSetupRoute: typeof EventsEventIdSetupRoute
   EventsEventIdShiftsRoute: typeof EventsEventIdShiftsRoute
@@ -336,6 +356,7 @@ interface EventsEventIdRouteChildren {
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdImportsRoute: EventsEventIdImportsRoute,
+  EventsEventIdReadinessRoute: EventsEventIdReadinessRoute,
   EventsEventIdScheduleRoute: EventsEventIdScheduleRoute,
   EventsEventIdSetupRoute: EventsEventIdSetupRoute,
   EventsEventIdShiftsRoute: EventsEventIdShiftsRoute,

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -37,6 +37,14 @@ function EventShell() {
             Overview
           </Link>
           <Link
+            to="/events/$eventId/readiness"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Readiness
+          </Link>
+          <Link
             to="/events/$eventId/setup"
             params={{ eventId }}
             activeProps={{ className: "bg-muted text-foreground" }}

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -1,3 +1,4 @@
+// @lat: [[crew#Pilot Readiness Checklist]]
 import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
 import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
 

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -1,3 +1,4 @@
+// @lat: [[crew#Pilot Readiness Checklist]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { formatCrewValue, getSafeHttpUrl } from "@/lib/crew-event-display"
 import {

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -54,6 +54,25 @@ function EventOverviewPage() {
         />
       </div>
 
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Pilot readiness</h2>
+            <p className="text-sm text-muted-foreground">
+              Check event setup, imports, schedule, roster, shifts, judge
+              publishing, and assignment confirmations before handoff.
+            </p>
+          </div>
+          <Link
+            to="/events/$eventId/readiness"
+            params={{ eventId }}
+            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Open checklist
+          </Link>
+        </div>
+      </section>
+
       <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
         <section className="rounded-md border bg-card p-5 shadow-sm">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">

--- a/apps/crew/src/routes/events/$eventId/readiness.tsx
+++ b/apps/crew/src/routes/events/$eventId/readiness.tsx
@@ -1,3 +1,4 @@
+// @lat: [[crew#Pilot Readiness Checklist]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { AlertCircle, CheckCircle2, CircleAlert } from "lucide-react"
 import {

--- a/apps/crew/src/routes/events/$eventId/readiness.tsx
+++ b/apps/crew/src/routes/events/$eventId/readiness.tsx
@@ -1,0 +1,212 @@
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import { AlertCircle, CheckCircle2, CircleAlert } from "lucide-react"
+import {
+  crewReadinessStatusLabels,
+  type CrewReadinessChecklistItem,
+  type CrewReadinessStatus,
+} from "@/lib/crew/readiness"
+import { getCrewReadinessPageFn } from "@/server-fns/crew-readiness-fns"
+
+export const Route = createFileRoute("/events/$eventId/readiness")({
+  loader: async ({ params }) =>
+    await getCrewReadinessPageFn({ data: { eventId: params.eventId } }),
+  component: EventReadinessPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+function EventReadinessPage() {
+  const { eventId } = parentRoute.useParams()
+  const { readiness, facts } = Route.useLoaderData()
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Pilot readiness</h2>
+          <p className="text-sm text-muted-foreground">
+            Read-only operator checklist for the founding organizer pilot.
+          </p>
+        </div>
+        <StatusBadge status={readiness.summary.highestStatus} />
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="grid gap-4 md:grid-cols-4">
+          <StatusPanel
+            label="Ready"
+            value={`${readiness.summary.ready}/${readiness.summary.total}`}
+          />
+          <StatusPanel
+            label="Needs attention"
+            value={readiness.summary.needsAttention}
+          />
+          <StatusPanel label="Blocked" value={readiness.summary.blocked} />
+          <StatusPanel
+            label="Progress"
+            value={`${readiness.summary.progressPercent}%`}
+          />
+        </div>
+        <ProgressBar value={readiness.summary.progressPercent} />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {readiness.items.map((item) => (
+          <ReadinessItemCard
+            key={item.category}
+            eventId={eventId}
+            item={item}
+          />
+        ))}
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h3 className="font-semibold">Source counts</h3>
+        <dl className="mt-4 grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
+          <Fact
+            label="Setup checks"
+            value={`${facts.setup.completed}/${facts.setup.total}`}
+          />
+          <Fact
+            label="Venues and lanes"
+            value={`${facts.venues.venueCount} / ${facts.venues.totalLaneCount}`}
+          />
+          <Fact
+            label="Workouts and heats"
+            value={`${facts.schedule.workoutCount} / ${facts.schedule.heatCount}`}
+          />
+          <Fact
+            label="Roster"
+            value={`${facts.roster.total} total, ${facts.roster.assignable} assignable`}
+          />
+          <Fact
+            label="Shift coverage"
+            value={`${facts.shifts.assignedSlots}/${facts.shifts.capacity}`}
+          />
+          <Fact
+            label="Confirmations"
+            value={`${facts.shifts.confirmationSummary.confirmed}/${facts.shifts.assignedSlots}`}
+          />
+          <Fact
+            label="No response"
+            value={facts.shifts.confirmationSummary.pending}
+          />
+          <Fact label="Judge versions" value={facts.judge.activeVersionCount} />
+        </dl>
+      </section>
+    </section>
+  )
+}
+
+function ReadinessItemCard({
+  eventId,
+  item,
+}: {
+  eventId: string
+  item: CrewReadinessChecklistItem
+}) {
+  const Icon =
+    item.status === "ready"
+      ? CheckCircle2
+      : item.status === "blocked"
+        ? AlertCircle
+        : CircleAlert
+
+  return (
+    <article className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 gap-3">
+          <Icon
+            className={`mt-0.5 size-5 shrink-0 ${statusIconClass(item.status)}`}
+          />
+          <div className="min-w-0">
+            <h3 className="font-semibold">{item.label}</h3>
+            <p className="mt-1 text-sm text-muted-foreground">{item.summary}</p>
+          </div>
+        </div>
+        <StatusBadge status={item.status} compact />
+      </div>
+
+      <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+        {item.details.map((detail) => (
+          <li key={detail}>{detail}</li>
+        ))}
+      </ul>
+
+      <Link
+        to={item.action.to}
+        params={{ eventId }}
+        className="mt-5 inline-flex rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        {item.action.label}
+      </Link>
+    </article>
+  )
+}
+
+function StatusPanel({
+  label,
+  value,
+}: {
+  label: string
+  value: number | string
+}) {
+  return (
+    <section className="rounded-md border bg-background p-4">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function StatusBadge({
+  status,
+  compact = false,
+}: {
+  status: CrewReadinessStatus
+  compact?: boolean
+}) {
+  return (
+    <span
+      className={`inline-flex shrink-0 rounded-md border px-2 py-1 text-xs font-medium ${statusBadgeClass(status)} ${compact ? "" : "self-start"}`}
+    >
+      {crewReadinessStatusLabels[status]}
+    </span>
+  )
+}
+
+function Fact({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function ProgressBar({ value }: { value: number }) {
+  return (
+    <div className="mt-5 h-2 overflow-hidden rounded-full bg-muted">
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  )
+}
+
+function statusBadgeClass(status: CrewReadinessStatus) {
+  if (status === "ready") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "blocked") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+}
+
+function statusIconClass(status: CrewReadinessStatus) {
+  if (status === "ready") return "text-emerald-600"
+  if (status === "blocked") return "text-destructive"
+  return "text-amber-600"
+}

--- a/apps/crew/src/server-fns/crew-readiness-fns.ts
+++ b/apps/crew/src/server-fns/crew-readiness-fns.ts
@@ -1,6 +1,6 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
 import { createServerFn } from "@tanstack/react-start"
-import { and, eq } from "drizzle-orm"
+import { and, count, eq } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "../db"
 import {
@@ -121,12 +121,12 @@ async function requireCrewReadinessEvent(eventId: string) {
       timezone: competitionsTable.timezone,
       settingsText: crewEventSettingsTable.settings,
     })
-    .from(crewEventSettingsTable)
-    .innerJoin(
-      competitionsTable,
+    .from(competitionsTable)
+    .leftJoin(
+      crewEventSettingsTable,
       eq(crewEventSettingsTable.competitionId, competitionsTable.id),
     )
-    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .where(eq(competitionsTable.id, eventId))
     .limit(1)
 
   if (!event) {
@@ -239,11 +239,11 @@ async function loadJudgeSummary(
   const db = getDb()
   const [rotations, assignments, activeVersions] = await Promise.all([
     db
-      .select({ id: competitionJudgeRotationsTable.id })
+      .select({ count: count() })
       .from(competitionJudgeRotationsTable)
       .where(eq(competitionJudgeRotationsTable.competitionId, competitionId)),
     db
-      .select({ id: judgeHeatAssignmentsTable.id })
+      .select({ count: count() })
       .from(judgeHeatAssignmentsTable)
       .innerJoin(
         competitionHeatsTable,
@@ -251,7 +251,7 @@ async function loadJudgeSummary(
       )
       .where(eq(competitionHeatsTable.competitionId, competitionId)),
     db
-      .select({ id: judgeAssignmentVersionsTable.id })
+      .select({ count: count() })
       .from(judgeAssignmentVersionsTable)
       .innerJoin(
         trackWorkoutsTable,
@@ -270,8 +270,8 @@ async function loadJudgeSummary(
   ])
 
   return {
-    rotationCount: rotations.length,
-    assignmentCount: assignments.length,
-    activeVersionCount: activeVersions.length,
+    rotationCount: rotations[0]?.count ?? 0,
+    assignmentCount: assignments[0]?.count ?? 0,
+    activeVersionCount: activeVersions[0]?.count ?? 0,
   }
 }

--- a/apps/crew/src/server-fns/crew-readiness-fns.ts
+++ b/apps/crew/src/server-fns/crew-readiness-fns.ts
@@ -1,0 +1,277 @@
+// @lat: [[crew#Pilot Readiness Checklist]]
+import { createServerFn } from "@tanstack/react-start"
+import { and, eq } from "drizzle-orm"
+import { z } from "zod"
+import { getDb } from "../db"
+import {
+  competitionHeatsTable,
+  competitionsTable,
+  competitionVenuesTable,
+} from "../db/schemas/competitions"
+import {
+  CREW_IMPORT_KIND,
+  CREW_IMPORT_STATUS,
+  crewImportsTable,
+} from "../db/schemas/crew-imports"
+import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import {
+  programmingTracksTable,
+  trackWorkoutsTable,
+} from "../db/schemas/programming"
+import {
+  competitionJudgeRotationsTable,
+  judgeAssignmentVersionsTable,
+  judgeHeatAssignmentsTable,
+} from "../db/schemas/volunteers"
+import {
+  calculateSetupProgress,
+  parseCrewSettings,
+} from "../lib/crew-event-setup"
+import {
+  buildCrewReadinessChecklist,
+  type CrewReadinessChecklist,
+  type CrewReadinessImportInput,
+  type CrewReadinessJudgeInput,
+  type CrewReadinessScheduleInput,
+  type CrewReadinessVenueInput,
+} from "../lib/crew/readiness"
+import { summarizeCrewRoster } from "../lib/crew/roster-shifts"
+import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
+import {
+  loadCrewRoster,
+  loadCrewShifts,
+  summarizeCrewShifts,
+  type CrewShiftSummary,
+} from "./crew-roster-shift-fns"
+
+const eventIdSchema = z.string().min(1, "Event ID is required")
+
+export interface CrewReadinessPageData {
+  readiness: CrewReadinessChecklist
+  facts: {
+    setup: ReturnType<typeof calculateSetupProgress>
+    venues: CrewReadinessVenueInput
+    schedule: CrewReadinessScheduleInput
+    imports: CrewReadinessImportInput
+    roster: ReturnType<typeof summarizeCrewRoster>
+    shifts: CrewShiftSummary
+    judge: CrewReadinessJudgeInput
+  }
+}
+
+export const getCrewReadinessPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    z.object({ eventId: eventIdSchema }).parse(data),
+  )
+  .handler(async ({ data }): Promise<CrewReadinessPageData> => {
+    requireLocalCrewOperatorAccess("Crew pilot readiness")
+
+    const event = await requireCrewReadinessEvent(data.eventId)
+    const [roster, shifts, venues, schedule, imports, judge] =
+      await Promise.all([
+        loadCrewRoster(event.competitionTeamId),
+        loadCrewShifts(event.id),
+        loadVenueSummary(event.id),
+        loadScheduleSummary(event.id),
+        loadImportSummary(event.id),
+        loadJudgeSummary(event.id),
+      ])
+
+    const parsedSettings = parseCrewSettings(event.settingsText)
+    const setup = calculateSetupProgress(parsedSettings.setup)
+    const rosterSummary = summarizeCrewRoster(roster)
+    const shiftSummary = summarizeCrewShifts(shifts)
+    const readiness = buildCrewReadinessChecklist({
+      event: {
+        startDate: event.startDate,
+        endDate: event.endDate,
+        timezone: event.timezone,
+      },
+      setup,
+      venues,
+      schedule,
+      imports,
+      roster: rosterSummary,
+      shifts: shiftSummary,
+      judge,
+    })
+
+    return {
+      readiness,
+      facts: {
+        setup,
+        venues,
+        schedule,
+        imports,
+        roster: rosterSummary,
+        shifts: shiftSummary,
+        judge,
+      },
+    }
+  })
+
+async function requireCrewReadinessEvent(eventId: string) {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      competitionTeamId: competitionsTable.competitionTeamId,
+      startDate: competitionsTable.startDate,
+      endDate: competitionsTable.endDate,
+      timezone: competitionsTable.timezone,
+      settingsText: crewEventSettingsTable.settings,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  return event
+}
+
+async function loadVenueSummary(
+  competitionId: string,
+): Promise<CrewReadinessVenueInput> {
+  const db = getDb()
+  const venues = await db
+    .select({
+      id: competitionVenuesTable.id,
+      laneCount: competitionVenuesTable.laneCount,
+    })
+    .from(competitionVenuesTable)
+    .where(eq(competitionVenuesTable.competitionId, competitionId))
+
+  return {
+    venueCount: venues.length,
+    totalLaneCount: venues.reduce(
+      (total, venue) => total + (venue.laneCount ?? 0),
+      0,
+    ),
+  }
+}
+
+async function loadScheduleSummary(
+  competitionId: string,
+): Promise<CrewReadinessScheduleInput> {
+  const db = getDb()
+  const [workouts, heats] = await Promise.all([
+    db
+      .select({
+        id: trackWorkoutsTable.id,
+        eventStatus: trackWorkoutsTable.eventStatus,
+      })
+      .from(trackWorkoutsTable)
+      .innerJoin(
+        programmingTracksTable,
+        eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+      )
+      .where(eq(programmingTracksTable.competitionId, competitionId)),
+    db
+      .select({
+        id: competitionHeatsTable.id,
+        scheduledTime: competitionHeatsTable.scheduledTime,
+        schedulePublishedAt: competitionHeatsTable.schedulePublishedAt,
+      })
+      .from(competitionHeatsTable)
+      .where(eq(competitionHeatsTable.competitionId, competitionId)),
+  ])
+
+  return {
+    workoutCount: workouts.length,
+    publishedWorkoutCount: workouts.filter(
+      (workout) => workout.eventStatus === "published",
+    ).length,
+    heatCount: heats.length,
+    scheduledHeatCount: heats.filter((heat) => Boolean(heat.scheduledTime))
+      .length,
+    publishedHeatCount: heats.filter((heat) =>
+      Boolean(heat.schedulePublishedAt),
+    ).length,
+  }
+}
+
+async function loadImportSummary(
+  competitionId: string,
+): Promise<CrewReadinessImportInput> {
+  const db = getDb()
+  const imports = await db
+    .select({
+      kind: crewImportsTable.kind,
+      status: crewImportsTable.status,
+    })
+    .from(crewImportsTable)
+    .where(eq(crewImportsTable.competitionId, competitionId))
+
+  return imports.reduce<CrewReadinessImportInput>(
+    (summary, row) => {
+      if (row.kind === CREW_IMPORT_KIND.VOLUNTEERS) {
+        summary.volunteerImportCount += 1
+        if (row.status === CREW_IMPORT_STATUS.APPLIED) {
+          summary.appliedVolunteerImportCount += 1
+        }
+      } else if (row.kind === CREW_IMPORT_KIND.HEAT_SCHEDULE) {
+        summary.heatScheduleImportCount += 1
+        if (row.status === CREW_IMPORT_STATUS.APPLIED) {
+          summary.appliedHeatScheduleImportCount += 1
+        }
+      }
+      return summary
+    },
+    {
+      volunteerImportCount: 0,
+      appliedVolunteerImportCount: 0,
+      heatScheduleImportCount: 0,
+      appliedHeatScheduleImportCount: 0,
+    },
+  )
+}
+
+async function loadJudgeSummary(
+  competitionId: string,
+): Promise<CrewReadinessJudgeInput> {
+  const db = getDb()
+  const [rotations, assignments, activeVersions] = await Promise.all([
+    db
+      .select({ id: competitionJudgeRotationsTable.id })
+      .from(competitionJudgeRotationsTable)
+      .where(eq(competitionJudgeRotationsTable.competitionId, competitionId)),
+    db
+      .select({ id: judgeHeatAssignmentsTable.id })
+      .from(judgeHeatAssignmentsTable)
+      .innerJoin(
+        competitionHeatsTable,
+        eq(judgeHeatAssignmentsTable.heatId, competitionHeatsTable.id),
+      )
+      .where(eq(competitionHeatsTable.competitionId, competitionId)),
+    db
+      .select({ id: judgeAssignmentVersionsTable.id })
+      .from(judgeAssignmentVersionsTable)
+      .innerJoin(
+        trackWorkoutsTable,
+        eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutsTable.id),
+      )
+      .innerJoin(
+        programmingTracksTable,
+        eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+      )
+      .where(
+        and(
+          eq(programmingTracksTable.competitionId, competitionId),
+          eq(judgeAssignmentVersionsTable.isActive, true),
+        ),
+      ),
+  ])
+
+  return {
+    rotationCount: rotations.length,
+    assignmentCount: assignments.length,
+    activeVersionCount: activeVersions.length,
+  }
+}

--- a/apps/crew/src/server-fns/crew-roster-shift-fns.ts
+++ b/apps/crew/src/server-fns/crew-roster-shift-fns.ts
@@ -573,7 +573,7 @@ async function requireCrewRosterEvent(
   return event
 }
 
-async function loadCrewRoster(competitionTeamId: string) {
+export async function loadCrewRoster(competitionTeamId: string) {
   const db = getDb()
   const [invitations, memberships] = await Promise.all([
     db.query.teamInvitationTable.findMany({
@@ -599,7 +599,7 @@ async function loadCrewRoster(competitionTeamId: string) {
   return buildCrewRoster(invitations, memberships)
 }
 
-async function loadCrewShifts(
+export async function loadCrewShifts(
   competitionId: string,
 ): Promise<CrewShiftBoardItem[]> {
   const db = getDb()
@@ -674,7 +674,9 @@ async function loadCrewShifts(
   })
 }
 
-function summarizeCrewShifts(shifts: CrewShiftBoardItem[]): CrewShiftSummary {
+export function summarizeCrewShifts(
+  shifts: CrewShiftBoardItem[],
+): CrewShiftSummary {
   const summary = shifts.reduce(
     (nextSummary, shift) => {
       nextSummary.totalShifts += 1

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -8,6 +8,14 @@ Crew event setup pages let an operator create and review a normal competition wi
 
 Additional setup dashboard state is stored in the existing `crew_event_settings.settings` JSON text field until a later slice proves that dedicated typed columns or tables are needed.
 
+## Pilot Readiness Checklist
+
+Crew pilot readiness is a read-only operator surface for deciding whether a founding organizer event is ready for handoff.
+
+[[apps/crew/src/routes/events/$eventId/readiness.tsx]] renders the per-event checklist. [[apps/crew/src/server-fns/crew-readiness-fns.ts]] aggregates existing event, setup, venue, workout, heat, import, roster, shift, confirmation, and judge-publishing counts without creating schema or mutating event data. [[apps/crew/src/lib/crew/readiness.ts]] owns deterministic status, severity, progress, and summary derivation for the checklist.
+
+The checklist treats event basics, venues and lanes, workouts and heats, volunteer roster, shifts and assignments, judge publishing, and assignment confirmations as separate readiness categories. Judge publishing is a manual pilot checkpoint until the dedicated Crew judge rotation workflow exists.
+
 ## Staffing Calculator
 
 The public Crew calculator route estimates event-day staffing needs from event dimensions and editable role assumptions.


### PR DESCRIPTION
## Summary
- add a pure Crew readiness checklist helper with summary/status derivation and focused coverage
- add a local-operator-only Crew readiness read layer that aggregates existing event setup, venue/lane, workout/heat, import, roster, shift, confirmation, and judge-publishing counts
- add /events/$eventId/readiness plus event nav and overview entry points

## Validation
- pnpm --filter crew test -- src/lib/crew/readiness.test.ts
- pnpm --filter crew type-check
- pnpm --filter crew lint (exits 0; existing unrelated warnings remain)
- pnpm --filter crew build (used ignored .alchemy/local/wrangler.jsonc local validation config)
- pnpm check:schema-ownership
- git diff --check

## Notes / limitations
- read-only slice; no schema, migrations, email sends, reminders, or live infrastructure mutations
- judge rotation/publishing readiness is intentionally a placeholder/manual checkpoint until the dedicated judge rotation UI/publishing slice lands
- build required the established ignored local Alchemy/Wrangler config workaround for this fresh worktree

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only pilot readiness checklist for Crew events with a new `/events/$eventId/readiness` page that shows overall status, progress, and a source counts panel; added nav links from the event header and Overview.

- **New Features**
  - Checklist builder with derived statuses and summary across event basics, venues/lanes, workouts/heats, volunteers, shifts/assignments, judge publishing, and confirmations.
  - Local-operator-only server read layer that aggregates counts and returns facts plus computed readiness.
  - New page `/events/$eventId/readiness` with status badges, progress bar, item cards with actions, and a “Source counts” panel; added header tab and Overview CTA.
  - Tests for summary math, blocking rules, publish gating, and confirmation surfacing.
  - Judge rotation/publishing is a temporary manual checkpoint until the dedicated UI lands.

<sup>Written for commit 1f0814237cdece44d1856a8fca19a366de725730. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced crew readiness checklist to track event preparation status across event setup, venues, schedules, volunteers, shifts, and judge assignments
  * Displays overall readiness summary with progress percentage and item-level status indicators (ready, needs attention, blocked)
  * Provides navigation links to relevant sections for addressing incomplete items

* **Tests**
  * Added comprehensive test suite for readiness checklist calculations and status scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->