### PR TITLE
feat(crew): add manual volunteer intake

### DIFF
--- a/apps/crew/src/lib/crew/manual-volunteer-intake.test.ts
+++ b/apps/crew/src/lib/crew/manual-volunteer-intake.test.ts
@@ -1,0 +1,168 @@
+// @lat: [[crew#Manual Volunteer Intake]]
+import { describe, expect, it } from "vitest"
+import { INVITATION_STATUS } from "../../db/schemas/teams"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_INVITE_SOURCE,
+  VOLUNTEER_ROLE_TYPES,
+} from "../../db/schemas/volunteers"
+import {
+  buildManualVolunteerMetadata,
+  parseManualVolunteerEmailPaste,
+  planManualVolunteerIntake,
+} from "./manual-volunteer-intake"
+
+describe("parseManualVolunteerEmailPaste", () => {
+  it("normalizes newline and comma separated emails", () => {
+    const result = parseManualVolunteerEmailPaste(
+      " ADA@example.com\nbob@example.com, Cara@Example.COM ",
+    )
+
+    expect(result.valid.map((row) => row.email)).toEqual([
+      "ada@example.com",
+      "bob@example.com",
+      "cara@example.com",
+    ])
+    expect(result.skipped).toEqual([])
+    expect(result.invalid).toEqual([])
+  })
+
+  it("skips duplicate emails inside the paste", () => {
+    const result = parseManualVolunteerEmailPaste(
+      "ada@example.com, ADA@example.com\nbob@example.com",
+    )
+
+    expect(result.valid.map((row) => row.email)).toEqual([
+      "ada@example.com",
+      "bob@example.com",
+    ])
+    expect(result.skipped).toEqual([
+      {
+        rowNumber: 2,
+        email: "ada@example.com",
+        reason: "duplicate_in_paste",
+      },
+    ])
+  })
+
+  it("reports invalid rows and batch limit rows", () => {
+    const result = parseManualVolunteerEmailPaste(
+      "ada@example.com,not-an-email,bob@example.com,cara@example.com",
+      2,
+    )
+
+    expect(result.valid.map((row) => row.email)).toEqual([
+      "ada@example.com",
+      "bob@example.com",
+    ])
+    expect(result.invalid).toEqual([
+      {
+        rowNumber: 2,
+        value: "not-an-email",
+        reason: "invalid_email",
+      },
+      {
+        rowNumber: 4,
+        value: "cara@example.com",
+        reason: "batch_limit",
+      },
+    ])
+  })
+})
+
+describe("buildManualVolunteerMetadata", () => {
+  it("defaults missing volunteer roles through the roster role helper", () => {
+    const metadata = buildManualVolunteerMetadata(
+      {
+        email: " ADA@example.com ",
+        name: "Ada Lovelace",
+        phone: "555-0100",
+        availability: VOLUNTEER_AVAILABILITY.MORNING,
+        availabilityNotes: "Before lunch",
+        notes: "Can lead check-in",
+      },
+      new Date("2026-06-19T12:00:00.000Z"),
+    )
+
+    expect(metadata).toMatchObject({
+      volunteerRoleTypes: [VOLUNTEER_ROLE_TYPES.GENERAL],
+      availability: VOLUNTEER_AVAILABILITY.MORNING,
+      availabilityNotes: "Before lunch",
+      internalNotes: "Can lead check-in",
+      status: "pending",
+      inviteSource: VOLUNTEER_INVITE_SOURCE.DIRECT,
+      signupEmail: "ada@example.com",
+      signupName: "Ada Lovelace",
+      signupPhone: "555-0100",
+      crewSignupSource: "manual_operator",
+      manualCreatedAt: "2026-06-19T12:00:00.000Z",
+    })
+  })
+})
+
+describe("planManualVolunteerIntake", () => {
+  it("creates a pending invitation when no roster row exists", () => {
+    expect(
+      planManualVolunteerIntake("ada@example.com", {
+        existingInvitations: [],
+        existingMemberships: [],
+      }),
+    ).toEqual({ action: "create_invitation", targetId: null })
+  })
+
+  it("skips existing invitations and memberships by normalized email", () => {
+    expect(
+      planManualVolunteerIntake("ADA@example.com", {
+        existingInvitations: [
+          {
+            id: "tinv_pending",
+            email: "ada@example.com",
+            status: INVITATION_STATUS.PENDING,
+          },
+        ],
+        existingMemberships: [],
+      }),
+    ).toMatchObject({
+      action: "skip",
+      targetId: "tinv_pending",
+      reason: "pending_invitation",
+    })
+
+    expect(
+      planManualVolunteerIntake("ada@example.com", {
+        existingInvitations: [],
+        existingMemberships: [
+          {
+            id: "tmem_active",
+            email: "ADA@example.com",
+            isActive: true,
+          },
+        ],
+      }),
+    ).toMatchObject({
+      action: "skip",
+      targetId: "tmem_active",
+      reason: "active_membership",
+    })
+  })
+
+  it("uses metadata signup emails for duplicate checks", () => {
+    const plan = planManualVolunteerIntake("ada@example.com", {
+      existingInvitations: [],
+      existingMemberships: [
+        {
+          id: "tmem_metadata",
+          email: "account@example.com",
+          isActive: true,
+          metadata: JSON.stringify({ signupEmail: "ADA@example.com" }),
+        },
+      ],
+    })
+
+    expect(plan).toMatchObject({
+      action: "skip",
+      targetId: "tmem_metadata",
+      reason: "active_membership",
+    })
+  })
+})

