### PR TITLE
fix(crew): harden judge assignment version publishing

### DIFF
--- a/apps/crew/src/server-fns/judge-scheduling-fns.ts
+++ b/apps/crew/src/server-fns/judge-scheduling-fns.ts
@@ -88,7 +88,7 @@ const heatIdSchema = z.string().startsWith("cheat_", "Invalid heat ID")
 
 const assignmentIdSchema = z
   .string()
-  .startsWith("chvol_", "Invalid assignment ID")
+  .startsWith("hvol_", "Invalid assignment ID")
 
 const volunteerRoleTypeSchema = z.enum([
   VOLUNTEER_ROLE_TYPES.JUDGE,
@@ -377,9 +377,7 @@ export const getJudgeSchedulingDataForEventsFn = createServerFn({
   method: "GET",
 })
   .inputValidator((data: unknown) =>
-    z
-      .object({ trackWorkoutIds: z.array(z.string().min(1)) })
-      .parse(data),
+    z.object({ trackWorkoutIds: z.array(z.string().min(1)) }).parse(data),
   )
   .handler(async ({ data }) => {
     const { trackWorkoutIds } = data
@@ -480,9 +478,7 @@ export const getJudgeSchedulingDataForEventsFn = createServerFn({
     // Assignments only exist under a published (active) version; a version
     // belongs to exactly one event, so filtering by active version ids is
     // sufficient to scope assignments to their events.
-    const activeVersionIds = versions
-      .filter((v) => v.isActive)
-      .map((v) => v.id)
+    const activeVersionIds = versions.filter((v) => v.isActive).map((v) => v.id)
 
     if (activeVersionIds.length > 0) {
       const assignments = await db

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-heat-card.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-heat-card.tsx
@@ -296,6 +296,7 @@ interface JudgeHeatCardProps {
     targetLane: number,
     assignment: JudgeHeatAssignment,
   ) => void
+  onScheduleRevisionPublished?: () => Promise<void> | void
   selectedJudgeIds?: Set<string>
   onClearSelection?: () => void
   filterEmptyLanes?: boolean
@@ -317,6 +318,7 @@ export function JudgeHeatCard({
   onDelete,
   onAssignmentChange,
   onMoveAssignment,
+  onScheduleRevisionPublished,
   selectedJudgeIds,
   onClearSelection,
   filterEmptyLanes,
@@ -331,6 +333,14 @@ export function JudgeHeatCard({
 
   // Get this heat's judge assignments
   const heatAssignments = judgeAssignments.filter((ja) => ja.heatId === heat.id)
+
+  async function refreshAfterRevisionIfNeeded(result: {
+    revisionPublished?: boolean
+  }) {
+    if (!result.revisionPublished) return false
+    await onScheduleRevisionPublished?.()
+    return true
+  }
 
   // Get occupied lanes
   const occupiedLanes = new Set(heatAssignments.map((a) => a.laneNumber))
@@ -369,6 +379,12 @@ export function JudgeHeatCard({
       })
 
       if (result?.data) {
+        if (await refreshAfterRevisionIfNeeded(result)) {
+          setIsAssignOpen(false)
+          setSelectedMembershipId("")
+          return
+        }
+
         // Find the volunteer data
         const volunteer = unassignedVolunteers.find(
           (v) => v.membershipId === selectedMembershipId,
@@ -397,13 +413,17 @@ export function JudgeHeatCard({
   async function handleRemove(assignmentId: string) {
     setIsRemoving(true)
     try {
-      await removeJudgeFromHeatFn({
+      const result = await removeJudgeFromHeatFn({
         data: {
           assignmentId,
           competitionId,
           organizingTeamId,
         },
       })
+
+      if (await refreshAfterRevisionIfNeeded(result)) {
+        return
+      }
 
       onAssignmentChange(heatAssignments.filter((a) => a.id !== assignmentId))
     } catch (err) {
@@ -458,6 +478,10 @@ export function JudgeHeatCard({
         })
 
         if (result?.data) {
+          if (await refreshAfterRevisionIfNeeded(result)) {
+            return
+          }
+
           const volunteer = unassignedVolunteers.find(
             (v) => v.membershipId === assignment.membershipId,
           )
@@ -488,6 +512,10 @@ export function JudgeHeatCard({
         })
 
         if (result?.data) {
+          if (await refreshAfterRevisionIfNeeded(result)) {
+            return
+          }
+
           // Build new assignments from result
           const newAssignments = result.data
             .map((assignment) => {
@@ -532,7 +560,7 @@ export function JudgeHeatCard({
     try {
       // If moving within same heat, just update lane
       if (sourceHeatId === heat.id) {
-        await moveJudgeAssignmentFn({
+        const result = await moveJudgeAssignmentFn({
           data: {
             assignmentId,
             competitionId,
@@ -542,6 +570,10 @@ export function JudgeHeatCard({
           },
         })
 
+        if (await refreshAfterRevisionIfNeeded(result)) {
+          return
+        }
+
         // Update local state
         onAssignmentChange(
           heatAssignments.map((a) =>
@@ -550,7 +582,7 @@ export function JudgeHeatCard({
         )
       } else {
         // Cross-heat move
-        await moveJudgeAssignmentFn({
+        const result = await moveJudgeAssignmentFn({
           data: {
             assignmentId,
             competitionId,
@@ -559,6 +591,10 @@ export function JudgeHeatCard({
             targetLaneNumber: targetLane,
           },
         })
+
+        if (await refreshAfterRevisionIfNeeded(result)) {
+          return
+        }
 
         if (onMoveAssignment) {
           // Let parent handle state updates for both heats

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-heat-card.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-heat-card.tsx
@@ -338,7 +338,8 @@ export function JudgeHeatCard({
     revisionPublished?: boolean
   }) {
     if (!result.revisionPublished) return false
-    await onScheduleRevisionPublished?.()
+    if (!onScheduleRevisionPublished) return false
+    await onScheduleRevisionPublished()
     return true
   }
 
@@ -479,6 +480,7 @@ export function JudgeHeatCard({
 
         if (result?.data) {
           if (await refreshAfterRevisionIfNeeded(result)) {
+            onClearSelection?.()
             return
           }
 
@@ -513,6 +515,7 @@ export function JudgeHeatCard({
 
         if (result?.data) {
           if (await refreshAfterRevisionIfNeeded(result)) {
+            onClearSelection?.()
             return
           }
 

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-scheduling-container.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/-components/judges/judge-scheduling-container.tsx
@@ -754,6 +754,7 @@ export function JudgeSchedulingContainer({
                       handleAssignmentChange(heat.id, newAssignments)
                     }
                     onMoveAssignment={handleMoveAssignment}
+                    onScheduleRevisionPublished={refreshVersionData}
                     selectedJudgeIds={selectedJudgeIds}
                     onClearSelection={clearSelection}
                     filterEmptyLanes={filterEmptyLanes}

--- a/apps/wodsmith-start/src/server-fns/cohost/cohost-judge-rotation-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/cohost/cohost-judge-rotation-fns.ts
@@ -8,7 +8,10 @@ import { createServerFn } from "@tanstack/react-start"
 import { and, asc, desc, eq, inArray } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
-import type { CompetitionJudgeRotation, JudgeAssignmentVersion } from "@/db/schema"
+import type {
+  CompetitionJudgeRotation,
+  JudgeAssignmentVersion,
+} from "@/db/schema"
 import {
   competitionHeatsTable,
   competitionJudgeRotationsTable,
@@ -21,8 +24,16 @@ import {
   programmingTracksTable,
   trackWorkoutsTable,
 } from "@/db/schema"
+import { createJudgeAssignmentVersionId } from "@/db/schemas/common"
 import { expandRotationToAssignments } from "@/lib/judge-rotation-utils"
-import { requireCohostCompetitionOwnership, requireCohostPermission } from "@/utils/cohost-auth"
+import {
+  requireCohostCompetitionOwnership,
+  requireCohostPermission,
+} from "@/utils/cohost-auth"
+import {
+  getNextJudgeAssignmentVersionNumber,
+  withJudgeAssignmentVersionLock,
+} from "../judge-assignment-versioning"
 
 // ============================================================================
 // Input Schemas
@@ -475,10 +486,7 @@ function calculateLane(
 /**
  * Expand rotations into individual heat+lane assignments
  */
-async function materializeRotations(
-  trackWorkoutId: string,
-  maxLanes: number,
-) {
+async function materializeRotations(trackWorkoutId: string, maxLanes: number) {
   const db = getDb()
 
   type MaterializedAssignment = Record<string, unknown> & {
@@ -550,7 +558,10 @@ export const cohostCreateJudgeRotationFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => createRotationSchema.parse(data))
   .handler(async ({ data }) => {
     await requireCohostPermission(data.competitionTeamId, "volunteers")
-    await requireCohostCompetitionOwnership(data.competitionTeamId, data.competitionId)
+    await requireCohostCompetitionOwnership(
+      data.competitionTeamId,
+      data.competitionId,
+    )
 
     const validation = await validateRotationConflictsInternal({
       trackWorkoutId: data.trackWorkoutId,
@@ -660,7 +671,10 @@ export const cohostUpdateEventDefaultsFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => updateEventDefaultsSchema.parse(data))
   .handler(async ({ data }) => {
     await requireCohostPermission(data.competitionTeamId, "volunteers")
-    await requireCohostCompetitionOwnership(data.competitionTeamId, data.competitionId)
+    await requireCohostCompetitionOwnership(
+      data.competitionTeamId,
+      data.competitionId,
+    )
 
     const db = getDb()
 
@@ -698,7 +712,10 @@ export const cohostBatchCreateRotationsFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => batchCreateRotationsSchema.parse(data))
   .handler(async ({ data }) => {
     await requireCohostPermission(data.competitionTeamId, "volunteers")
-    await requireCohostCompetitionOwnership(data.competitionTeamId, data.competitionId)
+    await requireCohostCompetitionOwnership(
+      data.competitionTeamId,
+      data.competitionId,
+    )
 
     const db = getDb()
 
@@ -796,7 +813,10 @@ export const cohostBatchUpdateVolunteerRotationsFn = createServerFn({
   )
   .handler(async ({ data }) => {
     await requireCohostPermission(data.competitionTeamId, "volunteers")
-    await requireCohostCompetitionOwnership(data.competitionTeamId, data.competitionId)
+    await requireCohostCompetitionOwnership(
+      data.competitionTeamId,
+      data.competitionId,
+    )
 
     const db = getDb()
 
@@ -920,9 +940,7 @@ export const cohostBatchUpdateVolunteerRotationsFn = createServerFn({
 export const cohostDeleteVolunteerRotationsFn = createServerFn({
   method: "POST",
 })
-  .inputValidator((data: unknown) =>
-    deleteVolunteerRotationsSchema.parse(data),
-  )
+  .inputValidator((data: unknown) => deleteVolunteerRotationsSchema.parse(data))
   .handler(async ({ data }) => {
     await requireCohostPermission(data.competitionTeamId, "volunteers")
 
@@ -969,7 +987,10 @@ export const cohostBatchDeleteRotationsFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => batchDeleteRotationsSchema.parse(data))
   .handler(async ({ data }) => {
     await requireCohostPermission(data.competitionTeamId, "volunteers")
-    await requireCohostCompetitionOwnership(data.competitionTeamId, data.competitionId)
+    await requireCohostCompetitionOwnership(
+      data.competitionTeamId,
+      data.competitionId,
+    )
 
     const db = getDb()
 
@@ -1045,70 +1066,78 @@ export const cohostPublishRotationsFn = createServerFn({ method: "POST" })
       3,
     )
 
-    // Get next version number
-    const versions = await db.query.judgeAssignmentVersionsTable.findMany({
-      where: eq(
-        judgeAssignmentVersionsTable.trackWorkoutId,
-        data.trackWorkoutId,
-      ),
-      orderBy: desc(judgeAssignmentVersionsTable.version),
-    })
-    const nextVersion =
-      versions.length > 0 ? (versions[0]?.version ?? 0) + 1 : 1
-
     // Materialize all rotations
     const materializedAssignments = await materializeRotations(
       data.trackWorkoutId,
       maxLanes,
     )
 
-    const { createJudgeAssignmentVersionId } = await import("@/db/schema")
-    const newVersionId = createJudgeAssignmentVersionId()
+    const newVersion = await withJudgeAssignmentVersionLock(
+      db,
+      data.trackWorkoutId,
+      async () =>
+        db.transaction(async (tx) => {
+          const versions = await tx.query.judgeAssignmentVersionsTable.findMany(
+            {
+              where: eq(
+                judgeAssignmentVersionsTable.trackWorkoutId,
+                data.trackWorkoutId,
+              ),
+              orderBy: desc(judgeAssignmentVersionsTable.version),
+            },
+          )
+          const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
+          const newVersionId = createJudgeAssignmentVersionId()
 
-    const newVersion = await db.transaction(async (tx) => {
-      // Deactivate previous versions
-      await tx
-        .update(judgeAssignmentVersionsTable)
-        .set({ isActive: false, updatedAt: new Date() })
-        .where(
-          eq(judgeAssignmentVersionsTable.trackWorkoutId, data.trackWorkoutId),
-        )
+          // Deactivate previous versions
+          await tx
+            .update(judgeAssignmentVersionsTable)
+            .set({ isActive: false, updatedAt: new Date() })
+            .where(
+              eq(
+                judgeAssignmentVersionsTable.trackWorkoutId,
+                data.trackWorkoutId,
+              ),
+            )
 
-      // Create new version
-      await tx.insert(judgeAssignmentVersionsTable).values({
-        id: newVersionId,
-        trackWorkoutId: data.trackWorkoutId,
-        version: nextVersion,
-        publishedBy: data.publishedBy,
-        notes: data.notes ?? null,
-        isActive: true,
-      })
+          // Create new version
+          await tx.insert(judgeAssignmentVersionsTable).values({
+            id: newVersionId,
+            trackWorkoutId: data.trackWorkoutId,
+            version: nextVersion,
+            publishedBy: data.publishedBy,
+            notes: data.notes ?? null,
+            isActive: true,
+          })
 
-      const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
-        where: eq(judgeAssignmentVersionsTable.id, newVersionId),
-      })
+          const version = await tx.query.judgeAssignmentVersionsTable.findFirst(
+            {
+              where: eq(judgeAssignmentVersionsTable.id, newVersionId),
+            },
+          )
 
-      if (!version) {
-        throw new Error("Failed to create version")
-      }
+          if (!version) {
+            throw new Error("Failed to create version")
+          }
 
-      // Bulk insert all assignments
-      if (materializedAssignments.length > 0) {
-        await tx.insert(judgeHeatAssignmentsTable).values(
-          materializedAssignments.map((a) => ({
-            heatId: a.heatId,
-            membershipId: a.membershipId,
-            rotationId: a.rotationId,
-            laneNumber: a.laneNumber,
-            position: a.position,
-            versionId: version.id,
-            isManualOverride: false,
-          })),
-        )
-      }
+          // Bulk insert all assignments
+          if (materializedAssignments.length > 0) {
+            await tx.insert(judgeHeatAssignmentsTable).values(
+              materializedAssignments.map((a) => ({
+                heatId: a.heatId,
+                membershipId: a.membershipId,
+                rotationId: a.rotationId,
+                laneNumber: a.laneNumber,
+                position: a.position,
+                versionId: version.id,
+                isManualOverride: false,
+              })),
+            )
+          }
 
-      return version
-    })
+          return version
+        }),
+    )
 
     return newVersion
   })
@@ -1177,7 +1206,10 @@ export const cohostAdjustRotationsForOccupiedLanesFn = createServerFn({
   )
   .handler(async ({ data }) => {
     await requireCohostPermission(data.competitionTeamId, "volunteers")
-    await requireCohostCompetitionOwnership(data.competitionTeamId, data.competitionId)
+    await requireCohostCompetitionOwnership(
+      data.competitionTeamId,
+      data.competitionId,
+    )
 
     const db = getDb()
 

--- a/apps/wodsmith-start/src/server-fns/cohost/cohost-judge-rotation-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/cohost/cohost-judge-rotation-fns.ts
@@ -5,7 +5,7 @@
  */
 
 import { createServerFn } from "@tanstack/react-start"
-import { and, asc, desc, eq, inArray } from "drizzle-orm"
+import { and, asc, eq, inArray } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "@/db"
 import type {
@@ -24,15 +24,14 @@ import {
   programmingTracksTable,
   trackWorkoutsTable,
 } from "@/db/schema"
-import { createJudgeAssignmentVersionId } from "@/db/schemas/common"
 import { expandRotationToAssignments } from "@/lib/judge-rotation-utils"
 import {
   requireCohostCompetitionOwnership,
   requireCohostPermission,
 } from "@/utils/cohost-auth"
 import {
-  getNextJudgeAssignmentVersionNumber,
-  withJudgeAssignmentVersionLock,
+  type MaterializedJudgeAssignmentForVersion,
+  publishMaterializedJudgeAssignmentsVersion,
 } from "../judge-assignment-versioning"
 
 // ============================================================================
@@ -486,18 +485,12 @@ function calculateLane(
 /**
  * Expand rotations into individual heat+lane assignments
  */
-async function materializeRotations(trackWorkoutId: string, maxLanes: number) {
-  const db = getDb()
-
-  type MaterializedAssignment = Record<string, unknown> & {
-    heatId: string
-    membershipId: string
-    rotationId: string
-    laneNumber: number
-    position: "judge"
-  }
-
-  const assignments: MaterializedAssignment[] = []
+async function materializeRotations(
+  db: Pick<ReturnType<typeof getDb>, "query" | "select">,
+  trackWorkoutId: string,
+  maxLanes: number,
+) {
+  const assignments: MaterializedJudgeAssignmentForVersion[] = []
 
   const rotations = await db.query.competitionJudgeRotationsTable.findMany({
     where: eq(competitionJudgeRotationsTable.trackWorkoutId, trackWorkoutId),
@@ -1066,77 +1059,14 @@ export const cohostPublishRotationsFn = createServerFn({ method: "POST" })
       3,
     )
 
-    // Materialize all rotations
-    const materializedAssignments = await materializeRotations(
-      data.trackWorkoutId,
-      maxLanes,
-    )
-
-    const newVersion = await withJudgeAssignmentVersionLock(
+    const newVersion = await publishMaterializedJudgeAssignmentsVersion(
       db,
-      data.trackWorkoutId,
-      async () =>
-        db.transaction(async (tx) => {
-          const versions = await tx.query.judgeAssignmentVersionsTable.findMany(
-            {
-              where: eq(
-                judgeAssignmentVersionsTable.trackWorkoutId,
-                data.trackWorkoutId,
-              ),
-              orderBy: desc(judgeAssignmentVersionsTable.version),
-            },
-          )
-          const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
-          const newVersionId = createJudgeAssignmentVersionId()
-
-          // Deactivate previous versions
-          await tx
-            .update(judgeAssignmentVersionsTable)
-            .set({ isActive: false, updatedAt: new Date() })
-            .where(
-              eq(
-                judgeAssignmentVersionsTable.trackWorkoutId,
-                data.trackWorkoutId,
-              ),
-            )
-
-          // Create new version
-          await tx.insert(judgeAssignmentVersionsTable).values({
-            id: newVersionId,
-            trackWorkoutId: data.trackWorkoutId,
-            version: nextVersion,
-            publishedBy: data.publishedBy,
-            notes: data.notes ?? null,
-            isActive: true,
-          })
-
-          const version = await tx.query.judgeAssignmentVersionsTable.findFirst(
-            {
-              where: eq(judgeAssignmentVersionsTable.id, newVersionId),
-            },
-          )
-
-          if (!version) {
-            throw new Error("Failed to create version")
-          }
-
-          // Bulk insert all assignments
-          if (materializedAssignments.length > 0) {
-            await tx.insert(judgeHeatAssignmentsTable).values(
-              materializedAssignments.map((a) => ({
-                heatId: a.heatId,
-                membershipId: a.membershipId,
-                rotationId: a.rotationId,
-                laneNumber: a.laneNumber,
-                position: a.position,
-                versionId: version.id,
-                isManualOverride: false,
-              })),
-            )
-          }
-
-          return version
-        }),
+      {
+        trackWorkoutId: data.trackWorkoutId,
+        publishedBy: data.publishedBy,
+        notes: data.notes,
+      },
+      (tx) => materializeRotations(tx, data.trackWorkoutId, maxLanes),
     )
 
     return newVersion

--- a/apps/wodsmith-start/src/server-fns/db-execute.ts
+++ b/apps/wodsmith-start/src/server-fns/db-execute.ts
@@ -1,0 +1,15 @@
+export function getExecuteRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) {
+    if (Array.isArray(result[0])) return result[0] as T[]
+    return result as T[]
+  }
+
+  return ((result as { rows?: T[] })?.rows ?? []) as T[]
+}
+
+export function getFirstExecuteValue(result: unknown): unknown {
+  const [row] = getExecuteRows<unknown>(result)
+  if (Array.isArray(row)) return row[0]
+  if (row && typeof row === "object") return Object.values(row)[0]
+  return row
+}

--- a/apps/wodsmith-start/src/server-fns/judge-assignment-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/judge-assignment-fns.ts
@@ -20,12 +20,11 @@ import {
   programmingTracksTable,
   trackWorkoutsTable,
 } from "@/db/schema"
-import { createJudgeAssignmentVersionId } from "@/db/schemas/common"
 import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
 import { requireTeamPermission } from "@/utils/team-auth"
 import {
-  getNextJudgeAssignmentVersionNumber,
-  withJudgeAssignmentVersionLock,
+  type MaterializedJudgeAssignmentForVersion,
+  publishMaterializedJudgeAssignmentsVersion,
 } from "./judge-assignment-versioning"
 
 // ============================================================================
@@ -42,14 +41,6 @@ export interface PublishRotationsParams {
 export interface RollbackToVersionParams {
   versionId: string
   teamId: string // For permission check
-}
-
-type MaterializedAssignment = Record<string, unknown> & {
-  heatId: string
-  membershipId: string
-  rotationId: string
-  laneNumber: number
-  position: "judge" // Judge rotations always create judge assignments
 }
 
 // ============================================================================
@@ -114,11 +105,11 @@ function calculateLane(
  * Expand rotations into individual heat+lane assignments
  */
 async function materializeRotations(
+  db: Pick<ReturnType<typeof getDb>, "query" | "select">,
   trackWorkoutId: string,
   maxLanes: number,
-): Promise<MaterializedAssignment[]> {
-  const db = getDb()
-  const assignments: MaterializedAssignment[] = []
+): Promise<MaterializedJudgeAssignmentForVersion[]> {
+  const assignments: MaterializedJudgeAssignmentForVersion[] = []
 
   // Get all rotations for this event
   const rotations = await db.query.competitionJudgeRotationsTable.findMany({
@@ -360,78 +351,15 @@ export const publishRotationsFn = createServerFn({ method: "POST" })
       3,
     )
 
-    // Materialize all rotations (read-only, before transaction)
-    const materializedAssignments = await materializeRotations(
-      data.trackWorkoutId,
-      maxLanes,
-    )
-
-    // Use transaction for atomic version switch + assignment creation
-    const newVersion = await withJudgeAssignmentVersionLock(
+    // Materialize rotations inside the publish lock + transaction.
+    const newVersion = await publishMaterializedJudgeAssignmentsVersion(
       db,
-      data.trackWorkoutId,
-      async () =>
-        db.transaction(async (tx) => {
-          const versions = await tx.query.judgeAssignmentVersionsTable.findMany(
-            {
-              where: eq(
-                judgeAssignmentVersionsTable.trackWorkoutId,
-                data.trackWorkoutId,
-              ),
-              orderBy: desc(judgeAssignmentVersionsTable.version),
-            },
-          )
-          const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
-          const newVersionId = createJudgeAssignmentVersionId()
-
-          // Deactivate previous versions
-          await tx
-            .update(judgeAssignmentVersionsTable)
-            .set({ isActive: false, updatedAt: new Date() })
-            .where(
-              eq(
-                judgeAssignmentVersionsTable.trackWorkoutId,
-                data.trackWorkoutId,
-              ),
-            )
-
-          // Create new version
-          await tx.insert(judgeAssignmentVersionsTable).values({
-            id: newVersionId,
-            trackWorkoutId: data.trackWorkoutId,
-            version: nextVersion,
-            publishedBy: data.publishedBy,
-            notes: data.notes ?? null,
-            isActive: true,
-          })
-
-          const version = await tx.query.judgeAssignmentVersionsTable.findFirst(
-            {
-              where: eq(judgeAssignmentVersionsTable.id, newVersionId),
-            },
-          )
-
-          if (!version) {
-            throw new Error("Failed to create version")
-          }
-
-          // Bulk insert all assignments in a single query (MySQL has no param limit)
-          if (materializedAssignments.length > 0) {
-            await tx.insert(judgeHeatAssignmentsTable).values(
-              materializedAssignments.map((a) => ({
-                heatId: a.heatId,
-                membershipId: a.membershipId,
-                rotationId: a.rotationId,
-                laneNumber: a.laneNumber,
-                position: a.position,
-                versionId: version.id,
-                isManualOverride: false,
-              })),
-            )
-          }
-
-          return version
-        }),
+      {
+        trackWorkoutId: data.trackWorkoutId,
+        publishedBy: data.publishedBy,
+        notes: data.notes,
+      },
+      (tx) => materializeRotations(tx, data.trackWorkoutId, maxLanes),
     )
 
     return newVersion

--- a/apps/wodsmith-start/src/server-fns/judge-assignment-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/judge-assignment-fns.ts
@@ -20,8 +20,13 @@ import {
   programmingTracksTable,
   trackWorkoutsTable,
 } from "@/db/schema"
+import { createJudgeAssignmentVersionId } from "@/db/schemas/common"
 import { TEAM_PERMISSIONS } from "@/db/schemas/teams"
 import { requireTeamPermission } from "@/utils/team-auth"
+import {
+  getNextJudgeAssignmentVersionNumber,
+  withJudgeAssignmentVersionLock,
+} from "./judge-assignment-versioning"
 
 // ============================================================================
 // Types
@@ -355,71 +360,79 @@ export const publishRotationsFn = createServerFn({ method: "POST" })
       3,
     )
 
-    // Get next version number
-    const versions = await db.query.judgeAssignmentVersionsTable.findMany({
-      where: eq(
-        judgeAssignmentVersionsTable.trackWorkoutId,
-        data.trackWorkoutId,
-      ),
-      orderBy: desc(judgeAssignmentVersionsTable.version),
-    })
-    const nextVersion =
-      versions.length > 0 ? (versions[0]?.version ?? 0) + 1 : 1
-
     // Materialize all rotations (read-only, before transaction)
     const materializedAssignments = await materializeRotations(
       data.trackWorkoutId,
       maxLanes,
     )
 
-    const { createJudgeAssignmentVersionId } = await import("@/db/schema")
-    const newVersionId = createJudgeAssignmentVersionId()
-
     // Use transaction for atomic version switch + assignment creation
-    const newVersion = await db.transaction(async (tx) => {
-      // Deactivate previous versions
-      await tx
-        .update(judgeAssignmentVersionsTable)
-        .set({ isActive: false, updatedAt: new Date() })
-        .where(
-          eq(judgeAssignmentVersionsTable.trackWorkoutId, data.trackWorkoutId),
-        )
+    const newVersion = await withJudgeAssignmentVersionLock(
+      db,
+      data.trackWorkoutId,
+      async () =>
+        db.transaction(async (tx) => {
+          const versions = await tx.query.judgeAssignmentVersionsTable.findMany(
+            {
+              where: eq(
+                judgeAssignmentVersionsTable.trackWorkoutId,
+                data.trackWorkoutId,
+              ),
+              orderBy: desc(judgeAssignmentVersionsTable.version),
+            },
+          )
+          const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
+          const newVersionId = createJudgeAssignmentVersionId()
 
-      // Create new version
-      await tx.insert(judgeAssignmentVersionsTable).values({
-        id: newVersionId,
-        trackWorkoutId: data.trackWorkoutId,
-        version: nextVersion,
-        publishedBy: data.publishedBy,
-        notes: data.notes ?? null,
-        isActive: true,
-      })
+          // Deactivate previous versions
+          await tx
+            .update(judgeAssignmentVersionsTable)
+            .set({ isActive: false, updatedAt: new Date() })
+            .where(
+              eq(
+                judgeAssignmentVersionsTable.trackWorkoutId,
+                data.trackWorkoutId,
+              ),
+            )
 
-      const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
-        where: eq(judgeAssignmentVersionsTable.id, newVersionId),
-      })
+          // Create new version
+          await tx.insert(judgeAssignmentVersionsTable).values({
+            id: newVersionId,
+            trackWorkoutId: data.trackWorkoutId,
+            version: nextVersion,
+            publishedBy: data.publishedBy,
+            notes: data.notes ?? null,
+            isActive: true,
+          })
 
-      if (!version) {
-        throw new Error("Failed to create version")
-      }
+          const version = await tx.query.judgeAssignmentVersionsTable.findFirst(
+            {
+              where: eq(judgeAssignmentVersionsTable.id, newVersionId),
+            },
+          )
 
-      // Bulk insert all assignments in a single query (MySQL has no param limit)
-      if (materializedAssignments.length > 0) {
-        await tx.insert(judgeHeatAssignmentsTable).values(
-          materializedAssignments.map((a) => ({
-            heatId: a.heatId,
-            membershipId: a.membershipId,
-            rotationId: a.rotationId,
-            laneNumber: a.laneNumber,
-            position: a.position,
-            versionId: version.id,
-            isManualOverride: false,
-          })),
-        )
-      }
+          if (!version) {
+            throw new Error("Failed to create version")
+          }
 
-      return version
-    })
+          // Bulk insert all assignments in a single query (MySQL has no param limit)
+          if (materializedAssignments.length > 0) {
+            await tx.insert(judgeHeatAssignmentsTable).values(
+              materializedAssignments.map((a) => ({
+                heatId: a.heatId,
+                membershipId: a.membershipId,
+                rotationId: a.rotationId,
+                laneNumber: a.laneNumber,
+                position: a.position,
+                versionId: version.id,
+                isManualOverride: false,
+              })),
+            )
+          }
+
+          return version
+        }),
+    )
 
     return newVersion
   })

--- a/apps/wodsmith-start/src/server-fns/judge-assignment-versioning.ts
+++ b/apps/wodsmith-start/src/server-fns/judge-assignment-versioning.ts
@@ -1,0 +1,192 @@
+// @lat: [[crew#Judge Assignment Version Publishing]]
+
+import { and, desc, eq, sql } from "drizzle-orm"
+import type { getDb } from "@/db"
+import {
+  judgeAssignmentVersionsTable,
+  judgeHeatAssignmentsTable,
+} from "@/db/schema"
+import {
+  createHeatVolunteerId,
+  createJudgeAssignmentVersionId,
+} from "@/db/schemas/common"
+import { getFirstExecuteValue } from "./db-execute"
+
+type DbClient = ReturnType<typeof getDb>
+type JudgeAssignmentVersionRow =
+  typeof judgeAssignmentVersionsTable.$inferSelect
+type JudgeHeatAssignmentRow = typeof judgeHeatAssignmentsTable.$inferSelect
+type JudgeHeatAssignmentInsert = typeof judgeHeatAssignmentsTable.$inferInsert
+
+type AdvisoryLockDb = {
+  execute(query: unknown): Promise<unknown>
+}
+
+export type ClonedJudgeAssignmentForRevision = JudgeHeatAssignmentInsert & {
+  id: string
+  sourceAssignmentId: string | null
+}
+
+export interface PublishedJudgeAssignmentRevision {
+  version: JudgeAssignmentVersionRow
+  resultAssignmentIds: string[]
+}
+
+export function getNextJudgeAssignmentVersionNumber(
+  versions: Pick<JudgeAssignmentVersionRow, "version">[],
+) {
+  return versions.length > 0 ? (versions[0]?.version ?? 0) + 1 : 1
+}
+
+export function cloneJudgeAssignmentsForRevision(
+  activeAssignments: JudgeHeatAssignmentRow[],
+  versionId: string,
+  createId: () => string = createHeatVolunteerId,
+): ClonedJudgeAssignmentForRevision[] {
+  return activeAssignments.map((assignment) => ({
+    id: createId(),
+    sourceAssignmentId: assignment.id,
+    heatId: assignment.heatId,
+    membershipId: assignment.membershipId,
+    rotationId: assignment.rotationId,
+    versionId,
+    laneNumber: assignment.laneNumber,
+    position: assignment.position,
+    instructions: assignment.instructions,
+    isManualOverride: assignment.isManualOverride,
+  }))
+}
+
+export function findClonedJudgeAssignmentOrThrow(
+  assignments: ClonedJudgeAssignmentForRevision[],
+  sourceAssignmentId: string,
+) {
+  const assignment = assignments.find(
+    (candidate) => candidate.sourceAssignmentId === sourceAssignmentId,
+  )
+  if (!assignment) {
+    throw new Error("Judge assignment not found in the active version")
+  }
+  return assignment
+}
+
+export function toJudgeHeatAssignmentInserts(
+  assignments: ClonedJudgeAssignmentForRevision[],
+): JudgeHeatAssignmentInsert[] {
+  return assignments.map(
+    ({ sourceAssignmentId: _sourceAssignmentId, ...row }) => row,
+  )
+}
+
+export async function withJudgeAssignmentVersionLock<T>(
+  db: AdvisoryLockDb,
+  trackWorkoutId: string,
+  callback: () => Promise<T>,
+) {
+  let acquired = false
+  const lockName = await createJudgeAssignmentVersionLockName(trackWorkoutId)
+
+  try {
+    const result = await db.execute(
+      sql`SELECT GET_LOCK(${lockName}, 5) FROM dual`,
+    )
+    acquired = Number(getFirstExecuteValue(result) ?? 0) === 1
+    if (!acquired) {
+      throw new Error("Judge assignment version could not be published")
+    }
+
+    return await callback()
+  } finally {
+    if (acquired) {
+      await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
+    }
+  }
+}
+
+export async function createPublishedJudgeAssignmentRevision(
+  db: DbClient,
+  trackWorkoutId: string,
+  editClonedAssignments: (
+    assignments: ClonedJudgeAssignmentForRevision[],
+    versionId: string,
+  ) => {
+    assignments: ClonedJudgeAssignmentForRevision[]
+    resultAssignmentIds?: string[]
+  },
+): Promise<PublishedJudgeAssignmentRevision | null> {
+  return withJudgeAssignmentVersionLock(db, trackWorkoutId, async () =>
+    db.transaction(async (tx) => {
+      const activeVersion =
+        await tx.query.judgeAssignmentVersionsTable.findFirst({
+          where: and(
+            eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
+            eq(judgeAssignmentVersionsTable.isActive, true),
+          ),
+        })
+
+      if (!activeVersion) {
+        return null
+      }
+
+      const versions = await tx.query.judgeAssignmentVersionsTable.findMany({
+        where: eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
+        orderBy: desc(judgeAssignmentVersionsTable.version),
+      })
+      const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
+      const newVersionId = createJudgeAssignmentVersionId()
+      const activeAssignments =
+        await tx.query.judgeHeatAssignmentsTable.findMany({
+          where: eq(judgeHeatAssignmentsTable.versionId, activeVersion.id),
+        })
+      const clonedAssignments = cloneJudgeAssignmentsForRevision(
+        activeAssignments,
+        newVersionId,
+      )
+      const edited = editClonedAssignments(clonedAssignments, newVersionId)
+      const timestamp = new Date()
+
+      await tx
+        .update(judgeAssignmentVersionsTable)
+        .set({ isActive: false, updatedAt: timestamp })
+        .where(eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId))
+
+      await tx.insert(judgeAssignmentVersionsTable).values({
+        id: newVersionId,
+        trackWorkoutId,
+        version: nextVersion,
+        publishedBy: null,
+        notes: "Manual judge assignment edit",
+        isActive: true,
+      })
+
+      if (edited.assignments.length > 0) {
+        await tx
+          .insert(judgeHeatAssignmentsTable)
+          .values(toJudgeHeatAssignmentInserts(edited.assignments))
+      }
+
+      const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
+        where: eq(judgeAssignmentVersionsTable.id, newVersionId),
+      })
+      if (!version) {
+        throw new Error("Failed to create judge assignment version")
+      }
+
+      return {
+        version,
+        resultAssignmentIds: edited.resultAssignmentIds ?? [],
+      }
+    }),
+  )
+}
+
+async function createJudgeAssignmentVersionLockName(trackWorkoutId: string) {
+  const encoded = new TextEncoder().encode(
+    `judge-assignment-version:${trackWorkoutId}`,
+  )
+  const digest = await crypto.subtle.digest("SHA-256", encoded)
+  const hex = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")
+  return `jav:${hex.slice(0, 60)}`
+}

--- a/apps/wodsmith-start/src/server-fns/judge-assignment-versioning.ts
+++ b/apps/wodsmith-start/src/server-fns/judge-assignment-versioning.ts
@@ -13,6 +13,8 @@ import {
 import { getFirstExecuteValue } from "./db-execute"
 
 type DbClient = ReturnType<typeof getDb>
+type TransactionCallback = Parameters<DbClient["transaction"]>[0]
+type TransactionClient = Parameters<TransactionCallback>[0]
 type JudgeAssignmentVersionRow =
   typeof judgeAssignmentVersionsTable.$inferSelect
 type JudgeHeatAssignmentRow = typeof judgeHeatAssignmentsTable.$inferSelect
@@ -32,10 +34,25 @@ export interface PublishedJudgeAssignmentRevision {
   resultAssignmentIds: string[]
 }
 
+export type MaterializedJudgeAssignmentForVersion = Pick<
+  JudgeHeatAssignmentInsert,
+  "heatId" | "membershipId" | "rotationId" | "laneNumber" | "position"
+>
+
+export interface PublishMaterializedJudgeAssignmentsVersionParams {
+  trackWorkoutId: string
+  publishedBy: string
+  notes?: string | null
+}
+
 export function getNextJudgeAssignmentVersionNumber(
   versions: Pick<JudgeAssignmentVersionRow, "version">[],
 ) {
-  return versions.length > 0 ? (versions[0]?.version ?? 0) + 1 : 1
+  const currentMax = versions.reduce(
+    (max, version) => Math.max(max, version.version),
+    0,
+  )
+  return currentMax + 1
 }
 
 export function cloneJudgeAssignmentsForRevision(
@@ -84,6 +101,7 @@ export async function withJudgeAssignmentVersionLock<T>(
   callback: () => Promise<T>,
 ) {
   let acquired = false
+  let callbackFailed = false
   const lockName = await createJudgeAssignmentVersionLockName(trackWorkoutId)
 
   try {
@@ -95,12 +113,97 @@ export async function withJudgeAssignmentVersionLock<T>(
       throw new Error("Judge assignment version could not be published")
     }
 
-    return await callback()
+    try {
+      return await callback()
+    } catch (error) {
+      callbackFailed = true
+      throw error
+    }
   } finally {
     if (acquired) {
-      await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
+      try {
+        await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
+      } catch (releaseError) {
+        if (callbackFailed) {
+          console.warn(
+            "Failed to release judge assignment version lock after callback error",
+            releaseError,
+          )
+        } else {
+          console.warn(
+            "Failed to release judge assignment version lock",
+            releaseError,
+          )
+        }
+      }
     }
   }
+}
+
+export async function publishMaterializedJudgeAssignmentsVersion(
+  db: DbClient,
+  params: PublishMaterializedJudgeAssignmentsVersionParams,
+  materializeAssignments: (
+    tx: TransactionClient,
+  ) => Promise<MaterializedJudgeAssignmentForVersion[]>,
+) {
+  return withJudgeAssignmentVersionLock(db, params.trackWorkoutId, async () =>
+    db.transaction(async (tx) => {
+      const versions = await tx.query.judgeAssignmentVersionsTable.findMany({
+        where: eq(
+          judgeAssignmentVersionsTable.trackWorkoutId,
+          params.trackWorkoutId,
+        ),
+        orderBy: desc(judgeAssignmentVersionsTable.version),
+      })
+      const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
+      const newVersionId = createJudgeAssignmentVersionId()
+      const materializedAssignments = await materializeAssignments(tx)
+
+      await tx
+        .update(judgeAssignmentVersionsTable)
+        .set({ isActive: false, updatedAt: new Date() })
+        .where(
+          eq(
+            judgeAssignmentVersionsTable.trackWorkoutId,
+            params.trackWorkoutId,
+          ),
+        )
+
+      await tx.insert(judgeAssignmentVersionsTable).values({
+        id: newVersionId,
+        trackWorkoutId: params.trackWorkoutId,
+        version: nextVersion,
+        publishedBy: params.publishedBy,
+        notes: params.notes ?? null,
+        isActive: true,
+      })
+
+      const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
+        where: eq(judgeAssignmentVersionsTable.id, newVersionId),
+      })
+
+      if (!version) {
+        throw new Error("Failed to create version")
+      }
+
+      if (materializedAssignments.length > 0) {
+        await tx.insert(judgeHeatAssignmentsTable).values(
+          materializedAssignments.map((assignment) => ({
+            heatId: assignment.heatId,
+            membershipId: assignment.membershipId,
+            rotationId: assignment.rotationId,
+            laneNumber: assignment.laneNumber,
+            position: assignment.position,
+            versionId: version.id,
+            isManualOverride: false,
+          })),
+        )
+      }
+
+      return version
+    }),
+  )
 }
 
 export async function createPublishedJudgeAssignmentRevision(

--- a/apps/wodsmith-start/src/server-fns/judge-scheduling-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/judge-scheduling-fns.ts
@@ -32,6 +32,11 @@ import type {
   VolunteerMembershipMetadata,
 } from "@/db/schemas/volunteers"
 import { requireTeamPermission } from "@/utils/team-auth"
+import {
+  type ClonedJudgeAssignmentForRevision,
+  createPublishedJudgeAssignmentRevision,
+  findClonedJudgeAssignmentOrThrow,
+} from "./judge-assignment-versioning"
 
 // ============================================================================
 // Types
@@ -88,7 +93,7 @@ const heatIdSchema = z.string().startsWith("cheat_", "Invalid heat ID")
 
 const assignmentIdSchema = z
   .string()
-  .startsWith("chvol_", "Invalid assignment ID")
+  .startsWith("hvol_", "Invalid assignment ID")
 
 const volunteerRoleTypeSchema = z.enum([
   VOLUNTEER_ROLE_TYPES.JUDGE,
@@ -132,6 +137,77 @@ function isJudge(metadata: string | null): boolean {
     meta.volunteerRoleTypes.includes(VOLUNTEER_ROLE_TYPES.JUDGE) ||
     meta.volunteerRoleTypes.includes(VOLUNTEER_ROLE_TYPES.HEAD_JUDGE)
   )
+}
+
+type DbClient = ReturnType<typeof getDb>
+
+async function getTrackWorkoutIdForHeatOrThrow(
+  db: DbClient,
+  heatId: string,
+): Promise<string> {
+  const [heat] = await db
+    .select({ trackWorkoutId: competitionHeatsTable.trackWorkoutId })
+    .from(competitionHeatsTable)
+    .where(eq(competitionHeatsTable.id, heatId))
+
+  if (!heat) {
+    throw new Error("Heat not found")
+  }
+
+  return heat.trackWorkoutId
+}
+
+async function getAssignmentContextOrThrow(
+  db: DbClient,
+  assignmentId: string,
+): Promise<{
+  trackWorkoutId: string
+  versionId: string | null
+}> {
+  const [assignment] = await db
+    .select({
+      trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+      versionId: judgeHeatAssignmentsTable.versionId,
+    })
+    .from(judgeHeatAssignmentsTable)
+    .innerJoin(
+      competitionHeatsTable,
+      eq(judgeHeatAssignmentsTable.heatId, competitionHeatsTable.id),
+    )
+    .where(eq(judgeHeatAssignmentsTable.id, assignmentId))
+
+  if (!assignment) {
+    throw new Error("Judge assignment not found")
+  }
+
+  return assignment
+}
+
+function appendManualJudgeAssignment(
+  assignments: ClonedJudgeAssignmentForRevision[],
+  data: {
+    heatId: string
+    membershipId: string
+    laneNumber: number | null
+    position?: ClonedJudgeAssignmentForRevision["position"]
+    instructions?: string | null
+    versionId: string
+  },
+) {
+  const id = createHeatVolunteerId()
+  assignments.push({
+    id,
+    sourceAssignmentId: null,
+    heatId: data.heatId,
+    membershipId: data.membershipId,
+    laneNumber: data.laneNumber,
+    position: data.position ?? null,
+    instructions: data.instructions ?? null,
+    rotationId: null,
+    versionId: data.versionId,
+    isManualOverride: true,
+  })
+  return id
 }
 
 // ============================================================================
@@ -377,9 +453,7 @@ export const getJudgeSchedulingDataForEventsFn = createServerFn({
   method: "GET",
 })
   .inputValidator((data: unknown) =>
-    z
-      .object({ trackWorkoutIds: z.array(z.string().min(1)) })
-      .parse(data),
+    z.object({ trackWorkoutIds: z.array(z.string().min(1)) }).parse(data),
   )
   .handler(async ({ data }) => {
     const { trackWorkoutIds } = data
@@ -480,9 +554,7 @@ export const getJudgeSchedulingDataForEventsFn = createServerFn({
     // Assignments only exist under a published (active) version; a version
     // belongs to exactly one event, so filtering by active version ids is
     // sufficient to scope assignments to their events.
-    const activeVersionIds = versions
-      .filter((v) => v.isActive)
-      .map((v) => v.id)
+    const activeVersionIds = versions.filter((v) => v.isActive).map((v) => v.id)
 
     if (activeVersionIds.length > 0) {
       const assignments = await db
@@ -702,6 +774,49 @@ export const assignJudgeToHeatFn = createServerFn({ method: "POST" })
     )
 
     const db = getDb()
+    const trackWorkoutId = await getTrackWorkoutIdForHeatOrThrow(
+      db,
+      data.heatId,
+    )
+    const publishedRevision = await createPublishedJudgeAssignmentRevision(
+      db,
+      trackWorkoutId,
+      (assignments, versionId) => {
+        const assignmentId = appendManualJudgeAssignment(assignments, {
+          heatId: data.heatId,
+          membershipId: data.membershipId,
+          laneNumber: data.laneNumber,
+          position: data.position,
+          instructions: data.instructions,
+          versionId,
+        })
+        return { assignments, resultAssignmentIds: [assignmentId] }
+      },
+    )
+
+    if (publishedRevision) {
+      const [assignment] = await db
+        .select()
+        .from(judgeHeatAssignmentsTable)
+        .where(
+          eq(
+            judgeHeatAssignmentsTable.id,
+            publishedRevision.resultAssignmentIds[0] ?? "",
+          ),
+        )
+
+      if (!assignment) {
+        throw new Error("Failed to assign judge to heat")
+      }
+
+      return {
+        success: true,
+        data: assignment,
+        revisionPublished: true,
+        versionId: publishedRevision.version.id,
+      }
+    }
+
     const assignmentId = createHeatVolunteerId()
     await db.insert(judgeHeatAssignmentsTable).values({
       id: assignmentId,
@@ -722,7 +837,7 @@ export const assignJudgeToHeatFn = createServerFn({ method: "POST" })
       throw new Error("Failed to assign judge to heat")
     }
 
-    return { success: true, data: assignment }
+    return { success: true, data: assignment, revisionPublished: false }
   })
 
 /**
@@ -757,6 +872,54 @@ export const bulkAssignJudgesToHeatFn = createServerFn({ method: "POST" })
     }
 
     const db = getDb()
+    const trackWorkoutId = await getTrackWorkoutIdForHeatOrThrow(
+      db,
+      data.heatId,
+    )
+
+    const publishedRevision = await createPublishedJudgeAssignmentRevision(
+      db,
+      trackWorkoutId,
+      (clonedAssignments, versionId) => {
+        const insertedIds: string[] = []
+        for (const assignment of data.assignments) {
+          insertedIds.push(
+            appendManualJudgeAssignment(clonedAssignments, {
+              heatId: data.heatId,
+              membershipId: assignment.membershipId,
+              laneNumber: assignment.laneNumber,
+              position: assignment.position,
+              instructions: assignment.instructions,
+              versionId,
+            }),
+          )
+        }
+
+        return {
+          assignments: clonedAssignments,
+          resultAssignmentIds: insertedIds,
+        }
+      },
+    )
+
+    if (publishedRevision) {
+      const results = await db
+        .select()
+        .from(judgeHeatAssignmentsTable)
+        .where(
+          inArray(
+            judgeHeatAssignmentsTable.id,
+            publishedRevision.resultAssignmentIds,
+          ),
+        )
+
+      return {
+        success: true,
+        data: results,
+        revisionPublished: true,
+        versionId: publishedRevision.version.id,
+      }
+    }
 
     // Insert all assignments in a single query (MySQL has no param limit)
     const insertedIds: string[] = []
@@ -781,7 +944,7 @@ export const bulkAssignJudgesToHeatFn = createServerFn({ method: "POST" })
       .from(judgeHeatAssignmentsTable)
       .where(inArray(judgeHeatAssignmentsTable.id, insertedIds))
 
-    return { success: true, data: results }
+    return { success: true, data: results, revisionPublished: false }
   })
 
 /**
@@ -804,11 +967,40 @@ export const removeJudgeFromHeatFn = createServerFn({ method: "POST" })
     )
 
     const db = getDb()
+    const assignmentContext = await getAssignmentContextOrThrow(
+      db,
+      data.assignmentId,
+    )
+    const publishedRevision = await createPublishedJudgeAssignmentRevision(
+      db,
+      assignmentContext.trackWorkoutId,
+      (assignments) => {
+        findClonedJudgeAssignmentOrThrow(assignments, data.assignmentId)
+        return {
+          assignments: assignments.filter(
+            (assignment) => assignment.sourceAssignmentId !== data.assignmentId,
+          ),
+        }
+      },
+    )
+
+    if (publishedRevision) {
+      return {
+        success: true,
+        revisionPublished: true,
+        versionId: publishedRevision.version.id,
+      }
+    }
+
+    if (assignmentContext.versionId) {
+      throw new Error("Judge assignment not found in the active version")
+    }
+
     await db
       .delete(judgeHeatAssignmentsTable)
       .where(eq(judgeHeatAssignmentsTable.id, data.assignmentId))
 
-    return { success: true }
+    return { success: true, revisionPublished: false }
   })
 
 /**
@@ -833,6 +1025,43 @@ export const moveJudgeAssignmentFn = createServerFn({ method: "POST" })
     )
 
     const db = getDb()
+    const [assignmentContext, targetTrackWorkoutId] = await Promise.all([
+      getAssignmentContextOrThrow(db, data.assignmentId),
+      getTrackWorkoutIdForHeatOrThrow(db, data.targetHeatId),
+    ])
+
+    if (assignmentContext.trackWorkoutId !== targetTrackWorkoutId) {
+      throw new Error("Target heat is in a different event")
+    }
+
+    const publishedRevision = await createPublishedJudgeAssignmentRevision(
+      db,
+      assignmentContext.trackWorkoutId,
+      (assignments) => {
+        const assignment = findClonedJudgeAssignmentOrThrow(
+          assignments,
+          data.assignmentId,
+        )
+        assignment.heatId = data.targetHeatId
+        assignment.laneNumber = data.targetLaneNumber
+        assignment.isManualOverride = true
+
+        return { assignments }
+      },
+    )
+
+    if (publishedRevision) {
+      return {
+        success: true,
+        revisionPublished: true,
+        versionId: publishedRevision.version.id,
+      }
+    }
+
+    if (assignmentContext.versionId) {
+      throw new Error("Judge assignment not found in the active version")
+    }
+
     await db
       .update(judgeHeatAssignmentsTable)
       .set({
@@ -842,7 +1071,7 @@ export const moveJudgeAssignmentFn = createServerFn({ method: "POST" })
       })
       .where(eq(judgeHeatAssignmentsTable.id, data.assignmentId))
 
-    return { success: true }
+    return { success: true, revisionPublished: false }
   })
 
 /**

--- a/apps/wodsmith-start/test/server/judge-assignment-versioning.test.ts
+++ b/apps/wodsmith-start/test/server/judge-assignment-versioning.test.ts
@@ -1,5 +1,3 @@
-// @lat: [[crew#Judge Assignment Version Publishing]]
-
 import { describe, expect, it, vi } from "vitest"
 import {
   cloneJudgeAssignmentsForRevision,
@@ -9,9 +7,17 @@ import {
   withJudgeAssignmentVersionLock,
 } from "@/server-fns/judge-assignment-versioning"
 
+// @lat: [[crew#Judge Assignment Version Publishing]]
 describe("judge assignment version publishing helpers", () => {
-  it("allocates the next version from the current highest version", () => {
+  it("allocates the next version from the current max version defensively", () => {
     expect(getNextJudgeAssignmentVersionNumber([])).toBe(1)
+    expect(
+      getNextJudgeAssignmentVersionNumber([
+        { version: 4 },
+        { version: 9 },
+        { version: 5 },
+      ]),
+    ).toBe(10)
     expect(
       getNextJudgeAssignmentVersionNumber([{ version: 5 }, { version: 4 }]),
     ).toBe(6)
@@ -115,6 +121,48 @@ describe("judge assignment version publishing helpers", () => {
     ).resolves.toBe("published")
 
     expect(db.execute).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not mask a successful publish when lock release fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const db = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce([[{ lockAcquired: 1 }]])
+        .mockRejectedValueOnce(new Error("release failed")),
+    }
+
+    await expect(
+      withJudgeAssignmentVersionLock(db, "tw_event1", async () => "published"),
+    ).resolves.toBe("published")
+
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to release judge assignment version lock",
+      expect.any(Error),
+    )
+    warn.mockRestore()
+  })
+
+  it("preserves callback errors when lock release also fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const db = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce([[{ lockAcquired: 1 }]])
+        .mockRejectedValueOnce(new Error("release failed")),
+    }
+
+    await expect(
+      withJudgeAssignmentVersionLock(db, "tw_event1", async () => {
+        throw new Error("publish failed")
+      }),
+    ).rejects.toThrow("publish failed")
+
+    expect(warn).toHaveBeenCalledWith(
+      "Failed to release judge assignment version lock after callback error",
+      expect.any(Error),
+    )
+    warn.mockRestore()
   })
 
   it("does not run the callback when the advisory lock cannot be acquired", async () => {

--- a/apps/wodsmith-start/test/server/judge-assignment-versioning.test.ts
+++ b/apps/wodsmith-start/test/server/judge-assignment-versioning.test.ts
@@ -1,0 +1,133 @@
+// @lat: [[crew#Judge Assignment Version Publishing]]
+
+import { describe, expect, it, vi } from "vitest"
+import {
+  cloneJudgeAssignmentsForRevision,
+  findClonedJudgeAssignmentOrThrow,
+  getNextJudgeAssignmentVersionNumber,
+  toJudgeHeatAssignmentInserts,
+  withJudgeAssignmentVersionLock,
+} from "@/server-fns/judge-assignment-versioning"
+
+describe("judge assignment version publishing helpers", () => {
+  it("allocates the next version from the current highest version", () => {
+    expect(getNextJudgeAssignmentVersionNumber([])).toBe(1)
+    expect(
+      getNextJudgeAssignmentVersionNumber([{ version: 5 }, { version: 4 }]),
+    ).toBe(6)
+  })
+
+  it("clones active assignments into a new version without reusing row ids", () => {
+    const ids = ["hvol_clone1", "hvol_clone2"]
+    const assignments = cloneJudgeAssignmentsForRevision(
+      [
+        {
+          id: "hvol_original1",
+          heatId: "cheat_1",
+          membershipId: "tmem_1",
+          rotationId: "jrot_1",
+          versionId: "jver_old",
+          laneNumber: 1,
+          position: "judge",
+          instructions: "Lane 1",
+          isManualOverride: false,
+          updateCounter: null,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+        {
+          id: "hvol_original2",
+          heatId: "cheat_2",
+          membershipId: "tmem_2",
+          rotationId: null,
+          versionId: "jver_old",
+          laneNumber: 2,
+          position: "head_judge",
+          instructions: null,
+          isManualOverride: true,
+          updateCounter: null,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+      "jver_new",
+      () => ids.shift() ?? "hvol_extra",
+    )
+
+    expect(assignments).toMatchObject([
+      {
+        id: "hvol_clone1",
+        sourceAssignmentId: "hvol_original1",
+        versionId: "jver_new",
+        heatId: "cheat_1",
+        membershipId: "tmem_1",
+      },
+      {
+        id: "hvol_clone2",
+        sourceAssignmentId: "hvol_original2",
+        versionId: "jver_new",
+        heatId: "cheat_2",
+        membershipId: "tmem_2",
+      },
+    ])
+    expect(toJudgeHeatAssignmentInserts(assignments)[0]).not.toHaveProperty(
+      "sourceAssignmentId",
+    )
+  })
+
+  it("fails loudly when an edit references an assignment outside the active version", () => {
+    const assignments = cloneJudgeAssignmentsForRevision(
+      [
+        {
+          id: "hvol_active",
+          heatId: "cheat_1",
+          membershipId: "tmem_1",
+          rotationId: null,
+          versionId: "jver_old",
+          laneNumber: 1,
+          position: "judge",
+          instructions: null,
+          isManualOverride: false,
+          updateCounter: null,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
+      "jver_new",
+      () => "hvol_clone",
+    )
+
+    expect(() =>
+      findClonedJudgeAssignmentOrThrow(assignments, "hvol_stale"),
+    ).toThrow("Judge assignment not found in the active version")
+  })
+
+  it("serializes version publication with a per-event advisory lock", async () => {
+    const db = {
+      execute: vi
+        .fn()
+        .mockResolvedValueOnce([[{ lockAcquired: 1 }]])
+        .mockResolvedValueOnce([[{ released: 1 }]]),
+    }
+
+    await expect(
+      withJudgeAssignmentVersionLock(db, "tw_event1", async () => "published"),
+    ).resolves.toBe("published")
+
+    expect(db.execute).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not run the callback when the advisory lock cannot be acquired", async () => {
+    const db = {
+      execute: vi.fn().mockResolvedValue([[{ lockAcquired: 0 }]]),
+    }
+    const callback = vi.fn()
+
+    await expect(
+      withJudgeAssignmentVersionLock(db, "tw_event1", callback),
+    ).rejects.toThrow("Judge assignment version could not be published")
+
+    expect(callback).not.toHaveBeenCalled()
+    expect(db.execute).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -50,7 +50,9 @@ Crew shift board pilot ops adapts the existing shift surface into an operator ha
 
 ## Judge Assignment Version Publishing
 
-Published judge assignment edits use the existing `judge_assignment_versions` and `judge_heat_assignments` model. Editing an active published judge schedule creates a new active version, clones the previous active assignments into that version, applies the edit to the cloned rows, and leaves the prior active version's rows immutable for audit and rollback.
+Published judge assignment edits use the existing `judge_assignment_versions` and `judge_heat_assignments` model.
+
+Editing an active published judge schedule creates a new active version, clones the previous active assignments into that version, applies the edit to the cloned rows, and leaves the prior active version's rows immutable for audit and rollback.
 
 Per-event publishing uses an advisory lock before allocating the next version number so frequent day-of edits do not race the `(trackWorkoutId, version)` uniqueness boundary. Edits against assignment IDs that are not present in the active version fail instead of silently mutating an inactive version or producing an empty revision.
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -48,6 +48,12 @@ Crew shift board pilot ops adapts the existing shift surface into an operator ha
 
 [[apps/crew/src/lib/crew/shift-board-pilot-ops.ts]] derives per-shift open-slot, confirmation, availability, role, double-booking, import-source, and ready/blocked status signals for the route.
 
+## Judge Assignment Version Publishing
+
+Published judge assignment edits use the existing `judge_assignment_versions` and `judge_heat_assignments` model. Editing an active published judge schedule creates a new active version, clones the previous active assignments into that version, applies the edit to the cloned rows, and leaves the prior active version's rows immutable for audit and rollback.
+
+Per-event publishing uses an advisory lock before allocating the next version number so frequent day-of edits do not race the `(trackWorkoutId, version)` uniqueness boundary. Edits against assignment IDs that are not present in the active version fail instead of silently mutating an inactive version or producing an empty revision.
+
 ## Manual Volunteer Intake
 
 Manual volunteer intake lets Crew operators build the roster from [[apps/crew/src/routes/events/$eventId/volunteers.tsx|the event volunteer page]] without leaving the existing volunteer primitives.


### PR DESCRIPTION
## Summary
- add an advisory-locked judge assignment versioning helper for Start
- publish edits to active judge schedules by cloning the active version before applying add/remove/move changes
- harden organizer and cohost rotation publishing so next version allocation happens under the per-event lock
- refresh the judge scheduling UI after server-side revision publishing to avoid stale assignment ids
- add focused helper tests and LAT docs for crew#Judge Assignment Version Publishing

## Validation
- pnpm --filter wodsmith-start type-check
- pnpm --filter wodsmith-start test -- judge
- pnpm --filter wodsmith-start lint (exits 0; existing warnings remain)
- pnpm --filter crew type-check
- pnpm check:schema-ownership
- pnpm dlx lat.md locate 'crew#Judge Assignment Version Publishing'\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely publishes judge schedule edits with per-event advisory locks and clone-on-edit revisions to prevent races and stale IDs. The UI now refreshes after server-side publication to keep assignment IDs in sync.

- **New Features**
  - Added `withJudgeAssignmentVersionLock`, `createPublishedJudgeAssignmentRevision`, and `publishMaterializedJudgeAssignmentsVersion` to serialize publishing, allocate the next version, and clone active assignments for edits and rotation materialization.
  - Assign, bulk assign, remove, and move now publish a new version by editing cloned rows; responses include `revisionPublished` and `versionId`. Organizer and cohost rotation publishing now uses the shared publisher under the lock.
  - `JudgeHeatCard` refreshes after a revision via optional `onScheduleRevisionPublished` (container wired); added focused tests and LAT docs.

- **Bug Fixes**
  - Corrected assignment ID validation to `hvol_` to match generated IDs.

<sup>Written for commit a657807d4dfa2c6d8e0879823ffd4ddaf0a415e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Judge assignment revision publishing with concurrency protection to prevent race conditions during simultaneous edits
  * Automatic data refresh when schedule revisions are published

* **Documentation**
  * Added Judge Assignment Version Publishing guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->