### PR TITLE
feat(crew): add staffing page and gap report

### DIFF
--- a/apps/crew/src/lib/crew/staffing/index.ts
+++ b/apps/crew/src/lib/crew/staffing/index.ts
@@ -1,4 +1,6 @@
 // @lat: [[crew#Staffing Matrix Core]]
 export { buildCrewStaffingMatrix } from "./matrix"
+export { buildCrewStaffingReport } from "./report"
 export { normalizeCrewStaffingMatrixInput } from "./normalize"
 export type * from "./types"
+export type * from "./report"

--- a/apps/crew/src/lib/crew/staffing/report.test.ts
+++ b/apps/crew/src/lib/crew/staffing/report.test.ts
@@ -1,0 +1,196 @@
+// @lat: [[crew#Staffing Page Gap Report]]
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+} from "../../../db/schemas/crew-imports"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_ROLE_TYPES,
+} from "../../../db/schemas/volunteers"
+import { buildCrewStaffingMatrix } from "./matrix"
+import { buildCrewStaffingReport } from "./report"
+import type { CrewStaffingMatrixInput } from "./types"
+
+describe("Crew staffing report", () => {
+  it("summarizes actionable gaps over the staffing matrix", () => {
+    const input = createStaffingInput()
+    const matrix = buildCrewStaffingMatrix(input)
+    const report = buildCrewStaffingReport(input, matrix)
+
+    expect(report.status).toBe("critical")
+    expect(report.summaryLabel).toBe("Critical gaps")
+    expect(report.sourceCounts).toMatchObject({
+      venues: 1,
+      workouts: 1,
+      heats: 1,
+      heatLaneAssignments: 2,
+      roster: 2,
+      assignableRoster: 2,
+      shifts: 1,
+      shiftAssignments: 2,
+      judgeAssignments: 1,
+    })
+    expect(report.roleSummaries).toEqual([
+      {
+        roleType: VOLUNTEER_ROLE_TYPES.CHECK_IN,
+        roleLabel: "Check-In",
+        needed: 3,
+        filled: 2,
+        open: 1,
+        timeBlocks: 1,
+      },
+      {
+        roleType: VOLUNTEER_ROLE_TYPES.JUDGE,
+        roleLabel: "Judge",
+        needed: 2,
+        filled: 1,
+        open: 1,
+        timeBlocks: 1,
+      },
+    ])
+    expect(
+      Object.fromEntries(
+        report.issueSummary.map((issue) => [issue.key, issue.count]),
+      ),
+    ).toMatchObject({
+      open_capacity: 2,
+      judge_lane_gaps: 1,
+      double_booked: 1,
+      outside_availability: 2,
+      credential_warnings: 1,
+      confirmation_declines: 1,
+      confirmation_change_requests: 1,
+      confirmation_no_responses: 1,
+    })
+    expect(report.underfilledRows).toHaveLength(2)
+  })
+
+  it("marks fully covered and confirmed staffing as covered", () => {
+    const input: CrewStaffingMatrixInput = {
+      event: { id: "comp_1", timezone: "UTC" },
+      roster: [
+        {
+          membershipId: "tmem_1",
+          name: "Alex Judge",
+          roleTypes: [VOLUNTEER_ROLE_TYPES.JUDGE],
+          availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+          isActive: true,
+        },
+      ],
+      venues: [{ id: "venue_1", name: "Floor 1", laneCount: 1 }],
+      workouts: [{ id: "tw_1", name: "Workout 1", sortOrder: 1 }],
+      heats: [
+        {
+          id: "heat_1",
+          trackWorkoutId: "tw_1",
+          heatNumber: 1,
+          venueId: "venue_1",
+          scheduledTime: "2026-06-19T15:00:00.000Z",
+          durationMinutes: 30,
+        },
+      ],
+      judgeAssignments: [
+        {
+          id: "jha_1",
+          heatId: "heat_1",
+          membershipId: "tmem_1",
+          laneNumber: 1,
+          confirmation: {
+            type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+            status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+          },
+        },
+      ],
+    }
+
+    const report = buildCrewStaffingReport(
+      input,
+      buildCrewStaffingMatrix(input),
+    )
+
+    expect(report.status).toBe("covered")
+    expect(report.summaryLabel).toBe("Staffing covered")
+    expect(report.summaryDetail).toBe(
+      "All current staffing blocks are filled and confirmed.",
+    )
+  })
+})
+
+function createStaffingInput(): CrewStaffingMatrixInput {
+  return {
+    event: { id: "comp_1", timezone: "UTC" },
+    venues: [{ id: "venue_1", name: "Floor 1", laneCount: 2 }],
+    workouts: [{ id: "tw_1", name: "Workout 1", sortOrder: 1 }],
+    heats: [
+      {
+        id: "heat_1",
+        trackWorkoutId: "tw_1",
+        heatNumber: 1,
+        venueId: "venue_1",
+        scheduledTime: "2026-06-19T13:00:00.000Z",
+        durationMinutes: 60,
+      },
+    ],
+    heatLaneAssignments: [
+      { heatId: "heat_1", laneNumber: 1 },
+      { heatId: "heat_1", laneNumber: 2 },
+    ],
+    roster: [
+      {
+        membershipId: "tmem_1",
+        name: "Avery Lead",
+        roleTypes: [VOLUNTEER_ROLE_TYPES.GENERAL],
+        availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+        isActive: true,
+      },
+      {
+        membershipId: "tmem_2",
+        name: "Blake Check-In",
+        roleTypes: [VOLUNTEER_ROLE_TYPES.CHECK_IN],
+        availability: VOLUNTEER_AVAILABILITY.MORNING,
+        isActive: true,
+      },
+    ],
+    shifts: [
+      {
+        id: "vshf_1",
+        name: "Afternoon check-in",
+        roleType: VOLUNTEER_ROLE_TYPES.CHECK_IN,
+        startTime: "2026-06-19T13:00:00.000Z",
+        endTime: "2026-06-19T15:00:00.000Z",
+        capacity: 3,
+        assignments: [
+          {
+            id: "vsha_1",
+            membershipId: "tmem_1",
+            confirmation: {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+            },
+          },
+          {
+            id: "vsha_2",
+            membershipId: "tmem_2",
+            confirmation: {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+            },
+          },
+        ],
+      },
+    ],
+    judgeAssignments: [
+      {
+        id: "jha_1",
+        heatId: "heat_1",
+        membershipId: "tmem_2",
+        laneNumber: 1,
+        position: VOLUNTEER_ROLE_TYPES.JUDGE,
+        confirmation: {
+          type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
+        },
+      },
+    ],
+  }
+}

--- a/apps/crew/src/lib/crew/staffing/report.test.ts
+++ b/apps/crew/src/lib/crew/staffing/report.test.ts
@@ -114,6 +114,84 @@ describe("Crew staffing report", () => {
       "All current staffing blocks are filled and confirmed.",
     )
   })