--- a/apps/crew/src/lib/crew/manual-volunteer-intake.test.ts
+++ b/apps/crew/src/lib/crew/manual-volunteer-intake.test.ts
@@ -47,14 +47,11 @@ describe("parseManualVolunteerEmailPaste", () => {
 
   it("reports invalid rows and batch limit rows", () => {
     const result = parseManualVolunteerEmailPaste(
-      "ada@example.com,not-an-email,bob@example.com,cara@example.com",
-      2,
+      "ada@example.com,not-an-email,bob@example.com,bob@example.com",
+      1,
     )
 
-    expect(result.valid.map((row) => row.email)).toEqual([
-      "ada@example.com",
-      "bob@example.com",
-    ])
+    expect(result.valid.map((row) => row.email)).toEqual(["ada@example.com"])
     expect(result.invalid).toEqual([
       {
         rowNumber: 2,
@@ -62,11 +59,17 @@ describe("parseManualVolunteerEmailPaste", () => {
         reason: "invalid_email",
       },
       {
+        rowNumber: 3,
+        value: "bob@example.com",
+        reason: "batch_limit",
+      },
+      {
         rowNumber: 4,
-        value: "cara@example.com",
+        value: "bob@example.com",
         reason: "batch_limit",
       },
     ])
+    expect(result.skipped).toEqual([])
   })
 })
 

--- a/apps/crew/src/lib/crew/manual-volunteer-intake.ts
+++ b/apps/crew/src/lib/crew/manual-volunteer-intake.ts
@@ -1,0 +1,246 @@
+// @lat: [[crew#Manual Volunteer Intake]]
+import { INVITATION_STATUS } from "../../db/schemas/teams"
+import type {
+  VolunteerAvailability,
+  VolunteerMembershipMetadata,
+  VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+import { VOLUNTEER_INVITE_SOURCE } from "../../db/schemas/volunteers"
+import {
+  getCrewRosterRoleTypes,
+  parseCrewRosterMetadata,
+} from "./roster-shifts"
+
+export const MANUAL_VOLUNTEER_PASTE_BATCH_LIMIT = 500
+
+export interface ManualVolunteerMetadataInput {
+  email: string
+  name?: string
+  phone?: string
+  roleTypes?: VolunteerRoleType[]
+  availability?: VolunteerAvailability | ""
+  availabilityNotes?: string
+  notes?: string
+}
+
+export type ManualVolunteerMetadata = VolunteerMembershipMetadata & {
+  crewSignupSource?: "manual_operator"
+  manualCreatedAt?: string
+}
+
+export interface ManualVolunteerPasteValidRow {
+  rowNumber: number
+  email: string
+}
+
+export interface ManualVolunteerPasteSkippedRow {
+  rowNumber: number
+  email: string
+  reason: "duplicate_in_paste"
+}
+
+export interface ManualVolunteerPasteInvalidRow {
+  rowNumber: number
+  value: string
+  reason: "invalid_email" | "batch_limit"
+}
+
+export interface ManualVolunteerPasteParseResult {
+  valid: ManualVolunteerPasteValidRow[]
+  skipped: ManualVolunteerPasteSkippedRow[]
+  invalid: ManualVolunteerPasteInvalidRow[]
+}
+
+export interface ExistingManualVolunteerInvitation {
+  id: string
+  email: string
+  acceptedAt?: Date | string | null
+  status?: string | null
+  metadata?: string | null
+}
+
+export interface ExistingManualVolunteerMembership {
+  id: string
+  email?: string | null
+  isActive?: boolean | null
+  metadata?: string | null
+}
+
+export type ManualVolunteerIntakePlan =
+  | {
+      action: "create_invitation"
+      targetId: null
+    }
+  | {
+      action: "skip"
+      targetId: string
+      reason:
+        | "pending_invitation"
+        | "accepted_invitation"
+        | "active_membership"
+        | "inactive_membership"
+      message: string
+    }
+
+export function normalizeManualVolunteerEmail(value: string) {
+  return value.trim().toLowerCase()
+}
+
+export function parseManualVolunteerEmailPaste(
+  pasteText: string,
+  limit = MANUAL_VOLUNTEER_PASTE_BATCH_LIMIT,
+): ManualVolunteerPasteParseResult {
+  const result: ManualVolunteerPasteParseResult = {
+    valid: [],
+    skipped: [],
+    invalid: [],
+  }
+  const seenEmails = new Set<string>()
+  const values = pasteText
+    .split(/[\n,]+/)
+    .map((value) => value.trim())
+    .filter(Boolean)
+
+  values.forEach((value, index) => {
+    const rowNumber = index + 1
+    const email = normalizeManualVolunteerEmail(value)
+
+    if (!isValidVolunteerEmail(email)) {
+      result.invalid.push({ rowNumber, value, reason: "invalid_email" })
+      return
+    }
+
+    if (seenEmails.has(email)) {
+      result.skipped.push({ rowNumber, email, reason: "duplicate_in_paste" })
+      return
+    }
+
+    seenEmails.add(email)
+    if (result.valid.length >= limit) {
+      result.invalid.push({ rowNumber, value, reason: "batch_limit" })
+      return
+    }
+
+    result.valid.push({ rowNumber, email })
+  })
+
+  return result
+}
+
+export function buildManualVolunteerMetadata(
+  input: ManualVolunteerMetadataInput,
+  createdAt = new Date(),
+): ManualVolunteerMetadata {
+  const availability = input.availability || undefined
+
+  return removeUndefined({
+    volunteerRoleTypes: getCrewRosterRoleTypes(input.roleTypes),
+    availability,
+    availabilityNotes: emptyToUndefined(input.availabilityNotes),
+    internalNotes: emptyToUndefined(input.notes),
+    status: "pending" as const,
+    inviteSource: VOLUNTEER_INVITE_SOURCE.DIRECT,
+    signupEmail: normalizeManualVolunteerEmail(input.email),
+    signupName: emptyToUndefined(input.name),
+    signupPhone: emptyToUndefined(input.phone),
+    crewSignupSource: "manual_operator" as const,
+    manualCreatedAt: createdAt.toISOString(),
+  })
+}
+
+export function planManualVolunteerIntake(
+  emailInput: string,
+  context: {
+    existingInvitations: ExistingManualVolunteerInvitation[]
+    existingMemberships: ExistingManualVolunteerMembership[]
+  },
+): ManualVolunteerIntakePlan {
+  const email = normalizeManualVolunteerEmail(emailInput)
+  const matchingMembership = context.existingMemberships.find((membership) =>
+    getExistingMembershipEmails(membership).includes(email),
+  )
+
+  if (matchingMembership) {
+    if (matchingMembership.isActive === false) {
+      return {
+        action: "skip",
+        targetId: matchingMembership.id,
+        reason: "inactive_membership",
+        message: "A matching inactive volunteer membership already exists.",
+      }
+    }
+
+    return {
+      action: "skip",
+      targetId: matchingMembership.id,
+      reason: "active_membership",
+      message: "A matching volunteer membership already exists.",
+    }
+  }
+
+  const matchingInvitation = context.existingInvitations.find((invitation) =>
+    getExistingInvitationEmails(invitation).includes(email),
+  )
+
+  if (matchingInvitation) {
+    if (
+      matchingInvitation.acceptedAt ||
+      matchingInvitation.status === INVITATION_STATUS.ACCEPTED
+    ) {
+      return {
+        action: "skip",
+        targetId: matchingInvitation.id,
+        reason: "accepted_invitation",
+        message: "A matching accepted volunteer invitation already exists.",
+      }
+    }
+
+    return {
+      action: "skip",
+      targetId: matchingInvitation.id,
+      reason: "pending_invitation",
+      message: "A matching pending volunteer invitation already exists.",
+    }
+  }
+
+  return { action: "create_invitation", targetId: null }
+}
+
+export function getExistingInvitationEmails(
+  invitation: ExistingManualVolunteerInvitation,
+) {
+  return normalizeExistingEmails(invitation.email, invitation.metadata)
+}
+
+export function getExistingMembershipEmails(
+  membership: ExistingManualVolunteerMembership,
+) {
+  return normalizeExistingEmails(membership.email, membership.metadata)
+}
+
+function normalizeExistingEmails(
+  email: string | null | undefined,
+  metadata: string | null | undefined,
+) {
+  const parsed = parseCrewRosterMetadata(metadata)
+  return [
+    normalizeManualVolunteerEmail(email ?? ""),
+    normalizeManualVolunteerEmail(parsed.signupEmail ?? ""),
+  ].filter(Boolean)
+}
+
+function isValidVolunteerEmail(email: string) {
+  if (email.length === 0 || email.length > 255) return false
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+}
+
+function emptyToUndefined(value: string | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function removeUndefined<T extends Record<string, unknown>>(value: T) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T
+}

--- a/apps/crew/src/lib/crew/manual-volunteer-intake.ts
+++ b/apps/crew/src/lib/crew/manual-volunteer-intake.ts
@@ -115,12 +115,12 @@ export function parseManualVolunteerEmailPaste(
       return
     }
 
-    seenEmails.add(email)
     if (result.valid.length >= limit) {
       result.invalid.push({ rowNumber, value, reason: "batch_limit" })
       return
     }
 
+    seenEmails.add(email)
     result.valid.push({ rowNumber, email })
   })
 

--- a/apps/crew/src/routes/events/$eventId/volunteers.tsx
+++ b/apps/crew/src/routes/events/$eventId/volunteers.tsx
@@ -1,12 +1,48 @@
-import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import type { FormEvent, ReactNode } from "react"
+import {
+  createFileRoute,
+  getRouteApi,
+  Link,
+  useRouter,
+} from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { ClipboardPaste, Loader2, UserPlus } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import type {
+  VolunteerAvailability,
+  VolunteerRoleType,
+} from "@/db/schemas/volunteers"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_ROLE_OPTIONS,
+} from "@/db/schemas/volunteers"
 import { formatCrewValue } from "@/lib/crew-event-display"
