### PR TITLE
fix(crew): prevent duplicate import panels on tab navigation

### DIFF
--- a/apps/crew/src/routes/events/$eventId/imports.tsx
+++ b/apps/crew/src/routes/events/$eventId/imports.tsx
@@ -47,6 +47,38 @@ function EventImportsPage() {
   const router = useRouter()
   const { eventId } = parentRoute.useParams()
   const { history, reference } = Route.useLoaderData()
+  const handleHistoryRefresh = async () => {
+    await router.invalidate()
+  }
+
+  const handleApplyComplete = async () => {
+    await router.invalidate()
+  }
+
+  return (
+    <EventImportTabs
+      eventId={eventId}
+      history={history}
+      reference={reference}
+      onApplyComplete={handleApplyComplete}
+      onHistoryRefresh={handleHistoryRefresh}
+    />
+  )
+}
+
+export function EventImportTabs({
+  eventId,
+  history,
+  reference,
+  onApplyComplete,
+  onHistoryRefresh,
+}: {
+  eventId: string
+  history: CrewImportHistoryItem[]
+  reference: CrewImportReferenceData
+  onApplyComplete: (result: CrewImportApplyResult) => Promise<void>
+  onHistoryRefresh: () => Promise<void>
+}) {
   const [activeTab, setActiveTab] = useState<ImportsTab>("volunteers")
   const [latestPreview, setLatestPreview] =
     useState<PersistedCrewImportPreview | null>(null)
@@ -62,7 +94,7 @@ function EventImportsPage() {
         ? { ...current, status: result.status }
         : current,
     )
-    await router.invalidate()
+    await onApplyComplete(result)
   }
 
   return (
@@ -98,30 +130,64 @@ function EventImportsPage() {
         </div>
       </div>
 
-      {activeTab === "volunteers" || activeTab === "heat_schedule" ? (
+      <ImportTabContent
+        key={activeTab}
+        activeTab={activeTab}
+        eventId={eventId}
+        history={history}
+        latestPreview={latestPreview}
+        reference={reference}
+        onApplyComplete={handleApplyComplete}
+        onHistoryRefresh={onHistoryRefresh}
+        onPreviewComplete={handlePreviewComplete}
+      />
+    </section>
+  )
+}
+
+function ImportTabContent({
+  activeTab,
+  eventId,
+  history,
+  latestPreview,
+  reference,
+  onApplyComplete,
+  onHistoryRefresh,
+  onPreviewComplete,
+}: {
+  activeTab: ImportsTab
+  eventId: string
+  history: CrewImportHistoryItem[]
+  latestPreview: PersistedCrewImportPreview | null
+  reference: CrewImportReferenceData
+  onApplyComplete: (result: CrewImportApplyResult) => Promise<void>
+  onHistoryRefresh: () => Promise<void>
+  onPreviewComplete: (preview: PersistedCrewImportPreview) => void
+}) {
+  switch (activeTab) {
+    case "volunteers":
+    case "heat_schedule":
+      return (
         <div className="grid gap-6 xl:grid-cols-[minmax(0,24rem)_1fr]">
           <ImportUploadPanel
-            key={activeTab}
             eventId={eventId}
             kind={activeTab}
-            onPreviewComplete={handlePreviewComplete}
-            onHistoryRefresh={() => router.invalidate()}
+            onPreviewComplete={onPreviewComplete}
+            onHistoryRefresh={onHistoryRefresh}
           />
           <PreviewPanel
-            key={latestPreview?.importId ?? activeTab}
             eventId={eventId}
             preview={latestPreview}
             expectedKind={activeTab}
-            onApplyComplete={handleApplyComplete}
+            onApplyComplete={onApplyComplete}
           />
         </div>
-      ) : null}
-
-      {activeTab === "roles" ? <ReferencePanel reference={reference} /> : null}
-
-      {activeTab === "history" ? <HistoryPanel history={history} /> : null}
-    </section>
-  )
+      )
+    case "roles":
+      return <ReferencePanel reference={reference} />
+    case "history":
+      return <HistoryPanel history={history} />
+  }
 }
 
 function ImportUploadPanel({
@@ -660,6 +726,7 @@ function ImportTabButton({
   return (
     <button
       type="button"
+      aria-pressed={active}
       onClick={onClick}
       className={
         active

--- a/apps/crew/test/routes/event-import-tabs.test.tsx
+++ b/apps/crew/test/routes/event-import-tabs.test.tsx
@@ -19,6 +19,7 @@ const reference = {
 }
 
 describe("EventImportTabs", () => {
+  // @lat: [[crew#Import Tabs Duplicate Panel Regression]]
   it("keeps a single tab panel mounted while navigating import tabs", () => {
     render(
       <EventImportTabs

--- a/apps/crew/test/routes/event-import-tabs.test.tsx
+++ b/apps/crew/test/routes/event-import-tabs.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { EventImportTabs } from "@/routes/events/$eventId/imports"
+
+vi.mock("@tanstack/react-start", () => ({
+  useServerFn: () => vi.fn(),
+}))
+
+vi.mock("@/server-fns/crew-import-fns", () => ({
+  applyCrewImportFn: vi.fn(),
+  getCrewImportsPageFn: vi.fn(),
+}))
+
+const reference = {
+  roleLabels: ["Judge", "Floor"],
+  divisions: [{ id: "div_rx", label: "Rx" }],
+  workouts: [{ id: "workout_1", label: "Workout 1", trackOrder: 1 }],
+  heats: [],
+}
+
+describe("EventImportTabs", () => {
+  it("keeps a single tab panel mounted while navigating import tabs", () => {
+    render(
+      <EventImportTabs
+        eventId="comp_crew_demo"
+        history={[]}
+        reference={reference}
+        onApplyComplete={async () => {}}
+        onHistoryRefresh={async () => {}}
+      />,
+    )
+
+    expectUploadPanel("Volunteers CSV")
+
+    fireEvent.click(screen.getByRole("button", { name: "Heat schedule" }))
+    expectUploadPanel("Heat schedule CSV")
+
+    fireEvent.click(screen.getByRole("button", { name: "Roles" }))
+    expectNoUploadPanels()
+    expect(screen.getByText("Role assumptions")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "History" }))
+    expectNoUploadPanels()
+    expect(screen.getByText("No import previews yet.")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Volunteers" }))
+    expectUploadPanel("Volunteers CSV")
+
+    fireEvent.click(screen.getByRole("button", { name: "Heat schedule" }))
+    expectUploadPanel("Heat schedule CSV")
+
+    fireEvent.click(screen.getByRole("button", { name: "Volunteers" }))
+    expectUploadPanel("Volunteers CSV")
+  })
+})
+
+function expectUploadPanel(expectedTitle: "Volunteers CSV" | "Heat schedule CSV") {
+  const otherTitle =
+    expectedTitle === "Volunteers CSV" ? "Heat schedule CSV" : "Volunteers CSV"
+
+  expect(screen.getAllByText(expectedTitle)).toHaveLength(1)
+  expect(screen.queryByText(otherTitle)).not.toBeInTheDocument()
+  expect(screen.getAllByRole("button", { name: "Preview CSV" })).toHaveLength(
+    1,
+  )
+}
+
+function expectNoUploadPanels() {
+  expect(screen.queryByText("Volunteers CSV")).not.toBeInTheDocument()
+  expect(screen.queryByText("Heat schedule CSV")).not.toBeInTheDocument()
+  expect(
+    screen.queryByRole("button", { name: "Preview CSV" }),
+  ).not.toBeInTheDocument()
+}


### PR DESCRIPTION
## Summary
- Extract the Crew imports tab UI into a single keyed tab body so tab navigation replaces the active panel set instead of allowing stale upload forms to remain mounted.
- Add `aria-pressed` to import tab buttons for active-state semantics.
- Add a focused regression test that clicks Volunteers → Heat schedule → Roles → History → Volunteers → Heat schedule → Volunteers and asserts only one upload panel is mounted on upload tabs.

## Validation
- `pnpm --filter crew exec vitest run test/routes/event-import-tabs.test.tsx`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (passes with existing unrelated warnings)
- `pnpm --filter crew build` (passes with existing Vite chunk-size warning)
- `git diff --check`

## Notes
- No schema-adjacent files touched; `pnpm check:schema-ownership` was not required for this slice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes duplicate upload panels in Crew Imports by mounting a single keyed tab body. Switching tabs now replaces the panel set, so stale upload forms no longer linger.

- **Bug Fixes**
  - Use a keyed `ImportTabContent` so only the active panel is mounted, preventing duplicate upload forms on tab navigation.
  - Add `aria-pressed` to tab buttons for correct active-state semantics.
  - Add a regression test (with LAT reference) that navigates across tabs and asserts only one upload panel is present.

- **Refactors**
  - Extract `EventImportTabs` and `ImportTabContent` to simplify tab state and improve testability.
  - Move `router.invalidate()` into `onApplyComplete` and `onHistoryRefresh` callbacks passed to tabs.

<sup>Written for commit 7753495846d04a75f27997cac0c8895fb7a14a32. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility with improved button state indicators for tab navigation.

* **Refactor**
  * Improved event import tab component with refined callback handling and cleaner tab content logic.

* **Tests**
  * Added comprehensive test suite for import tab navigation and panel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->