+
+  it("marks setup-only events without staffing blocks as needing attention", () => {
+    const input: CrewStaffingMatrixInput = {
+      event: { id: "comp_1", timezone: "UTC" },
+      roster: [
+        {
+          membershipId: "tmem_1",
+          name: "Alex Volunteer",
+          roleTypes: [VOLUNTEER_ROLE_TYPES.GENERAL],
+          availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+          isActive: true,
+        },
+      ],
+    }
+
+    const report = buildCrewStaffingReport(
+      input,
+      buildCrewStaffingMatrix(input),
+    )
+
+    expect(report.status).toBe("needs_attention")
+    expect(report.summaryLabel).toBe("No staffing blocks")
+    expect(report.summaryDetail).toBe(
+      "Add shifts or scheduled heats before reviewing staffing.",
+    )
+    expect(report.issueSummary.every((issue) => issue.count === 0)).toBe(true)
+  })
+
+  it("marks warning-only confirmation gaps as needing attention", () => {
+    const input: CrewStaffingMatrixInput = {
+      event: { id: "comp_1", timezone: "UTC" },
+      roster: [
+        {
+          membershipId: "tmem_1",
+          name: "Alex Volunteer",
+          roleTypes: [VOLUNTEER_ROLE_TYPES.GENERAL],
+          availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+          isActive: true,
+        },
+      ],
+      shifts: [
+        {
+          id: "vshf_1",
+          name: "Morning floor",
+          roleType: VOLUNTEER_ROLE_TYPES.GENERAL,
+          startTime: "2026-06-19T09:00:00.000Z",
+          endTime: "2026-06-19T11:00:00.000Z",
+          capacity: 1,
+          assignments: [
+            {
+              id: "vsha_1",
+              membershipId: "tmem_1",
+              confirmation: {
+                type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+                status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    const report = buildCrewStaffingReport(
+      input,
+      buildCrewStaffingMatrix(input),
+    )
+
+    expect(report.status).toBe("needs_attention")
+    expect(report.summaryLabel).toBe("Responses needed")
+    expect(report.summaryDetail).toBe(
+      "Collect 1 outstanding assignment response.",
+    )
+    expect(
+      report.issueSummary.find(
+        (issue) => issue.key === "confirmation_no_responses",
+      ),
+    ).toMatchObject({ count: 1, severity: "warning" })
+  })
 })
 
 function createStaffingInput(): CrewStaffingMatrixInput {

--- a/apps/crew/src/lib/crew/staffing/report.ts
+++ b/apps/crew/src/lib/crew/staffing/report.ts
@@ -219,7 +219,10 @@ function getReportStatus(params: {
   criticalIssues: number
   warningIssues: number
 }): CrewStaffingReportStatus {
-  if (!params.hasStaffingBlocks || params.criticalIssues > 0) {
+  if (!params.hasStaffingBlocks) {
+    return "needs_attention"
+  }
+  if (params.criticalIssues > 0) {
     return "critical"
   }
   if (params.warningIssues > 0) {

--- a/apps/crew/src/lib/crew/staffing/report.ts
+++ b/apps/crew/src/lib/crew/staffing/report.ts
@@ -1,0 +1,261 @@
+// @lat: [[crew#Staffing Page Gap Report]]
+import {
+  VOLUNTEER_ROLE_LABELS,
+  type VolunteerRoleType,
+} from "../../../db/schemas/volunteers"
+import type {
+  CrewStaffingCoverageRow,
+  CrewStaffingMatrix,
+  CrewStaffingMatrixInput,
+} from "./types"
+
+export type CrewStaffingReportStatus =
+  | "covered"
+  | "needs_attention"
+  | "critical"
+
+export type CrewStaffingReportIssueKey =
+  | "open_capacity"
+  | "judge_lane_gaps"
+  | "double_booked"
+  | "outside_availability"
+  | "credential_warnings"
+  | "confirmation_no_responses"
+  | "confirmation_declines"
+  | "confirmation_change_requests"
+  | "confirmation_no_shows"
+
+export interface CrewStaffingRoleSummary {
+  roleType: VolunteerRoleType
+  roleLabel: string
+  needed: number
+  filled: number
+  open: number
+  timeBlocks: number
+}
+
+export interface CrewStaffingReportIssueSummary {
+  key: CrewStaffingReportIssueKey
+  label: string
+  count: number
+  severity: "critical" | "warning"
+}
+
+export interface CrewStaffingReportSourceCounts {
+  venues: number
+  workouts: number
+  heats: number
+  heatLaneAssignments: number
+  roster: number
+  assignableRoster: number
+  shifts: number
+  shiftAssignments: number
+  judgeAssignments: number
+}
+
+export interface CrewStaffingReport {
+  status: CrewStaffingReportStatus
+  summaryLabel: string
+  summaryDetail: string
+  sourceCounts: CrewStaffingReportSourceCounts
+  roleSummaries: CrewStaffingRoleSummary[]
+  issueSummary: CrewStaffingReportIssueSummary[]
+  underfilledRows: CrewStaffingCoverageRow[]
+}
+
+export function buildCrewStaffingReport(
+  input: CrewStaffingMatrixInput,
+  matrix: CrewStaffingMatrix,
+): CrewStaffingReport {
+  const issueSummary = buildIssueSummary(matrix)
+  const criticalIssues = issueSummary
+    .filter((issue) => issue.severity === "critical")
+    .reduce((total, issue) => total + issue.count, 0)
+  const warningIssues = issueSummary
+    .filter((issue) => issue.severity === "warning")
+    .reduce((total, issue) => total + issue.count, 0)
+  const hasStaffingBlocks =
+    matrix.timeBlocks.length > 0 && matrix.summary.totalNeeded > 0
+
+  return {
+    status: getReportStatus({
+      hasStaffingBlocks,
+      criticalIssues,
+      warningIssues,
+    }),
+    summaryLabel: getSummaryLabel({
+      hasStaffingBlocks,
+      criticalIssues,
+      warningIssues,
+    }),
+    summaryDetail: getSummaryDetail({
+      hasStaffingBlocks,
+      criticalIssues,
+      warningIssues,
+    }),
+    sourceCounts: buildSourceCounts(input),
+    roleSummaries: buildRoleSummaries(matrix.coverageRows),
+    issueSummary,
+    underfilledRows: matrix.coverageRows.filter((row) => row.open > 0),
+  }
+}
+
+function buildSourceCounts(
+  input: CrewStaffingMatrixInput,
+): CrewStaffingReportSourceCounts {
+  const roster = input.roster ?? []
+  const shifts = input.shifts ?? []
+
+  return {
+    venues: input.venues?.length ?? 0,
+    workouts: input.workouts?.length ?? 0,
+    heats: input.heats?.length ?? 0,
+    heatLaneAssignments: input.heatLaneAssignments?.length ?? 0,
+    roster: roster.length,
+    assignableRoster: roster.filter((volunteer) => volunteer.isActive !== false)
+      .length,
+    shifts: shifts.length,
+    shiftAssignments: shifts.reduce(
+      (total, shift) => total + shift.assignments.length,
+      0,
+    ),
+    judgeAssignments: input.judgeAssignments?.length ?? 0,
+  }
+}
+
+function buildRoleSummaries(
+  coverageRows: CrewStaffingCoverageRow[],
+): CrewStaffingRoleSummary[] {
+  const byRole = new Map<VolunteerRoleType, CrewStaffingRoleSummary>()
+
+  for (const row of coverageRows) {
+    const existing = byRole.get(row.roleType) ?? {
+      roleType: row.roleType,
+      roleLabel: VOLUNTEER_ROLE_LABELS[row.roleType] ?? row.roleType,
+      needed: 0,
+      filled: 0,
+      open: 0,
+      timeBlocks: 0,
+    }
+
+    existing.needed += row.needed
+    existing.filled += row.filled
+    existing.open += row.open
+    existing.timeBlocks += 1
+    byRole.set(row.roleType, existing)
+  }
+
+  return [...byRole.values()].sort(
+    (left, right) =>
+      right.open - left.open ||
+      right.needed - left.needed ||
+      left.roleLabel.localeCompare(right.roleLabel),
+  )
+}
+
+function buildIssueSummary(
+  matrix: CrewStaffingMatrix,
+): CrewStaffingReportIssueSummary[] {
+  return [
+    {
+      key: "open_capacity",
+      label: "Open capacity",
+      count: matrix.summary.openCapacity,
+      severity: "critical",
+    },
+    {
+      key: "judge_lane_gaps",
+      label: "Judge lane gaps",
+      count: matrix.summary.judgeLaneGaps,
+      severity: "critical",
+    },
+    {
+      key: "double_booked",
+      label: "Double booked",
+      count: matrix.summary.doubleBookedVolunteers,
+      severity: "critical",
+    },
+    {
+      key: "outside_availability",
+      label: "Outside availability",
+      count: matrix.summary.outsideAvailabilityAssignments,
+      severity: "critical",
+    },
+    {
+      key: "credential_warnings",
+      label: "Role warnings",
+      count: matrix.summary.credentialWarnings,
+      severity: "critical",
+    },
+    {
+      key: "confirmation_declines",
+      label: "Declines",
+      count: matrix.summary.confirmationDeclines,
+      severity: "critical",
+    },
+    {
+      key: "confirmation_change_requests",
+      label: "Change requests",
+      count: matrix.summary.confirmationChangeRequests,
+      severity: "critical",
+    },
+    {
+      key: "confirmation_no_shows",
+      label: "No-shows",
+      count: matrix.summary.confirmationNoShows,
+      severity: "critical",
+    },
+    {
+      key: "confirmation_no_responses",
+      label: "No responses",
+      count: matrix.summary.confirmationNoResponses,
+      severity: "warning",
+    },
+  ]
+}
+
+function getReportStatus(params: {
+  hasStaffingBlocks: boolean
+  criticalIssues: number
+  warningIssues: number
+}): CrewStaffingReportStatus {
+  if (!params.hasStaffingBlocks || params.criticalIssues > 0) {
+    return "critical"
+  }
+  if (params.warningIssues > 0) {
+    return "needs_attention"
+  }
+  return "covered"
+}
+
+function getSummaryLabel(params: {
+  hasStaffingBlocks: boolean
+  criticalIssues: number
+  warningIssues: number
+}) {
+  if (!params.hasStaffingBlocks) return "No staffing blocks"
+  if (params.criticalIssues > 0) return "Critical gaps"
+  if (params.warningIssues > 0) return "Responses needed"
+  return "Staffing covered"
+}
+
+function getSummaryDetail(params: {
+  hasStaffingBlocks: boolean
+  criticalIssues: number
+  warningIssues: number
+}) {
+  if (!params.hasStaffingBlocks) {
+    return "Add shifts or scheduled heats before reviewing staffing."
+  }
+  if (params.criticalIssues > 0) {
+    return `Resolve ${params.criticalIssues} high-priority issue${plural(params.criticalIssues)} before handoff.`
+  }
+  if (params.warningIssues > 0) {
+    return `Collect ${params.warningIssues} outstanding assignment response${plural(params.warningIssues)}.`
+  }
+  return "All current staffing blocks are filled and confirmed."
+}
+
+function plural(count: number) {
+  return count === 1 ? "" : "s"
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as EventsNewRouteImport } from './routes/events/new'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
 import { Route as EventsEventIdIndexRouteImport } from './routes/events/$eventId/index'
 import { Route as EventsEventIdVolunteersRouteImport } from './routes/events/$eventId/volunteers'
+import { Route as EventsEventIdStaffingRouteImport } from './routes/events/$eventId/staffing'
 import { Route as EventsEventIdShiftsRouteImport } from './routes/events/$eventId/shifts'
 import { Route as EventsEventIdSetupRouteImport } from './routes/events/$eventId/setup'
 import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$eventId/schedule'
@@ -59,6 +60,11 @@ const EventsEventIdIndexRoute = EventsEventIdIndexRouteImport.update({
 const EventsEventIdVolunteersRoute = EventsEventIdVolunteersRouteImport.update({
   id: '/volunteers',
   path: '/volunteers',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
+const EventsEventIdStaffingRoute = EventsEventIdStaffingRouteImport.update({
+  id: '/staffing',
+  path: '/staffing',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
 const EventsEventIdShiftsRoute = EventsEventIdShiftsRouteImport.update({
@@ -120,6 +126,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
+  '/events/$eventId/staffing': typeof EventsEventIdStaffingRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
@@ -137,6 +144,7 @@ export interface FileRoutesByTo {
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
+  '/events/$eventId/staffing': typeof EventsEventIdStaffingRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
@@ -156,6 +164,7 @@ export interface FileRoutesById {
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
+  '/events/$eventId/staffing': typeof EventsEventIdStaffingRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
@@ -176,6 +185,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/shifts'
+    | '/events/$eventId/staffing'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
     | '/e/$slug/confirm/$token'
@@ -193,6 +203,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/shifts'
+    | '/events/$eventId/staffing'
     | '/events/$eventId/volunteers'
     | '/events/$eventId'
     | '/e/$slug/confirm/$token'
@@ -211,6 +222,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
     | '/events/$eventId/shifts'
+    | '/events/$eventId/staffing'
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
     | '/e/$slug/confirm/$token'
@@ -276,6 +288,13 @@ declare module '@tanstack/react-router' {
       path: '/volunteers'
       fullPath: '/events/$eventId/volunteers'
       preLoaderRoute: typeof EventsEventIdVolunteersRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
+    '/events/$eventId/staffing': {
+      id: '/events/$eventId/staffing'
+      path: '/staffing'
+      fullPath: '/events/$eventId/staffing'
+      preLoaderRoute: typeof EventsEventIdStaffingRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
     '/events/$eventId/shifts': {
@@ -350,6 +369,7 @@ interface EventsEventIdRouteChildren {
   EventsEventIdScheduleRoute: typeof EventsEventIdScheduleRoute
   EventsEventIdSetupRoute: typeof EventsEventIdSetupRoute
   EventsEventIdShiftsRoute: typeof EventsEventIdShiftsRoute
+  EventsEventIdStaffingRoute: typeof EventsEventIdStaffingRoute
   EventsEventIdVolunteersRoute: typeof EventsEventIdVolunteersRoute
   EventsEventIdIndexRoute: typeof EventsEventIdIndexRoute
 }
@@ -360,6 +380,7 @@ const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdScheduleRoute: EventsEventIdScheduleRoute,
   EventsEventIdSetupRoute: EventsEventIdSetupRoute,
   EventsEventIdShiftsRoute: EventsEventIdShiftsRoute,
+  EventsEventIdStaffingRoute: EventsEventIdStaffingRoute,
   EventsEventIdVolunteersRoute: EventsEventIdVolunteersRoute,
   EventsEventIdIndexRoute: EventsEventIdIndexRoute,
 }

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -1,4 +1,5 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
+// @lat: [[crew#Staffing Page Gap Report]]
 import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
 import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
 
@@ -44,6 +45,14 @@ function EventShell() {
             className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             Readiness
+          </Link>
+          <Link
+            to="/events/$eventId/staffing"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Staffing
           </Link>
           <Link
             to="/events/$eventId/setup"

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -1,4 +1,5 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
+// @lat: [[crew#Staffing Page Gap Report]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { formatCrewValue, getSafeHttpUrl } from "@/lib/crew-event-display"
 import {
@@ -70,6 +71,25 @@ function EventOverviewPage() {
             className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             Open checklist
+          </Link>
+        </div>
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Staffing report</h2>
+            <p className="text-sm text-muted-foreground">
+              Review coverage, judge lane gaps, conflicts, availability
+              warnings, and confirmation gaps.
+            </p>
+          </div>
+          <Link
+            to="/events/$eventId/staffing"
+            params={{ eventId }}
+            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Open staffing
           </Link>
         </div>
       </section>

--- a/apps/crew/src/routes/events/$eventId/staffing.tsx
+++ b/apps/crew/src/routes/events/$eventId/staffing.tsx
@@ -1,0 +1,493 @@
+// @lat: [[crew#Staffing Page Gap Report]]
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import { AlertCircle, CheckCircle2, CircleAlert } from "lucide-react"
+import type { ReactNode } from "react"
+import { getCrewAssignmentConfirmationStatusBadgeClassName } from "@/lib/crew/assignment-confirmation-display"
+import type {
+  CrewStaffingCoverageRow,
+  CrewStaffingReportIssueSummary,
+  CrewStaffingReportStatus,
+  CrewStaffingTimeBlock,
+} from "@/lib/crew/staffing"
+import {
+  formatVolunteerAvailability,
+  formatVolunteerRole,
+} from "@/lib/crew/roster-shifts"
+import { formatCrewValue } from "@/lib/crew-event-display"
+import { getCrewStaffingReportPageFn } from "@/server-fns/crew-staffing-fns"
+import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
+
+export const Route = createFileRoute("/events/$eventId/staffing")({
+  loader: async ({ params }) =>
+    await getCrewStaffingReportPageFn({ data: { eventId: params.eventId } }),
+  component: EventStaffingPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+function EventStaffingPage() {
+  const { eventId } = parentRoute.useParams()
+  const { matrix, report, sources, event } = Route.useLoaderData()
+  const timezone = event.timezone ?? "America/Denver"
+  const timeBlockById = new Map(
+    matrix.timeBlocks.map((block) => [block.id, block]),
+  )
+  const criticalIssueCount = report.issueSummary
+    .filter((issue) => issue.severity === "critical")
+    .reduce((total, issue) => total + issue.count, 0)
+  const responseIssueCount =
+    matrix.summary.confirmationNoResponses +
+    matrix.summary.confirmationDeclines +
+    matrix.summary.confirmationChangeRequests +
+    matrix.summary.confirmationNoShows
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Staffing</h2>
+          <p className="text-sm text-muted-foreground">
+            {report.summaryLabel}. {report.summaryDetail}
+          </p>
+        </div>
+        <StatusBadge status={report.status} />
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="grid gap-4 md:grid-cols-4">
+          <StatusPanel
+            label="Filled"
+            value={`${matrix.summary.totalFilled}/${matrix.summary.totalNeeded}`}
+          />
+          <StatusPanel label="Open" value={matrix.summary.openCapacity} />
+          <StatusPanel label="Critical" value={criticalIssueCount} />
+          <StatusPanel label="Responses" value={responseIssueCount} />
+        </div>
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-3">
+        {report.issueSummary.map((issue) => (
+          <IssuePanel key={issue.key} issue={issue} />
+        ))}
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="font-semibold">Coverage by role</h3>
+            <p className="text-sm text-muted-foreground">
+              Filled and needed totals across shifts and heat lanes.
+            </p>
+          </div>
+          <Link
+            to="/events/$eventId/shifts"
+            params={{ eventId }}
+            className="w-fit rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Manage shifts
+          </Link>
+        </div>
+        {report.roleSummaries.length > 0 ? (
+          <div className="mt-5 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+            {report.roleSummaries.map((role) => (
+              <article
+                key={role.roleType}
+                className="rounded-md border bg-background p-4"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h4 className="font-medium">{role.roleLabel}</h4>
+                    <p className="text-sm text-muted-foreground">
+                      {role.timeBlocks} block{plural(role.timeBlocks)}
+                    </p>
+                  </div>
+                  <span
+                    className={`rounded-md border px-2 py-1 text-xs font-medium ${
+                      role.open > 0
+                        ? "border-amber-500/30 bg-amber-500/10 text-amber-700"
+                        : "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+                    }`}
+                  >
+                    {role.open} open
+                  </span>
+                </div>
+                <p className="mt-4 text-2xl font-semibold">
+                  {role.filled}/{role.needed}
+                </p>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <EmptyState message="No staffing role rows yet." />
+        )}
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h3 className="font-semibold">Coverage by time block</h3>
+        <CoverageTable
+          rows={matrix.coverageRows}
+          timeBlockById={timeBlockById}
+          timezone={timezone}
+        />
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+        <section className="space-y-6">
+          <ActionList
+            title="Open capacity"
+            count={report.underfilledRows.length}
+            empty="No open capacity in current coverage rows."
+          >
+            {report.underfilledRows.map((row) => (
+              <GapRow key={row.id}>
+                <span>{getTimeBlockLabel(timeBlockById, row.timeBlockId)}</span>
+                <span className="text-muted-foreground">
+                  {formatVolunteerRole(row.roleType)} needs {row.open} more.
+                </span>
+              </GapRow>
+            ))}
+          </ActionList>
+
+          <ActionList
+            title="Judge lane gaps"
+            count={matrix.judgeLaneGaps.length}
+            empty="No uncovered judge lanes."
+          >
+            {matrix.judgeLaneGaps.map((gap) => (
+              <GapRow key={`${gap.heatId}:${gap.laneNumber}`}>
+                <span>{getTimeBlockLabel(timeBlockById, gap.timeBlockId)}</span>
+                <span className="text-muted-foreground">
+                  Heat {gap.heatNumber}, lane {gap.laneNumber}
+                </span>
+              </GapRow>
+            ))}
+          </ActionList>
+
+          <ActionList
+            title="Volunteer conflicts"
+            count={matrix.doubleBookedVolunteers.length}
+            empty="No double-booked volunteers."
+          >
+            {matrix.doubleBookedVolunteers.map((booking) => (
+              <GapRow
+                key={`${booking.membershipId}:${booking.assignmentIds.join(":")}`}
+              >
+                <span>{booking.volunteerName}</span>
+                <span className="text-muted-foreground">
+                  {booking.timeBlockIds
+                    .map((timeBlockId) =>
+                      getTimeBlockLabel(timeBlockById, timeBlockId),
+                    )
+                    .join(" / ")}
+                </span>
+              </GapRow>
+            ))}
+          </ActionList>
+
+          <ActionList
+            title="Availability warnings"
+            count={matrix.outsideAvailabilityAssignments.length}
+            empty="No outside-availability assignments."
+          >
+            {matrix.outsideAvailabilityAssignments.map((warning) => (
+              <GapRow key={`${warning.assignmentId}:${warning.timeBlockId}`}>
+                <span>{warning.volunteerName}</span>
+                <span className="text-muted-foreground">
+                  {formatVolunteerAvailability(warning.availability)} /{" "}
+                  {getTimeBlockLabel(timeBlockById, warning.timeBlockId)}
+                </span>
+              </GapRow>
+            ))}
+          </ActionList>
+
+          <ActionList
+            title="Role warnings"
+            count={matrix.credentialWarnings.length}
+            empty="No role or credential warnings."
+          >
+            {matrix.credentialWarnings.map((warning) => (
+              <GapRow key={`${warning.assignmentId}:${warning.reason}`}>
+                <span>{warning.volunteerName}</span>
+                <span className="text-muted-foreground">
+                  {formatCrewValue(warning.reason)} / needs{" "}
+                  {formatVolunteerRole(warning.requiredRoleType)}
+                </span>
+              </GapRow>
+            ))}
+          </ActionList>
+
+          <ActionList
+            title="Confirmation gaps"
+            count={matrix.confirmationGaps.length}
+            empty="No assignment confirmation gaps."
+          >
+            {matrix.confirmationGaps.map((gap) => (
+              <GapRow key={`${gap.assignmentId}:${gap.reason}`}>
+                <span>{gap.volunteerName}</span>
+                <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
+                  {formatCrewValue(gap.reason)} /{" "}
+                  {getTimeBlockLabel(timeBlockById, gap.timeBlockId)}
+                  <ConfirmationBadge status={gap.status ?? "missing"} />
+                </span>
+              </GapRow>
+            ))}
+          </ActionList>
+        </section>
+
+        <aside className="rounded-md border bg-card p-5 shadow-sm">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Source counts
+          </h3>
+          <dl className="mt-4 space-y-4 text-sm">
+            <Fact label="Venues" value={sources.venues} />
+            <Fact label="Workouts" value={sources.workouts} />
+            <Fact label="Heats" value={sources.heats} />
+            <Fact
+              label="Lane assignments"
+              value={sources.heatLaneAssignments}
+            />
+            <Fact label="Roster" value={sources.roster} />
+            <Fact label="Assignable" value={sources.assignableRoster} />
+            <Fact label="Shifts" value={sources.shifts} />
+            <Fact label="Shift assignments" value={sources.shiftAssignments} />
+            <Fact
+              label="Active judge versions"
+              value={sources.activeJudgeVersions}
+            />
+            <Fact label="Judge assignments" value={sources.judgeAssignments} />
+          </dl>
+        </aside>
+      </div>
+    </section>
+  )
+}
+
+function CoverageTable({
+  rows,
+  timeBlockById,
+  timezone,
+}: {
+  rows: CrewStaffingCoverageRow[]
+  timeBlockById: Map<string, CrewStaffingTimeBlock>
+  timezone: string
+}) {
+  if (rows.length === 0) {
+    return <EmptyState message="No coverage rows yet." />
+  }
+
+  return (
+    <div className="mt-4 overflow-x-auto rounded-md border">
+      <table className="w-full min-w-[44rem] border-collapse text-sm">
+        <thead className="bg-muted/60 text-left text-muted-foreground">
+          <tr>
+            <th className="px-3 py-2 font-medium">Time block</th>
+            <th className="px-3 py-2 font-medium">Role</th>
+            <th className="px-3 py-2 font-medium">Window</th>
+            <th className="px-3 py-2 text-right font-medium">Filled</th>
+            <th className="px-3 py-2 text-right font-medium">Needed</th>
+            <th className="px-3 py-2 text-right font-medium">Open</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => {
+            const block = timeBlockById.get(row.timeBlockId)
+            return (
+              <tr key={row.id} className="border-t">
+                <td className="px-3 py-3 font-medium">
+                  {block?.label ?? row.timeBlockId}
+                </td>
+                <td className="px-3 py-3">
+                  {formatVolunteerRole(row.roleType)}
+                </td>
+                <td className="px-3 py-3 text-muted-foreground">
+                  {formatTimeWindow(block, timezone)}
+                </td>
+                <td className="px-3 py-3 text-right">{row.filled}</td>
+                <td className="px-3 py-3 text-right">{row.needed}</td>
+                <td className="px-3 py-3 text-right">
+                  <span
+                    className={
+                      row.open > 0 ? "font-semibold text-amber-700" : ""
+                    }
+                  >
+                    {row.open}
+                  </span>
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function ActionList({
+  title,
+  count,
+  empty,
+  children,
+}: {
+  title: string
+  count: number
+  empty: string
+  children: ReactNode
+}) {
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="font-semibold">{title}</h3>
+        <span className="rounded-md border bg-background px-2 py-1 text-xs font-medium">
+          {count}
+        </span>
+      </div>
+      {count > 0 ? (
+        <div className="mt-4 space-y-2">{children}</div>
+      ) : (
+        <EmptyState message={empty} compact />
+      )}
+    </section>
+  )
+}
+
+function GapRow({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1 rounded-md border bg-background p-3 text-sm sm:flex-row sm:items-center sm:justify-between">
+      {children}
+    </div>
+  )
+}
+
+function IssuePanel({ issue }: { issue: CrewStaffingReportIssueSummary }) {
+  return (
+    <article className="rounded-md border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="text-sm text-muted-foreground">{issue.label}</p>
+          <p className="mt-2 text-xl font-semibold">{issue.count}</p>
+        </div>
+        <span
+          className={`rounded-md border px-2 py-1 text-xs font-medium ${
+            issue.severity === "critical"
+              ? "border-destructive/30 bg-destructive/10 text-destructive"
+              : "border-amber-500/30 bg-amber-500/10 text-amber-700"
+          }`}
+        >
+          {issue.severity}
+        </span>
+      </div>
+    </article>
+  )
+}
+
+function StatusPanel({
+  label,
+  value,
+}: {
+  label: string
+  value: number | string
+}) {
+  return (
+    <section className="rounded-md border bg-background p-4">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function StatusBadge({ status }: { status: CrewStaffingReportStatus }) {
+  const Icon =
+    status === "covered"
+      ? CheckCircle2
+      : status === "critical"
+        ? AlertCircle
+        : CircleAlert
+
+  return (
+    <span
+      className={`inline-flex w-fit items-center gap-2 rounded-md border px-2 py-1 text-xs font-medium ${statusBadgeClass(status)}`}
+    >
+      <Icon className="size-3.5" />
+      {status === "covered"
+        ? "Covered"
+        : status === "critical"
+          ? "Critical gaps"
+          : "Needs attention"}
+    </span>
+  )
+}
+
+function ConfirmationBadge({ status }: { status: string }) {
+  return (
+    <span
+      className={`rounded-md border px-2 py-1 text-xs font-medium ${getCrewAssignmentConfirmationStatusBadgeClassName(status)}`}
+    >
+      {formatCrewValue(status)}
+    </span>
+  )
+}
+
+function Fact({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function EmptyState({
+  message,
+  compact = false,
+}: {
+  message: string
+  compact?: boolean
+}) {
+  return (
+    <div
+      className={`rounded-md border bg-background text-center text-sm text-muted-foreground ${
+        compact ? "mt-4 p-3" : "mt-4 p-6"
+      }`}
+    >
+      {message}
+    </div>
+  )
+}
+
+function getTimeBlockLabel(
+  timeBlockById: Map<string, CrewStaffingTimeBlock>,
+  timeBlockId: string,
+) {
+  return timeBlockById.get(timeBlockId)?.label ?? timeBlockId
+}
+
+function formatTimeWindow(
+  block: CrewStaffingTimeBlock | undefined,
+  timezone: string,
+) {
+  if (!block?.startTime) return "Unscheduled"
+  const start = formatDateTimeInTimezone(
+    block.startTime,
+    timezone,
+    "EEE, MMM d h:mm a",
+  )
+  const end = block.endTime
+    ? formatDateTimeInTimezone(block.endTime, timezone, "h:mm a")
+    : ""
+
+  return end ? `${start} to ${end}` : start
+}
+
+function statusBadgeClass(status: CrewStaffingReportStatus) {
+  if (status === "covered") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "critical") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+}
+
+function plural(count: number) {
+  return count === 1 ? "" : "s"
+}

--- a/apps/crew/src/server-fns/crew-staffing-fns.server.ts
+++ b/apps/crew/src/server-fns/crew-staffing-fns.server.ts
@@ -1,0 +1,370 @@
+// @lat: [[crew#Staffing Page Gap Report]]
+import { and, asc, desc, eq, inArray } from "drizzle-orm"
+import { getDb } from "../db"
+import {
+  competitionHeatAssignmentsTable,
+  competitionHeatsTable,
+  competitionsTable,
+  competitionVenuesTable,
+} from "../db/schemas/competitions"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+  crewAssignmentConfirmationsTable,
+} from "../db/schemas/crew-imports"
+import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import {
+  programmingTracksTable,
+  trackWorkoutsTable,
+} from "../db/schemas/programming"
+import {
+  judgeAssignmentVersionsTable,
+  judgeHeatAssignmentsTable,
+} from "../db/schemas/volunteers"
+import { workouts as workoutsTable } from "../db/schemas/workouts"
+import {
+  buildCrewStaffingMatrix,
+  buildCrewStaffingReport,
+  type CrewStaffingConfirmationInput,
+  type CrewStaffingMatrix,
+  type CrewStaffingMatrixInput,
+  type CrewStaffingReport,
+} from "../lib/crew/staffing"
+import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
+import {
+  loadCrewRoster,
+  loadCrewShifts,
+  type CrewShiftBoardItem,
+} from "./crew-roster-shift-fns"
+
+type DbClient = ReturnType<typeof getDb>
+
+export interface CrewStaffingReportEvent {
+  id: string
+  name: string
+  slug: string
+  competitionTeamId: string
+  timezone: string | null
+  startDate: string | null
+  endDate: string | null
+}
+
+export interface CrewStaffingReportPageData {
+  event: CrewStaffingReportEvent
+  matrix: CrewStaffingMatrix
+  report: CrewStaffingReport
+  sources: CrewStaffingReport["sourceCounts"] & {
+    activeJudgeVersions: number
+  }
+}
+
+export async function getCrewStaffingReportPage(
+  eventId: string,
+): Promise<CrewStaffingReportPageData> {
+  requireLocalCrewOperatorAccess("Crew staffing")
+
+  const event = await requireCrewStaffingEvent(eventId)
+  const { input, activeJudgeVersions } =
+    await loadCrewStaffingMatrixInput(event)
+  const matrix = buildCrewStaffingMatrix(input)
+  const report = buildCrewStaffingReport(input, matrix)
+
+  return {
+    event,
+    matrix,
+    report,
+    sources: {
+      ...report.sourceCounts,
+      activeJudgeVersions,
+    },
+  }
+}
+
+async function requireCrewStaffingEvent(
+  eventId: string,
+): Promise<CrewStaffingReportEvent> {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      name: competitionsTable.name,
+      slug: competitionsTable.slug,
+      competitionTeamId: competitionsTable.competitionTeamId,
+      timezone: competitionsTable.timezone,
+      startDate: competitionsTable.startDate,
+      endDate: competitionsTable.endDate,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  return event
+}
+
+async function loadCrewStaffingMatrixInput(event: CrewStaffingReportEvent) {
+  const [roster, shifts, venues, workouts, heats] = await Promise.all([
+    loadCrewRoster(event.competitionTeamId),
+    loadCrewShifts(event.id),
+    loadStaffingVenues(event.id),
+    loadStaffingWorkouts(event.id),
+    loadStaffingHeats(event.id),
+  ])
+  const heatIds = heats.map((heat) => heat.id)
+  const trackWorkoutIds = [...new Set(heats.map((heat) => heat.trackWorkoutId))]
+  const [heatLaneAssignments, judgeData] = await Promise.all([
+    loadHeatLaneAssignments(heatIds),
+    loadActiveJudgeAssignments(heatIds, trackWorkoutIds),
+  ])
+
+  const input: CrewStaffingMatrixInput = {
+    event: {
+      id: event.id,
+      name: event.name,
+      timezone: event.timezone,
+      startDate: event.startDate,
+      endDate: event.endDate,
+    },
+    venues,
+    workouts,
+    heats,
+    heatLaneAssignments,
+    roster: roster.flatMap((volunteer) => {
+      if (!volunteer.membershipId) return []
+      return {
+        membershipId: volunteer.membershipId,
+        name: volunteer.name,
+        email: volunteer.email,
+        roleTypes: volunteer.roleTypes,
+        availability: volunteer.availability,
+        credentials: volunteer.credentials,
+        isActive: volunteer.status === "active",
+      }
+    }),
+    shifts: toStaffingShifts(shifts),
+    judgeAssignments: judgeData.judgeAssignments,
+  }
+
+  return {
+    input,
+    activeJudgeVersions: judgeData.activeVersionCount,
+  }
+}
+
+async function loadStaffingVenues(competitionId: string) {
+  const db = getDb()
+  return db
+    .select({
+      id: competitionVenuesTable.id,
+      name: competitionVenuesTable.name,
+      laneCount: competitionVenuesTable.laneCount,
+      sortOrder: competitionVenuesTable.sortOrder,
+    })
+    .from(competitionVenuesTable)
+    .where(eq(competitionVenuesTable.competitionId, competitionId))
+    .orderBy(
+      asc(competitionVenuesTable.sortOrder),
+      asc(competitionVenuesTable.name),
+    )
+}
+
+async function loadStaffingWorkouts(competitionId: string) {
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: trackWorkoutsTable.id,
+      name: workoutsTable.name,
+      sortOrder: trackWorkoutsTable.trackOrder,
+    })
+    .from(trackWorkoutsTable)
+    .innerJoin(
+      programmingTracksTable,
+      eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+    )
+    .leftJoin(workoutsTable, eq(trackWorkoutsTable.workoutId, workoutsTable.id))
+    .where(eq(programmingTracksTable.competitionId, competitionId))
+    .orderBy(asc(trackWorkoutsTable.trackOrder), asc(trackWorkoutsTable.id))
+
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name ?? "Workout",
+    sortOrder: Number(row.sortOrder ?? 0),
+  }))
+}
+
+async function loadStaffingHeats(competitionId: string) {
+  const db = getDb()
+  return db
+    .select({
+      id: competitionHeatsTable.id,
+      trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+      heatNumber: competitionHeatsTable.heatNumber,
+      venueId: competitionHeatsTable.venueId,
+      scheduledTime: competitionHeatsTable.scheduledTime,
+      durationMinutes: competitionHeatsTable.durationMinutes,
+    })
+    .from(competitionHeatsTable)
+    .where(eq(competitionHeatsTable.competitionId, competitionId))
+    .orderBy(
+      asc(competitionHeatsTable.scheduledTime),
+      asc(competitionHeatsTable.heatNumber),
+      asc(competitionHeatsTable.id),
+    )
+}
+
+async function loadHeatLaneAssignments(heatIds: string[]) {
+  if (heatIds.length === 0) return []
+
+  const db = getDb()
+  return db
+    .select({
+      heatId: competitionHeatAssignmentsTable.heatId,
+      laneNumber: competitionHeatAssignmentsTable.laneNumber,
+    })
+    .from(competitionHeatAssignmentsTable)
+    .where(inArray(competitionHeatAssignmentsTable.heatId, heatIds))
+    .orderBy(
+      asc(competitionHeatAssignmentsTable.heatId),
+      asc(competitionHeatAssignmentsTable.laneNumber),
+    )
+}
+
+async function loadActiveJudgeAssignments(
+  heatIds: string[],
+  trackWorkoutIds: string[],
+) {
+  if (heatIds.length === 0 || trackWorkoutIds.length === 0) {
+    return {
+      activeVersionCount: 0,
+      judgeAssignments: [],
+    }
+  }
+
+  const db = getDb()
+  const activeVersions = await db
+    .select({
+      id: judgeAssignmentVersionsTable.id,
+    })
+    .from(judgeAssignmentVersionsTable)
+    .where(
+      and(
+        inArray(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutIds),
+        eq(judgeAssignmentVersionsTable.isActive, true),
+      ),
+    )
+  const versionIds = activeVersions.map((version) => version.id)
+
+  if (versionIds.length === 0) {
+    return {
+      activeVersionCount: 0,
+      judgeAssignments: [],
+    }
+  }
+
+  const assignments = await db
+    .select({
+      id: judgeHeatAssignmentsTable.id,
+      heatId: judgeHeatAssignmentsTable.heatId,
+      membershipId: judgeHeatAssignmentsTable.membershipId,
+      laneNumber: judgeHeatAssignmentsTable.laneNumber,
+      position: judgeHeatAssignmentsTable.position,
+      versionId: judgeHeatAssignmentsTable.versionId,
+      rotationId: judgeHeatAssignmentsTable.rotationId,
+    })
+    .from(judgeHeatAssignmentsTable)
+    .where(
+      and(
+        inArray(judgeHeatAssignmentsTable.heatId, heatIds),
+        inArray(judgeHeatAssignmentsTable.versionId, versionIds),
+      ),
+    )
+    .orderBy(
+      asc(judgeHeatAssignmentsTable.heatId),
+      asc(judgeHeatAssignmentsTable.laneNumber),
+      asc(judgeHeatAssignmentsTable.id),
+    )
+  const confirmationMap = await loadJudgeAssignmentConfirmationMap(
+    db,
+    assignments.map((assignment) => assignment.id),
+  )
+
+  return {
+    activeVersionCount: activeVersions.length,
+    judgeAssignments: assignments.map((assignment) => ({
+      ...assignment,
+      confirmation: confirmationMap.get(assignment.id) ?? null,
+    })),
+  }
+}
+
+async function loadJudgeAssignmentConfirmationMap(
+  db: DbClient,
+  assignmentIds: string[],
+) {
+  if (assignmentIds.length === 0) {
+    return new Map<string, CrewStaffingConfirmationInput>()
+  }
+
+  const rows = await db
+    .select({
+      assignmentId: crewAssignmentConfirmationsTable.assignmentId,
+      type: crewAssignmentConfirmationsTable.assignmentType,
+      status: crewAssignmentConfirmationsTable.status,
+      respondedAt: crewAssignmentConfirmationsTable.respondedAt,
+      responseNote: crewAssignmentConfirmationsTable.responseNote,
+      updatedAt: crewAssignmentConfirmationsTable.updatedAt,
+    })
+    .from(crewAssignmentConfirmationsTable)
+    .where(
+      and(
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+        ),
+        inArray(crewAssignmentConfirmationsTable.assignmentId, assignmentIds),
+      ),
+    )
+    .orderBy(desc(crewAssignmentConfirmationsTable.updatedAt))
+
+  const byAssignment = new Map<string, CrewStaffingConfirmationInput>()
+  for (const row of rows) {
+    if (byAssignment.has(row.assignmentId)) continue
+    byAssignment.set(row.assignmentId, {
+      type: row.type,
+      status: row.status,
+      respondedAt: row.respondedAt,
+      responseNote: row.responseNote,
+    })
+  }
+  return byAssignment
+}
+
+function toStaffingShifts(shifts: CrewShiftBoardItem[]) {
+  return shifts.map((shift) => ({
+    id: shift.id,
+    name: shift.name,
+    roleType: shift.roleType,
+    startTime: shift.startTime,
+    endTime: shift.endTime,
+    capacity: shift.capacity,
+    location: shift.location,
+    assignments: shift.assignments.map((assignment) => ({
+      id: assignment.id,
+      membershipId: assignment.membershipId,
+      confirmation: assignment.confirmation
+        ? {
+            type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+            status: assignment.confirmation.status,
+            respondedAt: assignment.confirmation.respondedAt,
+            responseNote: assignment.confirmation.responseNote,
+          }
+        : null,
+    })),
+  }))
+}

--- a/apps/crew/src/server-fns/crew-staffing-fns.ts
+++ b/apps/crew/src/server-fns/crew-staffing-fns.ts
@@ -1,0 +1,21 @@
+// @lat: [[crew#Staffing Page Gap Report]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type {
+  CrewStaffingReportEvent,
+  CrewStaffingReportPageData,
+} from "./crew-staffing-fns.server"
+
+const eventIdSchema = z.string().min(1, "Event ID is required")
+
+export const getCrewStaffingReportPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    z.object({ eventId: eventIdSchema }).parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewStaffingReportPage } = await import(
+      "./crew-staffing-fns.server"
+    )
+    return getCrewStaffingReportPage(data.eventId)
+  })

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -24,6 +24,18 @@ Crew staffing matrix core is a pure data-shape layer for deriving event staffing
 
 The matrix core is read-only. It does not create shifts, assign volunteers, publish judge rotations, send reminders, mutate imports, or add Crew schema.
 
+## Staffing Page Gap Report
+
+Crew staffing pages expose the matrix core as a read-only event operations report.
+
+[[apps/crew/src/server-fns/crew-staffing-fns.ts]] exposes a lightweight route-safe server-function wrapper.
+
+[[apps/crew/src/server-fns/crew-staffing-fns.server.ts]] hydrates the matrix from existing event, venue, heat, lane, roster, shift, active judge assignment, and confirmation data.
+
+[[apps/crew/src/routes/events/$eventId/staffing.tsx]] renders coverage, open capacity, judge lane gaps, conflicts, availability warnings, role warnings, confirmation gaps, and source counts without mutating schema or assignments.
+
+[[apps/crew/src/lib/crew/staffing/report.ts]] owns the deterministic event-level status and report summaries used by the page.
+
 ## Staffing Calculator
 
 The public Crew calculator route estimates event-day staffing needs from event dimensions and editable role assumptions.


### PR DESCRIPTION
## Summary

- Adds a read-only Crew staffing report at `/events/$eventId/staffing` using the merged staffing matrix core.
- Hydrates the matrix from existing event, venue, heat/lane, roster, shift, active judge assignment, and assignment confirmation data.
- Shows event-level status, filled/needed role coverage, open capacity, judge lane gaps, double-booked volunteers, availability warnings, role warnings, confirmation gaps, and source counts.
- Adds event nav/overview entry points, focused report helper tests, and `crew#Staffing Page Gap Report` LAT docs/refs.
- Keeps the new staffing server function aligned with the upcoming runtime-boundary fix: route imports the lightweight `createServerFn` wrapper, while DB/runtime reads live in `crew-staffing-fns.server.ts` and are dynamically imported inside the handler.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/staffing/report.test.ts src/lib/crew/staffing/matrix.test.ts` — passed, 10 tests.
- `pnpm --filter crew type-check` — passed.
- `pnpm --filter crew lint` — exited 0; existing Crew warnings remain outside this diff.
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` — passed client and SSR builds. The exact Vite import-analysis failure for `cloudflare:workers` did not occur; build still prints the existing unused `cloudflare:workers` warning from `src/db/index.ts`.
- `pnpm check:schema-ownership` — passed.
- `pnpm dlx lat.md locate 'crew#Staffing Page Gap Report'` — passed.
- `pnpm dlx lat.md refs 'crew#Staffing Page Gap Report'` — passed.
- `git diff --check` — passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Crew Staffing page and gap report to show coverage and issues at a glance. Built on the staffing matrix core, it surfaces open capacity, judge lane gaps, conflicts, and confirmation status, with clear guidance when no staffing blocks exist.

- New Features
  - New staffing report page at `/events/$eventId/staffing` with status badge and role/time-block coverage.
  - Hydrates from venues, workouts, heats, lane assignments, roster, shifts, active judge assignments, and confirmations.
  - Summarizes open capacity, judge lane gaps, double-booked volunteers, availability and credential warnings, and confirmation gaps; includes source counts and active judge version count.
  - Adds `buildCrewStaffingReport` with deterministic statuses (covered, needs_attention, critical); empty reports now show “Needs attention” with guidance.
  - Event overview card and nav link to Staffing; focused unit tests for report logic.
  - Route uses lightweight `createServerFn` wrapper; DB reads live in `crew-staffing-fns.server.ts` and are dynamically imported.

<sup>Written for commit 7c10a9059d146d9cdd27e0c656084d719a6c7ca6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Staffing page for events displaying comprehensive staffing reports with gap detection capabilities.
  * Staffing page shows coverage by role and time block, identifies critical issues including open capacity and judge gaps, and provides source counts summary.
  * Added Staffing report card to the event overview page linking to the new staffing page.

* **Tests**
  * Added test coverage for staffing report functionality validating gap detection and status reporting.

* **Documentation**
  * Added Staffing Page Gap Report documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->