+import type {
+  CrewRosterStatus,
+  CrewRosterVolunteer,
+} from "@/lib/crew/roster-shifts"
 import {
   formatVolunteerAvailability,
   formatVolunteerRole,
-  type CrewRosterStatus,
-  type CrewRosterVolunteer,
 } from "@/lib/crew/roster-shifts"
-import { getCrewRosterPageFn } from "@/server-fns/crew-roster-shift-fns"
+import type { ManualCrewVolunteerMutationResult } from "@/server-fns/crew-roster-shift-fns"
+import {
+  createManualCrewVolunteerFn,
+  getCrewRosterPageFn,
+  pasteManualCrewVolunteerEmailsFn,
+} from "@/server-fns/crew-roster-shift-fns"
 
 export const Route = createFileRoute("/events/$eventId/volunteers")({
   loader: async ({ params }) =>
@@ -19,6 +55,12 @@ const parentRoute = getRouteApi("/events/$eventId")
 function VolunteersPage() {
   const { eventId } = parentRoute.useParams()
   const { roster, summary, shiftSummary } = Route.useLoaderData()
+  const router = useRouter()
+  const [addOpen, setAddOpen] = useState(false)
+  const [pasteOpen, setPasteOpen] = useState(false)
+  const reloadRoster = async () => {
+    await router.invalidate()
+  }
 
   return (
     <section className="space-y-6">
@@ -29,13 +71,21 @@ function VolunteersPage() {
             {summary.total} volunteers, {summary.assignable} assignable
           </p>
         </div>
-        <Link
-          to="/events/$eventId/shifts"
-          params={{ eventId }}
-          className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-        >
-          Manage shifts
-        </Link>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="outline" onClick={() => setPasteOpen(true)}>
+            <ClipboardPaste />
+            Paste emails
+          </Button>
+          <Button onClick={() => setAddOpen(true)}>
+            <UserPlus />
+            Add volunteer
+          </Button>
+          <Button asChild variant="outline">
+            <Link to="/events/$eventId/shifts" params={{ eventId }}>
+              Manage shifts
+            </Link>
+          </Button>
+        </div>
       </div>
 
       <div className="grid gap-4 md:grid-cols-5">
@@ -76,14 +126,425 @@ function VolunteersPage() {
           <div className="p-8 text-center">
             <h3 className="font-semibold">No volunteers yet</h3>
             <p className="mt-2 text-sm text-muted-foreground">
-              Import volunteers or share the public signup link to build the
-              roster.
+              Add volunteers one at a time, paste a list of emails, share the
+              public signup link, or import a file to build the roster.
             </p>
           </div>
         )}
       </section>
+
+      <AddVolunteerDialog
+        open={addOpen}
+        eventId={eventId}
+        onOpenChange={setAddOpen}
+        onCreated={reloadRoster}
+      />
+      <PasteVolunteerEmailsDialog
+        open={pasteOpen}
+        eventId={eventId}
+        onOpenChange={setPasteOpen}
+        onCreated={reloadRoster}
+      />
     </section>
   )
+}
+
+function AddVolunteerDialog({
+  open,
+  eventId,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean
+  eventId: string
+  onOpenChange: (open: boolean) => void
+  onCreated: () => Promise<void>
+}) {
+  const createVolunteer = useServerFn(createManualCrewVolunteerFn)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    const availability = getFormString(formData, "availability")
+
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      const result = await createVolunteer({
+        data: {
+          eventId,
+          email: getFormString(formData, "email"),
+          name: getFormString(formData, "name"),
+          phone: getFormString(formData, "phone"),
+          roleTypes: getFormStringList(formData, "roleTypes"),
+          availability: availability
+            ? (availability as VolunteerAvailability)
+            : undefined,
+          availabilityNotes: getFormString(formData, "availabilityNotes"),
+          notes: getFormString(formData, "notes"),
+        },
+      })
+
+      if (result.summary.created > 0) {
+        toast.success("Volunteer added")
+        form.reset()
+        onOpenChange(false)
+        await onCreated()
+      } else if (result.skipped.length > 0) {
+        const skipped = result.skipped[0]
+        const message = skipped?.message ?? "Volunteer already exists"
+        toast.warning(message)
+        setError(message)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Volunteer add failed")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) setError(null)
+        onOpenChange(nextOpen)
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Add volunteer</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Email" htmlFor="manual-volunteer-email">
+              <Input
+                id="manual-volunteer-email"
+                name="email"
+                type="email"
+                required
+                disabled={isSubmitting}
+              />
+            </Field>
+            <Field label="Name" htmlFor="manual-volunteer-name">
+              <Input
+                id="manual-volunteer-name"
+                name="name"
+                disabled={isSubmitting}
+              />
+            </Field>
+            <Field label="Phone" htmlFor="manual-volunteer-phone">
+              <Input
+                id="manual-volunteer-phone"
+                name="phone"
+                disabled={isSubmitting}
+              />
+            </Field>
+            <Field label="Availability" htmlFor="manual-volunteer-availability">
+              <select
+                id="manual-volunteer-availability"
+                name="availability"
+                className="h-10 rounded-md border bg-background px-3 text-sm"
+                disabled={isSubmitting}
+                defaultValue=""
+              >
+                <option value="">Not set</option>
+                <option value={VOLUNTEER_AVAILABILITY.MORNING}>Morning</option>
+                <option value={VOLUNTEER_AVAILABILITY.AFTERNOON}>
+                  Afternoon
+                </option>
+                <option value={VOLUNTEER_AVAILABILITY.ALL_DAY}>All day</option>
+              </select>
+            </Field>
+          </div>
+
+          <RoleTypeCheckboxes disabled={isSubmitting} />
+
+          <Field
+            label="Availability notes"
+            htmlFor="manual-volunteer-availability-notes"
+          >
+            <Textarea
+              id="manual-volunteer-availability-notes"
+              name="availabilityNotes"
+              disabled={isSubmitting}
+            />
+          </Field>
+
+          <Field label="Notes" htmlFor="manual-volunteer-notes">
+            <Textarea
+              id="manual-volunteer-notes"
+              name="notes"
+              disabled={isSubmitting}
+            />
+          </Field>
+
+          {error ? (
+            <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? <Loader2 className="animate-spin" /> : null}
+              Add volunteer
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function PasteVolunteerEmailsDialog({
+  open,
+  eventId,
+  onOpenChange,
+  onCreated,
+}: {
+  open: boolean
+  eventId: string
+  onOpenChange: (open: boolean) => void
+  onCreated: () => Promise<void>
+}) {
+  const pasteVolunteers = useServerFn(pasteManualCrewVolunteerEmailsFn)
+  const [pasteText, setPasteText] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] =
+    useState<ManualCrewVolunteerMutationResult | null>(null)
+
+  async function handleSubmit() {
+    setIsSubmitting(true)
+    setError(null)
+    setResult(null)
+    try {
+      const nextResult = await pasteVolunteers({
+        data: { eventId, pasteText },
+      })
+      setResult(nextResult)
+      if (nextResult.summary.created > 0) {
+        await onCreated()
+      }
+      const message = formatManualVolunteerResult(nextResult)
+      if (nextResult.summary.invalid > 0 || nextResult.summary.skipped > 0) {
+        toast.warning(message)
+      } else {
+        toast.success(message)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Email paste failed")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) {
+          setPasteText("")
+          setError(null)
+          setResult(null)
+        }
+        onOpenChange(nextOpen)
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Paste emails</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <Field label="Emails" htmlFor="manual-volunteer-paste">
+            <Textarea
+              id="manual-volunteer-paste"
+              className="h-48 font-mono text-sm"
+              value={pasteText}
+              onChange={(event) => setPasteText(event.target.value)}
+              disabled={isSubmitting}
+              placeholder={`jane@example.com\nbob@example.com\nor: jane@example.com, bob@example.com`}
+            />
+          </Field>
+
+          {result ? <ManualVolunteerResult result={result} /> : null}
+
+          {error ? (
+            <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              {result ? "Done" : "Cancel"}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleSubmit}
+              disabled={isSubmitting || pasteText.trim().length === 0}
+            >
+              {isSubmitting ? <Loader2 className="animate-spin" /> : null}
+              Add emails
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RoleTypeCheckboxes({ disabled }: { disabled: boolean }) {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-medium">Roles</legend>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {VOLUNTEER_ROLE_OPTIONS.map((option) => (
+          <label
+            key={option.value}
+            className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+          >
+            <input
+              type="checkbox"
+              name="roleTypes"
+              value={option.value}
+              disabled={disabled}
+              className="size-4"
+            />
+            {option.label}
+          </label>
+        ))}
+      </div>
+    </fieldset>
+  )
+}
+
+function ManualVolunteerResult({
+  result,
+}: {
+  result: ManualCrewVolunteerMutationResult
+}) {
+  return (
+    <section className="space-y-3 rounded-md border bg-muted/40 p-3 text-sm">
+      <div className="grid gap-2 sm:grid-cols-3">
+        <ResultCount label="Created" value={result.summary.created} />
+        <ResultCount label="Skipped" value={result.summary.skipped} />
+        <ResultCount label="Invalid" value={result.summary.invalid} />
+      </div>
+      {result.skipped.length > 0 ? (
+        <ResultList
+          label="Skipped rows"
+          rows={result.skipped.map(
+            (row) => `${row.rowNumber}: ${row.email} - ${row.message}`,
+          )}
+        />
+      ) : null}
+      {result.invalid.length > 0 ? (
+        <ResultList
+          label="Invalid rows"
+          rows={result.invalid.map(
+            (row) =>
+              `${row.rowNumber}: ${row.value} - ${formatInvalidReason(
+                row.reason,
+              )}`,
+          )}
+        />
+      ) : null}
+    </section>
+  )
+}
+
+function ResultCount({ label, value }: { label: string; value: number }) {
+  return (
+    <div>
+      <p className="text-muted-foreground">{label}</p>
+      <p className="font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function ResultList({ label, rows }: { label: string; rows: string[] }) {
+  const visibleRows = rows.slice(0, 8)
+  return (
+    <div>
+      <p className="font-medium">{label}</p>
+      <ul className="mt-1 space-y-1 text-muted-foreground">
+        {visibleRows.map((row) => (
+          <li key={row}>{row}</li>
+        ))}
+        {rows.length > visibleRows.length ? (
+          <li>{rows.length - visibleRows.length} more</li>
+        ) : null}
+      </ul>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string
+  htmlFor: string
+  children: ReactNode
+}) {
+  return (
+    <div className="grid gap-1 text-sm">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+    </div>
+  )
+}
+
+function formatManualVolunteerResult(
+  result: ManualCrewVolunteerMutationResult,
+) {
+  const parts = [`${result.summary.created} created`]
+  if (result.summary.skipped > 0)
+    parts.push(`${result.summary.skipped} skipped`)
+  if (result.summary.invalid > 0)
+    parts.push(`${result.summary.invalid} invalid`)
+  return parts.join(" · ")
+}
+
+function formatInvalidReason(
+  reason: ManualCrewVolunteerMutationResult["invalid"][number]["reason"],
+) {
+  if (reason === "batch_limit") return "Batch limit reached"
+  return "Invalid email"
+}
+
+function getFormString(formData: FormData, name: string) {
+  const value = formData.get(name)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function getFormStringList(
+  formData: FormData,
+  name: string,
+): VolunteerRoleType[] {
+  return formData
+    .getAll(name)
+    .filter((value): value is string => typeof value === "string")
+    .map((value) => value as VolunteerRoleType)
 }
 
 function VolunteerRow({ volunteer }: { volunteer: CrewRosterVolunteer }) {

--- a/apps/crew/src/server-fns/crew-roster-shift-fns.ts
+++ b/apps/crew/src/server-fns/crew-roster-shift-fns.ts
@@ -1,7 +1,11 @@
 // @lat: [[crew#Roster Shifts Assignments]]
 // @lat: [[crew#Server Function Runtime Boundary]]
+// @lat: [[crew#Manual Volunteer Intake]]
 import { createServerFn } from "@tanstack/react-start"
-import { VOLUNTEER_ROLE_TYPE_VALUES } from "@repo/wodsmith-db/schemas/volunteers"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_ROLE_TYPE_VALUES,
+} from "@repo/wodsmith-db/schemas/volunteers"
 import { z } from "zod"
 
 export type {
@@ -9,6 +13,7 @@ export type {
   CrewShiftBoardData,
   CrewShiftBoardItem,
   CrewShiftSummary,
+  ManualCrewVolunteerMutationResult,
 } from "../server/crew-roster-shift.server"
 
 const eventIdSchema = z.string().min(1, "Event ID is required")
@@ -18,6 +23,13 @@ const membershipIdSchema = z
   .string()
   .startsWith("tmem_", "Invalid membership ID")
 const roleTypeSchema = z.enum(VOLUNTEER_ROLE_TYPE_VALUES)
+const availabilitySchema = z
+  .enum([
+    VOLUNTEER_AVAILABILITY.MORNING,
+    VOLUNTEER_AVAILABILITY.AFTERNOON,
+    VOLUNTEER_AVAILABILITY.ALL_DAY,
+  ])
+  .optional()
 const shiftTextSchema = z.string().trim().max(1000).optional()
 const shiftDateSchema = z
   .string()
@@ -69,6 +81,30 @@ const deleteShiftInputSchema = z.object({
   shiftId: shiftIdSchema,
 })
 
+const manualVolunteerMetadataInputSchema = z.object({
+  eventId: eventIdSchema,
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Enter a valid email address")
+    .max(255),
+  name: z.string().trim().max(200).optional(),
+  phone: z.string().trim().max(50).optional(),
+  roleTypes: z
+    .array(roleTypeSchema)
+    .max(VOLUNTEER_ROLE_TYPE_VALUES.length)
+    .optional(),
+  availability: availabilitySchema,
+  availabilityNotes: z.string().trim().max(5000).optional(),
+  notes: z.string().trim().max(5000).optional(),
+})
+
+const manualVolunteerPasteInputSchema = z.object({
+  eventId: eventIdSchema,
+  pasteText: z.string().trim().min(1, "Paste at least one email").max(50000),
+})
+
 export const getCrewRosterPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => eventInputSchema.parse(data))
   .handler(async ({ data }) => {
@@ -105,6 +141,30 @@ export const createCrewShiftFn = createServerFn({ method: "POST" })
       "../server/crew-roster-shift.server"
     )
     return createCrewShift(data)
+  })
+
+export const createManualCrewVolunteerFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    manualVolunteerMetadataInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { createManualCrewVolunteer } = await import(
+      "../server/crew-roster-shift.server"
+    )
+    return createManualCrewVolunteer(data)
+  })
+
+export const pasteManualCrewVolunteerEmailsFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) =>
+    manualVolunteerPasteInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { pasteManualCrewVolunteerEmails } = await import(
+      "../server/crew-roster-shift.server"
+    )
+    return pasteManualCrewVolunteerEmails(data)
   })
 
 export const updateCrewShiftFn = createServerFn({ method: "POST" })

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -692,6 +692,8 @@ async function createManualCrewVolunteerRows(
 
     for (const row of rows) {
       const email = normalizeManualVolunteerEmail(row.email)
+      // team_invitations has no team/email uniqueness constraint, so serialize
+      // each manual intake write before rereading duplicate state.
       await withManualVolunteerIntakeLock(
         client,
         event.competitionTeamId,

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -1,7 +1,7 @@
 // @lat: [[crew#Roster Shifts Assignments]]
 // @lat: [[crew#Manual Volunteer Intake]]
 import { createId } from "@paralleldrive/cuid2"
-import { and, asc, eq, inArray } from "drizzle-orm"
+import { and, asc, eq, inArray, sql } from "drizzle-orm"
 import { getDb } from "../db"
 import {
   createTeamInvitationId,
@@ -62,6 +62,7 @@ import {
   DEFAULT_TIMEZONE,
   formatDateTimeInTimezone,
 } from "../utils/timezone-utils"
+import { getFirstExecuteValue } from "../server-fns/db-execute"
 
 type DbClient = ReturnType<typeof getDb>
 
@@ -688,65 +689,66 @@ async function createManualCrewVolunteerRows(
 
   await db.transaction(async (tx) => {
     const client = tx as unknown as DbClient
-    const [existingInvitations, existingMemberships] = await Promise.all([
-      listManualVolunteerInvitations(client, event.competitionTeamId),
-      listManualVolunteerMemberships(client, event.competitionTeamId),
-    ])
 
     for (const row of rows) {
       const email = normalizeManualVolunteerEmail(row.email)
-      const plan = planManualVolunteerIntake(email, {
-        existingInvitations,
-        existingMemberships,
-      })
+      await withManualVolunteerIntakeLock(
+        client,
+        event.competitionTeamId,
+        email,
+        async () => {
+          const [existingInvitations, existingMemberships] = await Promise.all([
+            listManualVolunteerInvitations(client, event.competitionTeamId),
+            listManualVolunteerMemberships(client, event.competitionTeamId),
+          ])
+          const plan = planManualVolunteerIntake(email, {
+            existingInvitations,
+            existingMemberships,
+          })
 
-      if (plan.action === "skip") {
-        skipped.push({
-          rowNumber: row.rowNumber,
-          email,
-          reason: plan.reason,
-          message: plan.message,
-          targetId: plan.targetId,
-        })
-        continue
-      }
+          if (plan.action === "skip") {
+            skipped.push({
+              rowNumber: row.rowNumber,
+              email,
+              reason: plan.reason,
+              message: plan.message,
+              targetId: plan.targetId,
+            })
+            return
+          }
 
-      const invitationId = createTeamInvitationId()
-      const metadata = buildManualVolunteerMetadata(
-        {
-          ...row,
-          email,
+          const invitationId = createTeamInvitationId()
+          const metadata = buildManualVolunteerMetadata(
+            {
+              ...row,
+              email,
+            },
+            timestamp,
+          )
+          const metadataJson = JSON.stringify(metadata)
+
+          await client.insert(teamInvitationTable).values({
+            id: invitationId,
+            teamId: event.competitionTeamId,
+            email,
+            roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+            isSystemRole: true,
+            token: createId(),
+            invitedBy: null,
+            expiresAt,
+            status: INVITATION_STATUS.PENDING,
+            metadata: metadataJson,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          })
+
+          created.push({
+            rowNumber: row.rowNumber,
+            email,
+            invitationId,
+          })
         },
-        timestamp,
       )
-      const metadataJson = JSON.stringify(metadata)
-
-      await client.insert(teamInvitationTable).values({
-        id: invitationId,
-        teamId: event.competitionTeamId,
-        email,
-        roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
-        isSystemRole: true,
-        token: createId(),
-        invitedBy: null,
-        expiresAt,
-        status: INVITATION_STATUS.PENDING,
-        metadata: metadataJson,
-        createdAt: timestamp,
-        updatedAt: timestamp,
-      })
-
-      existingInvitations.push({
-        id: invitationId,
-        email,
-        status: INVITATION_STATUS.PENDING,
-        metadata: metadataJson,
-      })
-      created.push({
-        rowNumber: row.rowNumber,
-        email,
-        invitationId,
-      })
     }
   })
 
@@ -755,6 +757,48 @@ async function createManualCrewVolunteerRows(
     skipped,
     invalid: [],
   })
+}
+
+async function withManualVolunteerIntakeLock<T>(
+  db: DbClient,
+  competitionTeamId: string,
+  email: string,
+  callback: () => Promise<T>,
+) {
+  let acquired = false
+  const lockName = await createManualVolunteerIntakeLockName(
+    competitionTeamId,
+    email,
+  )
+
+  try {
+    const result = await db.execute(
+      sql`SELECT GET_LOCK(${lockName}, 5) FROM dual`,
+    )
+    acquired = Number(getFirstExecuteValue(result) ?? 0) === 1
+    if (!acquired) {
+      throw new Error("Manual volunteer could not be saved")
+    }
+
+    return await callback()
+  } finally {
+    if (acquired) {
+      await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
+    }
+  }
+}
+
+async function createManualVolunteerIntakeLockName(
+  competitionTeamId: string,
+  email: string,
+) {
+  const encoded = new TextEncoder().encode(
+    `crew-manual-volunteer:${competitionTeamId}:${email}`,
+  )
+  const digest = await crypto.subtle.digest("SHA-256", encoded)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")
 }
 
 async function listManualVolunteerInvitations(

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -687,68 +687,71 @@ async function createManualCrewVolunteerRows(
   const expiresAt = new Date(timestamp)
   expiresAt.setFullYear(expiresAt.getFullYear() + 1)
 
-  for (const row of rows) {
-    const email = normalizeManualVolunteerEmail(row.email)
-    // team_invitations has no team/email uniqueness constraint, so the lock
-    // wraps the duplicate reread and autocommitted insert before release.
-    await withManualVolunteerIntakeLock(
-      db,
-      event.competitionTeamId,
-      email,
-      async () => {
-        const [existingInvitations, existingMemberships] = await Promise.all([
-          listManualVolunteerInvitations(db, event.competitionTeamId),
-          listManualVolunteerMemberships(db, event.competitionTeamId),
-        ])
-        const plan = planManualVolunteerIntake(email, {
-          existingInvitations,
-          existingMemberships,
-        })
+  // team_invitations has no team/email uniqueness constraint, so serialize
+  // manual intake for this roster until the batch transaction commits.
+  await withManualVolunteerIntakeBatchLock(
+    db,
+    event.competitionTeamId,
+    async () => {
+      await db.transaction(async (tx) => {
+        const client = tx as unknown as DbClient
 
-        if (plan.action === "skip") {
-          skipped.push({
+        for (const row of rows) {
+          const email = normalizeManualVolunteerEmail(row.email)
+          const [existingInvitations, existingMemberships] = await Promise.all([
+            listManualVolunteerInvitations(client, event.competitionTeamId),
+            listManualVolunteerMemberships(client, event.competitionTeamId),
+          ])
+          const plan = planManualVolunteerIntake(email, {
+            existingInvitations,
+            existingMemberships,
+          })
+
+          if (plan.action === "skip") {
+            skipped.push({
+              rowNumber: row.rowNumber,
+              email,
+              reason: plan.reason,
+              message: plan.message,
+              targetId: plan.targetId,
+            })
+            continue
+          }
+
+          const invitationId = createTeamInvitationId()
+          const metadata = buildManualVolunteerMetadata(
+            {
+              ...row,
+              email,
+            },
+            timestamp,
+          )
+          const metadataJson = JSON.stringify(metadata)
+
+          await client.insert(teamInvitationTable).values({
+            id: invitationId,
+            teamId: event.competitionTeamId,
+            email,
+            roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+            isSystemRole: true,
+            token: createId(),
+            invitedBy: null,
+            expiresAt,
+            status: INVITATION_STATUS.PENDING,
+            metadata: metadataJson,
+            createdAt: timestamp,
+            updatedAt: timestamp,
+          })
+
+          created.push({
             rowNumber: row.rowNumber,
             email,
-            reason: plan.reason,
-            message: plan.message,
-            targetId: plan.targetId,
+            invitationId,
           })
-          return
         }
-
-        const invitationId = createTeamInvitationId()
-        const metadata = buildManualVolunteerMetadata(
-          {
-            ...row,
-            email,
-          },
-          timestamp,
-        )
-        const metadataJson = JSON.stringify(metadata)
-
-        await db.insert(teamInvitationTable).values({
-          id: invitationId,
-          teamId: event.competitionTeamId,
-          email,
-          roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
-          isSystemRole: true,
-          token: createId(),
-          invitedBy: null,
-          expiresAt,
-          status: INVITATION_STATUS.PENDING,
-          metadata: metadataJson,
-          createdAt: timestamp,
-          updatedAt: timestamp,
-        })
-
-        created.push({
-          rowNumber: row.rowNumber,
-          email,
-          invitationId,
-        })
-      },
-    )
-  }
+      })
+    },
+  )
 
   return buildManualCrewVolunteerMutationResult({
     created,
@@ -757,17 +760,14 @@ async function createManualCrewVolunteerRows(
   })
 }
 
-async function withManualVolunteerIntakeLock<T>(
+async function withManualVolunteerIntakeBatchLock<T>(
   db: DbClient,
   competitionTeamId: string,
-  email: string,
   callback: () => Promise<T>,
 ) {
   let acquired = false
-  const lockName = await createManualVolunteerIntakeLockName(
-    competitionTeamId,
-    email,
-  )
+  const lockName =
+    await createManualVolunteerIntakeBatchLockName(competitionTeamId)
 
   try {
     const result = await db.execute(
@@ -786,12 +786,11 @@ async function withManualVolunteerIntakeLock<T>(
   }
 }
 
-async function createManualVolunteerIntakeLockName(
+async function createManualVolunteerIntakeBatchLockName(
   competitionTeamId: string,
-  email: string,
 ) {
   const encoded = new TextEncoder().encode(
-    `crew-manual-volunteer:${competitionTeamId}:${email}`,
+    `crew-manual-volunteer:${competitionTeamId}`,
   )
   const digest = await crypto.subtle.digest("SHA-256", encoded)
   return Array.from(new Uint8Array(digest), (byte) =>

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -1,20 +1,45 @@
 // @lat: [[crew#Roster Shifts Assignments]]
+// @lat: [[crew#Manual Volunteer Intake]]
+import { createId } from "@paralleldrive/cuid2"
 import { and, asc, eq, inArray } from "drizzle-orm"
 import { getDb } from "../db"
-import { createVolunteerShiftAssignmentId } from "../db/schemas/common"
-import { competitionsTable, type Competition } from "../db/schemas/competitions"
+import {
+  createTeamInvitationId,
+  createVolunteerShiftAssignmentId,
+} from "../db/schemas/common"
+import type { Competition } from "../db/schemas/competitions"
+import { competitionsTable } from "../db/schemas/competitions"
 import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
 import {
+  INVITATION_STATUS,
   SYSTEM_ROLES_ENUM,
   teamInvitationTable,
   teamMembershipTable,
 } from "../db/schemas/teams"
 import { userTable } from "../db/schemas/users"
+import type {
+  VolunteerAvailability,
+  VolunteerRoleType,
+} from "../db/schemas/volunteers"
 import {
   volunteerShiftAssignmentsTable,
   volunteerShiftsTable,
-  type VolunteerRoleType,
 } from "../db/schemas/volunteers"
+import type {
+  ExistingManualVolunteerInvitation,
+  ExistingManualVolunteerMembership,
+  ManualVolunteerPasteInvalidRow,
+} from "../lib/crew/manual-volunteer-intake"
+import {
+  buildManualVolunteerMetadata,
+  normalizeManualVolunteerEmail,
+  parseManualVolunteerEmailPaste,
+  planManualVolunteerIntake,
+} from "../lib/crew/manual-volunteer-intake"
+import type {
+  CrewRosterSummary,
+  CrewRosterVolunteer,
+} from "../lib/crew/roster-shifts"
 import {
   buildCrewRoster,
   formatVolunteerRole,
@@ -24,8 +49,6 @@ import {
   summarizeCrewRoster,
   validateShiftAssignment,
   validateShiftCapacityUpdate,
-  type CrewRosterSummary,
-  type CrewRosterVolunteer,
 } from "../lib/crew/roster-shifts"
 import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
 import {
@@ -33,8 +56,8 @@ import {
   ensureCrewShiftAssignmentConfirmation,
   loadCrewShiftAssignmentConfirmationMap,
   summarizeCrewShiftAssignmentConfirmations,
-  type CrewShiftAssignmentConfirmationStatus,
 } from "./crew-confirmation.server"
+import type { CrewShiftAssignmentConfirmationStatus } from "./crew-confirmation.server"
 import {
   DEFAULT_TIMEZONE,
   formatDateTimeInTimezone,
@@ -145,6 +168,55 @@ interface CrewShiftAssignmentInput extends DeleteCrewShiftInput {
   notes?: string
 }
 
+interface ManualCrewVolunteerInput extends CrewEventInput {
+  email: string
+  name?: string
+  phone?: string
+  roleTypes?: VolunteerRoleType[]
+  availability?: VolunteerAvailability
+  availabilityNotes?: string
+  notes?: string
+}
+
+interface ManualCrewVolunteerPasteInput extends CrewEventInput {
+  pasteText: string
+}
+
+interface ManualCrewVolunteerCreateRow
+  extends Omit<ManualCrewVolunteerInput, "eventId"> {
+  rowNumber: number
+}
+
+export interface ManualCrewVolunteerCreatedRow {
+  rowNumber: number
+  email: string
+  invitationId: string
+}
+
+export interface ManualCrewVolunteerSkippedRow {
+  rowNumber: number
+  email: string
+  reason:
+    | "duplicate_in_paste"
+    | "pending_invitation"
+    | "accepted_invitation"
+    | "active_membership"
+    | "inactive_membership"
+  message: string
+  targetId: string | null
+}
+
+export interface ManualCrewVolunteerMutationResult {
+  created: ManualCrewVolunteerCreatedRow[]
+  skipped: ManualCrewVolunteerSkippedRow[]
+  invalid: ManualVolunteerPasteInvalidRow[]
+  summary: {
+    created: number
+    skipped: number
+    invalid: number
+  }
+}
+
 export async function getCrewRosterPage(
   data: CrewEventInput,
 ): Promise<CrewRosterPageData> {
@@ -197,6 +269,57 @@ export async function getCrewEventRosterShiftSummary(data: CrewEventInput) {
     rosterSummary: summarizeCrewRoster(roster),
     shiftSummary: summarizeCrewShifts(shifts),
   }
+}
+
+export async function createManualCrewVolunteer(
+  data: ManualCrewVolunteerInput,
+): Promise<ManualCrewVolunteerMutationResult> {
+  requireLocalCrewOperatorAccess("Crew roster")
+
+  const event = await requireCrewRosterEvent(data.eventId)
+  return createManualCrewVolunteerRows(event, [
+    {
+      rowNumber: 1,
+      email: normalizeManualVolunteerEmail(data.email),
+      name: data.name,
+      phone: data.phone,
+      roleTypes: data.roleTypes,
+      availability: data.availability,
+      availabilityNotes: data.availabilityNotes,
+      notes: data.notes,
+    },
+  ])
+}
+
+export async function pasteManualCrewVolunteerEmails(
+  data: ManualCrewVolunteerPasteInput,
+): Promise<ManualCrewVolunteerMutationResult> {
+  requireLocalCrewOperatorAccess("Crew roster")
+
+  const event = await requireCrewRosterEvent(data.eventId)
+  const parsed = parseManualVolunteerEmailPaste(data.pasteText)
+  const result = await createManualCrewVolunteerRows(
+    event,
+    parsed.valid.map((row) => ({
+      rowNumber: row.rowNumber,
+      email: row.email,
+    })),
+  )
+
+  return buildManualCrewVolunteerMutationResult({
+    created: result.created,
+    skipped: [
+      ...parsed.skipped.map((row) => ({
+        rowNumber: row.rowNumber,
+        email: row.email,
+        reason: row.reason,
+        message: "Email was already included in this paste.",
+        targetId: null,
+      })),
+      ...result.skipped,
+    ],
+    invalid: parsed.invalid,
+  })
 }
 
 export async function createCrewShift(data: CrewShiftInput) {
@@ -550,6 +673,147 @@ export async function loadCrewRoster(competitionTeamId: string) {
   ])
 
   return buildCrewRoster(invitations, memberships)
+}
+
+async function createManualCrewVolunteerRows(
+  event: CrewRosterCompetition,
+  rows: ManualCrewVolunteerCreateRow[],
+): Promise<ManualCrewVolunteerMutationResult> {
+  const db = getDb()
+  const created: ManualCrewVolunteerCreatedRow[] = []
+  const skipped: ManualCrewVolunteerSkippedRow[] = []
+  const timestamp = new Date()
+  const expiresAt = new Date(timestamp)
+  expiresAt.setFullYear(expiresAt.getFullYear() + 1)
+
+  await db.transaction(async (tx) => {
+    const client = tx as unknown as DbClient
+    const [existingInvitations, existingMemberships] = await Promise.all([
+      listManualVolunteerInvitations(client, event.competitionTeamId),
+      listManualVolunteerMemberships(client, event.competitionTeamId),
+    ])
+
+    for (const row of rows) {
+      const email = normalizeManualVolunteerEmail(row.email)
+      const plan = planManualVolunteerIntake(email, {
+        existingInvitations,
+        existingMemberships,
+      })
+
+      if (plan.action === "skip") {
+        skipped.push({
+          rowNumber: row.rowNumber,
+          email,
+          reason: plan.reason,
+          message: plan.message,
+          targetId: plan.targetId,
+        })
+        continue
+      }
+
+      const invitationId = createTeamInvitationId()
+      const metadata = buildManualVolunteerMetadata(
+        {
+          ...row,
+          email,
+        },
+        timestamp,
+      )
+      const metadataJson = JSON.stringify(metadata)
+
+      await client.insert(teamInvitationTable).values({
+        id: invitationId,
+        teamId: event.competitionTeamId,
+        email,
+        roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+        isSystemRole: true,
+        token: createId(),
+        invitedBy: null,
+        expiresAt,
+        status: INVITATION_STATUS.PENDING,
+        metadata: metadataJson,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+
+      existingInvitations.push({
+        id: invitationId,
+        email,
+        status: INVITATION_STATUS.PENDING,
+        metadata: metadataJson,
+      })
+      created.push({
+        rowNumber: row.rowNumber,
+        email,
+        invitationId,
+      })
+    }
+  })
+
+  return buildManualCrewVolunteerMutationResult({
+    created,
+    skipped,
+    invalid: [],
+  })
+}
+
+async function listManualVolunteerInvitations(
+  db: DbClient,
+  competitionTeamId: string,
+): Promise<ExistingManualVolunteerInvitation[]> {
+  return db
+    .select({
+      id: teamInvitationTable.id,
+      email: teamInvitationTable.email,
+      acceptedAt: teamInvitationTable.acceptedAt,
+      status: teamInvitationTable.status,
+      metadata: teamInvitationTable.metadata,
+    })
+    .from(teamInvitationTable)
+    .where(
+      and(
+        eq(teamInvitationTable.teamId, competitionTeamId),
+        eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamInvitationTable.isSystemRole, true),
+      ),
+    )
+}
+
+async function listManualVolunteerMemberships(
+  db: DbClient,
+  competitionTeamId: string,
+): Promise<ExistingManualVolunteerMembership[]> {
+  return db
+    .select({
+      id: teamMembershipTable.id,
+      email: userTable.email,
+      isActive: teamMembershipTable.isActive,
+      metadata: teamMembershipTable.metadata,
+    })
+    .from(teamMembershipTable)
+    .leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(
+      and(
+        eq(teamMembershipTable.teamId, competitionTeamId),
+        eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamMembershipTable.isSystemRole, true),
+      ),
+    )
+}
+
+function buildManualCrewVolunteerMutationResult(input: {
+  created: ManualCrewVolunteerCreatedRow[]
+  skipped: ManualCrewVolunteerSkippedRow[]
+  invalid: ManualVolunteerPasteInvalidRow[]
+}): ManualCrewVolunteerMutationResult {
+  return {
+    ...input,
+    summary: {
+      created: input.created.length,
+      skipped: input.skipped.length,
+      invalid: input.invalid.length,
+    },
+  }
 }
 
 export async function loadCrewShifts(

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -687,72 +687,68 @@ async function createManualCrewVolunteerRows(
   const expiresAt = new Date(timestamp)
   expiresAt.setFullYear(expiresAt.getFullYear() + 1)
 
-  await db.transaction(async (tx) => {
-    const client = tx as unknown as DbClient
+  for (const row of rows) {
+    const email = normalizeManualVolunteerEmail(row.email)
+    // team_invitations has no team/email uniqueness constraint, so the lock
+    // wraps the duplicate reread and autocommitted insert before release.
+    await withManualVolunteerIntakeLock(
+      db,
+      event.competitionTeamId,
+      email,
+      async () => {
+        const [existingInvitations, existingMemberships] = await Promise.all([
+          listManualVolunteerInvitations(db, event.competitionTeamId),
+          listManualVolunteerMemberships(db, event.competitionTeamId),
+        ])
+        const plan = planManualVolunteerIntake(email, {
+          existingInvitations,
+          existingMemberships,
+        })
 
-    for (const row of rows) {
-      const email = normalizeManualVolunteerEmail(row.email)
-      // team_invitations has no team/email uniqueness constraint, so serialize
-      // each manual intake write before rereading duplicate state.
-      await withManualVolunteerIntakeLock(
-        client,
-        event.competitionTeamId,
-        email,
-        async () => {
-          const [existingInvitations, existingMemberships] = await Promise.all([
-            listManualVolunteerInvitations(client, event.competitionTeamId),
-            listManualVolunteerMemberships(client, event.competitionTeamId),
-          ])
-          const plan = planManualVolunteerIntake(email, {
-            existingInvitations,
-            existingMemberships,
-          })
-
-          if (plan.action === "skip") {
-            skipped.push({
-              rowNumber: row.rowNumber,
-              email,
-              reason: plan.reason,
-              message: plan.message,
-              targetId: plan.targetId,
-            })
-            return
-          }
-
-          const invitationId = createTeamInvitationId()
-          const metadata = buildManualVolunteerMetadata(
-            {
-              ...row,
-              email,
-            },
-            timestamp,
-          )
-          const metadataJson = JSON.stringify(metadata)
-
-          await client.insert(teamInvitationTable).values({
-            id: invitationId,
-            teamId: event.competitionTeamId,
-            email,
-            roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
-            isSystemRole: true,
-            token: createId(),
-            invitedBy: null,
-            expiresAt,
-            status: INVITATION_STATUS.PENDING,
-            metadata: metadataJson,
-            createdAt: timestamp,
-            updatedAt: timestamp,
-          })
-
-          created.push({
+        if (plan.action === "skip") {
+          skipped.push({
             rowNumber: row.rowNumber,
             email,
-            invitationId,
+            reason: plan.reason,
+            message: plan.message,
+            targetId: plan.targetId,
           })
-        },
-      )
-    }
-  })
+          return
+        }
+
+        const invitationId = createTeamInvitationId()
+        const metadata = buildManualVolunteerMetadata(
+          {
+            ...row,
+            email,
+          },
+          timestamp,
+        )
+        const metadataJson = JSON.stringify(metadata)
+
+        await db.insert(teamInvitationTable).values({
+          id: invitationId,
+          teamId: event.competitionTeamId,
+          email,
+          roleId: SYSTEM_ROLES_ENUM.VOLUNTEER,
+          isSystemRole: true,
+          token: createId(),
+          invitedBy: null,
+          expiresAt,
+          status: INVITATION_STATUS.PENDING,
+          metadata: metadataJson,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        })
+
+        created.push({
+          rowNumber: row.rowNumber,
+          email,
+          invitationId,
+        })
+      },
+    )
+  }
 
   return buildManualCrewVolunteerMutationResult({
     created,

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -40,11 +40,11 @@ The pure helpers preserve source identity for invitations and memberships, deriv
 
 ## Manual Volunteer Intake
 
-Manual volunteer intake lets Crew operators build the roster from the event volunteer page without leaving the existing volunteer primitives.
+Manual volunteer intake lets Crew operators build the roster from [[apps/crew/src/routes/events/$eventId/volunteers.tsx|the event volunteer page]] without leaving the existing volunteer primitives.
 
-Single-add and paste flows create pending volunteer `team_invitations` with `SYSTEM_ROLES_ENUM.VOLUNTEER`, normalize email casing and whitespace, skip existing volunteer invitations or memberships, and use the same volunteer membership metadata shape consumed by public signup, import, roster display, shifts, and assignment validation.
+Single-add and paste flows call [[apps/crew/src/server-fns/crew-roster-shift-fns.ts|route-safe server functions]] backed by [[apps/crew/src/server/crew-roster-shift.server.ts|server-only roster mutations]] to create pending volunteer `team_invitations` with `SYSTEM_ROLES_ENUM.VOLUNTEER`, normalize email casing and whitespace, skip existing volunteer invitations or memberships, and use the same volunteer membership metadata shape consumed by [[crew#Roster Shifts Assignments]], public signup, import, roster display, shifts, and assignment validation.
 
-Missing role selections default through `getCrewRosterRoleTypes()` so manually entered volunteers display as General and stay compatible with shift assignment behavior.
+[[apps/crew/src/lib/crew/manual-volunteer-intake.ts|Manual intake helpers]] parse pasted email batches and default missing role selections through `getCrewRosterRoleTypes()` so manually entered volunteers display as General and stay compatible with shift assignment behavior.
 
 ## Staffing Page Gap Report
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -38,6 +38,14 @@ Roster shifts assignments normalize volunteer invitations, memberships, shifts, 
 
 The pure helpers preserve source identity for invitations and memberships, derive roster status, and keep role, availability, credential, import, and assignment details together so Crew pages can render staffing state without mutating event data.
 
+## Manual Volunteer Intake
+
+Manual volunteer intake lets Crew operators build the roster from the event volunteer page without leaving the existing volunteer primitives.
+
+Single-add and paste flows create pending volunteer `team_invitations` with `SYSTEM_ROLES_ENUM.VOLUNTEER`, normalize email casing and whitespace, skip existing volunteer invitations or memberships, and use the same volunteer membership metadata shape consumed by public signup, import, roster display, shifts, and assignment validation.
+
+Missing role selections default through `getCrewRosterRoleTypes()` so manually entered volunteers display as General and stay compatible with shift assignment behavior.
+
 ## Staffing Page Gap Report
 
 Crew staffing pages expose the matrix core as a read-only event operations report.


### PR DESCRIPTION
## Summary

- Adds quiet roster-page actions for single volunteer entry and bulk pasted emails on `/events/$eventId/volunteers`.
- Persists manual volunteers as pending `team_invitations` with `SYSTEM_ROLES_ENUM.VOLUNTEER`, shared volunteer metadata, duplicate skips, email normalization, paste dedupe, invalid-row reporting, and General role defaulting via `getCrewRosterRoleTypes()`.
- Keeps DB/runtime work behind the existing Crew roster server-function boundary and adds `crew#Manual Volunteer Intake` LAT coverage.

## Validation

- `pnpm --filter crew test -- src/lib/crew/manual-volunteer-intake.test.ts src/lib/crew/roster-shifts.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; existing baseline warnings outside this slice still print)
- `pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Manual Volunteer Intake'`
- `git diff --check`

## Notes

- No schema, live email sending, queue, token-route, or infrastructure changes.
- Local build used the existing ignored Crew workaround: copied `apps/crew/wrangler.jsonc` to `apps/crew/.alchemy/local/wrangler.jsonc`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds manual volunteer intake to the Crew roster page for single adds and bulk email paste. Creates pending volunteer invitations with normalized emails, sensible role defaults, clear feedback, and atomic, roster-scoped batch processing to prevent duplicates.

- **New Features**
  - UI: “Add volunteer” and “Paste emails” dialogs on `/events/$eventId/volunteers` with validation, toasts, and compact result summaries.
  - Persistence: Creates pending `team_invitations` with `SYSTEM_ROLES_ENUM.VOLUNTEER`; shared volunteer metadata; defaults roles via `getCrewRosterRoleTypes()`.
  - Safety: Normalizes emails, dedupes within paste, checks existing invitations/memberships (including `signupEmail` in metadata), enforces 500-item batch limits, and reports invalid rows.
  - Server boundary/tests/docs: `createManualCrewVolunteerFn` and `pasteManualCrewVolunteerEmailsFn`; unit tests for parsing/metadata/intake planning; LAT docs for `crew#Manual Volunteer Intake`.

- **Bug Fixes**
  - Concurrency: roster-scoped advisory lock held for the entire transaction serializes each intake batch, keeping multi-row pastes atomic and preventing duplicate invitations under contention.
  - Validation: stricter server-side schemas for email and paste inputs with clearer errors and size limits.

<sup>Written for commit b4d35d58dc76c766fbaf048f7f2012e689d8e4ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual volunteer intake for crew events, including single-add and bulk paste email flows.
  * Implemented email normalization, in-paste deduping, duplicate skipping against existing invitations/memberships, and a 500-item batch limit.
  * Added result reporting for created, skipped, and invalid rows, plus roster page actions with dialogs and toast summaries.
* **Documentation**
  * Added “Manual Volunteer Intake” guidance to the crew documentation, including how pasting and single-add behave.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->