### PR TITLE
feat(crew): adapt shift board for pilot ops

### DIFF
--- a/apps/crew/src/lib/crew/shift-board-pilot-ops.test.ts
+++ b/apps/crew/src/lib/crew/shift-board-pilot-ops.test.ts
@@ -209,6 +209,80 @@ describe("Crew shift board pilot ops helpers", () => {
       }).map((filteredShift) => filteredShift.id),
     ).toEqual(["vshf_medical"])
   })
+
+  it("keeps mixed-source shifts in the direct assignment filter", () => {
+    const roster = [
+      rosterVolunteer({
+        membershipId: "tmem_imported_judge",
+        name: "Imported Judge",
+        roleTypes: ["judge"],
+        imported: true,
+      }),
+      rosterVolunteer({
+        membershipId: "tmem_direct_judge",
+        name: "Direct Judge",
+        roleTypes: ["judge"],
+      }),
+    ]
+    const shifts = [
+      shift({
+        id: "vshf_imported_only",
+        roleType: "judge",
+        capacity: 1,
+        assignments: [
+          {
+            id: "vsha_imported",
+            membershipId: "tmem_imported_judge",
+            confirmation: { status: "confirmed" },
+          },
+        ],
+      }),
+      shift({
+        id: "vshf_mixed",
+        roleType: "judge",
+        capacity: 2,
+        assignments: [
+          {
+            id: "vsha_mixed_imported",
+            membershipId: "tmem_imported_judge",
+            confirmation: { status: "confirmed" },
+          },
+          {
+            id: "vsha_mixed_direct",
+            membershipId: "tmem_direct_judge",
+            confirmation: { status: "confirmed" },
+          },
+        ],
+      }),
+    ]
+    const matrix = buildCrewStaffingMatrix({
+      event: {
+        id: "comp_pilot",
+        timezone: "America/Denver",
+      },
+      roster: toStaffingRoster(roster),
+      shifts: toStaffingShifts(shifts),
+    })
+    const pilotOps = buildCrewShiftBoardPilotOps({
+      shifts,
+      roster,
+      matrix,
+    })
+
+    expect(
+      filterCrewShiftBoardPilotShifts({
+        shifts,
+        roster,
+        pilotOps,
+        filters: {
+          roleType: "all",
+          status: "all",
+          source: "direct_assignments",
+          credentialQuery: "",
+        },
+      }).map((filteredShift) => filteredShift.id),
+    ).toEqual(["vshf_mixed"])
+  })
 })
 
 function rosterVolunteer(

--- a/apps/crew/src/lib/crew/shift-board-pilot-ops.test.ts
+++ b/apps/crew/src/lib/crew/shift-board-pilot-ops.test.ts
@@ -1,0 +1,288 @@
+// @lat: [[crew#Shift Board Pilot Ops]]
+import { describe, expect, it } from "vitest"
+import type { CrewRosterVolunteer } from "./roster-shifts"
+import {
+  buildCrewShiftBoardPilotOps,
+  filterCrewShiftBoardPilotShifts,
+  type CrewShiftPilotOpsShift,
+} from "./shift-board-pilot-ops"
+import { buildCrewStaffingMatrix } from "./staffing"
+
+describe("Crew shift board pilot ops helpers", () => {
+  it("derives shift-level gap, confirmation, availability, and status signals", () => {
+    const roster = [
+      rosterVolunteer({
+        membershipId: "tmem_imported_judge",
+        name: "Imported Judge",
+        roleTypes: ["judge"],
+        availability: "morning",
+        credentials: "L1 Judge",
+        imported: true,
+      }),
+      rosterVolunteer({
+        membershipId: "tmem_medical",
+        name: "Medical Lead",
+        roleTypes: ["medical"],
+        availability: "all_day",
+        credentials: "EMT",
+      }),
+      rosterVolunteer({
+        membershipId: "tmem_equipment",
+        name: "Equipment Lead",
+        roleTypes: ["equipment"],
+        availability: "all_day",
+        credentials: "Rigging",
+      }),
+    ]
+    const shifts = [
+      shift({
+        id: "vshf_open",
+        roleType: "judge",
+        capacity: 2,
+        startTime: "2026-07-04T20:00:00.000Z",
+        endTime: "2026-07-04T22:00:00.000Z",
+        assignments: [
+          {
+            id: "vsha_pending",
+            membershipId: "tmem_imported_judge",
+            confirmation: { status: "pending" },
+          },
+        ],
+      }),
+      shift({
+        id: "vshf_response",
+        roleType: "medical",
+        capacity: 1,
+        assignments: [
+          {
+            id: "vsha_medical",
+            membershipId: "tmem_medical",
+            confirmation: { status: "pending" },
+          },
+        ],
+      }),
+      shift({
+        id: "vshf_ready",
+        roleType: "equipment",
+        capacity: 1,
+        assignments: [
+          {
+            id: "vsha_equipment",
+            membershipId: "tmem_equipment",
+            confirmation: { status: "confirmed" },
+          },
+        ],
+      }),
+    ]
+    const matrix = buildCrewStaffingMatrix({
+      event: {
+        id: "comp_pilot",
+        timezone: "America/Denver",
+      },
+      roster: toStaffingRoster(roster),
+      shifts: toStaffingShifts(shifts),
+    })
+
+    const pilotOps = buildCrewShiftBoardPilotOps({
+      shifts,
+      roster,
+      matrix,
+    })
+
+    expect(pilotOps.summary).toMatchObject({
+      totalShifts: 3,
+      readyShifts: 1,
+      responsesNeededShiftCount: 1,
+      blockedShiftCount: 1,
+      openSlots: 1,
+      importedRosterCount: 1,
+      importedAssignmentCount: 1,
+      credentialedAssignableCount: 3,
+    })
+    expect(pilotOps.shiftsById.vshf_open).toMatchObject({
+      status: "blocked",
+      importedAssignmentCount: 1,
+      confirmationCounts: { pending: 1 },
+    })
+    expect(
+      pilotOps.shiftsById.vshf_open?.warnings.map((warning) => warning.kind),
+    ).toEqual(["open_capacity", "confirmation_gap", "outside_availability"])
+    expect(pilotOps.shiftsById.vshf_response?.status).toBe("responses_needed")
+    expect(pilotOps.shiftsById.vshf_ready?.status).toBe("ready")
+  })
+
+  it("filters shifts by role, status, assignment source, and credentials", () => {
+    const roster = [
+      rosterVolunteer({
+        membershipId: "tmem_imported_judge",
+        name: "Imported Judge",
+        roleTypes: ["judge"],
+        credentials: "L1 Judge",
+        imported: true,
+      }),
+      rosterVolunteer({
+        membershipId: "tmem_medical",
+        name: "Medical Lead",
+        roleTypes: ["medical"],
+        credentials: "EMT",
+      }),
+    ]
+    const shifts = [
+      shift({
+        id: "vshf_imported",
+        roleType: "judge",
+        capacity: 1,
+        assignments: [
+          {
+            id: "vsha_imported",
+            membershipId: "tmem_imported_judge",
+            confirmation: { status: "confirmed" },
+          },
+        ],
+      }),
+      shift({
+        id: "vshf_medical",
+        roleType: "medical",
+        capacity: 1,
+        assignments: [
+          {
+            id: "vsha_medical",
+            membershipId: "tmem_medical",
+            confirmation: { status: "pending" },
+          },
+        ],
+      }),
+    ]
+    const matrix = buildCrewStaffingMatrix({
+      event: {
+        id: "comp_pilot",
+        timezone: "America/Denver",
+      },
+      roster: toStaffingRoster(roster),
+      shifts: toStaffingShifts(shifts),
+    })
+    const pilotOps = buildCrewShiftBoardPilotOps({
+      shifts,
+      roster,
+      matrix,
+    })
+
+    expect(
+      filterCrewShiftBoardPilotShifts({
+        shifts,
+        roster,
+        pilotOps,
+        filters: {
+          roleType: "medical",
+          status: "all",
+          source: "all",
+          credentialQuery: "",
+        },
+      }).map((filteredShift) => filteredShift.id),
+    ).toEqual(["vshf_medical"])
+
+    expect(
+      filterCrewShiftBoardPilotShifts({
+        shifts,
+        roster,
+        pilotOps,
+        filters: {
+          roleType: "all",
+          status: "ready",
+          source: "imported_assignments",
+          credentialQuery: "judge",
+        },
+      }).map((filteredShift) => filteredShift.id),
+    ).toEqual(["vshf_imported"])
+
+    expect(
+      filterCrewShiftBoardPilotShifts({
+        shifts,
+        roster,
+        pilotOps,
+        filters: {
+          roleType: "all",
+          status: "responses_needed",
+          source: "direct_assignments",
+          credentialQuery: "emt",
+        },
+      }).map((filteredShift) => filteredShift.id),
+    ).toEqual(["vshf_medical"])
+  })
+})
+
+function rosterVolunteer(
+  overrides: Partial<CrewRosterVolunteer> & {
+    membershipId: string
+    name: string
+  },
+): CrewRosterVolunteer {
+  return {
+    id: `membership:${overrides.membershipId}`,
+    source: "team_membership",
+    sourceId: overrides.membershipId,
+    membershipId: overrides.membershipId,
+    invitationId: null,
+    email: `${overrides.membershipId}@example.com`,
+    name: overrides.name,
+    phone: null,
+    status: "active",
+    roleTypes: overrides.roleTypes ?? ["general"],
+    availability: overrides.availability ?? "all_day",
+    availabilityNotes: null,
+    credentials: overrides.credentials ?? null,
+    imported: overrides.imported ?? false,
+    signupSource: null,
+    createdAt: null,
+    updatedAt: null,
+    ...overrides,
+  }
+}
+
+function shift(
+  overrides: Omit<Partial<CrewShiftPilotOpsShift>, "assignments" | "roleType"> &
+    Pick<CrewShiftPilotOpsShift, "id" | "roleType" | "capacity"> & {
+      assignments?: CrewShiftPilotOpsShift["assignments"]
+      startTime?: string
+      endTime?: string
+    },
+): CrewShiftPilotOpsShift & { startTime: string; endTime: string } {
+  const assignments = overrides.assignments ?? []
+  return {
+    name: overrides.id,
+    assignedCount: assignments.length,
+    openSlots: Math.max(overrides.capacity - assignments.length, 0),
+    startTime: overrides.startTime ?? "2026-07-04T15:00:00.000Z",
+    endTime: overrides.endTime ?? "2026-07-04T17:00:00.000Z",
+    ...overrides,
+    assignments,
+  }
+}
+
+function toStaffingRoster(roster: CrewRosterVolunteer[]) {
+  return roster.map((volunteer) => ({
+    membershipId: volunteer.membershipId ?? "",
+    name: volunteer.name,
+    email: volunteer.email,
+    roleTypes: volunteer.roleTypes,
+    availability: volunteer.availability,
+    credentials: volunteer.credentials,
+    isActive: volunteer.status === "active",
+  }))
+}
+
+function toStaffingShifts(
+  shifts: Array<
+    CrewShiftPilotOpsShift & { startTime: string; endTime: string }
+  >,
+) {
+  return shifts.map((crewShift) => ({
+    id: crewShift.id,
+    name: crewShift.name,
+    roleType: crewShift.roleType,
+    startTime: crewShift.startTime,
+    endTime: crewShift.endTime,
+    capacity: crewShift.capacity,
+    assignments: crewShift.assignments,
+  }))
+}

--- a/apps/crew/src/lib/crew/shift-board-pilot-ops.ts
+++ b/apps/crew/src/lib/crew/shift-board-pilot-ops.ts
@@ -264,8 +264,9 @@ export function filterCrewShiftBoardPilotShifts<
 
     if (
       input.filters.source === "direct_assignments" &&
-      shift.assignments.some((assignment) =>
-        isImportedAssignment(assignment.membershipId, rosterByMembershipId),
+      !shift.assignments.some(
+        (assignment) =>
+          !isImportedAssignment(assignment.membershipId, rosterByMembershipId),
       )
     ) {
       return false

--- a/apps/crew/src/lib/crew/shift-board-pilot-ops.ts
+++ b/apps/crew/src/lib/crew/shift-board-pilot-ops.ts
@@ -1,0 +1,498 @@
+// @lat: [[crew#Shift Board Pilot Ops]]
+import type { CrewAssignmentConfirmationStatus } from "../../db/schemas/crew-imports"
+import {
+  VOLUNTEER_ROLE_LABELS,
+  type VolunteerAvailability,
+  type VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+import {
+  isVolunteerCompatibleWithShift,
+  type CrewRosterVolunteer,
+} from "./roster-shifts"
+import type {
+  CrewStaffingConfirmationGap,
+  CrewStaffingCredentialWarning,
+  CrewStaffingMatrix,
+  CrewStaffingOutsideAvailabilityAssignment,
+} from "./staffing"
+
+export type CrewShiftPilotStatus =
+  | "ready"
+  | "open_slots"
+  | "responses_needed"
+  | "blocked"
+
+export type CrewShiftPilotWarningKind =
+  | "open_capacity"
+  | "confirmation_gap"
+  | "outside_availability"
+  | "credential_warning"
+  | "double_booked"
+
+export type CrewShiftPilotWarningSeverity = "critical" | "warning"
+
+export type CrewShiftPilotStatusFilter =
+  | "all"
+  | "ready"
+  | "open_slots"
+  | "responses_needed"
+  | "blocked"
+
+export type CrewShiftPilotSourceFilter =
+  | "all"
+  | "imported_assignments"
+  | "direct_assignments"
+
+export interface CrewShiftBoardPilotFilters {
+  roleType: VolunteerRoleType | "all"
+  status: CrewShiftPilotStatusFilter
+  source: CrewShiftPilotSourceFilter
+  credentialQuery: string
+}
+
+export interface CrewShiftPilotOpsAssignment {
+  id: string
+  membershipId: string
+  confirmation?: {
+    status: CrewAssignmentConfirmationStatus
+  } | null
+}
+
+export interface CrewShiftPilotOpsShift {
+  id: string
+  name: string
+  roleType: VolunteerRoleType
+  capacity: number
+  assignments: CrewShiftPilotOpsAssignment[]
+  assignedCount: number
+  openSlots: number
+}
+
+export interface CrewShiftPilotWarning {
+  kind: CrewShiftPilotWarningKind
+  severity: CrewShiftPilotWarningSeverity
+  label: string
+  detail: string
+  assignmentId?: string
+  membershipId?: string
+}
+
+export interface CrewShiftPilotShiftState {
+  shiftId: string
+  status: CrewShiftPilotStatus
+  statusLabel: string
+  severity: "covered" | "warning" | "critical"
+  openSlots: number
+  importedAssignmentCount: number
+  directAssignmentCount: number
+  confirmationCounts: Record<
+    CrewAssignmentConfirmationStatus | "missing",
+    number
+  >
+  warnings: CrewShiftPilotWarning[]
+}
+
+export interface CrewShiftBoardPilotOpsData {
+  summary: {
+    totalShifts: number
+    readyShifts: number
+    openShiftCount: number
+    responsesNeededShiftCount: number
+    blockedShiftCount: number
+    openSlots: number
+    warningCount: number
+    criticalWarningCount: number
+    importedRosterCount: number
+    importedAssignmentCount: number
+    credentialedAssignableCount: number
+  }
+  shiftsById: Record<string, CrewShiftPilotShiftState>
+}
+
+export function buildCrewShiftBoardPilotOps(input: {
+  shifts: CrewShiftPilotOpsShift[]
+  roster: CrewRosterVolunteer[]
+  matrix: CrewStaffingMatrix
+}): CrewShiftBoardPilotOpsData {
+  const rosterByMembershipId = buildRosterByMembershipId(input.roster)
+  const rowByShiftId = new Map(
+    input.matrix.coverageRows
+      .filter((row) => row.timeBlockId.startsWith("shift:"))
+      .map((row) => [row.timeBlockId.slice("shift:".length), row]),
+  )
+  const confirmationGapsByShiftId = groupShiftWarnings(
+    input.matrix.confirmationGaps,
+  )
+  const availabilityWarningsByShiftId = groupShiftWarnings(
+    input.matrix.outsideAvailabilityAssignments,
+  )
+  const credentialWarningsByShiftId = groupShiftWarnings(
+    input.matrix.credentialWarnings,
+  )
+  const doubleBookingsByShiftId = new Map<string, string[]>()
+
+  for (const doubleBooking of input.matrix.doubleBookedVolunteers) {
+    for (const timeBlockId of doubleBooking.timeBlockIds) {
+      const shiftId = getShiftIdFromTimeBlock(timeBlockId)
+      if (!shiftId) continue
+      const existing = doubleBookingsByShiftId.get(shiftId) ?? []
+      existing.push(doubleBooking.volunteerName)
+      doubleBookingsByShiftId.set(shiftId, existing)
+    }
+  }
+
+  const shiftsById: Record<string, CrewShiftPilotShiftState> = {}
+  for (const shift of input.shifts) {
+    const coverageRow = rowByShiftId.get(shift.id)
+    const warnings = [
+      ...buildOpenCapacityWarnings(shift, coverageRow?.open ?? shift.openSlots),
+      ...buildConfirmationWarnings(
+        confirmationGapsByShiftId.get(shift.id) ?? [],
+      ),
+      ...buildAvailabilityWarnings(
+        availabilityWarningsByShiftId.get(shift.id) ?? [],
+      ),
+      ...buildCredentialWarnings(
+        credentialWarningsByShiftId.get(shift.id) ?? [],
+      ),
+      ...buildDoubleBookingWarnings(
+        doubleBookingsByShiftId.get(shift.id) ?? [],
+      ),
+    ]
+    const importedAssignmentCount = shift.assignments.filter((assignment) =>
+      isImportedAssignment(assignment.membershipId, rosterByMembershipId),
+    ).length
+    const confirmationCounts = countAssignmentConfirmations(shift.assignments)
+    const status = getShiftPilotStatus(warnings)
+
+    shiftsById[shift.id] = {
+      shiftId: shift.id,
+      status,
+      statusLabel: getStatusLabel(status),
+      severity: getStatusSeverity(status),
+      openSlots: coverageRow?.open ?? shift.openSlots,
+      importedAssignmentCount,
+      directAssignmentCount: Math.max(
+        shift.assignments.length - importedAssignmentCount,
+        0,
+      ),
+      confirmationCounts,
+      warnings,
+    }
+  }
+
+  const states = Object.values(shiftsById)
+  const warningCount = states.reduce(
+    (total, state) => total + state.warnings.length,
+    0,
+  )
+  const criticalWarningCount = states.reduce(
+    (total, state) =>
+      total +
+      state.warnings.filter((warning) => warning.severity === "critical")
+        .length,
+    0,
+  )
+
+  return {
+    summary: {
+      totalShifts: input.shifts.length,
+      readyShifts: states.filter((state) => state.status === "ready").length,
+      openShiftCount: states.filter((state) => state.status === "open_slots")
+        .length,
+      responsesNeededShiftCount: states.filter(
+        (state) => state.status === "responses_needed",
+      ).length,
+      blockedShiftCount: states.filter((state) => state.status === "blocked")
+        .length,
+      openSlots: states.reduce((total, state) => total + state.openSlots, 0),
+      warningCount,
+      criticalWarningCount,
+      importedRosterCount: input.roster.filter(
+        (volunteer) => volunteer.imported,
+      ).length,
+      importedAssignmentCount: states.reduce(
+        (total, state) => total + state.importedAssignmentCount,
+        0,
+      ),
+      credentialedAssignableCount: input.roster.filter(
+        (volunteer) =>
+          volunteer.status === "active" &&
+          volunteer.membershipId &&
+          hasText(volunteer.credentials),
+      ).length,
+    },
+    shiftsById,
+  }
+}
+
+export function filterCrewShiftBoardPilotShifts<
+  T extends CrewShiftPilotOpsShift,
+>(input: {
+  shifts: T[]
+  roster: CrewRosterVolunteer[]
+  pilotOps: CrewShiftBoardPilotOpsData
+  filters: CrewShiftBoardPilotFilters
+}): T[] {
+  const rosterByMembershipId = buildRosterByMembershipId(input.roster)
+  const credentialQuery = normalizeSearch(input.filters.credentialQuery)
+
+  return input.shifts.filter((shift) => {
+    if (
+      input.filters.roleType !== "all" &&
+      shift.roleType !== input.filters.roleType
+    ) {
+      return false
+    }
+
+    const state = input.pilotOps.shiftsById[shift.id]
+    if (
+      input.filters.status !== "all" &&
+      state?.status !== input.filters.status
+    ) {
+      return false
+    }
+
+    if (
+      input.filters.source === "imported_assignments" &&
+      !shift.assignments.some((assignment) =>
+        isImportedAssignment(assignment.membershipId, rosterByMembershipId),
+      )
+    ) {
+      return false
+    }
+
+    if (
+      input.filters.source === "direct_assignments" &&
+      shift.assignments.some((assignment) =>
+        isImportedAssignment(assignment.membershipId, rosterByMembershipId),
+      )
+    ) {
+      return false
+    }
+
+    if (
+      credentialQuery &&
+      !shiftMatchesCredentialQuery(shift, input.roster, credentialQuery)
+    ) {
+      return false
+    }
+
+    return true
+  })
+}
+
+export function getRoleFilterOptions(shifts: CrewShiftPilotOpsShift[]) {
+  return [...new Set(shifts.map((shift) => shift.roleType))]
+    .sort((left, right) => formatRole(left).localeCompare(formatRole(right)))
+    .map((roleType) => ({
+      value: roleType,
+      label: formatRole(roleType),
+    }))
+}
+
+function buildOpenCapacityWarnings(
+  shift: CrewShiftPilotOpsShift,
+  openSlots: number,
+): CrewShiftPilotWarning[] {
+  if (openSlots <= 0) return []
+  return [
+    {
+      kind: "open_capacity",
+      severity: "critical",
+      label: `${openSlots} open slot${plural(openSlots)}`,
+      detail: `${formatRole(shift.roleType)} coverage is ${shift.assignedCount}/${shift.capacity}.`,
+    },
+  ]
+}
+
+function buildConfirmationWarnings(
+  gaps: CrewStaffingConfirmationGap[],
+): CrewShiftPilotWarning[] {
+  return gaps.map((gap) => ({
+    kind: "confirmation_gap",
+    severity:
+      gap.reason === "missing_confirmation" || gap.reason === "no_response"
+        ? "warning"
+        : "critical",
+    label: getConfirmationGapLabel(gap),
+    detail: gap.volunteerName,
+    assignmentId: gap.assignmentId,
+    membershipId: gap.membershipId,
+  }))
+}
+
+function buildAvailabilityWarnings(
+  warnings: CrewStaffingOutsideAvailabilityAssignment[],
+): CrewShiftPilotWarning[] {
+  return warnings.map((warning) => ({
+    kind: "outside_availability",
+    severity: "critical",
+    label: "Outside availability",
+    detail: `${warning.volunteerName} is marked ${formatAvailability(warning.availability)}.`,
+    assignmentId: warning.assignmentId,
+    membershipId: warning.membershipId,
+  }))
+}
+
+function buildCredentialWarnings(
+  warnings: CrewStaffingCredentialWarning[],
+): CrewShiftPilotWarning[] {
+  return warnings.map((warning) => ({
+    kind: "credential_warning",
+    severity: "critical",
+    label: "Role warning",
+    detail: `${warning.volunteerName} needs ${formatRole(warning.requiredRoleType)}.`,
+    assignmentId: warning.assignmentId,
+    membershipId: warning.membershipId,
+  }))
+}
+
+function buildDoubleBookingWarnings(
+  volunteerNames: string[],
+): CrewShiftPilotWarning[] {
+  return [...new Set(volunteerNames)].sort().map((volunteerName) => ({
+    kind: "double_booked",
+    severity: "critical",
+    label: "Double booked",
+    detail: volunteerName,
+  }))
+}
+
+function getShiftPilotStatus(
+  warnings: CrewShiftPilotWarning[],
+): CrewShiftPilotStatus {
+  if (
+    warnings.some(
+      (warning) =>
+        warning.severity === "critical" && warning.kind !== "open_capacity",
+    )
+  ) {
+    return "blocked"
+  }
+  if (warnings.some((warning) => warning.kind === "open_capacity")) {
+    return "open_slots"
+  }
+  if (warnings.some((warning) => warning.kind === "confirmation_gap")) {
+    return "responses_needed"
+  }
+  return "ready"
+}
+
+function getStatusLabel(status: CrewShiftPilotStatus) {
+  if (status === "ready") return "Ready"
+  if (status === "open_slots") return "Open slots"
+  if (status === "responses_needed") return "Responses needed"
+  return "Blocked"
+}
+
+function getStatusSeverity(status: CrewShiftPilotStatus) {
+  if (status === "ready") return "covered"
+  if (status === "responses_needed") return "warning"
+  return "critical"
+}
+
+function countAssignmentConfirmations(
+  assignments: CrewShiftPilotOpsAssignment[],
+): CrewShiftPilotShiftState["confirmationCounts"] {
+  return assignments.reduce<CrewShiftPilotShiftState["confirmationCounts"]>(
+    (counts, assignment) => {
+      const status = assignment.confirmation?.status ?? "missing"
+      counts[status] += 1
+      return counts
+    },
+    {
+      missing: 0,
+      pending: 0,
+      confirmed: 0,
+      declined: 0,
+      change_requested: 0,
+      no_show: 0,
+      cancelled: 0,
+    },
+  )
+}
+
+function groupShiftWarnings<T extends { timeBlockId: string }>(items: T[]) {
+  const grouped = new Map<string, T[]>()
+  for (const item of items) {
+    const shiftId = getShiftIdFromTimeBlock(item.timeBlockId)
+    if (!shiftId) continue
+    const existing = grouped.get(shiftId) ?? []
+    existing.push(item)
+    grouped.set(shiftId, existing)
+  }
+  return grouped
+}
+
+function getShiftIdFromTimeBlock(timeBlockId: string) {
+  return timeBlockId.startsWith("shift:")
+    ? timeBlockId.slice("shift:".length)
+    : null
+}
+
+function buildRosterByMembershipId(roster: CrewRosterVolunteer[]) {
+  return new Map(
+    roster.flatMap((volunteer) =>
+      volunteer.membershipId ? [[volunteer.membershipId, volunteer]] : [],
+    ),
+  )
+}
+
+function isImportedAssignment(
+  membershipId: string,
+  rosterByMembershipId: Map<string, CrewRosterVolunteer>,
+) {
+  return rosterByMembershipId.get(membershipId)?.imported === true
+}
+
+function shiftMatchesCredentialQuery(
+  shift: CrewShiftPilotOpsShift,
+  roster: CrewRosterVolunteer[],
+  credentialQuery: string,
+) {
+  const assignedMembershipIds = new Set(
+    shift.assignments.map((assignment) => assignment.membershipId),
+  )
+  return roster.some((volunteer) => {
+    if (!volunteer.membershipId) return false
+    if (!normalizeSearch(volunteer.credentials).includes(credentialQuery)) {
+      return false
+    }
+    if (assignedMembershipIds.has(volunteer.membershipId)) return true
+    return (
+      volunteer.status === "active" &&
+      isVolunteerCompatibleWithShift(shift.roleType, volunteer.roleTypes)
+    )
+  })
+}
+
+function getConfirmationGapLabel(gap: CrewStaffingConfirmationGap) {
+  if (gap.reason === "missing_confirmation") return "Confirmation missing"
+  if (gap.reason === "no_response") return "No response"
+  if (gap.reason === "declined") return "Declined"
+  if (gap.reason === "change_requested") return "Change requested"
+  return "No-show"
+}
+
+function formatRole(roleType: VolunteerRoleType) {
+  return VOLUNTEER_ROLE_LABELS[roleType] ?? roleType
+}
+
+function formatAvailability(availability: VolunteerAvailability) {
+  if (availability === "morning") return "morning"
+  if (availability === "afternoon") return "afternoon"
+  return "all day"
+}
+
+function normalizeSearch(value: string | null | undefined) {
+  return value?.trim().toLowerCase() ?? ""
+}
+
+function hasText(value: string | null | undefined) {
+  return Boolean(value?.trim())
+}
+
+function plural(count: number) {
+  return count === 1 ? "" : "s"
+}

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -4,7 +4,9 @@ import {
   createFileRoute,
   getRouteApi,
   Link,
+  useNavigate,
   useRouter,
+  useSearch,
 } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import {
@@ -55,17 +57,42 @@ export const Route = createFileRoute("/events/$eventId/shifts")({
 
 const parentRoute = getRouteApi("/events/$eventId")
 
+const DEFAULT_SHIFT_BOARD_FILTERS: CrewShiftBoardPilotFilters = {
+  roleType: "all",
+  status: "all",
+  source: "all",
+  credentialQuery: "",
+}
+
+const SHIFT_BOARD_STATUS_FILTERS = new Set<
+  CrewShiftBoardPilotFilters["status"]
+>(["all", "ready", "open_slots", "responses_needed", "blocked"])
+
+const SHIFT_BOARD_SOURCE_FILTERS = new Set<
+  CrewShiftBoardPilotFilters["source"]
+>(["all", "imported_assignments", "direct_assignments"])
+
 function EventShiftsPage() {
   const { eventId } = parentRoute.useParams()
   const { event, roster, rosterSummary, shifts, shiftSummary, pilotOps } =
     Route.useLoaderData()
   const timezone = event.timezone ?? "America/Denver"
-  const [filters, setFilters] = useState<CrewShiftBoardPilotFilters>({
-    roleType: "all",
-    status: "all",
-    source: "all",
-    credentialQuery: "",
-  })
+  const navigate = useNavigate()
+  const searchParams = useSearch({ strict: false }) as Record<string, unknown>
+  const filters = useMemo(
+    () => getShiftBoardFiltersFromSearch(searchParams),
+    [searchParams],
+  )
+  function setFilters(nextFilters: CrewShiftBoardPilotFilters) {
+    void navigate({
+      to: ".",
+      search: (previous: Record<string, unknown>) => ({
+        ...previous,
+        ...toShiftBoardFilterSearch(nextFilters),
+      }),
+      replace: true,
+    })
+  }
   const roleFilterOptions = useMemo(
     () => getRoleFilterOptions(shifts),
     [shifts],
@@ -184,6 +211,54 @@ function EventShiftsPage() {
       </div>
     </section>
   )
+}
+
+function getShiftBoardFiltersFromSearch(
+  searchParams: Record<string, unknown>,
+): CrewShiftBoardPilotFilters {
+  const roleType = getSearchString(searchParams.roleType)
+  const status = getSearchString(searchParams.status)
+  const source = getSearchString(searchParams.source)
+  const credentialQuery = getSearchString(searchParams.credentialQuery).trim()
+
+  return {
+    roleType: VOLUNTEER_ROLE_OPTIONS.some((option) => option.value === roleType)
+      ? (roleType as VolunteerRoleType)
+      : DEFAULT_SHIFT_BOARD_FILTERS.roleType,
+    status: SHIFT_BOARD_STATUS_FILTERS.has(
+      status as CrewShiftBoardPilotFilters["status"],
+    )
+      ? (status as CrewShiftBoardPilotFilters["status"])
+      : DEFAULT_SHIFT_BOARD_FILTERS.status,
+    source: SHIFT_BOARD_SOURCE_FILTERS.has(
+      source as CrewShiftBoardPilotFilters["source"],
+    )
+      ? (source as CrewShiftBoardPilotFilters["source"])
+      : DEFAULT_SHIFT_BOARD_FILTERS.source,
+    credentialQuery,
+  }
+}
+
+function toShiftBoardFilterSearch(filters: CrewShiftBoardPilotFilters) {
+  return {
+    roleType:
+      filters.roleType === DEFAULT_SHIFT_BOARD_FILTERS.roleType
+        ? undefined
+        : filters.roleType,
+    status:
+      filters.status === DEFAULT_SHIFT_BOARD_FILTERS.status
+        ? undefined
+        : filters.status,
+    source:
+      filters.source === DEFAULT_SHIFT_BOARD_FILTERS.source
+        ? undefined
+        : filters.source,
+    credentialQuery: filters.credentialQuery.trim() || undefined,
+  }
+}
+
+function getSearchString(value: unknown) {
+  return typeof value === "string" ? value : ""
 }
 
 function PilotOpsFilters({

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -1,12 +1,34 @@
+// @lat: [[crew#Shift Board Pilot Ops]]
 import type { FormEvent } from "react"
-import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
+import {
+  createFileRoute,
+  getRouteApi,
+  Link,
+  useRouter,
+} from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
-import { Loader2, Plus, Trash2 } from "lucide-react"
-import { useState } from "react"
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Clock3,
+  Loader2,
+  Plus,
+  Search,
+  Trash2,
+  UploadCloud,
+} from "lucide-react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 import { getCrewAssignmentConfirmationStatusBadgeClassName } from "@/lib/crew/assignment-confirmation-display"
 import { formatCrewValue } from "@/lib/crew-event-display"
 import {
+  filterCrewShiftBoardPilotShifts,
+  getRoleFilterOptions,
+  type CrewShiftBoardPilotFilters,
+  type CrewShiftPilotShiftState,
+} from "@/lib/crew/shift-board-pilot-ops"
+import {
+  formatVolunteerAvailability,
   isVolunteerCompatibleWithShift,
   type CrewRosterVolunteer,
 } from "@/lib/crew/roster-shifts"
@@ -35,9 +57,29 @@ const parentRoute = getRouteApi("/events/$eventId")
 
 function EventShiftsPage() {
   const { eventId } = parentRoute.useParams()
-  const { event, roster, rosterSummary, shifts, shiftSummary } =
+  const { event, roster, rosterSummary, shifts, shiftSummary, pilotOps } =
     Route.useLoaderData()
   const timezone = event.timezone ?? "America/Denver"
+  const [filters, setFilters] = useState<CrewShiftBoardPilotFilters>({
+    roleType: "all",
+    status: "all",
+    source: "all",
+    credentialQuery: "",
+  })
+  const roleFilterOptions = useMemo(
+    () => getRoleFilterOptions(shifts),
+    [shifts],
+  )
+  const visibleShifts = useMemo(
+    () =>
+      filterCrewShiftBoardPilotShifts({
+        shifts,
+        roster,
+        pilotOps,
+        filters,
+      }),
+    [filters, pilotOps, roster, shifts],
+  )
   const assignableVolunteers = roster.filter(
     (volunteer) => volunteer.membershipId && volunteer.status === "active",
   )
@@ -46,15 +88,43 @@ function EventShiftsPage() {
     <section className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="text-xl font-semibold">Shifts</h2>
+          <h2 className="text-xl font-semibold">Shift board</h2>
           <p className="text-sm text-muted-foreground">
-            {shiftSummary.totalShifts} shifts, {shiftSummary.openSlots} open
-            slots
+            {pilotOps.summary.readyShifts} ready,{" "}
+            {pilotOps.summary.openShiftCount} with open slots,{" "}
+            {pilotOps.summary.blockedShiftCount} blocked
           </p>
         </div>
+        <Link
+          to="/events/$eventId/staffing"
+          params={{ eventId }}
+          className="inline-flex h-10 w-fit items-center rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          Staffing report
+        </Link>
       </div>
 
       <div className="grid gap-4 md:grid-cols-5">
+        <StatusPanel
+          label="Ready shifts"
+          value={pilotOps.summary.readyShifts}
+        />
+        <StatusPanel label="Open slots" value={pilotOps.summary.openSlots} />
+        <StatusPanel
+          label="Blocked"
+          value={pilotOps.summary.blockedShiftCount}
+        />
+        <StatusPanel
+          label="Needs response"
+          value={pilotOps.summary.responsesNeededShiftCount}
+        />
+        <StatusPanel
+          label="Imported assignments"
+          value={pilotOps.summary.importedAssignmentCount}
+        />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
         <StatusPanel label="Active volunteers" value={rosterSummary.active} />
         <StatusPanel label="Assignable" value={rosterSummary.assignable} />
         <StatusPanel
@@ -65,15 +135,15 @@ function EventShiftsPage() {
           label="Confirmed"
           value={shiftSummary.confirmationSummary.confirmed}
         />
-        <StatusPanel
-          label="Needs response"
-          value={
-            shiftSummary.confirmationSummary.pending +
-            shiftSummary.confirmationSummary.changeRequested +
-            shiftSummary.confirmationSummary.declined
-          }
-        />
       </div>
+
+      <PilotOpsFilters
+        filters={filters}
+        roleOptions={roleFilterOptions}
+        visibleCount={visibleShifts.length}
+        totalCount={shifts.length}
+        onChange={setFilters}
+      />
 
       <CreateShiftForm
         eventId={eventId}
@@ -82,16 +152,27 @@ function EventShiftsPage() {
       />
 
       <div className="space-y-4">
-        {shifts.length > 0 ? (
-          shifts.map((shift) => (
+        {visibleShifts.length > 0 ? (
+          visibleShifts.map((shift) => (
             <ShiftCard
               key={shift.id}
               eventId={eventId}
               shift={shift}
+              pilotState={pilotOps.shiftsById[shift.id]}
               volunteers={assignableVolunteers}
               timezone={timezone}
+              credentialQuery={filters.credentialQuery}
             />
           ))
+        ) : shifts.length > 0 ? (
+          <section className="rounded-md border bg-card p-8 text-center shadow-sm">
+            <h3 className="font-semibold">
+              No shifts match the current filters
+            </h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Adjust the role, status, source, or credential filter.
+            </p>
+          </section>
         ) : (
           <section className="rounded-md border bg-card p-8 text-center shadow-sm">
             <h3 className="font-semibold">No shifts yet</h3>
@@ -100,6 +181,107 @@ function EventShiftsPage() {
             </p>
           </section>
         )}
+      </div>
+    </section>
+  )
+}
+
+function PilotOpsFilters({
+  filters,
+  roleOptions,
+  visibleCount,
+  totalCount,
+  onChange,
+}: {
+  filters: CrewShiftBoardPilotFilters
+  roleOptions: Array<{ value: VolunteerRoleType; label: string }>
+  visibleCount: number
+  totalCount: number
+  onChange: (filters: CrewShiftBoardPilotFilters) => void
+}) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <label className="grid gap-1 text-sm">
+            <span className="font-medium">Role</span>
+            <select
+              value={filters.roleType}
+              onChange={(event) =>
+                onChange({
+                  ...filters,
+                  roleType: event.target.value as VolunteerRoleType | "all",
+                })
+              }
+              className="h-10 min-w-0 rounded-md border bg-background px-3"
+            >
+              <option value="all">All roles</option>
+              {roleOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="grid gap-1 text-sm">
+            <span className="font-medium">Status</span>
+            <select
+              value={filters.status}
+              onChange={(event) =>
+                onChange({
+                  ...filters,
+                  status: event.target
+                    .value as CrewShiftBoardPilotFilters["status"],
+                })
+              }
+              className="h-10 min-w-0 rounded-md border bg-background px-3"
+            >
+              <option value="all">All statuses</option>
+              <option value="ready">Ready</option>
+              <option value="open_slots">Open slots</option>
+              <option value="responses_needed">Responses needed</option>
+              <option value="blocked">Blocked</option>
+            </select>
+          </label>
+          <label className="grid gap-1 text-sm">
+            <span className="font-medium">Source</span>
+            <select
+              value={filters.source}
+              onChange={(event) =>
+                onChange({
+                  ...filters,
+                  source: event.target
+                    .value as CrewShiftBoardPilotFilters["source"],
+                })
+              }
+              className="h-10 min-w-0 rounded-md border bg-background px-3"
+            >
+              <option value="all">All assignments</option>
+              <option value="imported_assignments">Imported assignments</option>
+              <option value="direct_assignments">Direct assignments</option>
+            </select>
+          </label>
+          <label className="grid gap-1 text-sm">
+            <span className="font-medium">Credential</span>
+            <span className="relative">
+              <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={filters.credentialQuery}
+                onChange={(event) =>
+                  onChange({
+                    ...filters,
+                    credentialQuery: event.target.value,
+                  })
+                }
+                className="h-10 w-full min-w-0 rounded-md border bg-background pl-9 pr-3 text-sm"
+                placeholder="EMT, L1, rigging"
+              />
+            </span>
+          </label>
+        </div>
+        <p className="text-sm text-muted-foreground">
+          {visibleCount}/{totalCount} shifts
+        </p>
       </div>
     </section>
   )
@@ -186,13 +368,17 @@ function CreateShiftForm({
 function ShiftCard({
   eventId,
   shift,
+  pilotState,
   volunteers,
   timezone,
+  credentialQuery,
 }: {
   eventId: string
   shift: CrewShiftBoardItem
+  pilotState: CrewShiftPilotShiftState | undefined
   volunteers: CrewRosterVolunteer[]
   timezone: string
+  credentialQuery: string
 }) {
   const router = useRouter()
   const assignVolunteer = useServerFn(assignCrewVolunteerToShiftFn)
@@ -209,7 +395,8 @@ function ShiftCard({
     (volunteer) =>
       volunteer.membershipId &&
       !assignedMembershipIds.has(volunteer.membershipId) &&
-      isVolunteerCompatibleWithShift(shift.roleType, volunteer.roleTypes),
+      isVolunteerCompatibleWithShift(shift.roleType, volunteer.roleTypes) &&
+      volunteerMatchesCredentialQuery(volunteer, credentialQuery),
   )
 
   async function handleAssign(event: FormEvent<HTMLFormElement>) {
@@ -311,12 +498,19 @@ function ShiftCard({
         <div>
           <div className="flex flex-wrap items-center gap-2">
             <h3 className="text-lg font-semibold">{shift.name}</h3>
+            {pilotState ? <PilotStatusBadge state={pilotState} /> : null}
             <span className="rounded-md border bg-background px-2 py-1 text-xs">
               {shift.roleLabel}
             </span>
             <span className="rounded-md border bg-background px-2 py-1 text-xs">
               {shift.assignedCount}/{shift.capacity}
             </span>
+            {pilotState?.importedAssignmentCount ? (
+              <span className="inline-flex items-center gap-1 rounded-md border border-sky-500/30 bg-sky-500/10 px-2 py-1 text-xs font-medium text-sky-700">
+                <UploadCloud className="size-3.5" />
+                {pilotState.importedAssignmentCount} imported
+              </span>
+            ) : null}
           </div>
           <p className="mt-2 text-sm text-muted-foreground">
             {formatDateTimeInTimezone(
@@ -349,6 +543,17 @@ function ShiftCard({
         </p>
       ) : null}
 
+      {pilotState?.warnings.length ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {pilotState.warnings.map((warning) => (
+            <PilotWarningBadge
+              key={`${warning.kind}:${warning.assignmentId ?? warning.detail}`}
+              warning={warning}
+            />
+          ))}
+        </div>
+      ) : null}
+
       <div className="mt-5 grid gap-5 lg:grid-cols-[1fr_22rem]">
         <div className="space-y-3">
           <h4 className="text-sm font-semibold">Assignments</h4>
@@ -371,6 +576,11 @@ function ShiftCard({
                     <div className="text-sm text-muted-foreground">
                       {assignment.volunteer.email}
                     </div>
+                    <VolunteerDetailTags volunteer={assignment.volunteer} />
+                    <AssignmentResponseDetail
+                      confirmation={assignment.confirmation}
+                      timezone={timezone}
+                    />
                     {assignment.confirmation?.responseNote ? (
                       <div className="mt-1 max-w-md text-sm text-muted-foreground">
                         {assignment.confirmation.responseNote}
@@ -407,11 +617,18 @@ function ShiftCard({
               <option value="">Choose volunteer</option>
               {availableVolunteers.map((volunteer) => (
                 <option key={volunteer.id} value={volunteer.membershipId ?? ""}>
-                  {volunteer.name} · {volunteer.email}
+                  {volunteer.name} · {volunteer.email} ·{" "}
+                  {formatVolunteerAvailability(volunteer.availability)}
+                  {volunteer.credentials ? ` · ${volunteer.credentials}` : ""}
                 </option>
               ))}
             </select>
           </label>
+          {credentialQuery.trim() && availableVolunteers.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No compatible volunteers match that credential filter.
+            </p>
+          ) : null}
           <button
             type="submit"
             disabled={
@@ -465,6 +682,117 @@ function ShiftCard({
   )
 }
 
+function PilotStatusBadge({ state }: { state: CrewShiftPilotShiftState }) {
+  const className =
+    state.severity === "covered"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+      : state.severity === "warning"
+        ? "border-amber-500/30 bg-amber-500/10 text-amber-700"
+        : "border-destructive/30 bg-destructive/10 text-destructive"
+  const Icon =
+    state.severity === "covered"
+      ? CheckCircle2
+      : state.severity === "warning"
+        ? Clock3
+        : AlertTriangle
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium ${className}`}
+    >
+      <Icon className="size-3.5" />
+      {state.statusLabel}
+    </span>
+  )
+}
+
+function PilotWarningBadge({
+  warning,
+}: {
+  warning: CrewShiftPilotShiftState["warnings"][number]
+}) {
+  const className =
+    warning.severity === "critical"
+      ? "border-destructive/30 bg-destructive/10 text-destructive"
+      : "border-amber-500/30 bg-amber-500/10 text-amber-700"
+
+  return (
+    <span
+      className={`inline-flex max-w-full items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium ${className}`}
+      title={warning.detail}
+    >
+      <AlertTriangle className="size-3.5 shrink-0" />
+      <span className="truncate">{warning.label}</span>
+    </span>
+  )
+}
+
+function VolunteerDetailTags({
+  volunteer,
+}: {
+  volunteer: CrewShiftBoardItem["assignments"][number]["volunteer"]
+}) {
+  return (
+    <div className="mt-2 flex flex-wrap gap-2 text-xs text-muted-foreground">
+      <span className="rounded-md border bg-muted/40 px-2 py-1">
+        {formatRoleList(volunteer.roleTypes)}
+      </span>
+      <span className="rounded-md border bg-muted/40 px-2 py-1">
+        {formatVolunteerAvailability(volunteer.availability)}
+      </span>
+      {volunteer.credentials ? (
+        <span className="rounded-md border bg-muted/40 px-2 py-1">
+          {volunteer.credentials}
+        </span>
+      ) : null}
+      {volunteer.imported ? (
+        <span className="inline-flex items-center gap-1 rounded-md border border-sky-500/30 bg-sky-500/10 px-2 py-1 font-medium text-sky-700">
+          <UploadCloud className="size-3.5" />
+          Imported
+        </span>
+      ) : null}
+      {volunteer.signupSource ? (
+        <span className="rounded-md border bg-muted/40 px-2 py-1">
+          {formatCrewValue(volunteer.signupSource)}
+        </span>
+      ) : null}
+    </div>
+  )
+}
+
+function AssignmentResponseDetail({
+  confirmation,
+  timezone,
+}: {
+  confirmation: CrewShiftBoardItem["assignments"][number]["confirmation"]
+  timezone: string
+}) {
+  if (!confirmation) {
+    return <p className="mt-2 text-xs text-amber-700">Confirmation missing</p>
+  }
+
+  if (!confirmation.respondedAt) {
+    return (
+      <p className="mt-2 text-xs text-muted-foreground">
+        {confirmation.status === "pending"
+          ? "Awaiting response"
+          : formatCrewValue(confirmation.status)}
+      </p>
+    )
+  }
+
+  return (
+    <p className="mt-2 text-xs text-muted-foreground">
+      {formatCrewValue(confirmation.status)}{" "}
+      {formatDateTimeInTimezone(
+        confirmation.respondedAt,
+        timezone,
+        "MMM d h:mm a",
+      )}
+    </p>
+  )
+}
+
 function ConfirmationBadge({ status }: { status: string }) {
   const className = getCrewAssignmentConfirmationStatusBadgeClassName(status)
 
@@ -475,6 +803,25 @@ function ConfirmationBadge({ status }: { status: string }) {
       {formatCrewValue(status)}
     </span>
   )
+}
+
+function volunteerMatchesCredentialQuery(
+  volunteer: CrewRosterVolunteer,
+  credentialQuery: string,
+) {
+  const query = credentialQuery.trim().toLowerCase()
+  if (!query) return true
+  return volunteer.credentials?.toLowerCase().includes(query) ?? false
+}
+
+function formatRoleList(roleTypes: VolunteerRoleType[]) {
+  return roleTypes
+    .map(
+      (roleType) =>
+        VOLUNTEER_ROLE_OPTIONS.find((option) => option.value === roleType)
+          ?.label ?? formatCrewValue(roleType),
+    )
+    .join(", ")
 }
 
 function ShiftFields({

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -1,5 +1,6 @@
 // @lat: [[crew#Roster Shifts Assignments]]
 // @lat: [[crew#Manual Volunteer Intake]]
+// @lat: [[crew#Shift Board Pilot Ops]]
 import { createId } from "@paralleldrive/cuid2"
 import { and, asc, eq, inArray, sql } from "drizzle-orm"
 import { getDb } from "../db"
@@ -9,6 +10,7 @@ import {
 } from "../db/schemas/common"
 import type { Competition } from "../db/schemas/competitions"
 import { competitionsTable } from "../db/schemas/competitions"
+import { CREW_ASSIGNMENT_CONFIRMATION_TYPE } from "../db/schemas/crew-imports"
 import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
 import {
   INVITATION_STATUS,
@@ -50,6 +52,14 @@ import {
   validateShiftAssignment,
   validateShiftCapacityUpdate,
 } from "../lib/crew/roster-shifts"
+import {
+  buildCrewShiftBoardPilotOps,
+  type CrewShiftBoardPilotOpsData,
+} from "../lib/crew/shift-board-pilot-ops"
+import {
+  buildCrewStaffingMatrix,
+  type CrewStaffingMatrixInput,
+} from "../lib/crew/staffing"
 import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
 import {
   cancelCrewShiftAssignmentConfirmations,
@@ -82,6 +92,10 @@ export interface CrewShiftAssignmentVolunteer {
   name: string
   email: string
   roleTypes: VolunteerRoleType[]
+  availability: VolunteerAvailability | null
+  credentials: string | null
+  imported: boolean
+  signupSource: string | null
 }
 
 export interface CrewShiftAssignmentItem {
@@ -121,6 +135,7 @@ export interface CrewShiftBoardData {
   rosterSummary: CrewRosterSummary
   shifts: CrewShiftBoardItem[]
   shiftSummary: CrewShiftSummary
+  pilotOps: CrewShiftBoardPilotOpsData
 }
 
 export interface CrewShiftSummary {
@@ -247,6 +262,8 @@ export async function getCrewShiftBoard(
     loadCrewRoster(event.competitionTeamId),
     loadCrewShifts(event.id),
   ])
+  const matrixInput = buildShiftBoardStaffingMatrixInput(event, roster, shifts)
+  const matrix = buildCrewStaffingMatrix(matrixInput)
 
   return {
     event,
@@ -254,6 +271,11 @@ export async function getCrewShiftBoard(
     rosterSummary: summarizeCrewRoster(roster),
     shifts,
     shiftSummary: summarizeCrewShifts(shifts),
+    pilotOps: buildCrewShiftBoardPilotOps({
+      shifts,
+      roster,
+      matrix,
+    }),
   }
 }
 
@@ -910,6 +932,11 @@ export async function loadCrewShifts(
           email:
             metadata.signupEmail ?? assignment.membership.user?.email ?? "",
           roleTypes,
+          availability: metadata.availability ?? null,
+          credentials: metadata.credentials ?? null,
+          imported: Boolean(metadata.crewImportId),
+          signupSource:
+            metadata.crewSignupSource ?? metadata.inviteSource ?? null,
         },
       }
     })
@@ -930,6 +957,55 @@ export async function loadCrewShifts(
       openSlots: Math.max(shift.capacity - assignments.length, 0),
     }
   })
+}
+
+function buildShiftBoardStaffingMatrixInput(
+  event: CrewRosterCompetition,
+  roster: CrewRosterVolunteer[],
+  shifts: CrewShiftBoardItem[],
+): CrewStaffingMatrixInput {
+  return {
+    event: {
+      id: event.id,
+      name: event.name,
+      timezone: event.timezone,
+      startDate: event.startDate,
+      endDate: event.endDate,
+    },
+    roster: roster.flatMap((volunteer) => {
+      if (!volunteer.membershipId) return []
+      return {
+        membershipId: volunteer.membershipId,
+        name: volunteer.name,
+        email: volunteer.email,
+        roleTypes: volunteer.roleTypes,
+        availability: volunteer.availability,
+        credentials: volunteer.credentials,
+        isActive: volunteer.status === "active",
+      }
+    }),
+    shifts: shifts.map((shift) => ({
+      id: shift.id,
+      name: shift.name,
+      roleType: shift.roleType,
+      startTime: shift.startTime,
+      endTime: shift.endTime,
+      capacity: shift.capacity,
+      location: shift.location,
+      assignments: shift.assignments.map((assignment) => ({
+        id: assignment.id,
+        membershipId: assignment.membershipId,
+        confirmation: assignment.confirmation
+          ? {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: assignment.confirmation.status,
+              respondedAt: assignment.confirmation.respondedAt,
+              responseNote: assignment.confirmation.responseNote,
+            }
+          : null,
+      })),
+    })),
+  }
 }
 
 export function summarizeCrewShifts(

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -38,6 +38,16 @@ Roster shifts assignments normalize volunteer invitations, memberships, shifts, 
 
 The pure helpers preserve source identity for invitations and memberships, derive roster status, and keep role, availability, credential, import, and assignment details together so Crew pages can render staffing state without mutating event data.
 
+## Shift Board Pilot Ops
+
+Crew shift board pilot ops adapts the existing shift surface into an operator handoff board for real pilot events.
+
+[[apps/crew/src/routes/events/$eventId/shifts.tsx]] keeps Crew-owned shift create, edit, assign, and remove actions while adding role, credential, source, and status filters.
+
+[[apps/crew/src/server/crew-roster-shift.server.ts]] hydrates the board from existing roster, shift, assignment, confirmation, and staffing-matrix inputs without creating schema or mutating judge rows.
+
+[[apps/crew/src/lib/crew/shift-board-pilot-ops.ts]] derives per-shift open-slot, confirmation, availability, role, double-booking, import-source, and ready/blocked status signals for the route.
+
 ## Manual Volunteer Intake
 
 Manual volunteer intake lets Crew operators build the roster from [[apps/crew/src/routes/events/$eventId/volunteers.tsx|the event volunteer page]] without leaving the existing volunteer primitives.


### PR DESCRIPTION
## Summary
- Adds a pure Crew shift-board pilot-ops helper for per-shift status, warnings, import/source counts, and filters.
- Hydrates the existing Crew shift board with staffing-matrix signals from shifts, roster, assignments, and confirmations.
- Updates /events/$eventId/shifts with role/status/source/credential filters, pilot status badges, assignment response details, imported assignment markers, and LAT refs.

## Validation
- pnpm --filter crew exec vitest run src/lib/crew/shift-board-pilot-ops.test.ts
- pnpm --filter crew type-check
- pnpm --filter crew lint (passes with existing unrelated warning baseline)
- pnpm --filter crew build (passes with existing Vite chunk-size warning)
- pnpm check:schema-ownership
- pnpm dlx lat.md locate 'crew#Shift Board Pilot Ops'
- git diff --check

## Notes
- No schema, migrations, live email, queue, public-token, judge rotation, or infra mutations.
- Shift rows do not currently carry import IDs, so import source is surfaced at the assigned-volunteer level from existing roster metadata.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adapts the Crew shift board for pilot ops by computing per‑shift readiness and warnings, and adding role/status/source/credential filters to the shifts view. Lets operators spot gaps, confirm coverage, and see imported assignments at a glance.

- **New Features**
  - Added a pure helper to derive per‑shift status (ready/open_slots/responses_needed/blocked), warnings (open capacity, confirmation gap, outside availability, credential, double‑booked), import/source counts, and filtering utilities; tests included.
  - Server now hydrates `pilotOps` from existing roster, shifts, assignments, and confirmations via the staffing matrix; returned by `getCrewShiftBoard` with no schema or migration changes.
  - Updated shift board UI with status badges, warning chips, imported assignment counts, staffing summary cards, and assignment response details; volunteer tags now show availability, credentials, import source, and signup source.
  - Added filters: role, status, assignment source (imported vs direct), and credential text search, with live filtered count; filters persist in URL search params.
  - Added a link to the staffing report from the shift board.

- **Bug Fixes**
  - Direct assignment filter now includes shifts with mixed sources (both imported and direct assignments).

<sup>Written for commit ceed96de5f977760224020a3c0f469d8a30dc2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced shift board pilot operations with real-time shift status tracking (ready, blocked, responses needed, open slots).
  * Added comprehensive shift filtering by role, status, assignment source, and credential requirements.
  * Implemented visual status badges and warning indicators for shifts.
  * Enhanced shift summaries with volunteer assignment and confirmation metrics.

* **Documentation**
  * Added Shift Board Pilot Ops documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->