### PR TITLE
feat(crew): add staffing matrix core

### DIFF
--- a/apps/crew/src/lib/crew/staffing/index.ts
+++ b/apps/crew/src/lib/crew/staffing/index.ts
@@ -1,0 +1,4 @@
+// @lat: [[crew#Staffing Matrix Core]]
+export { buildCrewStaffingMatrix } from "./matrix"
+export { normalizeCrewStaffingMatrixInput } from "./normalize"
+export type * from "./types"

--- a/apps/crew/src/lib/crew/staffing/matrix.test.ts
+++ b/apps/crew/src/lib/crew/staffing/matrix.test.ts
@@ -115,6 +115,62 @@ describe("Crew staffing matrix core", () => {
     })
   })
 
+  it("flags morning and afternoon volunteers assigned across the noon boundary", () => {
+    const matrix = buildCrewStaffingMatrix({
+      event: {
+        id: "comp_1",
+        timezone: "America/Denver",
+      },
+      roster: [
+        {
+          membershipId: "tmem_morning",
+          name: "Morning Volunteer",
+          roleTypes: ["staff"],
+          availability: "morning",
+          isActive: true,
+        },
+        {
+          membershipId: "tmem_afternoon",
+          name: "Afternoon Volunteer",
+          roleTypes: ["staff"],
+          availability: "afternoon",
+          isActive: true,
+        },
+      ],
+      shifts: [
+        {
+          id: "shift_noon_crossing",
+          name: "Noon crossing",
+          roleType: "staff",
+          startTime: "2026-07-04T17:30:00.000Z",
+          endTime: "2026-07-04T18:30:00.000Z",
+          capacity: 2,
+          assignments: [
+            {
+              id: "vsha_morning_crossing",
+              membershipId: "tmem_morning",
+            },
+            {
+              id: "vsha_afternoon_crossing",
+              membershipId: "tmem_afternoon",
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(
+      matrix.outsideAvailabilityAssignments.map((assignment) => [
+        assignment.assignmentId,
+        assignment.availability,
+      ]),
+    ).toEqual([
+      ["vsha_afternoon_crossing", "afternoon"],
+      ["vsha_morning_crossing", "morning"],
+    ])
+    expect(matrix.summary.outsideAvailabilityAssignments).toBe(2)
+  })
+
   it("keeps missing and change-request confirmation gaps typed by assignment kind", () => {
     const matrix = buildCrewStaffingMatrix({
       event: { id: "comp_1" },

--- a/apps/crew/src/lib/crew/staffing/matrix.test.ts
+++ b/apps/crew/src/lib/crew/staffing/matrix.test.ts
@@ -27,9 +27,9 @@ describe("Crew staffing matrix core", () => {
       ]),
     ).toEqual([
       ["heat:heat_1", "judge", 2, 1, 1],
+      ["shift:shift_medical", "medical", 2, 1, 1],
       ["heat:heat_2", "judge", 3, 1, 2],
       ["shift:shift_check_in", "check_in", 2, 1, 1],
-      ["shift:shift_medical", "medical", 2, 1, 1],
     ])
     expect(matrix.summary).toMatchObject({
       timeBlocks: 4,
@@ -40,6 +40,39 @@ describe("Crew staffing matrix core", () => {
       underfilledRows: 4,
       openCapacity: 5,
     })
+  })
+
+  it("sorts heats with equal start times by heat number before id", () => {
+    const matrix = buildCrewStaffingMatrix({
+      event: { id: "comp_1" },
+      heats: [
+        {
+          id: "heat_alpha",
+          trackWorkoutId: "tw_final",
+          heatNumber: 2,
+          scheduledTime: "2026-07-04T15:00:00.000Z",
+          durationMinutes: 12,
+          laneCount: 1,
+        },
+        {
+          id: "heat_zulu",
+          trackWorkoutId: "tw_final",
+          heatNumber: 1,
+          scheduledTime: "2026-07-04T15:00:00.000Z",
+          durationMinutes: 12,
+          laneCount: 1,
+        },
+      ],
+    })
+
+    expect(matrix.timeBlocks.map((block) => block.id)).toEqual([
+      "heat:heat_zulu",
+      "heat:heat_alpha",
+    ])
+    expect(matrix.coverageRows.map((row) => row.timeBlockId)).toEqual([
+      "heat:heat_zulu",
+      "heat:heat_alpha",
+    ])
   })
 
   it("reports judge lane gaps from occupied lanes and venue lane counts", () => {
@@ -169,6 +202,112 @@ describe("Crew staffing matrix core", () => {
       ["vsha_morning_crossing", "morning"],
     ])
     expect(matrix.summary.outsideAvailabilityAssignments).toBe(2)
+  })
+
+  it("reports every later assignment overlapped by a long assignment", () => {
+    const matrix = buildCrewStaffingMatrix({
+      event: { id: "comp_1" },
+      roster: [
+        {
+          membershipId: "tmem_staff",
+          name: "Staff One",
+          roleTypes: ["staff"],
+          isActive: true,
+        },
+      ],
+      shifts: [
+        {
+          id: "shift_long",
+          name: "Long block",
+          roleType: "staff",
+          startTime: "2026-07-04T15:00:00.000Z",
+          endTime: "2026-07-04T18:00:00.000Z",
+          capacity: 1,
+          assignments: [
+            {
+              id: "vsha_long",
+              membershipId: "tmem_staff",
+            },
+          ],
+        },
+        {
+          id: "shift_middle",
+          name: "Middle block",
+          roleType: "staff",
+          startTime: "2026-07-04T15:30:00.000Z",
+          endTime: "2026-07-04T16:00:00.000Z",
+          capacity: 1,
+          assignments: [
+            {
+              id: "vsha_middle",
+              membershipId: "tmem_staff",
+            },
+          ],
+        },
+        {
+          id: "shift_late",
+          name: "Late block",
+          roleType: "staff",
+          startTime: "2026-07-04T16:30:00.000Z",
+          endTime: "2026-07-04T17:00:00.000Z",
+          capacity: 1,
+          assignments: [
+            {
+              id: "vsha_late",
+              membershipId: "tmem_staff",
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(
+      matrix.doubleBookedVolunteers.map((booking) => booking.assignmentIds),
+    ).toEqual([
+      ["vsha_late", "vsha_long"],
+      ["vsha_long", "vsha_middle"],
+    ])
+    expect(matrix.summary.doubleBookedVolunteers).toBe(2)
+  })
+
+  it("falls back to UTC availability checks when event timezone is invalid", () => {
+    const matrix = buildCrewStaffingMatrix({
+      event: {
+        id: "comp_1",
+        timezone: "Not/AZone",
+      },
+      roster: [
+        {
+          membershipId: "tmem_morning",
+          name: "Morning Volunteer",
+          roleTypes: ["staff"],
+          availability: "morning",
+          isActive: true,
+        },
+      ],
+      shifts: [
+        {
+          id: "shift_invalid_timezone",
+          name: "Invalid timezone block",
+          roleType: "staff",
+          startTime: "2026-07-04T13:00:00.000Z",
+          endTime: "2026-07-04T14:00:00.000Z",
+          capacity: 1,
+          assignments: [
+            {
+              id: "vsha_invalid_timezone",
+              membershipId: "tmem_morning",
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(matrix.outsideAvailabilityAssignments).toHaveLength(1)
+    expect(matrix.outsideAvailabilityAssignments[0]).toMatchObject({
+      assignmentId: "vsha_invalid_timezone",
+      availability: "morning",
+    })
   })
 
   it("keeps missing and change-request confirmation gaps typed by assignment kind", () => {

--- a/apps/crew/src/lib/crew/staffing/matrix.test.ts
+++ b/apps/crew/src/lib/crew/staffing/matrix.test.ts
@@ -1,0 +1,324 @@
+// @lat: [[crew#Staffing Matrix Core]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+} from "../../../db/schemas/crew-imports"
+import { buildCrewStaffingMatrix } from "./matrix"
+import type { CrewStaffingMatrixInput } from "./types"
+
+describe("Crew staffing matrix core", () => {
+  it("derives filled, needed, and open coverage by role and time block", () => {
+    const matrix = buildCrewStaffingMatrix(baseInput())
+
+    expect(matrix.timeBlocks.map((block) => block.id)).toEqual([
+      "heat:heat_1",
+      "shift:shift_medical",
+      "heat:heat_2",
+      "shift:shift_check_in",
+    ])
+    expect(
+      matrix.coverageRows.map((row) => [
+        row.timeBlockId,
+        row.roleType,
+        row.needed,
+        row.filled,
+        row.open,
+      ]),
+    ).toEqual([
+      ["heat:heat_1", "judge", 2, 1, 1],
+      ["heat:heat_2", "judge", 3, 1, 2],
+      ["shift:shift_check_in", "check_in", 2, 1, 1],
+      ["shift:shift_medical", "medical", 2, 1, 1],
+    ])
+    expect(matrix.summary).toMatchObject({
+      timeBlocks: 4,
+      roles: 3,
+      totalNeeded: 9,
+      totalFilled: 4,
+      totalOpen: 5,
+      underfilledRows: 4,
+      openCapacity: 5,
+    })
+  })
+
+  it("reports judge lane gaps from occupied lanes and venue lane counts", () => {
+    const matrix = buildCrewStaffingMatrix(baseInput())
+
+    expect(matrix.judgeLaneGaps).toEqual([
+      {
+        heatId: "heat_1",
+        heatNumber: 1,
+        laneNumber: 2,
+        timeBlockId: "heat:heat_1",
+      },
+      {
+        heatId: "heat_2",
+        heatNumber: 2,
+        laneNumber: 2,
+        timeBlockId: "heat:heat_2",
+      },
+      {
+        heatId: "heat_2",
+        heatNumber: 2,
+        laneNumber: 3,
+        timeBlockId: "heat:heat_2",
+      },
+    ])
+    expect(matrix.summary.judgeLaneGaps).toBe(3)
+  })
+
+  it("flags overlaps, outside availability, role warnings, and confirmations", () => {
+    const matrix = buildCrewStaffingMatrix(baseInput())
+
+    expect(matrix.doubleBookedVolunteers).toEqual([
+      {
+        membershipId: "tmem_judge",
+        volunteerName: "Judge One",
+        assignmentIds: ["jha_1", "vsha_medical"],
+        timeBlockIds: ["heat:heat_1", "shift:shift_medical"],
+      },
+    ])
+    expect(matrix.outsideAvailabilityAssignments).toEqual([
+      {
+        membershipId: "tmem_check",
+        volunteerName: "Check In Morning",
+        availability: "morning",
+        assignmentId: "vsha_check",
+        timeBlockId: "shift:shift_check_in",
+      },
+    ])
+    expect(
+      matrix.credentialWarnings.map((warning) => [
+        warning.assignmentId,
+        warning.membershipId,
+        warning.requiredRoleType,
+        warning.reason,
+      ]),
+    ).toEqual([["jha_2", "tmem_equipment", "judge", "role_mismatch"]])
+    expect(
+      matrix.confirmationGaps.map((gap) => [
+        gap.assignmentId,
+        gap.reason,
+        gap.status,
+      ]),
+    ).toEqual([
+      ["vsha_check", "no_response", "pending"],
+      ["jha_2", "declined", "declined"],
+    ])
+    expect(matrix.summary).toMatchObject({
+      doubleBookedVolunteers: 1,
+      outsideAvailabilityAssignments: 1,
+      credentialWarnings: 1,
+      confirmationNoResponses: 1,
+      confirmationDeclines: 1,
+    })
+  })
+
+  it("keeps missing and change-request confirmation gaps typed by assignment kind", () => {
+    const matrix = buildCrewStaffingMatrix({
+      event: { id: "comp_1" },
+      roster: [
+        {
+          membershipId: "tmem_judge",
+          name: "Judge One",
+          roleTypes: ["judge"],
+          isActive: true,
+        },
+        {
+          membershipId: "tmem_staff",
+          name: "Staff One",
+          roleTypes: ["staff"],
+          isActive: true,
+        },
+      ],
+      shifts: [
+        {
+          id: "shift_staff",
+          name: "Staff block",
+          roleType: "staff",
+          startTime: "2026-07-04T15:00:00.000Z",
+          endTime: "2026-07-04T16:00:00.000Z",
+          capacity: 1,
+          assignments: [
+            {
+              id: "vsha_missing",
+              membershipId: "tmem_staff",
+            },
+          ],
+        },
+      ],
+      heats: [
+        {
+          id: "heat_1",
+          trackWorkoutId: "tw_final",
+          heatNumber: 1,
+          scheduledTime: "2026-07-04T16:00:00.000Z",
+          durationMinutes: 12,
+          laneCount: 1,
+        },
+      ],
+      judgeAssignments: [
+        {
+          id: "jha_change",
+          heatId: "heat_1",
+          membershipId: "tmem_judge",
+          laneNumber: 1,
+          confirmation: {
+            type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+            status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
+          },
+        },
+      ],
+    })
+
+    expect(
+      matrix.confirmationGaps.map((gap) => [
+        gap.assignmentId,
+        gap.type,
+        gap.reason,
+      ]),
+    ).toEqual([
+      ["jha_change", "judge_heat", "change_requested"],
+      ["vsha_missing", "volunteer_shift", "missing_confirmation"],
+    ])
+    expect(matrix.summary).toMatchObject({
+      confirmationNoResponses: 1,
+      confirmationChangeRequests: 1,
+    })
+  })
+})
+
+function baseInput(): CrewStaffingMatrixInput {
+  return {
+    event: {
+      id: "comp_1",
+      name: "Mountain West Throwdown",
+      timezone: "America/Denver",
+    },
+    venues: [
+      {
+        id: "venue_main",
+        name: "Main floor",
+        laneCount: 3,
+      },
+    ],
+    workouts: [
+      {
+        id: "tw_final",
+        name: "Final",
+      },
+    ],
+    heats: [
+      {
+        id: "heat_2",
+        trackWorkoutId: "tw_final",
+        heatNumber: 2,
+        venueId: "venue_main",
+        scheduledTime: "2026-07-04T16:00:00.000Z",
+        durationMinutes: 12,
+      },
+      {
+        id: "heat_1",
+        trackWorkoutId: "tw_final",
+        heatNumber: 1,
+        venueId: "venue_main",
+        scheduledTime: "2026-07-04T15:00:00.000Z",
+        durationMinutes: 12,
+      },
+    ],
+    heatLaneAssignments: [
+      {
+        heatId: "heat_1",
+        laneNumber: 1,
+      },
+      {
+        heatId: "heat_1",
+        laneNumber: 2,
+      },
+    ],
+    roster: [
+      {
+        membershipId: "tmem_check",
+        name: "Check In Morning",
+        roleTypes: ["check_in"],
+        availability: "morning",
+        isActive: true,
+      },
+      {
+        membershipId: "tmem_equipment",
+        name: "Equipment Only",
+        roleTypes: ["equipment"],
+        availability: "all_day",
+        isActive: true,
+      },
+      {
+        membershipId: "tmem_judge",
+        name: "Judge One",
+        roleTypes: ["judge", "medical"],
+        availability: "all_day",
+        isActive: true,
+      },
+    ],
+    shifts: [
+      {
+        id: "shift_check_in",
+        name: "Check-in desk",
+        roleType: "check_in",
+        startTime: "2026-07-04T19:00:00.000Z",
+        endTime: "2026-07-04T21:00:00.000Z",
+        capacity: 2,
+        assignments: [
+          {
+            id: "vsha_check",
+            membershipId: "tmem_check",
+            confirmation: {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+            },
+          },
+        ],
+      },
+      {
+        id: "shift_medical",
+        name: "Medical station",
+        roleType: "medical",
+        startTime: "2026-07-04T15:05:00.000Z",
+        endTime: "2026-07-04T16:05:00.000Z",
+        capacity: 2,
+        assignments: [
+          {
+            id: "vsha_medical",
+            membershipId: "tmem_judge",
+            confirmation: {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+            },
+          },
+        ],
+      },
+    ],
+    judgeAssignments: [
+      {
+        id: "jha_2",
+        heatId: "heat_2",
+        membershipId: "tmem_equipment",
+        laneNumber: 1,
+        confirmation: {
+          type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+        },
+      },
+      {
+        id: "jha_1",
+        heatId: "heat_1",
+        membershipId: "tmem_judge",
+        laneNumber: 1,
+        confirmation: {
+          type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+        },
+      },
+    ],
+  }
+}

--- a/apps/crew/src/lib/crew/staffing/matrix.ts
+++ b/apps/crew/src/lib/crew/staffing/matrix.ts
@@ -43,7 +43,7 @@ export function buildCrewStaffingMatrix(
   const context = normalizeCrewStaffingMatrixInput(input)
   const timeBlocks = buildTimeBlocks(context)
   const timeBlockById = new Map(timeBlocks.map((block) => [block.id, block]))
-  const coverageRows = buildCoverageRows(context)
+  const coverageRows = buildCoverageRows(context, timeBlocks)
   const judgeLaneGaps = buildJudgeLaneGaps(context)
   const assignmentWindows = buildAssignmentWindows(context)
   const doubleBookedVolunteers = buildDoubleBookedVolunteers(
@@ -109,12 +109,23 @@ function buildTimeBlocks(context: NormalizedCrewStaffingInput) {
     }
   })
 
-  return [...shiftBlocks, ...heatBlocks].sort(compareTimeBlock)
+  return [...shiftBlocks, ...heatBlocks]
+    .map((block, index) => ({ block, index }))
+    .sort(
+      (left, right) =>
+        compareTimeBlockDate(left.block, right.block) ||
+        left.index - right.index,
+    )
+    .map(({ block }) => block)
 }
 
 function buildCoverageRows(
   context: NormalizedCrewStaffingInput,
+  timeBlocks: CrewStaffingTimeBlock[],
 ): CrewStaffingCoverageRow[] {
+  const timeBlockOrder = new Map(
+    timeBlocks.map((block, index) => [block.id, index]),
+  )
   const shiftRows = context.shifts.map((shift) => buildShiftCoverageRow(shift))
   const heatRows = context.heats.map((heat) => {
     const laneNumbers = getHeatLaneNumbers(heat, context)
@@ -140,7 +151,9 @@ function buildCoverageRows(
     }
   })
 
-  return [...shiftRows, ...heatRows].sort(compareCoverageRow)
+  return [...shiftRows, ...heatRows].sort((left, right) =>
+    compareCoverageRow(left, right, timeBlockOrder),
+  )
 }
 
 function buildShiftCoverageRow(
@@ -246,20 +259,35 @@ function buildDoubleBookedVolunteers(
     const sortedWindows = [...windows].sort(compareAssignmentWindow)
     for (let index = 0; index < sortedWindows.length; index++) {
       const current = sortedWindows[index]
-      const next = sortedWindows[index + 1]
-      if (!current || !next) continue
-      if (overlaps(current, next)) {
-        const volunteer = context.rosterByMembershipId.get(membershipId)
-        doubleBooked.push({
-          membershipId,
-          volunteerName: getVolunteerName(volunteer, membershipId),
-          assignmentIds: [current.assignmentId, next.assignmentId].sort(
-            compareText,
-          ),
-          timeBlockIds: [current.timeBlockId, next.timeBlockId].sort(
-            compareText,
-          ),
-        })
+      if (!current) continue
+
+      for (
+        let nextIndex = index + 1;
+        nextIndex < sortedWindows.length;
+        nextIndex++
+      ) {
+        const next = sortedWindows[nextIndex]
+        if (!next) continue
+        if (
+          current.endTime &&
+          next.startTime &&
+          next.startTime >= current.endTime
+        ) {
+          break
+        }
+        if (overlaps(current, next)) {
+          const volunteer = context.rosterByMembershipId.get(membershipId)
+          doubleBooked.push({
+            membershipId,
+            volunteerName: getVolunteerName(volunteer, membershipId),
+            assignmentIds: [current.assignmentId, next.assignmentId].sort(
+              compareText,
+            ),
+            timeBlockIds: [current.timeBlockId, next.timeBlockId].sort(
+              compareText,
+            ),
+          })
+        }
       }
     }
   }
@@ -569,21 +597,25 @@ const NOON_MINUTE = 12 * 60
 
 function getLocalMinuteOfDay(date: Date, timezone: string | null | undefined) {
   if (!timezone) return date.getUTCHours() * 60 + date.getUTCMinutes()
-  const formatter = new Intl.DateTimeFormat("en-US", {
-    timeZone: timezone,
-    hour: "numeric",
-    minute: "numeric",
-    hour12: false,
-    hourCycle: "h23",
-  })
-  const parts = formatter.formatToParts(date)
-  const hourPart = parts.find((part) => part.type === "hour")?.value
-  const minutePart = parts.find((part) => part.type === "minute")?.value
-  const hour = Number(hourPart)
-  const minute = Number(minutePart)
-  return Number.isFinite(hour) && Number.isFinite(minute)
-    ? (hour % 24) * 60 + minute
-    : date.getUTCHours() * 60 + date.getUTCMinutes()
+  try {
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "numeric",
+      minute: "numeric",
+      hour12: false,
+      hourCycle: "h23",
+    })
+    const parts = formatter.formatToParts(date)
+    const hourPart = parts.find((part) => part.type === "hour")?.value
+    const minutePart = parts.find((part) => part.type === "minute")?.value
+    const hour = Number(hourPart)
+    const minute = Number(minutePart)
+    return Number.isFinite(hour) && Number.isFinite(minute)
+      ? (hour % 24) * 60 + minute
+      : date.getUTCHours() * 60 + date.getUTCMinutes()
+  } catch {
+    return date.getUTCHours() * 60 + date.getUTCMinutes()
+  }
 }
 
 function getVolunteerName(
@@ -613,19 +645,24 @@ function dedupeDoubleBookings(
   return [...byKey.values()].sort(compareDoubleBooking)
 }
 
-function compareTimeBlock(
+function compareTimeBlockDate(
   left: CrewStaffingTimeBlock,
   right: CrewStaffingTimeBlock,
 ) {
-  return compareDateThenText(left.startTime, right.startTime, left.id, right.id)
+  return compareDateThenText(left.startTime, right.startTime, "", "")
 }
 
 function compareCoverageRow(
   left: CrewStaffingCoverageRow,
   right: CrewStaffingCoverageRow,
+  timeBlockOrder: Map<string, number>,
 ) {
+  const leftOrder = timeBlockOrder.get(left.timeBlockId)
+  const rightOrder = timeBlockOrder.get(right.timeBlockId)
+
   return (
-    compareText(left.timeBlockId, right.timeBlockId) ||
+    (leftOrder ?? Number.POSITIVE_INFINITY) -
+      (rightOrder ?? Number.POSITIVE_INFINITY) ||
     compareText(left.roleType, right.roleType) ||
     compareText(left.id, right.id)
   )

--- a/apps/crew/src/lib/crew/staffing/matrix.ts
+++ b/apps/crew/src/lib/crew/staffing/matrix.ts
@@ -547,29 +547,43 @@ function isWithinAvailability(
   context: NormalizedCrewStaffingInput,
 ) {
   if (!timeBlock.startTime || !timeBlock.endTime) return true
-  const startHour = getLocalHour(
+  const startMinute = getLocalMinuteOfDay(
     timeBlock.startTime,
     context.input.event.timezone,
   )
-  const endHour = getLocalHour(timeBlock.endTime, context.input.event.timezone)
+  const endMinute = getLocalMinuteOfDay(
+    timeBlock.endTime,
+    context.input.event.timezone,
+  )
 
-  if (availability === VOLUNTEER_AVAILABILITY.MORNING) return startHour < 12
-  if (availability === VOLUNTEER_AVAILABILITY.AFTERNOON) return endHour >= 12
+  if (availability === VOLUNTEER_AVAILABILITY.MORNING) {
+    return startMinute < NOON_MINUTE && endMinute <= NOON_MINUTE
+  }
+  if (availability === VOLUNTEER_AVAILABILITY.AFTERNOON) {
+    return startMinute >= NOON_MINUTE && endMinute > NOON_MINUTE
+  }
   return true
 }
 
-function getLocalHour(date: Date, timezone: string | null | undefined) {
-  if (!timezone) return date.getUTCHours()
+const NOON_MINUTE = 12 * 60
+
+function getLocalMinuteOfDay(date: Date, timezone: string | null | undefined) {
+  if (!timezone) return date.getUTCHours() * 60 + date.getUTCMinutes()
   const formatter = new Intl.DateTimeFormat("en-US", {
     timeZone: timezone,
     hour: "numeric",
+    minute: "numeric",
     hour12: false,
+    hourCycle: "h23",
   })
-  const hourPart = formatter
-    .formatToParts(date)
-    .find((part) => part.type === "hour")?.value
+  const parts = formatter.formatToParts(date)
+  const hourPart = parts.find((part) => part.type === "hour")?.value
+  const minutePart = parts.find((part) => part.type === "minute")?.value
   const hour = Number(hourPart)
-  return Number.isFinite(hour) ? hour : date.getUTCHours()
+  const minute = Number(minutePart)
+  return Number.isFinite(hour) && Number.isFinite(minute)
+    ? (hour % 24) * 60 + minute
+    : date.getUTCHours() * 60 + date.getUTCMinutes()
 }
 
 function getVolunteerName(

--- a/apps/crew/src/lib/crew/staffing/matrix.ts
+++ b/apps/crew/src/lib/crew/staffing/matrix.ts
@@ -1,0 +1,679 @@
+// @lat: [[crew#Staffing Matrix Core]]
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+} from "../../../db/schemas/crew-imports"
+import { VOLUNTEER_AVAILABILITY } from "../../../db/schemas/volunteers"
+import { isVolunteerCompatibleWithShift } from "../roster-shifts"
+import {
+  compareDateThenText,
+  compareText,
+  getAssignmentRoleType,
+  getHeatLaneNumbers,
+  normalizeCrewStaffingMatrixInput,
+  toDateOrNull,
+  type NormalizedCrewStaffingInput,
+} from "./normalize"
+import type {
+  CrewStaffingConfirmationGap,
+  CrewStaffingConfirmationInput,
+  CrewStaffingCoverageRow,
+  CrewStaffingCredentialWarning,
+  CrewStaffingDoubleBookedVolunteer,
+  CrewStaffingJudgeLaneGap,
+  CrewStaffingMatrix,
+  CrewStaffingMatrixInput,
+  CrewStaffingOutsideAvailabilityAssignment,
+  CrewStaffingShiftInput,
+  CrewStaffingTimeBlock,
+  CrewStaffingVolunteerInput,
+} from "./types"
+
+interface AssignmentWindow {
+  assignmentId: string
+  membershipId: string
+  timeBlockId: string
+  startTime: Date | null
+  endTime: Date | null
+}
+
+export function buildCrewStaffingMatrix(
+  input: CrewStaffingMatrixInput,
+): CrewStaffingMatrix {
+  const context = normalizeCrewStaffingMatrixInput(input)
+  const timeBlocks = buildTimeBlocks(context)
+  const timeBlockById = new Map(timeBlocks.map((block) => [block.id, block]))
+  const coverageRows = buildCoverageRows(context)
+  const judgeLaneGaps = buildJudgeLaneGaps(context)
+  const assignmentWindows = buildAssignmentWindows(context)
+  const doubleBookedVolunteers = buildDoubleBookedVolunteers(
+    assignmentWindows,
+    context,
+  )
+  const outsideAvailabilityAssignments = buildOutsideAvailabilityAssignments(
+    assignmentWindows,
+    timeBlockById,
+    context,
+  )
+  const credentialWarnings = buildCredentialWarnings(context)
+  const confirmationGaps = buildConfirmationGaps(context)
+
+  return {
+    timeBlocks,
+    coverageRows,
+    judgeLaneGaps,
+    doubleBookedVolunteers,
+    outsideAvailabilityAssignments,
+    credentialWarnings,
+    confirmationGaps,
+    summary: summarizeMatrix({
+      coverageRows,
+      timeBlocks,
+      judgeLaneGaps,
+      doubleBookedVolunteers,
+      outsideAvailabilityAssignments,
+      credentialWarnings,
+      confirmationGaps,
+    }),
+  }
+}
+
+function buildTimeBlocks(context: NormalizedCrewStaffingInput) {
+  const shiftBlocks = context.shifts.map<CrewStaffingTimeBlock>((shift) => ({
+    id: `shift:${shift.id}`,
+    source: "shift",
+    sourceId: shift.id,
+    label: shift.name,
+    startTime: toDateOrNull(shift.startTime),
+    endTime: toDateOrNull(shift.endTime),
+    workoutId: null,
+    heatId: null,
+    venueId: null,
+  }))
+
+  const heatBlocks = context.heats.map<CrewStaffingTimeBlock>((heat) => {
+    const startTime = toDateOrNull(heat.scheduledTime)
+    return {
+      id: `heat:${heat.id}`,
+      source: "heat",
+      sourceId: heat.id,
+      label: getHeatLabel(heat, context),
+      startTime,
+      endTime:
+        startTime && heat.durationMinutes
+          ? new Date(startTime.getTime() + heat.durationMinutes * 60_000)
+          : null,
+      workoutId: heat.trackWorkoutId,
+      heatId: heat.id,
+      venueId: heat.venueId ?? null,
+    }
+  })
+
+  return [...shiftBlocks, ...heatBlocks].sort(compareTimeBlock)
+}
+
+function buildCoverageRows(
+  context: NormalizedCrewStaffingInput,
+): CrewStaffingCoverageRow[] {
+  const shiftRows = context.shifts.map((shift) => buildShiftCoverageRow(shift))
+  const heatRows = context.heats.map((heat) => {
+    const laneNumbers = getHeatLaneNumbers(heat, context)
+    const judgeAssignments = (context.input.judgeAssignments ?? []).filter(
+      (assignment) => assignment.heatId === heat.id,
+    )
+    const coveredLaneNumbers = new Set(
+      judgeAssignments
+        .map((assignment) => assignment.laneNumber)
+        .filter((laneNumber): laneNumber is number =>
+          laneNumber ? laneNumbers.includes(laneNumber) : false,
+        ),
+    )
+
+    return {
+      id: `coverage:heat:${heat.id}:judge`,
+      timeBlockId: `heat:${heat.id}`,
+      roleType: getAssignmentRoleType("judge"),
+      needed: laneNumbers.length,
+      filled: coveredLaneNumbers.size,
+      open: Math.max(laneNumbers.length - coveredLaneNumbers.size, 0),
+      assignmentIds: judgeAssignments.map((assignment) => assignment.id).sort(),
+    }
+  })
+
+  return [...shiftRows, ...heatRows].sort(compareCoverageRow)
+}
+
+function buildShiftCoverageRow(
+  shift: CrewStaffingShiftInput,
+): CrewStaffingCoverageRow {
+  const filled = shift.assignments.length
+  return {
+    id: `coverage:shift:${shift.id}:${shift.roleType}`,
+    timeBlockId: `shift:${shift.id}`,
+    roleType: shift.roleType,
+    needed: shift.capacity,
+    filled,
+    open: Math.max(shift.capacity - filled, 0),
+    assignmentIds: shift.assignments
+      .map((assignment) => assignment.id)
+      .sort(compareText),
+  }
+}
+
+function buildJudgeLaneGaps(
+  context: NormalizedCrewStaffingInput,
+): CrewStaffingJudgeLaneGap[] {
+  const gaps: CrewStaffingJudgeLaneGap[] = []
+
+  for (const heat of context.heats) {
+    const laneNumbers = getHeatLaneNumbers(heat, context)
+    const coveredLaneNumbers = new Set(
+      (context.input.judgeAssignments ?? [])
+        .filter((assignment) => assignment.heatId === heat.id)
+        .map((assignment) => assignment.laneNumber)
+        .filter((laneNumber): laneNumber is number =>
+          laneNumber ? laneNumbers.includes(laneNumber) : false,
+        ),
+    )
+
+    for (const laneNumber of laneNumbers) {
+      if (!coveredLaneNumbers.has(laneNumber)) {
+        gaps.push({
+          heatId: heat.id,
+          heatNumber: heat.heatNumber,
+          laneNumber,
+          timeBlockId: `heat:${heat.id}`,
+        })
+      }
+    }
+  }
+
+  return gaps.sort(
+    (left, right) =>
+      compareText(left.heatId, right.heatId) ||
+      left.laneNumber - right.laneNumber,
+  )
+}
+
+function buildAssignmentWindows(
+  context: NormalizedCrewStaffingInput,
+): AssignmentWindow[] {
+  const shiftWindows = context.shifts.flatMap((shift) =>
+    shift.assignments.map<AssignmentWindow>((assignment) => ({
+      assignmentId: assignment.id,
+      membershipId: assignment.membershipId,
+      timeBlockId: `shift:${shift.id}`,
+      startTime: toDateOrNull(shift.startTime),
+      endTime: toDateOrNull(shift.endTime),
+    })),
+  )
+
+  const judgeWindows = (context.input.judgeAssignments ?? []).map(
+    (assignment) => {
+      const heat = context.heatById.get(assignment.heatId)
+      const startTime = toDateOrNull(heat?.scheduledTime)
+      return {
+        assignmentId: assignment.id,
+        membershipId: assignment.membershipId,
+        timeBlockId: `heat:${assignment.heatId}`,
+        startTime,
+        endTime:
+          startTime && heat?.durationMinutes
+            ? new Date(startTime.getTime() + heat.durationMinutes * 60_000)
+            : null,
+      }
+    },
+  )
+
+  return [...shiftWindows, ...judgeWindows].sort(compareAssignmentWindow)
+}
+
+function buildDoubleBookedVolunteers(
+  assignmentWindows: AssignmentWindow[],
+  context: NormalizedCrewStaffingInput,
+) {
+  const byMembershipId = new Map<string, AssignmentWindow[]>()
+  const doubleBooked: CrewStaffingDoubleBookedVolunteer[] = []
+
+  for (const assignmentWindow of assignmentWindows) {
+    if (!assignmentWindow.startTime || !assignmentWindow.endTime) continue
+    const existing = byMembershipId.get(assignmentWindow.membershipId) ?? []
+    existing.push(assignmentWindow)
+    byMembershipId.set(assignmentWindow.membershipId, existing)
+  }
+
+  for (const [membershipId, windows] of byMembershipId.entries()) {
+    const sortedWindows = [...windows].sort(compareAssignmentWindow)
+    for (let index = 0; index < sortedWindows.length; index++) {
+      const current = sortedWindows[index]
+      const next = sortedWindows[index + 1]
+      if (!current || !next) continue
+      if (overlaps(current, next)) {
+        const volunteer = context.rosterByMembershipId.get(membershipId)
+        doubleBooked.push({
+          membershipId,
+          volunteerName: getVolunteerName(volunteer, membershipId),
+          assignmentIds: [current.assignmentId, next.assignmentId].sort(
+            compareText,
+          ),
+          timeBlockIds: [current.timeBlockId, next.timeBlockId].sort(
+            compareText,
+          ),
+        })
+      }
+    }
+  }
+
+  return dedupeDoubleBookings(doubleBooked)
+}
+
+function buildOutsideAvailabilityAssignments(
+  assignmentWindows: AssignmentWindow[],
+  timeBlockById: Map<string, CrewStaffingTimeBlock>,
+  context: NormalizedCrewStaffingInput,
+) {
+  const warnings: CrewStaffingOutsideAvailabilityAssignment[] = []
+
+  for (const assignmentWindow of assignmentWindows) {
+    const volunteer = context.rosterByMembershipId.get(
+      assignmentWindow.membershipId,
+    )
+    const availability = volunteer?.availability
+    if (!availability || availability === VOLUNTEER_AVAILABILITY.ALL_DAY) {
+      continue
+    }
+    const timeBlock = timeBlockById.get(assignmentWindow.timeBlockId)
+    if (!timeBlock?.startTime || !timeBlock.endTime) continue
+
+    if (!isWithinAvailability(timeBlock, availability, context)) {
+      warnings.push({
+        membershipId: assignmentWindow.membershipId,
+        volunteerName: getVolunteerName(
+          volunteer,
+          assignmentWindow.membershipId,
+        ),
+        availability,
+        assignmentId: assignmentWindow.assignmentId,
+        timeBlockId: assignmentWindow.timeBlockId,
+      })
+    }
+  }
+
+  return warnings.sort(compareAvailabilityWarning)
+}
+
+function buildCredentialWarnings(context: NormalizedCrewStaffingInput) {
+  const warnings: CrewStaffingCredentialWarning[] = []
+
+  for (const shift of context.shifts) {
+    for (const assignment of shift.assignments) {
+      const volunteer = context.rosterByMembershipId.get(
+        assignment.membershipId,
+      )
+      const warning = getCredentialWarning({
+        volunteer,
+        membershipId: assignment.membershipId,
+        assignmentId: assignment.id,
+        timeBlockId: `shift:${shift.id}`,
+        requiredRoleType: shift.roleType,
+      })
+      if (warning) warnings.push(warning)
+    }
+  }
+
+  for (const assignment of context.input.judgeAssignments ?? []) {
+    const volunteer = context.rosterByMembershipId.get(assignment.membershipId)
+    const warning = getCredentialWarning({
+      volunteer,
+      membershipId: assignment.membershipId,
+      assignmentId: assignment.id,
+      timeBlockId: `heat:${assignment.heatId}`,
+      requiredRoleType: getAssignmentRoleType(assignment.position),
+    })
+    if (warning) warnings.push(warning)
+  }
+
+  return warnings.sort(compareCredentialWarning)
+}
+
+function buildConfirmationGaps(context: NormalizedCrewStaffingInput) {
+  const gaps: CrewStaffingConfirmationGap[] = []
+
+  for (const shift of context.shifts) {
+    for (const assignment of shift.assignments) {
+      const gap = getConfirmationGap({
+        assignmentId: assignment.id,
+        membershipId: assignment.membershipId,
+        timeBlockId: `shift:${shift.id}`,
+        confirmation: assignment.confirmation ?? null,
+        fallbackType: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        context,
+      })
+      if (gap) gaps.push(gap)
+    }
+  }
+
+  for (const assignment of context.input.judgeAssignments ?? []) {
+    const gap = getConfirmationGap({
+      assignmentId: assignment.id,
+      membershipId: assignment.membershipId,
+      timeBlockId: `heat:${assignment.heatId}`,
+      confirmation: assignment.confirmation ?? null,
+      fallbackType: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+      context,
+    })
+    if (gap) gaps.push(gap)
+  }
+
+  return gaps.sort(compareConfirmationGap)
+}
+
+function getCredentialWarning(params: {
+  volunteer: CrewStaffingVolunteerInput | undefined
+  membershipId: string
+  assignmentId: string
+  timeBlockId: string
+  requiredRoleType: CrewStaffingCredentialWarning["requiredRoleType"]
+}): CrewStaffingCredentialWarning | null {
+  const { volunteer } = params
+  if (!volunteer) {
+    return {
+      membershipId: params.membershipId,
+      volunteerName: params.membershipId,
+      assignmentId: params.assignmentId,
+      timeBlockId: params.timeBlockId,
+      requiredRoleType: params.requiredRoleType,
+      volunteerRoleTypes: [],
+      reason: "missing_volunteer",
+    }
+  }
+
+  if (volunteer.isActive === false) {
+    return {
+      membershipId: volunteer.membershipId,
+      volunteerName: getVolunteerName(volunteer, volunteer.membershipId),
+      assignmentId: params.assignmentId,
+      timeBlockId: params.timeBlockId,
+      requiredRoleType: params.requiredRoleType,
+      volunteerRoleTypes: volunteer.roleTypes,
+      reason: "inactive_volunteer",
+    }
+  }
+
+  if (
+    !isVolunteerCompatibleWithShift(
+      params.requiredRoleType,
+      volunteer.roleTypes,
+    )
+  ) {
+    return {
+      membershipId: volunteer.membershipId,
+      volunteerName: getVolunteerName(volunteer, volunteer.membershipId),
+      assignmentId: params.assignmentId,
+      timeBlockId: params.timeBlockId,
+      requiredRoleType: params.requiredRoleType,
+      volunteerRoleTypes: volunteer.roleTypes,
+      reason: "role_mismatch",
+    }
+  }
+
+  return null
+}
+
+function getConfirmationGap(params: {
+  assignmentId: string
+  membershipId: string
+  timeBlockId: string
+  confirmation: CrewStaffingConfirmationInput | null
+  fallbackType: CrewStaffingConfirmationGap["type"]
+  context: NormalizedCrewStaffingInput
+}): CrewStaffingConfirmationGap | null {
+  const volunteer = params.context.rosterByMembershipId.get(params.membershipId)
+  const base = {
+    assignmentId: params.assignmentId,
+    membershipId: params.membershipId,
+    volunteerName: getVolunteerName(volunteer, params.membershipId),
+    timeBlockId: params.timeBlockId,
+  }
+
+  if (!params.confirmation) {
+    return {
+      ...base,
+      type: params.fallbackType,
+      status: null,
+      reason: "missing_confirmation",
+    }
+  }
+
+  if (
+    params.confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING
+  ) {
+    return {
+      ...base,
+      type: params.confirmation.type,
+      status: params.confirmation.status,
+      reason: "no_response",
+    }
+  }
+  if (
+    params.confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED
+  ) {
+    return {
+      ...base,
+      type: params.confirmation.type,
+      status: params.confirmation.status,
+      reason: "declined",
+    }
+  }
+  if (
+    params.confirmation.status ===
+    CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+  ) {
+    return {
+      ...base,
+      type: params.confirmation.type,
+      status: params.confirmation.status,
+      reason: "change_requested",
+    }
+  }
+  if (
+    params.confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.NO_SHOW
+  ) {
+    return {
+      ...base,
+      type: params.confirmation.type,
+      status: params.confirmation.status,
+      reason: "no_show",
+    }
+  }
+
+  return null
+}
+
+function summarizeMatrix(input: {
+  timeBlocks: CrewStaffingTimeBlock[]
+  coverageRows: CrewStaffingCoverageRow[]
+  judgeLaneGaps: CrewStaffingJudgeLaneGap[]
+  doubleBookedVolunteers: CrewStaffingDoubleBookedVolunteer[]
+  outsideAvailabilityAssignments: CrewStaffingOutsideAvailabilityAssignment[]
+  credentialWarnings: CrewStaffingCredentialWarning[]
+  confirmationGaps: CrewStaffingConfirmationGap[]
+}) {
+  const roles = new Set(input.coverageRows.map((row) => row.roleType))
+  const confirmationNoResponses = input.confirmationGaps.filter(
+    (gap) =>
+      gap.reason === "missing_confirmation" || gap.reason === "no_response",
+  ).length
+
+  return {
+    timeBlocks: input.timeBlocks.length,
+    roles: roles.size,
+    totalNeeded: sumRows(input.coverageRows, "needed"),
+    totalFilled: sumRows(input.coverageRows, "filled"),
+    totalOpen: sumRows(input.coverageRows, "open"),
+    underfilledRows: input.coverageRows.filter((row) => row.open > 0).length,
+    openCapacity: sumRows(input.coverageRows, "open"),
+    judgeLaneGaps: input.judgeLaneGaps.length,
+    doubleBookedVolunteers: input.doubleBookedVolunteers.length,
+    outsideAvailabilityAssignments: input.outsideAvailabilityAssignments.length,
+    credentialWarnings: input.credentialWarnings.length,
+    confirmationNoResponses,
+    confirmationDeclines: input.confirmationGaps.filter(
+      (gap) => gap.reason === "declined",
+    ).length,
+    confirmationChangeRequests: input.confirmationGaps.filter(
+      (gap) => gap.reason === "change_requested",
+    ).length,
+    confirmationNoShows: input.confirmationGaps.filter(
+      (gap) => gap.reason === "no_show",
+    ).length,
+  }
+}
+
+function getHeatLabel(
+  heat: NormalizedCrewStaffingInput["heats"][number],
+  context: NormalizedCrewStaffingInput,
+) {
+  const workout = context.workoutById.get(heat.trackWorkoutId)
+  const venue = heat.venueId ? context.venueById.get(heat.venueId) : null
+  return [workout?.name ?? "Workout", `Heat ${heat.heatNumber}`, venue?.name]
+    .filter(Boolean)
+    .join(" - ")
+}
+
+function isWithinAvailability(
+  timeBlock: Pick<CrewStaffingTimeBlock, "startTime" | "endTime">,
+  availability: CrewStaffingOutsideAvailabilityAssignment["availability"],
+  context: NormalizedCrewStaffingInput,
+) {
+  if (!timeBlock.startTime || !timeBlock.endTime) return true
+  const startHour = getLocalHour(
+    timeBlock.startTime,
+    context.input.event.timezone,
+  )
+  const endHour = getLocalHour(timeBlock.endTime, context.input.event.timezone)
+
+  if (availability === VOLUNTEER_AVAILABILITY.MORNING) return startHour < 12
+  if (availability === VOLUNTEER_AVAILABILITY.AFTERNOON) return endHour >= 12
+  return true
+}
+
+function getLocalHour(date: Date, timezone: string | null | undefined) {
+  if (!timezone) return date.getUTCHours()
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: timezone,
+    hour: "numeric",
+    hour12: false,
+  })
+  const hourPart = formatter
+    .formatToParts(date)
+    .find((part) => part.type === "hour")?.value
+  const hour = Number(hourPart)
+  return Number.isFinite(hour) ? hour : date.getUTCHours()
+}
+
+function getVolunteerName(
+  volunteer: CrewStaffingVolunteerInput | undefined,
+  fallback: string,
+) {
+  return volunteer?.name || volunteer?.email || fallback
+}
+
+function overlaps(left: AssignmentWindow, right: AssignmentWindow) {
+  if (!left.startTime || !left.endTime || !right.startTime || !right.endTime) {
+    return false
+  }
+  return left.startTime < right.endTime && right.startTime < left.endTime
+}
+
+function dedupeDoubleBookings(
+  doubleBooked: CrewStaffingDoubleBookedVolunteer[],
+) {
+  const byKey = new Map<string, CrewStaffingDoubleBookedVolunteer>()
+  for (const booking of doubleBooked) {
+    byKey.set(
+      `${booking.membershipId}:${booking.assignmentIds.join(":")}`,
+      booking,
+    )
+  }
+  return [...byKey.values()].sort(compareDoubleBooking)
+}
+
+function compareTimeBlock(
+  left: CrewStaffingTimeBlock,
+  right: CrewStaffingTimeBlock,
+) {
+  return compareDateThenText(left.startTime, right.startTime, left.id, right.id)
+}
+
+function compareCoverageRow(
+  left: CrewStaffingCoverageRow,
+  right: CrewStaffingCoverageRow,
+) {
+  return (
+    compareText(left.timeBlockId, right.timeBlockId) ||
+    compareText(left.roleType, right.roleType) ||
+    compareText(left.id, right.id)
+  )
+}
+
+function compareAssignmentWindow(
+  left: AssignmentWindow,
+  right: AssignmentWindow,
+) {
+  return (
+    compareDateThenText(
+      left.startTime,
+      right.startTime,
+      left.assignmentId,
+      right.assignmentId,
+    ) || compareText(left.membershipId, right.membershipId)
+  )
+}
+
+function compareDoubleBooking(
+  left: CrewStaffingDoubleBookedVolunteer,
+  right: CrewStaffingDoubleBookedVolunteer,
+) {
+  return (
+    compareText(left.membershipId, right.membershipId) ||
+    compareText(left.assignmentIds.join(":"), right.assignmentIds.join(":"))
+  )
+}
+
+function compareAvailabilityWarning(
+  left: CrewStaffingOutsideAvailabilityAssignment,
+  right: CrewStaffingOutsideAvailabilityAssignment,
+) {
+  return (
+    compareText(left.membershipId, right.membershipId) ||
+    compareText(left.assignmentId, right.assignmentId)
+  )
+}
+
+function compareCredentialWarning(
+  left: CrewStaffingCredentialWarning,
+  right: CrewStaffingCredentialWarning,
+) {
+  return (
+    compareText(left.membershipId, right.membershipId) ||
+    compareText(left.assignmentId, right.assignmentId)
+  )
+}
+
+function compareConfirmationGap(
+  left: CrewStaffingConfirmationGap,
+  right: CrewStaffingConfirmationGap,
+) {
+  return (
+    compareText(left.membershipId, right.membershipId) ||
+    compareText(left.assignmentId, right.assignmentId)
+  )
+}
+
+function sumRows(
+  rows: CrewStaffingCoverageRow[],
+  key: "needed" | "filled" | "open",
+) {
+  return rows.reduce((total, row) => total + row[key], 0)
+}

--- a/apps/crew/src/lib/crew/staffing/normalize.ts
+++ b/apps/crew/src/lib/crew/staffing/normalize.ts
@@ -1,0 +1,204 @@
+// @lat: [[crew#Staffing Matrix Core]]
+import { VOLUNTEER_ROLE_TYPES } from "../../../db/schemas/volunteers"
+import type {
+  CrewStaffingHeatInput,
+  CrewStaffingHeatLaneAssignmentInput,
+  CrewStaffingMatrixInput,
+  CrewStaffingShiftInput,
+  CrewStaffingVenueInput,
+  CrewStaffingVolunteerInput,
+  CrewStaffingWorkoutInput,
+} from "./types"
+
+export interface NormalizedCrewStaffingInput {
+  input: CrewStaffingMatrixInput
+  venueById: Map<string, CrewStaffingVenueInput>
+  workoutById: Map<string, CrewStaffingWorkoutInput>
+  heatById: Map<string, CrewStaffingHeatInput>
+  rosterByMembershipId: Map<string, CrewStaffingVolunteerInput>
+  occupiedLaneNumbersByHeatId: Map<string, number[]>
+  shifts: CrewStaffingShiftInput[]
+  heats: CrewStaffingHeatInput[]
+}
+
+export function normalizeCrewStaffingMatrixInput(
+  input: CrewStaffingMatrixInput,
+): NormalizedCrewStaffingInput {
+  const venues = [...(input.venues ?? [])].sort(compareVenue)
+  const workouts = [...(input.workouts ?? [])].sort(compareWorkout)
+  const heats = [...(input.heats ?? [])].sort(compareHeat)
+  const roster = [...(input.roster ?? [])].sort(compareVolunteer)
+  const shifts = [...(input.shifts ?? [])].sort(compareShift)
+
+  return {
+    input: {
+      ...input,
+      venues,
+      workouts,
+      heats,
+      roster,
+      shifts,
+      heatLaneAssignments: [...(input.heatLaneAssignments ?? [])].sort(
+        compareHeatLaneAssignment,
+      ),
+      judgeAssignments: [...(input.judgeAssignments ?? [])].sort(
+        (left, right) => compareText(left.id, right.id),
+      ),
+    },
+    venueById: new Map(venues.map((venue) => [venue.id, venue])),
+    workoutById: new Map(workouts.map((workout) => [workout.id, workout])),
+    heatById: new Map(heats.map((heat) => [heat.id, heat])),
+    rosterByMembershipId: new Map(
+      roster.map((volunteer) => [volunteer.membershipId, volunteer]),
+    ),
+    occupiedLaneNumbersByHeatId: groupOccupiedLaneNumbers(
+      input.heatLaneAssignments ?? [],
+    ),
+    shifts,
+    heats,
+  }
+}
+
+export function toDateOrNull(value: Date | string | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function getHeatLaneNumbers(
+  heat: CrewStaffingHeatInput,
+  context: Pick<
+    NormalizedCrewStaffingInput,
+    "occupiedLaneNumbersByHeatId" | "venueById"
+  >,
+) {
+  const occupiedLanes = context.occupiedLaneNumbersByHeatId.get(heat.id)
+  if (occupiedLanes?.length) return occupiedLanes
+
+  const laneCount =
+    positiveIntegerOrNull(heat.laneCount) ??
+    positiveIntegerOrNull(
+      heat.venueId ? context.venueById.get(heat.venueId)?.laneCount : null,
+    ) ??
+    0
+
+  return Array.from({ length: laneCount }, (_, index) => index + 1)
+}
+
+export function getAssignmentRoleType(roleType: string | null | undefined) {
+  return roleType === VOLUNTEER_ROLE_TYPES.HEAD_JUDGE
+    ? VOLUNTEER_ROLE_TYPES.HEAD_JUDGE
+    : VOLUNTEER_ROLE_TYPES.JUDGE
+}
+
+export function compareText(left: string, right: string) {
+  return left.localeCompare(right)
+}
+
+export function compareDateThenText(
+  leftDate: Date | null,
+  rightDate: Date | null,
+  leftText: string,
+  rightText: string,
+) {
+  const leftTime = leftDate?.getTime() ?? Number.POSITIVE_INFINITY
+  const rightTime = rightDate?.getTime() ?? Number.POSITIVE_INFINITY
+  if (leftTime !== rightTime) return leftTime - rightTime
+  return compareText(leftText, rightText)
+}
+
+function groupOccupiedLaneNumbers(
+  assignments: CrewStaffingHeatLaneAssignmentInput[],
+) {
+  const grouped = new Map<string, Set<number>>()
+
+  for (const assignment of assignments) {
+    const laneNumber = positiveIntegerOrNull(assignment.laneNumber)
+    if (!laneNumber) continue
+    const existing = grouped.get(assignment.heatId) ?? new Set<number>()
+    existing.add(laneNumber)
+    grouped.set(assignment.heatId, existing)
+  }
+
+  return new Map(
+    [...grouped.entries()].map(([heatId, laneNumbers]) => [
+      heatId,
+      [...laneNumbers].sort((left, right) => left - right),
+    ]),
+  )
+}
+
+function compareVenue(
+  left: CrewStaffingVenueInput,
+  right: CrewStaffingVenueInput,
+) {
+  const leftOrder = left.sortOrder ?? Number.POSITIVE_INFINITY
+  const rightOrder = right.sortOrder ?? Number.POSITIVE_INFINITY
+  if (leftOrder !== rightOrder) return leftOrder - rightOrder
+  return compareText(left.name || left.id, right.name || right.id)
+}
+
+function compareWorkout(
+  left: CrewStaffingWorkoutInput,
+  right: CrewStaffingWorkoutInput,
+) {
+  const leftOrder = left.sortOrder ?? Number.POSITIVE_INFINITY
+  const rightOrder = right.sortOrder ?? Number.POSITIVE_INFINITY
+  if (leftOrder !== rightOrder) return leftOrder - rightOrder
+  return compareText(left.name || left.id, right.name || right.id)
+}
+
+function compareHeat(
+  left: CrewStaffingHeatInput,
+  right: CrewStaffingHeatInput,
+) {
+  return (
+    compareDateThenText(
+      toDateOrNull(left.scheduledTime),
+      toDateOrNull(right.scheduledTime),
+      left.id,
+      right.id,
+    ) ||
+    left.heatNumber - right.heatNumber ||
+    compareText(left.id, right.id)
+  )
+}
+
+function compareShift(
+  left: CrewStaffingShiftInput,
+  right: CrewStaffingShiftInput,
+) {
+  return compareDateThenText(
+    toDateOrNull(left.startTime),
+    toDateOrNull(right.startTime),
+    left.id,
+    right.id,
+  )
+}
+
+function compareVolunteer(
+  left: CrewStaffingVolunteerInput,
+  right: CrewStaffingVolunteerInput,
+) {
+  return (
+    compareText(
+      left.name || left.email || left.membershipId,
+      right.name || right.email || right.membershipId,
+    ) || compareText(left.membershipId, right.membershipId)
+  )
+}
+
+function compareHeatLaneAssignment(
+  left: CrewStaffingHeatLaneAssignmentInput,
+  right: CrewStaffingHeatLaneAssignmentInput,
+) {
+  return (
+    compareText(left.heatId, right.heatId) || left.laneNumber - right.laneNumber
+  )
+}
+
+function positiveIntegerOrNull(value: number | null | undefined) {
+  if (!Number.isFinite(value)) return null
+  const rounded = Math.floor(Number(value))
+  return rounded > 0 ? rounded : null
+}

--- a/apps/crew/src/lib/crew/staffing/normalize.ts
+++ b/apps/crew/src/lib/crew/staffing/normalize.ts
@@ -152,13 +152,13 @@ function compareHeat(
   left: CrewStaffingHeatInput,
   right: CrewStaffingHeatInput,
 ) {
+  const leftTime =
+    toDateOrNull(left.scheduledTime)?.getTime() ?? Number.POSITIVE_INFINITY
+  const rightTime =
+    toDateOrNull(right.scheduledTime)?.getTime() ?? Number.POSITIVE_INFINITY
+
   return (
-    compareDateThenText(
-      toDateOrNull(left.scheduledTime),
-      toDateOrNull(right.scheduledTime),
-      left.id,
-      right.id,
-    ) ||
+    leftTime - rightTime ||
     left.heatNumber - right.heatNumber ||
     compareText(left.id, right.id)
   )

--- a/apps/crew/src/lib/crew/staffing/types.ts
+++ b/apps/crew/src/lib/crew/staffing/types.ts
@@ -1,0 +1,201 @@
+// @lat: [[crew#Staffing Matrix Core]]
+import type {
+  CrewAssignmentConfirmationStatus,
+  CrewAssignmentConfirmationType,
+} from "../../../db/schemas/crew-imports"
+import type {
+  VolunteerAvailability,
+  VolunteerRoleType,
+} from "../../../db/schemas/volunteers"
+
+export interface CrewStaffingEventInput {
+  id: string
+  name?: string | null
+  timezone?: string | null
+  startDate?: string | null
+  endDate?: string | null
+}
+
+export interface CrewStaffingVenueInput {
+  id: string
+  name: string
+  laneCount: number
+  sortOrder?: number | null
+}
+
+export interface CrewStaffingWorkoutInput {
+  id: string
+  name: string
+  sortOrder?: number | null
+}
+
+export interface CrewStaffingHeatInput {
+  id: string
+  trackWorkoutId: string
+  heatNumber: number
+  venueId?: string | null
+  scheduledTime?: Date | string | null
+  durationMinutes?: number | null
+  laneCount?: number | null
+}
+
+export interface CrewStaffingHeatLaneAssignmentInput {
+  heatId: string
+  laneNumber: number
+}
+
+export interface CrewStaffingVolunteerInput {
+  membershipId: string
+  name: string
+  email?: string | null
+  roleTypes: VolunteerRoleType[]
+  availability?: VolunteerAvailability | null
+  credentials?: string | null
+  isActive?: boolean | null
+}
+
+export interface CrewStaffingShiftAssignmentInput {
+  id: string
+  membershipId: string
+  confirmation?: CrewStaffingConfirmationInput | null
+}
+
+export interface CrewStaffingShiftInput {
+  id: string
+  name: string
+  roleType: VolunteerRoleType
+  startTime: Date | string
+  endTime: Date | string
+  capacity: number
+  location?: string | null
+  assignments: CrewStaffingShiftAssignmentInput[]
+}
+
+export interface CrewStaffingJudgeAssignmentInput {
+  id: string
+  heatId: string
+  membershipId: string
+  laneNumber?: number | null
+  position?: VolunteerRoleType | null
+  versionId?: string | null
+  rotationId?: string | null
+  confirmation?: CrewStaffingConfirmationInput | null
+}
+
+export interface CrewStaffingConfirmationInput {
+  type: CrewAssignmentConfirmationType
+  status: CrewAssignmentConfirmationStatus
+  respondedAt?: Date | string | null
+  responseNote?: string | null
+}
+
+export interface CrewStaffingMatrixInput {
+  event: CrewStaffingEventInput
+  venues?: CrewStaffingVenueInput[]
+  workouts?: CrewStaffingWorkoutInput[]
+  heats?: CrewStaffingHeatInput[]
+  heatLaneAssignments?: CrewStaffingHeatLaneAssignmentInput[]
+  roster?: CrewStaffingVolunteerInput[]
+  shifts?: CrewStaffingShiftInput[]
+  judgeAssignments?: CrewStaffingJudgeAssignmentInput[]
+}
+
+export type CrewStaffingTimeBlockSource = "shift" | "heat"
+
+export interface CrewStaffingTimeBlock {
+  id: string
+  source: CrewStaffingTimeBlockSource
+  sourceId: string
+  label: string
+  startTime: Date | null
+  endTime: Date | null
+  workoutId: string | null
+  heatId: string | null
+  venueId: string | null
+}
+
+export interface CrewStaffingCoverageRow {
+  id: string
+  timeBlockId: string
+  roleType: VolunteerRoleType
+  needed: number
+  filled: number
+  open: number
+  assignmentIds: string[]
+}
+
+export interface CrewStaffingJudgeLaneGap {
+  heatId: string
+  heatNumber: number
+  laneNumber: number
+  timeBlockId: string
+}
+
+export interface CrewStaffingDoubleBookedVolunteer {
+  membershipId: string
+  volunteerName: string
+  assignmentIds: string[]
+  timeBlockIds: string[]
+}
+
+export interface CrewStaffingOutsideAvailabilityAssignment {
+  membershipId: string
+  volunteerName: string
+  availability: VolunteerAvailability
+  assignmentId: string
+  timeBlockId: string
+}
+
+export interface CrewStaffingCredentialWarning {
+  membershipId: string
+  volunteerName: string
+  assignmentId: string
+  timeBlockId: string
+  requiredRoleType: VolunteerRoleType
+  volunteerRoleTypes: VolunteerRoleType[]
+  reason: "inactive_volunteer" | "missing_volunteer" | "role_mismatch"
+}
+
+export interface CrewStaffingConfirmationGap {
+  assignmentId: string
+  membershipId: string
+  volunteerName: string
+  timeBlockId: string
+  type: CrewAssignmentConfirmationType
+  status: CrewAssignmentConfirmationStatus | null
+  reason:
+    | "missing_confirmation"
+    | "no_response"
+    | "declined"
+    | "change_requested"
+    | "no_show"
+}
+
+export interface CrewStaffingMatrixSummary {
+  timeBlocks: number
+  roles: number
+  totalNeeded: number
+  totalFilled: number
+  totalOpen: number
+  underfilledRows: number
+  openCapacity: number
+  judgeLaneGaps: number
+  doubleBookedVolunteers: number
+  outsideAvailabilityAssignments: number
+  credentialWarnings: number
+  confirmationNoResponses: number
+  confirmationDeclines: number
+  confirmationChangeRequests: number
+  confirmationNoShows: number
+}
+
+export interface CrewStaffingMatrix {
+  timeBlocks: CrewStaffingTimeBlock[]
+  coverageRows: CrewStaffingCoverageRow[]
+  judgeLaneGaps: CrewStaffingJudgeLaneGap[]
+  doubleBookedVolunteers: CrewStaffingDoubleBookedVolunteer[]
+  outsideAvailabilityAssignments: CrewStaffingOutsideAvailabilityAssignment[]
+  credentialWarnings: CrewStaffingCredentialWarning[]
+  confirmationGaps: CrewStaffingConfirmationGap[]
+  summary: CrewStaffingMatrixSummary
+}

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -16,6 +16,14 @@ Crew pilot readiness is a read-only operator surface for deciding whether a foun
 
 The checklist treats event basics, venues and lanes, workouts and heats, volunteer roster, shifts and assignments, judge publishing, and assignment confirmations as separate readiness categories. Judge publishing is a manual pilot checkpoint until the dedicated Crew judge rotation workflow exists.
 
+## Staffing Matrix Core
+
+Crew staffing matrix core is a pure data-shape layer for deriving event staffing coverage from existing Crew primitives.
+
+[[apps/crew/src/lib/crew/staffing/index.ts]] exports deterministic helpers that normalize venues, workouts, heats, athlete lane assignments, volunteer roster records, time-based shifts, shift assignments, judge heat assignments, and assignment confirmation status into staffing matrix output. The core reports filled and needed counts by role and time block, judge lane gaps, double-booked volunteers, outside-availability assignments, role and credential warnings, confirmation gaps, open capacity, and event-level summary counts.
+
+The matrix core is read-only. It does not create shifts, assign volunteers, publish judge rotations, send reminders, mutate imports, or add Crew schema.
+
 ## Staffing Calculator
 
 The public Crew calculator route estimates event-day staffing needs from event dimensions and editable role assumptions.


### PR DESCRIPTION
## Summary
- Add pure Crew staffing matrix types, normalization helpers, and matrix derivation under `apps/crew/src/lib/crew/staffing/*`.
- Derive filled/needed/open coverage by role and time block from existing venues, heats, lane assignments, roster roles/availability, shifts, shift assignments, judge heat assignments, and confirmation statuses.
- Report judge lane gaps, double-booked volunteers, outside-availability assignments, role/credential warnings, confirmation gaps, and event-level summary counts.
- Add focused Vitest coverage and a `crew#Staffing Matrix Core` LAT anchor.

## Validation
- `pnpm --filter crew test -- src/lib/crew/staffing/matrix.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew exec biome lint src/lib/crew/staffing`
- `pnpm --filter crew lint` (exits 0 with pre-existing warnings outside this slice)
- `pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `git diff --check`
- `pnpm dlx lat.md locate "crew#Staffing Matrix Core"`

## Notes
- Build validation used an ignored local `apps/crew/.alchemy/local/wrangler.jsonc` because fresh Crew worktrees do not include that generated config. The file is not tracked.
- `pnpm dlx lat.md check` still fails on pre-existing legacy broken anchors unrelated to this PR; the new Crew anchor locates successfully.
- This PR intentionally does not add schema, routes, pages, reports, publishing, reminders, exports, or live data mutations.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Crew staffing matrix core that derives coverage and gaps from roster, shifts, heats, and judge assignments. Hardens edge cases with stable ordering, safer availability checks, and clearer confirmation gap typing.

- **New Features**
  - New module under `apps/crew/src/lib/crew/staffing/*` with types, normalization, and matrix derivation; exports `buildCrewStaffingMatrix`, `normalizeCrewStaffingMatrixInput`, and types via `index.ts`.
  - Coverage rows compute needed/filled/open per role and time block; judge rows use venue lane counts or occupied lanes.
  - Flags judge lane gaps, double-booked volunteers, outside-availability, role/credential mismatches, and confirmation gaps (pending/declined/change/no-show/missing), with summary totals and focused `vitest` tests.

- **Bug Fixes**
  - Availability checks respect event timezone with strict noon boundary and fall back to UTC if timezone is invalid; assignments crossing noon are flagged.
  - Stable ordering for time blocks and rows: heats with equal start times sort by heat number then id; deterministic sorting for warnings and gaps.
  - Overlap detection reports all overlapping assignments and de-duplicates pairs; confirmation gaps retain the correct assignment type (judge vs shift).

<sup>Written for commit f11f782d1ca8d745488c309fb525f11c5bb2926f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a staffing matrix system that analyzes crew coverage against shift and judge role needs, flagging double-bookings, availability conflicts, credential mismatches, and confirmation gaps.

* **Tests**
  * Added comprehensive test suite for staffing matrix functionality.

* **Documentation**
  * Added staffing matrix documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->