### PR TITLE
feat(crew): add judge rotations

### DIFF
--- a/apps/crew/src/lib/crew/judge-rotations.test.ts
+++ b/apps/crew/src/lib/crew/judge-rotations.test.ts
@@ -1,0 +1,160 @@
+// @lat: [[crew#Judge Rotations]]
+import { describe, expect, it } from "vitest"
+import { LANE_SHIFT_PATTERN } from "@/db/schemas/volunteers"
+import {
+  expandCrewJudgeRotationDrafts,
+  hasCrewJudgeRotationErrors,
+  summarizeCrewJudgeCoverage,
+  validateCrewJudgeRotationDrafts,
+} from "./judge-rotations"
+
+const heats = [
+  { heatNumber: 1, laneCount: 3 },
+  { heatNumber: 2, laneCount: 3 },
+  { heatNumber: 3, laneCount: 3 },
+]
+
+describe("Crew judge rotation helpers", () => {
+  it("expands shift-right rotations across consecutive heats", () => {
+    expect(
+      expandCrewJudgeRotationDrafts({
+        heats,
+        rotations: [
+          {
+            membershipId: "tmem_judge_1",
+            startingHeat: 1,
+            startingLane: 2,
+            heatsCount: 3,
+            laneShiftPattern: LANE_SHIFT_PATTERN.SHIFT_RIGHT,
+          },
+        ],
+      }),
+    ).toEqual([
+      {
+        rotationId: "draft-0",
+        membershipId: "tmem_judge_1",
+        heatNumber: 1,
+        laneNumber: 2,
+      },
+      {
+        rotationId: "draft-0",
+        membershipId: "tmem_judge_1",
+        heatNumber: 2,
+        laneNumber: 3,
+      },
+      {
+        rotationId: "draft-0",
+        membershipId: "tmem_judge_1",
+        heatNumber: 3,
+        laneNumber: 1,
+      },
+    ])
+  })
+
+  it("rejects duplicate same-judge heat coverage in a replacement plan", () => {
+    const issues = validateCrewJudgeRotationDrafts({
+      heats,
+      rotations: [
+        {
+          membershipId: "tmem_judge_1",
+          startingHeat: 1,
+          startingLane: 1,
+          heatsCount: 2,
+          laneShiftPattern: LANE_SHIFT_PATTERN.STAY,
+        },
+        {
+          membershipId: "tmem_judge_1",
+          startingHeat: 2,
+          startingLane: 2,
+          heatsCount: 1,
+          laneShiftPattern: LANE_SHIFT_PATTERN.STAY,
+        },
+      ],
+    })
+
+    expect(hasCrewJudgeRotationErrors(issues)).toBe(true)
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "duplicate_judge_heat",
+          heatNumber: 2,
+        }),
+      ]),
+    )
+  })
+
+  it("rejects lanes already occupied by another judge rotation", () => {
+    const issues = validateCrewJudgeRotationDrafts({
+      heats,
+      occupiedSlots: [
+        {
+          rotationId: "jrot_existing",
+          membershipId: "tmem_other_judge",
+          heatNumber: 1,
+          laneNumber: 1,
+        },
+      ],
+      rotations: [
+        {
+          membershipId: "tmem_judge_1",
+          startingHeat: 1,
+          startingLane: 1,
+          heatsCount: 1,
+          laneShiftPattern: LANE_SHIFT_PATTERN.STAY,
+        },
+      ],
+    })
+
+    expect(hasCrewJudgeRotationErrors(issues)).toBe(true)
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "occupied_lane",
+          heatNumber: 1,
+          laneNumber: 1,
+        }),
+      ]),
+    )
+  })
+
+  it("summarizes coverage gaps and overlaps deterministically", () => {
+    const summary = summarizeCrewJudgeCoverage({
+      heats: [{ heatNumber: 1, laneCount: 2 }],
+      rotations: [
+        {
+          id: "jrot_a",
+          membershipId: "tmem_judge_1",
+          startingHeat: 1,
+          startingLane: 1,
+          heatsCount: 1,
+          laneShiftPattern: LANE_SHIFT_PATTERN.STAY,
+        },
+        {
+          id: "jrot_b",
+          membershipId: "tmem_judge_2",
+          startingHeat: 1,
+          startingLane: 1,
+          heatsCount: 1,
+          laneShiftPattern: LANE_SHIFT_PATTERN.STAY,
+        },
+      ],
+    })
+
+    expect(summary).toMatchObject({
+      totalSlots: 2,
+      coveredSlots: 1,
+      coveragePercent: 50,
+      gaps: [{ heatNumber: 1, laneNumber: 2 }],
+    })
+    expect(summary.overlaps).toEqual([
+      {
+        heatNumber: 1,
+        laneNumber: 1,
+        judges: [
+          { membershipId: "tmem_judge_1", rotationId: "jrot_a" },
+          { membershipId: "tmem_judge_2", rotationId: "jrot_b" },
+        ],
+      },
+    ])
+  })
+})

--- a/apps/crew/src/lib/crew/judge-rotations.test.ts
+++ b/apps/crew/src/lib/crew/judge-rotations.test.ts
@@ -4,6 +4,7 @@ import { LANE_SHIFT_PATTERN } from "@/db/schemas/volunteers"
 import {
   assertCrewJudgeRotationReplacementAllowed,
   expandCrewJudgeRotationDrafts,
+  getCrewJudgeHeatLaneCount,
   hasCrewJudgeRotationErrors,
   summarizeCrewJudgeCoverage,
   validateCrewJudgeRotationDrafts,
@@ -132,6 +133,15 @@ describe("Crew judge rotation helpers", () => {
         assignmentReferenceCount: 0,
       }),
     ).not.toThrow()
+  })
+
+  it("derives heat lane capacity from occupied lanes when they exceed the venue lane count", () => {
+    expect(
+      getCrewJudgeHeatLaneCount({
+        venueLaneCount: 3,
+        occupiedLanes: [1, 5],
+      }),
+    ).toBe(5)
   })
 
   it("summarizes coverage gaps and overlaps deterministically", () => {

--- a/apps/crew/src/lib/crew/judge-rotations.test.ts
+++ b/apps/crew/src/lib/crew/judge-rotations.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest"
 import { LANE_SHIFT_PATTERN } from "@/db/schemas/volunteers"
 import {
+  assertCrewJudgeRotationReplacementAllowed,
   expandCrewJudgeRotationDrafts,
   hasCrewJudgeRotationErrors,
   summarizeCrewJudgeCoverage,
@@ -115,6 +116,22 @@ describe("Crew judge rotation helpers", () => {
         }),
       ]),
     )
+  })
+
+  it("blocks draft rotation replacement when assignments already reference the rotations", () => {
+    expect(() =>
+      assertCrewJudgeRotationReplacementAllowed({
+        assignmentReferenceCount: 1,
+      }),
+    ).toThrow(
+      "These rotations are already attached to judge assignments. Publish a new judge schedule revision instead of replacing draft rotations.",
+    )
+
+    expect(() =>
+      assertCrewJudgeRotationReplacementAllowed({
+        assignmentReferenceCount: 0,
+      }),
+    ).not.toThrow()
   })
 
   it("summarizes coverage gaps and overlaps deterministically", () => {

--- a/apps/crew/src/lib/crew/judge-rotations.ts
+++ b/apps/crew/src/lib/crew/judge-rotations.ts
@@ -240,6 +240,20 @@ export function assertCrewJudgeRotationReplacementAllowed({
   }
 }
 
+export function getCrewJudgeHeatLaneCount({
+  venueLaneCount,
+  occupiedLanes = [],
+}: {
+  venueLaneCount?: number | null
+  occupiedLanes?: number[]
+}) {
+  return Math.max(
+    venueLaneCount ?? 10,
+    occupiedLanes.length > 0 ? Math.max(...occupiedLanes) : 0,
+    1,
+  )
+}
+
 export function summarizeCrewJudgeCoverage({
   rotations,
   heats,

--- a/apps/crew/src/lib/crew/judge-rotations.ts
+++ b/apps/crew/src/lib/crew/judge-rotations.ts
@@ -1,0 +1,287 @@
+// @lat: [[crew#Judge Rotations]]
+import type { LaneShiftPattern } from "@/db/schemas/volunteers"
+import { LANE_SHIFT_PATTERN } from "@/db/schemas/volunteers"
+
+export interface CrewJudgeRotationHeat {
+  heatNumber: number
+  laneCount: number
+}
+
+export interface CrewJudgeRotationDraft {
+  id?: string
+  membershipId: string
+  startingHeat: number
+  startingLane: number
+  heatsCount: number
+  laneShiftPattern: LaneShiftPattern
+}
+
+export interface CrewJudgeRotationSlot {
+  rotationId: string
+  membershipId: string
+  heatNumber: number
+  laneNumber: number
+}
+
+export interface CrewJudgeRotationValidationIssue {
+  type:
+    | "no_heats"
+    | "missing_heat"
+    | "invalid_lane"
+    | "empty_rotation"
+    | "duplicate_judge_heat"
+    | "occupied_lane"
+  severity: "error" | "warning"
+  message: string
+  heatNumber?: number
+  laneNumber?: number
+  rotationId?: string
+}
+
+export interface CrewJudgeCoverageSummary {
+  totalSlots: number
+  coveredSlots: number
+  coveragePercent: number
+  gaps: Array<{ heatNumber: number; laneNumber: number }>
+  overlaps: Array<{
+    heatNumber: number
+    laneNumber: number
+    judges: Array<{ membershipId: string; rotationId: string }>
+  }>
+}
+
+export function getCrewJudgeRotationLane({
+  startingLane,
+  heatIndex,
+  laneCount,
+  laneShiftPattern,
+}: {
+  startingLane: number
+  heatIndex: number
+  laneCount: number
+  laneShiftPattern: LaneShiftPattern
+}) {
+  if (laneShiftPattern === LANE_SHIFT_PATTERN.SHIFT_RIGHT) {
+    return ((startingLane - 1 + heatIndex) % laneCount) + 1
+  }
+
+  return startingLane
+}
+
+export function expandCrewJudgeRotationDrafts({
+  rotations,
+  heats,
+}: {
+  rotations: CrewJudgeRotationDraft[]
+  heats: CrewJudgeRotationHeat[]
+}): CrewJudgeRotationSlot[] {
+  const heatMap = new Map(heats.map((heat) => [heat.heatNumber, heat]))
+  const slots: CrewJudgeRotationSlot[] = []
+
+  rotations.forEach((rotation, index) => {
+    const rotationId = rotation.id ?? `draft-${index}`
+
+    for (let heatIndex = 0; heatIndex < rotation.heatsCount; heatIndex++) {
+      const heatNumber = rotation.startingHeat + heatIndex
+      const heat = heatMap.get(heatNumber)
+      if (!heat) continue
+
+      const laneNumber = getCrewJudgeRotationLane({
+        startingLane: rotation.startingLane,
+        heatIndex,
+        laneCount: heat.laneCount,
+        laneShiftPattern: rotation.laneShiftPattern,
+      })
+
+      if (laneNumber < 1 || laneNumber > heat.laneCount) continue
+
+      slots.push({
+        rotationId,
+        membershipId: rotation.membershipId,
+        heatNumber,
+        laneNumber,
+      })
+    }
+  })
+
+  return slots
+}
+
+export function validateCrewJudgeRotationDrafts({
+  rotations,
+  heats,
+  occupiedSlots = [],
+}: {
+  rotations: CrewJudgeRotationDraft[]
+  heats: CrewJudgeRotationHeat[]
+  occupiedSlots?: CrewJudgeRotationSlot[]
+}): CrewJudgeRotationValidationIssue[] {
+  const issues: CrewJudgeRotationValidationIssue[] = []
+  const heatMap = new Map(heats.map((heat) => [heat.heatNumber, heat]))
+  const seenJudgeHeat = new Map<string, CrewJudgeRotationSlot>()
+  const seenLane = new Map<string, CrewJudgeRotationSlot>()
+
+  if (heats.length === 0) {
+    return [
+      {
+        type: "no_heats",
+        severity: "error",
+        message: "Add heats before creating judge rotations.",
+      },
+    ]
+  }
+
+  for (const occupied of occupiedSlots) {
+    seenLane.set(`${occupied.heatNumber}:${occupied.laneNumber}`, occupied)
+  }
+
+  rotations.forEach((rotation, index) => {
+    const rotationId = rotation.id ?? `draft-${index}`
+    let matchedHeats = 0
+
+    for (let heatIndex = 0; heatIndex < rotation.heatsCount; heatIndex++) {
+      const heatNumber = rotation.startingHeat + heatIndex
+      const heat = heatMap.get(heatNumber)
+
+      if (!heat) {
+        issues.push({
+          type: "missing_heat",
+          severity: "warning",
+          message: `Heat ${heatNumber} does not exist and will be skipped.`,
+          heatNumber,
+          rotationId,
+        })
+        continue
+      }
+
+      matchedHeats++
+      const laneNumber = getCrewJudgeRotationLane({
+        startingLane: rotation.startingLane,
+        heatIndex,
+        laneCount: heat.laneCount,
+        laneShiftPattern: rotation.laneShiftPattern,
+      })
+
+      if (laneNumber < 1 || laneNumber > heat.laneCount) {
+        issues.push({
+          type: "invalid_lane",
+          severity: "error",
+          message: `Lane ${laneNumber} is outside heat ${heatNumber}'s ${heat.laneCount} lanes.`,
+          heatNumber,
+          laneNumber,
+          rotationId,
+        })
+        continue
+      }
+
+      const slot: CrewJudgeRotationSlot = {
+        rotationId,
+        membershipId: rotation.membershipId,
+        heatNumber,
+        laneNumber,
+      }
+      const judgeHeatKey = `${slot.membershipId}:${slot.heatNumber}`
+      const existingJudgeHeat = seenJudgeHeat.get(judgeHeatKey)
+      if (existingJudgeHeat) {
+        issues.push({
+          type: "duplicate_judge_heat",
+          severity: "error",
+          message: `Judge already has a rotation on heat ${slot.heatNumber}.`,
+          heatNumber: slot.heatNumber,
+          laneNumber: slot.laneNumber,
+          rotationId,
+        })
+      }
+      seenJudgeHeat.set(judgeHeatKey, slot)
+
+      const laneKey = `${slot.heatNumber}:${slot.laneNumber}`
+      const existingLane = seenLane.get(laneKey)
+      if (existingLane && existingLane.membershipId !== slot.membershipId) {
+        issues.push({
+          type: "occupied_lane",
+          severity: "error",
+          message: `Heat ${slot.heatNumber} lane ${slot.laneNumber} already has a judge rotation.`,
+          heatNumber: slot.heatNumber,
+          laneNumber: slot.laneNumber,
+          rotationId,
+        })
+      }
+      seenLane.set(laneKey, slot)
+    }
+
+    if (matchedHeats === 0) {
+      issues.push({
+        type: "empty_rotation",
+        severity: "error",
+        message: "Rotation does not match any existing heats.",
+        rotationId,
+      })
+    }
+  })
+
+  return issues
+}
+
+export function hasCrewJudgeRotationErrors(
+  issues: CrewJudgeRotationValidationIssue[],
+) {
+  return issues.some((issue) => issue.severity === "error")
+}
+
+export function summarizeCrewJudgeCoverage({
+  rotations,
+  heats,
+}: {
+  rotations: CrewJudgeRotationDraft[]
+  heats: CrewJudgeRotationHeat[]
+}): CrewJudgeCoverageSummary {
+  const coverage = new Map<string, CrewJudgeRotationSlot[]>()
+
+  for (const heat of heats) {
+    for (let laneNumber = 1; laneNumber <= heat.laneCount; laneNumber++) {
+      coverage.set(`${heat.heatNumber}:${laneNumber}`, [])
+    }
+  }
+
+  for (const slot of expandCrewJudgeRotationDrafts({ rotations, heats })) {
+    const key = `${slot.heatNumber}:${slot.laneNumber}`
+    coverage.set(key, [...(coverage.get(key) ?? []), slot])
+  }
+
+  const gaps: CrewJudgeCoverageSummary["gaps"] = []
+  const overlaps: CrewJudgeCoverageSummary["overlaps"] = []
+  let coveredSlots = 0
+
+  for (const [key, slots] of coverage.entries()) {
+    const [heatRaw, laneRaw] = key.split(":")
+    const heatNumber = Number(heatRaw)
+    const laneNumber = Number(laneRaw)
+
+    if (slots.length === 0) {
+      gaps.push({ heatNumber, laneNumber })
+      continue
+    }
+
+    coveredSlots++
+    if (slots.length > 1) {
+      overlaps.push({
+        heatNumber,
+        laneNumber,
+        judges: slots.map((slot) => ({
+          membershipId: slot.membershipId,
+          rotationId: slot.rotationId,
+        })),
+      })
+    }
+  }
+
+  const totalSlots = coverage.size
+  return {
+    totalSlots,
+    coveredSlots,
+    coveragePercent:
+      totalSlots > 0 ? Math.round((coveredSlots / totalSlots) * 100) : 0,
+    gaps,
+    overlaps,
+  }
+}

--- a/apps/crew/src/lib/crew/judge-rotations.ts
+++ b/apps/crew/src/lib/crew/judge-rotations.ts
@@ -228,6 +228,18 @@ export function hasCrewJudgeRotationErrors(
   return issues.some((issue) => issue.severity === "error")
 }
 
+export function assertCrewJudgeRotationReplacementAllowed({
+  assignmentReferenceCount,
+}: {
+  assignmentReferenceCount: number
+}) {
+  if (assignmentReferenceCount > 0) {
+    throw new Error(
+      "These rotations are already attached to judge assignments. Publish a new judge schedule revision instead of replacing draft rotations.",
+    )
+  }
+}
+
 export function summarizeCrewJudgeCoverage({
   rotations,
   heats,

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as EventsEventIdShiftsRouteImport } from './routes/events/$eventI
 import { Route as EventsEventIdSetupRouteImport } from './routes/events/$eventId/setup'
 import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$eventId/schedule'
 import { Route as EventsEventIdReadinessRouteImport } from './routes/events/$eventId/readiness'
+import { Route as EventsEventIdJudgesRouteImport } from './routes/events/$eventId/judges'
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
@@ -87,6 +88,11 @@ const EventsEventIdReadinessRoute = EventsEventIdReadinessRouteImport.update({
   path: '/readiness',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdJudgesRoute = EventsEventIdJudgesRouteImport.update({
+  id: '/judges',
+  path: '/judges',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const EventsEventIdImportsRoute = EventsEventIdImportsRouteImport.update({
   id: '/imports',
   path: '/imports',
@@ -122,6 +128,7 @@ export interface FileRoutesByFullPath {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
+  '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
@@ -140,6 +147,7 @@ export interface FileRoutesByTo {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
+  '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
@@ -160,6 +168,7 @@ export interface FileRoutesById {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
+  '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
@@ -181,6 +190,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
+    | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
@@ -199,6 +209,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
+    | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
@@ -218,6 +229,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/imports'
+    | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
@@ -325,6 +337,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdReadinessRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/judges': {
+      id: '/events/$eventId/judges'
+      path: '/judges'
+      fullPath: '/events/$eventId/judges'
+      preLoaderRoute: typeof EventsEventIdJudgesRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/events/$eventId/imports': {
       id: '/events/$eventId/imports'
       path: '/imports'
@@ -365,6 +384,7 @@ declare module '@tanstack/react-router' {
 
 interface EventsEventIdRouteChildren {
   EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
+  EventsEventIdJudgesRoute: typeof EventsEventIdJudgesRoute
   EventsEventIdReadinessRoute: typeof EventsEventIdReadinessRoute
   EventsEventIdScheduleRoute: typeof EventsEventIdScheduleRoute
   EventsEventIdSetupRoute: typeof EventsEventIdSetupRoute
@@ -376,6 +396,7 @@ interface EventsEventIdRouteChildren {
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdImportsRoute: EventsEventIdImportsRoute,
+  EventsEventIdJudgesRoute: EventsEventIdJudgesRoute,
   EventsEventIdReadinessRoute: EventsEventIdReadinessRoute,
   EventsEventIdScheduleRoute: EventsEventIdScheduleRoute,
   EventsEventIdSetupRoute: EventsEventIdSetupRoute,

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -87,6 +87,14 @@ function EventShell() {
             Shifts
           </Link>
           <Link
+            to="/events/$eventId/judges"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Judges
+          </Link>
+          <Link
             to="/events/$eventId/schedule"
             params={{ eventId }}
             activeProps={{ className: "bg-muted text-foreground" }}

--- a/apps/crew/src/routes/events/$eventId/judges.tsx
+++ b/apps/crew/src/routes/events/$eventId/judges.tsx
@@ -1,0 +1,919 @@
+// @lat: [[crew#Judge Rotations]]
+import type { FormEvent } from "react"
+import {
+  createFileRoute,
+  getRouteApi,
+  useNavigate,
+  useRouter,
+  useSearch,
+} from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { Plus, RotateCcw, Save, Send, Trash2 } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Textarea } from "@/components/ui/textarea"
+import {
+  LANE_SHIFT_PATTERN,
+  type LaneShiftPattern,
+} from "@/db/schemas/volunteers"
+import {
+  expandCrewJudgeRotationDrafts,
+  summarizeCrewJudgeCoverage,
+  validateCrewJudgeRotationDrafts,
+  type CrewJudgeRotationDraft,
+  type CrewJudgeRotationHeat,
+} from "@/lib/crew/judge-rotations"
+import {
+  getCrewJudgeRotationsPageFn,
+  publishCrewJudgeRotationsFn,
+  saveCrewJudgeRotationsForVolunteerFn,
+  type CrewJudgeRotationsPageData,
+  type CrewJudgeVolunteer,
+} from "@/server-fns/crew-judge-rotations-fns"
+
+export const Route = createFileRoute("/events/$eventId/judges")({
+  loader: async ({ params }) =>
+    await getCrewJudgeRotationsPageFn({
+      data: { eventId: params.eventId },
+    }),
+  component: EventJudgeRotationsPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+interface RotationFormRow {
+  clientId: string
+  startingHeat: number
+  startingLane: number
+  heatsCount: number
+  notes: string
+}
+
+function EventJudgeRotationsPage() {
+  const { eventId } = parentRoute.useParams()
+  const { page } = Route.useLoaderData()
+  const search = useSearch({ strict: false }) as {
+    workout?: string
+    judge?: string
+  }
+  const navigate = useNavigate()
+  const selectedWorkoutId =
+    search.workout &&
+    page.workouts.some((workout) => workout.id === search.workout)
+      ? search.workout
+      : page.workouts[0]?.id
+  const selectedJudgeId =
+    search.judge &&
+    page.judges.some((judge) => judge.membershipId === search.judge)
+      ? search.judge
+      : page.judges[0]?.membershipId
+  const selectedWorkout = page.workouts.find(
+    (workout) => workout.id === selectedWorkoutId,
+  )
+  const selectedJudge = page.judges.find(
+    (judge) => judge.membershipId === selectedJudgeId,
+  )
+  const workoutHeats = page.heats.filter(
+    (heat) => heat.trackWorkoutId === selectedWorkoutId,
+  )
+  const workoutRotations = page.rotations.filter(
+    (rotation) => rotation.trackWorkoutId === selectedWorkoutId,
+  )
+  const coverage = summarizeCrewJudgeCoverage({
+    heats: workoutHeats,
+    rotations: workoutRotations.map(toRotationDraft),
+  })
+  const activeVersion = selectedWorkoutId
+    ? page.activeVersionByWorkout[selectedWorkoutId]
+    : null
+
+  function updateSearch(next: { workout?: string; judge?: string }) {
+    void navigate({
+      to: ".",
+      search: (previous: Record<string, unknown>) => ({
+        ...previous,
+        ...next,
+      }),
+      replace: true,
+    })
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Judge rotations</h2>
+          <p className="text-sm text-muted-foreground">
+            {page.judges.length} judges, {page.rotations.length} rotations
+          </p>
+        </div>
+        {selectedWorkoutId ? (
+          <PublishRotationsPanel
+            eventId={eventId}
+            trackWorkoutId={selectedWorkoutId}
+            activeVersionLabel={
+              activeVersion ? `Version ${activeVersion.version}` : "No version"
+            }
+          />
+        ) : null}
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <StatusPanel label="Judges" value={page.judges.length} />
+        <StatusPanel label="Heats" value={workoutHeats.length} />
+        <StatusPanel label="Coverage" value={`${coverage.coveragePercent}%`} />
+        <StatusPanel
+          label="Published"
+          value={activeVersion ? `v${activeVersion.version}` : "Draft"}
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem]">
+        <section className="rounded-md border bg-card p-4 shadow-sm">
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="judge-workout">Workout</Label>
+              <Select
+                value={selectedWorkoutId ?? ""}
+                onValueChange={(workout) => updateSearch({ workout })}
+              >
+                <SelectTrigger id="judge-workout">
+                  <SelectValue placeholder="Select workout" />
+                </SelectTrigger>
+                <SelectContent>
+                  {page.workouts.map((workout) => (
+                    <SelectItem key={workout.id} value={workout.id}>
+                      {formatWorkoutLabel(workout)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="judge-volunteer">Judge</Label>
+              <Select
+                value={selectedJudgeId ?? ""}
+                onValueChange={(judge) => updateSearch({ judge })}
+              >
+                <SelectTrigger id="judge-volunteer">
+                  <SelectValue placeholder="Select judge" />
+                </SelectTrigger>
+                <SelectContent>
+                  {page.judges.map((judge) => (
+                    <SelectItem
+                      key={judge.membershipId}
+                      value={judge.membershipId}
+                    >
+                      {getJudgeName(judge)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+        </section>
+
+        <section className="rounded-md border bg-card p-4 shadow-sm">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Active version
+          </h3>
+          <div className="mt-3 space-y-2 text-sm">
+            <Fact
+              label="Version"
+              value={activeVersion ? `v${activeVersion.version}` : "None"}
+            />
+            <Fact
+              label="Published"
+              value={
+                activeVersion ? formatDateTime(activeVersion.publishedAt) : "No"
+              }
+            />
+            <Fact label="By" value={activeVersion?.publisherName ?? "System"} />
+          </div>
+        </section>
+      </div>
+
+      {page.workouts.length === 0 ? (
+        <EmptyState
+          title="No workouts"
+          body="Add workouts and heats before scheduling judges."
+        />
+      ) : page.judges.length === 0 ? (
+        <EmptyState
+          title="No judges"
+          body="Add volunteers with judge roles before creating rotations."
+        />
+      ) : selectedWorkout && selectedJudge ? (
+        <div className="grid gap-6 xl:grid-cols-[22rem_minmax(0,1fr)]">
+          <JudgeList
+            page={page}
+            selectedJudgeId={selectedJudge.membershipId}
+            selectedWorkoutId={selectedWorkout.id}
+            onSelectJudge={(judge) => updateSearch({ judge })}
+          />
+          <div className="space-y-6">
+            <RotationEditor
+              eventId={eventId}
+              selectedJudge={selectedJudge}
+              selectedWorkoutId={selectedWorkout.id}
+              heats={workoutHeats}
+              rotations={workoutRotations}
+              defaultLaneShiftPattern={
+                selectedWorkout.defaultLaneShiftPattern ??
+                LANE_SHIFT_PATTERN.SHIFT_RIGHT
+              }
+            />
+            <CoveragePreview
+              heats={workoutHeats}
+              rotations={workoutRotations}
+              judges={page.judges}
+              coverageLabel={`${coverage.coveredSlots}/${coverage.totalSlots}`}
+            />
+            <PublishedAssignments
+              assignments={page.activeAssignments.filter(
+                (assignment) =>
+                  assignment.trackWorkoutId === selectedWorkout.id,
+              )}
+            />
+            <VersionHistory
+              versions={page.versionHistoryByWorkout[selectedWorkout.id] ?? []}
+            />
+          </div>
+        </div>
+      ) : null}
+    </section>
+  )
+}
+
+function PublishRotationsPanel({
+  eventId,
+  trackWorkoutId,
+  activeVersionLabel,
+}: {
+  eventId: string
+  trackWorkoutId: string
+  activeVersionLabel: string
+}) {
+  const router = useRouter()
+  const publishRotations = useServerFn(publishCrewJudgeRotationsFn)
+  const [notes, setNotes] = useState("")
+  const [isPublishing, setIsPublishing] = useState(false)
+
+  async function handlePublish() {
+    setIsPublishing(true)
+    try {
+      const result = await publishRotations({
+        data: {
+          eventId,
+          trackWorkoutId,
+          notes,
+        },
+      })
+      toast.success(`Published judge schedule v${result.version.version}`)
+      setNotes("")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to publish rotations",
+      )
+    } finally {
+      setIsPublishing(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2 sm:min-w-80">
+      <div className="flex items-center justify-between gap-3 text-sm">
+        <span className="text-muted-foreground">{activeVersionLabel}</span>
+        <Button type="button" onClick={handlePublish} disabled={isPublishing}>
+          <Send />
+          Publish
+        </Button>
+      </div>
+      <Textarea
+        value={notes}
+        onChange={(event) => setNotes(event.target.value)}
+        placeholder="Version notes"
+        className="min-h-16"
+      />
+    </div>
+  )
+}
+
+function JudgeList({
+  page,
+  selectedJudgeId,
+  selectedWorkoutId,
+  onSelectJudge,
+}: {
+  page: CrewJudgeRotationsPageData
+  selectedJudgeId: string
+  selectedWorkoutId: string
+  onSelectJudge: (judgeId: string) => void
+}) {
+  return (
+    <aside className="space-y-3">
+      <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+        Judges
+      </h3>
+      <div className="space-y-2">
+        {page.judges.map((judge) => {
+          const count = page.rotations.filter(
+            (rotation) =>
+              rotation.trackWorkoutId === selectedWorkoutId &&
+              rotation.membershipId === judge.membershipId,
+          ).length
+          const selected = judge.membershipId === selectedJudgeId
+
+          return (
+            <button
+              key={judge.membershipId}
+              type="button"
+              onClick={() => onSelectJudge(judge.membershipId)}
+              className={
+                selected
+                  ? "w-full rounded-md border bg-muted px-3 py-3 text-left text-sm"
+                  : "w-full rounded-md border bg-card px-3 py-3 text-left text-sm hover:bg-muted"
+              }
+            >
+              <span className="block font-medium">{getJudgeName(judge)}</span>
+              <span className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                <Badge variant={count > 0 ? "default" : "outline"}>
+                  {count}
+                </Badge>
+                rotations
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}
+
+function RotationEditor({
+  eventId,
+  selectedJudge,
+  selectedWorkoutId,
+  heats,
+  rotations,
+  defaultLaneShiftPattern,
+}: {
+  eventId: string
+  selectedJudge: CrewJudgeVolunteer
+  selectedWorkoutId: string
+  heats: CrewJudgeRotationHeat[]
+  rotations: CrewJudgeRotationsPageData["rotations"]
+  defaultLaneShiftPattern: LaneShiftPattern
+}) {
+  const router = useRouter()
+  const saveRotations = useServerFn(saveCrewJudgeRotationsForVolunteerFn)
+  const selectedRotations = useMemo(
+    () =>
+      rotations.filter(
+        (rotation) => rotation.membershipId === selectedJudge.membershipId,
+      ),
+    [rotations, selectedJudge.membershipId],
+  )
+  const [laneShiftPattern, setLaneShiftPattern] = useState<LaneShiftPattern>(
+    selectedRotations[0]?.laneShiftPattern ?? defaultLaneShiftPattern,
+  )
+  const [rows, setRows] = useState<RotationFormRow[]>(() =>
+    toFormRows(selectedRotations),
+  )
+  const [isSaving, setIsSaving] = useState(false)
+  const otherRotationDrafts = rotations
+    .filter((rotation) => rotation.membershipId !== selectedJudge.membershipId)
+    .map(toRotationDraft)
+  const draftRows = rows.map(
+    (row): CrewJudgeRotationDraft => ({
+      membershipId: selectedJudge.membershipId,
+      startingHeat: row.startingHeat,
+      startingLane: row.startingLane,
+      heatsCount: row.heatsCount,
+      laneShiftPattern,
+    }),
+  )
+  const issues = validateCrewJudgeRotationDrafts({
+    heats,
+    occupiedSlots: expandCrewJudgeRotationDrafts({
+      heats,
+      rotations: otherRotationDrafts,
+    }),
+    rotations: draftRows,
+  })
+  const errorCount = issues.filter((issue) => issue.severity === "error").length
+  const warningCount = issues.length - errorCount
+
+  useEffect(() => {
+    setLaneShiftPattern(
+      selectedRotations[0]?.laneShiftPattern ?? defaultLaneShiftPattern,
+    )
+    setRows(toFormRows(selectedRotations))
+  }, [defaultLaneShiftPattern, selectedRotations])
+
+  function updateRow(
+    clientId: string,
+    key: keyof Omit<RotationFormRow, "clientId">,
+    value: string | number,
+  ) {
+    setRows((current) =>
+      current.map((row) =>
+        row.clientId === clientId ? { ...row, [key]: value } : row,
+      ),
+    )
+  }
+
+  function addRow() {
+    const lastRow = rows.at(-1)
+    setRows((current) => [
+      ...current,
+      {
+        clientId: crypto.randomUUID(),
+        startingHeat: lastRow ? lastRow.startingHeat + lastRow.heatsCount : 1,
+        startingLane: lastRow?.startingLane ?? 1,
+        heatsCount: 3,
+        notes: "",
+      },
+    ])
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setIsSaving(true)
+    try {
+      await saveRotations({
+        data: {
+          eventId,
+          trackWorkoutId: selectedWorkoutId,
+          membershipId: selectedJudge.membershipId,
+          laneShiftPattern,
+          rotations: rows.map((row) => ({
+            startingHeat: row.startingHeat,
+            startingLane: row.startingLane,
+            heatsCount: row.heatsCount,
+            notes: row.notes,
+          })),
+        },
+      })
+      toast.success("Judge rotations saved")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to save rotations",
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-md border bg-card p-4 shadow-sm"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">
+            {getJudgeName(selectedJudge)}
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            {rows.length} rotations
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Button type="button" variant="outline" onClick={addRow}>
+            <Plus />
+            Add
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setRows(toFormRows(selectedRotations))}
+          >
+            <RotateCcw />
+            Reset
+          </Button>
+          <Button type="submit" disabled={isSaving}>
+            <Save />
+            Save
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-[16rem_1fr]">
+        <div className="space-y-2">
+          <Label htmlFor="lane-shift-pattern">Lane shift</Label>
+          <Select
+            value={laneShiftPattern}
+            onValueChange={(value) =>
+              setLaneShiftPattern(value as LaneShiftPattern)
+            }
+          >
+            <SelectTrigger id="lane-shift-pattern">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={LANE_SHIFT_PATTERN.STAY}>Stay</SelectItem>
+              <SelectItem value={LANE_SHIFT_PATTERN.SHIFT_RIGHT}>
+                Shift right
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-end gap-2">
+          {errorCount > 0 ? (
+            <Badge variant="destructive">{errorCount} errors</Badge>
+          ) : (
+            <Badge variant="secondary">Valid</Badge>
+          )}
+          {warningCount > 0 ? (
+            <Badge variant="outline">{warningCount} warnings</Badge>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-md border">
+        <table className="w-full min-w-[760px] text-sm">
+          <thead className="border-b bg-muted/50 text-left text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2 font-medium">Start heat</th>
+              <th className="px-3 py-2 font-medium">Start lane</th>
+              <th className="px-3 py-2 font-medium">Heats</th>
+              <th className="px-3 py-2 font-medium">Notes</th>
+              <th className="w-12 px-3 py-2" />
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.clientId} className="border-b last:border-b-0">
+                <td className="px-3 py-2">
+                  <Input
+                    type="number"
+                    min={1}
+                    value={row.startingHeat}
+                    onChange={(event) =>
+                      updateRow(
+                        row.clientId,
+                        "startingHeat",
+                        normalizePositiveInteger(event.target.value),
+                      )
+                    }
+                  />
+                </td>
+                <td className="px-3 py-2">
+                  <Input
+                    type="number"
+                    min={1}
+                    value={row.startingLane}
+                    onChange={(event) =>
+                      updateRow(
+                        row.clientId,
+                        "startingLane",
+                        normalizePositiveInteger(event.target.value),
+                      )
+                    }
+                  />
+                </td>
+                <td className="px-3 py-2">
+                  <Input
+                    type="number"
+                    min={1}
+                    value={row.heatsCount}
+                    onChange={(event) =>
+                      updateRow(
+                        row.clientId,
+                        "heatsCount",
+                        normalizePositiveInteger(event.target.value),
+                      )
+                    }
+                  />
+                </td>
+                <td className="px-3 py-2">
+                  <Input
+                    value={row.notes}
+                    onChange={(event) =>
+                      updateRow(row.clientId, "notes", event.target.value)
+                    }
+                    placeholder="Optional"
+                  />
+                </td>
+                <td className="px-3 py-2">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    onClick={() =>
+                      setRows((current) =>
+                        current.filter(
+                          (candidate) => candidate.clientId !== row.clientId,
+                        ),
+                      )
+                    }
+                    aria-label="Remove rotation"
+                  >
+                    <Trash2 />
+                  </Button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {rows.length === 0 ? (
+          <div className="p-6 text-center text-sm text-muted-foreground">
+            No rotations for this judge.
+          </div>
+        ) : null}
+      </div>
+
+      {issues.length > 0 ? (
+        <div className="space-y-2 rounded-md border bg-background p-3 text-sm">
+          {issues.slice(0, 5).map((issue) => (
+            <p
+              key={`${issue.type}-${issue.rotationId}-${issue.heatNumber}-${issue.laneNumber}`}
+              className={
+                issue.severity === "error"
+                  ? "text-destructive"
+                  : "text-muted-foreground"
+              }
+            >
+              {issue.message}
+            </p>
+          ))}
+        </div>
+      ) : null}
+    </form>
+  )
+}
+
+function CoveragePreview({
+  heats,
+  rotations,
+  judges,
+  coverageLabel,
+}: {
+  heats: CrewJudgeRotationHeat[]
+  rotations: CrewJudgeRotationsPageData["rotations"]
+  judges: CrewJudgeVolunteer[]
+  coverageLabel: string
+}) {
+  const judgeById = new Map(judges.map((judge) => [judge.membershipId, judge]))
+  const slots = expandCrewJudgeRotationDrafts({
+    heats,
+    rotations: rotations.map(toRotationDraft),
+  })
+  const slotsByHeatLane = new Map<string, typeof slots>()
+
+  for (const slot of slots) {
+    const key = `${slot.heatNumber}:${slot.laneNumber}`
+    slotsByHeatLane.set(key, [...(slotsByHeatLane.get(key) ?? []), slot])
+  }
+
+  return (
+    <section className="space-y-3 rounded-md border bg-card p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-lg font-semibold">Coverage preview</h3>
+        <Badge variant="secondary">{coverageLabel}</Badge>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead className="border-b bg-muted/50 text-left text-muted-foreground">
+            <tr>
+              <th className="px-3 py-2 font-medium">Heat</th>
+              <th className="px-3 py-2 font-medium">Lane coverage</th>
+            </tr>
+          </thead>
+          <tbody>
+            {heats.map((heat) => (
+              <tr key={heat.heatNumber} className="border-b last:border-b-0">
+                <td className="whitespace-nowrap px-3 py-3 font-medium">
+                  Heat {heat.heatNumber}
+                </td>
+                <td className="px-3 py-3">
+                  <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                    {Array.from(
+                      { length: heat.laneCount },
+                      (_, index) => index + 1,
+                    ).map((laneNumber) => {
+                      const laneSlots =
+                        slotsByHeatLane.get(
+                          `${heat.heatNumber}:${laneNumber}`,
+                        ) ?? []
+                      return (
+                        <div
+                          key={laneNumber}
+                          className="rounded-md border bg-background px-2 py-2"
+                        >
+                          <span className="text-xs text-muted-foreground">
+                            Lane {laneNumber}
+                          </span>
+                          <div className="mt-1 min-h-5 font-medium">
+                            {laneSlots.length > 0
+                              ? laneSlots
+                                  .map((slot) =>
+                                    getJudgeName(
+                                      judgeById.get(slot.membershipId) ?? null,
+                                    ),
+                                  )
+                                  .join(", ")
+                              : "Open"}
+                          </div>
+                        </div>
+                      )
+                    })}
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function PublishedAssignments({
+  assignments,
+}: {
+  assignments: CrewJudgeRotationsPageData["activeAssignments"]
+}) {
+  return (
+    <section className="space-y-3 rounded-md border bg-card p-4 shadow-sm">
+      <h3 className="text-lg font-semibold">Published assignments</h3>
+      {assignments.length > 0 ? (
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[620px] text-sm">
+            <thead className="border-b bg-muted/50 text-left text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 font-medium">Heat</th>
+                <th className="px-3 py-2 font-medium">Lane</th>
+                <th className="px-3 py-2 font-medium">Judge</th>
+                <th className="px-3 py-2 font-medium">Source</th>
+              </tr>
+            </thead>
+            <tbody>
+              {assignments.map((assignment) => (
+                <tr key={assignment.id} className="border-b last:border-b-0">
+                  <td className="px-3 py-2">Heat {assignment.heatNumber}</td>
+                  <td className="px-3 py-2">
+                    {assignment.laneNumber ?? "Any"}
+                  </td>
+                  <td className="px-3 py-2">
+                    {getJudgeName(assignment.volunteer)}
+                  </td>
+                  <td className="px-3 py-2">
+                    {assignment.isManualOverride ? "Manual" : "Rotation"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No published judge assignments for this workout.
+        </p>
+      )}
+    </section>
+  )
+}
+
+function VersionHistory({
+  versions,
+}: {
+  versions: CrewJudgeRotationsPageData["versionHistoryByWorkout"][string]
+}) {
+  return (
+    <section className="space-y-3 rounded-md border bg-card p-4 shadow-sm">
+      <h3 className="text-lg font-semibold">Version history</h3>
+      {versions.length > 0 ? (
+        <div className="divide-y rounded-md border">
+          {versions.map((version) => (
+            <div
+              key={version.id}
+              className="grid gap-2 px-3 py-3 text-sm sm:grid-cols-[6rem_1fr_10rem]"
+            >
+              <div className="font-medium">v{version.version}</div>
+              <div className="text-muted-foreground">
+                {version.notes || "No notes"}
+              </div>
+              <div className="text-muted-foreground">
+                {formatDateTime(version.publishedAt)}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          No judge schedule has been published for this workout.
+        </p>
+      )}
+    </section>
+  )
+}
+
+function StatusPanel({
+  label,
+  value,
+}: {
+  label: string
+  value: number | string
+}) {
+  return (
+    <div className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-2xl font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="text-right font-medium">{value}</span>
+    </div>
+  )
+}
+
+function EmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <section className="rounded-md border bg-card p-8 text-center shadow-sm">
+      <h3 className="font-semibold">{title}</h3>
+      <p className="mt-2 text-sm text-muted-foreground">{body}</p>
+    </section>
+  )
+}
+
+function toFormRows(
+  rotations: CrewJudgeRotationsPageData["rotations"],
+): RotationFormRow[] {
+  return rotations.map((rotation) => ({
+    clientId: rotation.id,
+    startingHeat: rotation.startingHeat,
+    startingLane: rotation.startingLane,
+    heatsCount: rotation.heatsCount,
+    notes: rotation.notes ?? "",
+  }))
+}
+
+function toRotationDraft(
+  rotation: Pick<
+    CrewJudgeRotationsPageData["rotations"][number],
+    | "id"
+    | "membershipId"
+    | "startingHeat"
+    | "startingLane"
+    | "heatsCount"
+    | "laneShiftPattern"
+  >,
+): CrewJudgeRotationDraft {
+  return {
+    id: rotation.id,
+    membershipId: rotation.membershipId,
+    startingHeat: rotation.startingHeat,
+    startingLane: rotation.startingLane,
+    heatsCount: rotation.heatsCount,
+    laneShiftPattern: rotation.laneShiftPattern,
+  }
+}
+
+function getJudgeName(judge: CrewJudgeVolunteer | null | undefined) {
+  if (!judge) return "Unknown judge"
+  return (
+    [judge.firstName, judge.lastName].filter(Boolean).join(" ") ||
+    judge.email ||
+    judge.membershipId
+  )
+}
+
+function formatWorkoutLabel(
+  workout: CrewJudgeRotationsPageData["workouts"][number],
+) {
+  return `Event ${workout.trackOrder}: ${workout.workout.name}`
+}
+
+function formatDateTime(value: Date | string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(new Date(value))
+}
+
+function normalizePositiveInteger(value: string) {
+  const parsed = Number.parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1
+}

--- a/apps/crew/src/routes/events/$eventId/judges.tsx
+++ b/apps/crew/src/routes/events/$eventId/judges.tsx
@@ -389,6 +389,8 @@ function RotationEditor({
   const [laneShiftPattern, setLaneShiftPattern] = useState<LaneShiftPattern>(
     selectedRotations[0]?.laneShiftPattern ?? defaultLaneShiftPattern,
   )
+  const resetLaneShiftPattern =
+    selectedRotations[0]?.laneShiftPattern ?? defaultLaneShiftPattern
   const [rows, setRows] = useState<RotationFormRow[]>(() =>
     toFormRows(selectedRotations),
   )
@@ -417,11 +419,9 @@ function RotationEditor({
   const warningCount = issues.length - errorCount
 
   useEffect(() => {
-    setLaneShiftPattern(
-      selectedRotations[0]?.laneShiftPattern ?? defaultLaneShiftPattern,
-    )
+    setLaneShiftPattern(resetLaneShiftPattern)
     setRows(toFormRows(selectedRotations))
-  }, [defaultLaneShiftPattern, selectedRotations])
+  }, [resetLaneShiftPattern, selectedRotations])
 
   function updateRow(
     clientId: string,
@@ -500,7 +500,10 @@ function RotationEditor({
           <Button
             type="button"
             variant="outline"
-            onClick={() => setRows(toFormRows(selectedRotations))}
+            onClick={() => {
+              setLaneShiftPattern(resetLaneShiftPattern)
+              setRows(toFormRows(selectedRotations))
+            }}
           >
             <RotateCcw />
             Reset

--- a/apps/crew/src/server-fns/crew-judge-rotations-fns.ts
+++ b/apps/crew/src/server-fns/crew-judge-rotations-fns.ts
@@ -1,0 +1,88 @@
+// @lat: [[crew#Judge Rotations]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import { LANE_SHIFT_PATTERN } from "@/db/schemas/volunteers"
+
+export type {
+  CrewJudgeAssignmentVersion,
+  CrewJudgeEvent,
+  CrewJudgeHeat,
+  CrewJudgeHeatAssignment,
+  CrewJudgeRotationsPageData,
+  CrewJudgeVolunteer,
+  CrewJudgeWorkout,
+} from "../server/crew-judge-rotations.server"
+
+const eventIdSchema = z.string().min(1, "Event ID is required")
+const trackWorkoutIdSchema = z.string().min(1, "Workout ID is required")
+const membershipIdSchema = z
+  .string()
+  .startsWith("tmem_", "Invalid membership ID")
+const laneShiftPatternSchema = z.enum([
+  LANE_SHIFT_PATTERN.STAY,
+  LANE_SHIFT_PATTERN.SHIFT_RIGHT,
+])
+const optionalNotesSchema = z.string().trim().max(1000).nullable().optional()
+
+const getCrewJudgeRotationsPageInputSchema = z.object({
+  eventId: eventIdSchema,
+})
+
+const saveCrewJudgeRotationsForVolunteerInputSchema = z.object({
+  eventId: eventIdSchema,
+  trackWorkoutId: trackWorkoutIdSchema,
+  membershipId: membershipIdSchema,
+  laneShiftPattern: laneShiftPatternSchema,
+  rotations: z
+    .array(
+      z.object({
+        startingHeat: z.number().int().min(1),
+        startingLane: z.number().int().min(1),
+        heatsCount: z.number().int().min(1),
+        notes: optionalNotesSchema,
+      }),
+    )
+    .max(50),
+})
+
+const publishCrewJudgeRotationsInputSchema = z.object({
+  eventId: eventIdSchema,
+  trackWorkoutId: trackWorkoutIdSchema,
+  notes: optionalNotesSchema,
+})
+
+export const getCrewJudgeRotationsPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    getCrewJudgeRotationsPageInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewJudgeRotationsPage } = await import(
+      "../server/crew-judge-rotations.server"
+    )
+    return getCrewJudgeRotationsPage(data)
+  })
+
+export const saveCrewJudgeRotationsForVolunteerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) =>
+    saveCrewJudgeRotationsForVolunteerInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { saveCrewJudgeRotationsForVolunteer } = await import(
+      "../server/crew-judge-rotations.server"
+    )
+    return saveCrewJudgeRotationsForVolunteer(data)
+  })
+
+export const publishCrewJudgeRotationsFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    publishCrewJudgeRotationsInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { publishCrewJudgeRotations } = await import(
+      "../server/crew-judge-rotations.server"
+    )
+    return publishCrewJudgeRotations(data)
+  })

--- a/apps/crew/src/server/crew-judge-rotations.server.ts
+++ b/apps/crew/src/server/crew-judge-rotations.server.ts
@@ -28,6 +28,7 @@ import {
 import {
   assertCrewJudgeRotationReplacementAllowed,
   expandCrewJudgeRotationDrafts,
+  getCrewJudgeHeatLaneCount,
   getCrewJudgeRotationLane,
   hasCrewJudgeRotationErrors,
   type CrewJudgeRotationDraft,
@@ -47,6 +48,19 @@ type RotationQueryDb = Pick<DbClient, "select" | "query">
 type CompetitionJudgeRotation =
   typeof competitionJudgeRotationsTable.$inferSelect
 type JudgeAssignmentVersion = typeof judgeAssignmentVersionsTable.$inferSelect
+type CrewJudgeHeatRow = {
+  id: string
+  trackWorkoutId: string
+  heatNumber: number
+  scheduledTime: Date | null
+  durationMinutes: number | null
+  venueName: string | null
+  venueLaneCount: number | null
+}
+type CrewJudgeHeatLaneAssignmentRow = {
+  heatId: string
+  laneNumber: number | null
+}
 
 export interface CrewJudgeEvent {
   id: string
@@ -500,47 +514,12 @@ async function loadCrewJudgeHeats(eventId: string): Promise<CrewJudgeHeat[]> {
       asc(competitionHeatsTable.heatNumber),
     )
 
-  const heatIds = heatRows.map((heat) => heat.id)
-  const heatAssignmentRows =
-    heatIds.length > 0
-      ? await db
-          .select({
-            heatId: competitionHeatAssignmentsTable.heatId,
-            laneNumber: competitionHeatAssignmentsTable.laneNumber,
-          })
-          .from(competitionHeatAssignmentsTable)
-          .where(inArray(competitionHeatAssignmentsTable.heatId, heatIds))
-      : []
-  const occupiedLanesByHeat = new Map<string, Set<number>>()
+  const heatAssignmentRows = await loadCrewJudgeHeatLaneAssignments(
+    db,
+    heatRows.map((heat) => heat.id),
+  )
 
-  for (const assignment of heatAssignmentRows) {
-    if (!assignment.laneNumber) continue
-    const lanes = occupiedLanesByHeat.get(assignment.heatId) ?? new Set()
-    lanes.add(assignment.laneNumber)
-    occupiedLanesByHeat.set(assignment.heatId, lanes)
-  }
-
-  return heatRows.map((heat) => {
-    const occupiedLanes = Array.from(
-      occupiedLanesByHeat.get(heat.id) ?? [],
-    ).sort((a, b) => a - b)
-    const laneCount = Math.max(
-      heat.venueLaneCount ?? 10,
-      occupiedLanes.length > 0 ? Math.max(...occupiedLanes) : 0,
-      1,
-    )
-
-    return {
-      id: heat.id,
-      trackWorkoutId: heat.trackWorkoutId,
-      heatNumber: heat.heatNumber,
-      scheduledTime: heat.scheduledTime,
-      durationMinutes: heat.durationMinutes,
-      venueName: heat.venueName,
-      laneCount,
-      occupiedLanes,
-    }
-  })
+  return toCrewJudgeHeats(heatRows, heatAssignmentRows)
 }
 
 async function loadCrewJudgeVolunteers(
@@ -800,16 +779,61 @@ async function loadCrewJudgeHeatsForTrackWorkout(
     .where(eq(competitionHeatsTable.trackWorkoutId, trackWorkoutId))
     .orderBy(asc(competitionHeatsTable.heatNumber))
 
-  return heatRows.map((heat) => ({
-    id: heat.id,
-    trackWorkoutId: heat.trackWorkoutId,
-    heatNumber: heat.heatNumber,
-    scheduledTime: heat.scheduledTime,
-    durationMinutes: heat.durationMinutes,
-    venueName: heat.venueName,
-    laneCount: Math.max(heat.venueLaneCount ?? 10, 1),
-    occupiedLanes: [],
-  }))
+  const heatAssignmentRows = await loadCrewJudgeHeatLaneAssignments(
+    db,
+    heatRows.map((heat) => heat.id),
+  )
+
+  return toCrewJudgeHeats(heatRows, heatAssignmentRows)
+}
+
+async function loadCrewJudgeHeatLaneAssignments(
+  db: Pick<DbClient, "select">,
+  heatIds: string[],
+): Promise<CrewJudgeHeatLaneAssignmentRow[]> {
+  if (heatIds.length === 0) return []
+
+  return db
+    .select({
+      heatId: competitionHeatAssignmentsTable.heatId,
+      laneNumber: competitionHeatAssignmentsTable.laneNumber,
+    })
+    .from(competitionHeatAssignmentsTable)
+    .where(inArray(competitionHeatAssignmentsTable.heatId, heatIds))
+}
+
+function toCrewJudgeHeats(
+  heatRows: CrewJudgeHeatRow[],
+  heatAssignmentRows: CrewJudgeHeatLaneAssignmentRow[],
+): CrewJudgeHeat[] {
+  const occupiedLanesByHeat = new Map<string, Set<number>>()
+
+  for (const assignment of heatAssignmentRows) {
+    if (!assignment.laneNumber) continue
+    const lanes = occupiedLanesByHeat.get(assignment.heatId) ?? new Set()
+    lanes.add(assignment.laneNumber)
+    occupiedLanesByHeat.set(assignment.heatId, lanes)
+  }
+
+  return heatRows.map((heat) => {
+    const occupiedLanes = Array.from(
+      occupiedLanesByHeat.get(heat.id) ?? [],
+    ).sort((a, b) => a - b)
+
+    return {
+      id: heat.id,
+      trackWorkoutId: heat.trackWorkoutId,
+      heatNumber: heat.heatNumber,
+      scheduledTime: heat.scheduledTime,
+      durationMinutes: heat.durationMinutes,
+      venueName: heat.venueName,
+      laneCount: getCrewJudgeHeatLaneCount({
+        venueLaneCount: heat.venueLaneCount,
+        occupiedLanes,
+      }),
+      occupiedLanes,
+    }
+  })
 }
 
 function toCrewJudgeRotationDraft(

--- a/apps/crew/src/server/crew-judge-rotations.server.ts
+++ b/apps/crew/src/server/crew-judge-rotations.server.ts
@@ -26,6 +26,7 @@ import {
   VOLUNTEER_ROLE_TYPES,
 } from "../db/schemas/volunteers"
 import {
+  assertCrewJudgeRotationReplacementAllowed,
   expandCrewJudgeRotationDrafts,
   getCrewJudgeRotationLane,
   hasCrewJudgeRotationErrors,
@@ -278,12 +279,17 @@ export async function saveCrewJudgeRotationsForVolunteer(
 
     const existingRotationIds = existingRotations.map((rotation) => rotation.id)
     if (existingRotationIds.length > 0) {
-      await tx
-        .update(judgeHeatAssignmentsTable)
-        .set({ rotationId: null, updatedAt: new Date() })
+      const assignmentReferences = await tx
+        .select({ id: judgeHeatAssignmentsTable.id })
+        .from(judgeHeatAssignmentsTable)
         .where(
           inArray(judgeHeatAssignmentsTable.rotationId, existingRotationIds),
         )
+        .limit(1)
+
+      assertCrewJudgeRotationReplacementAllowed({
+        assignmentReferenceCount: assignmentReferences.length,
+      })
 
       await tx
         .delete(competitionJudgeRotationsTable)

--- a/apps/crew/src/server/crew-judge-rotations.server.ts
+++ b/apps/crew/src/server/crew-judge-rotations.server.ts
@@ -1,0 +1,869 @@
+// @lat: [[crew#Judge Rotations]]
+import { and, asc, desc, eq, inArray, ne } from "drizzle-orm"
+import { getDb } from "../db"
+import {
+  competitionHeatAssignmentsTable,
+  competitionHeatsTable,
+  competitionJudgeRotationsTable,
+  competitionsTable,
+  competitionVenuesTable,
+  crewEventSettingsTable,
+  judgeAssignmentVersionsTable,
+  judgeHeatAssignmentsTable,
+  programmingTracksTable,
+  teamMembershipTable,
+  trackWorkoutsTable,
+  userTable,
+  workouts,
+} from "../db/schema"
+import { createJudgeRotationId } from "../db/schemas/common"
+import {
+  LANE_SHIFT_PATTERN,
+  type LaneShiftPattern,
+  type VolunteerAvailability,
+  type VolunteerMembershipMetadata,
+  type VolunteerRoleType,
+  VOLUNTEER_ROLE_TYPES,
+} from "../db/schemas/volunteers"
+import {
+  expandCrewJudgeRotationDrafts,
+  getCrewJudgeRotationLane,
+  hasCrewJudgeRotationErrors,
+  type CrewJudgeRotationDraft,
+  type CrewJudgeRotationHeat,
+  validateCrewJudgeRotationDrafts,
+} from "../lib/crew/judge-rotations"
+import { getCrewRosterRoleTypes } from "../lib/crew/roster-shifts"
+import { getSessionFromCookie } from "../utils/auth"
+import { requireLocalCrewOperatorAccess } from "./crew-local-access"
+import {
+  type MaterializedJudgeAssignmentForVersion,
+  publishMaterializedJudgeAssignmentsVersion,
+} from "./judge-assignment-versioning.server"
+
+type DbClient = ReturnType<typeof getDb>
+type RotationQueryDb = Pick<DbClient, "select" | "query">
+type CompetitionJudgeRotation =
+  typeof competitionJudgeRotationsTable.$inferSelect
+type JudgeAssignmentVersion = typeof judgeAssignmentVersionsTable.$inferSelect
+
+export interface CrewJudgeEvent {
+  id: string
+  name: string
+  slug: string
+  organizingTeamId: string
+  competitionTeamId: string
+  startDate: string
+  endDate: string
+  timezone: string | null
+  competitionType: "in-person" | "online"
+}
+
+export interface CrewJudgeWorkout {
+  id: string
+  trackOrder: number
+  eventStatus: string | null
+  heatStatus: string | null
+  defaultHeatsCount: number | null
+  defaultLaneShiftPattern: LaneShiftPattern | null
+  minHeatBuffer: number | null
+  workout: {
+    id: string
+    name: string
+  }
+}
+
+export interface CrewJudgeHeat extends CrewJudgeRotationHeat {
+  id: string
+  trackWorkoutId: string
+  scheduledTime: Date | null
+  durationMinutes: number | null
+  venueName: string | null
+  occupiedLanes: number[]
+}
+
+export interface CrewJudgeVolunteer {
+  membershipId: string
+  userId: string
+  firstName: string | null
+  lastName: string | null
+  email: string | null
+  avatar: string | null
+  volunteerRoleTypes: VolunteerRoleType[]
+  credentials?: string
+  availability?: VolunteerAvailability
+  availabilityNotes?: string
+}
+
+export interface CrewJudgeHeatAssignment {
+  id: string
+  heatId: string
+  trackWorkoutId: string
+  heatNumber: number
+  membershipId: string
+  rotationId: string | null
+  versionId: string | null
+  laneNumber: number | null
+  position: VolunteerRoleType | null
+  isManualOverride: boolean
+  volunteer: CrewJudgeVolunteer | null
+}
+
+export interface CrewJudgeAssignmentVersion {
+  id: string
+  trackWorkoutId: string
+  version: number
+  publishedAt: Date
+  publishedBy: string | null
+  notes: string | null
+  isActive: boolean
+  publisherName: string | null
+}
+
+export interface CrewJudgeRotationsPageData {
+  event: CrewJudgeEvent
+  workouts: CrewJudgeWorkout[]
+  heats: CrewJudgeHeat[]
+  judges: CrewJudgeVolunteer[]
+  rotations: CompetitionJudgeRotation[]
+  activeAssignments: CrewJudgeHeatAssignment[]
+  versionHistoryByWorkout: Record<string, CrewJudgeAssignmentVersion[]>
+  activeVersionByWorkout: Record<string, CrewJudgeAssignmentVersion | null>
+}
+
+export interface SaveCrewJudgeRotationsInput {
+  eventId: string
+  trackWorkoutId: string
+  membershipId: string
+  laneShiftPattern: LaneShiftPattern
+  rotations: Array<{
+    startingHeat: number
+    startingLane: number
+    heatsCount: number
+    notes?: string | null
+  }>
+}
+
+export interface PublishCrewJudgeRotationsInput {
+  eventId: string
+  trackWorkoutId: string
+  notes?: string | null
+}
+
+function requireCrewJudgeRotationsAccess() {
+  requireLocalCrewOperatorAccess("Crew judge rotations")
+}
+
+export async function getCrewJudgeRotationsPage(data: {
+  eventId: string
+}): Promise<{ page: CrewJudgeRotationsPageData }> {
+  requireCrewJudgeRotationsAccess()
+
+  const event = await requireCrewJudgeEvent(data.eventId)
+  const [workoutsForEvent, heats, judges] = await Promise.all([
+    loadCrewJudgeWorkouts(event.id),
+    loadCrewJudgeHeats(event.id),
+    loadCrewJudgeVolunteers(event.competitionTeamId),
+  ])
+  const trackWorkoutIds = workoutsForEvent.map((workout) => workout.id)
+  const [rotations, versions] = await Promise.all([
+    loadCrewJudgeRotations(trackWorkoutIds),
+    loadCrewJudgeAssignmentVersions(trackWorkoutIds),
+  ])
+  const activeAssignments = await loadCrewJudgeActiveAssignments(
+    versions.filter((version) => version.isActive).map((version) => version.id),
+    judges,
+  )
+  const versionHistoryByWorkout = groupVersionsByWorkout(
+    trackWorkoutIds,
+    versions,
+  )
+  const activeVersionByWorkout = Object.fromEntries(
+    trackWorkoutIds.map((trackWorkoutId) => [
+      trackWorkoutId,
+      versionHistoryByWorkout[trackWorkoutId]?.find(
+        (version) => version.isActive,
+      ) ?? null,
+    ]),
+  )
+
+  return {
+    page: {
+      event,
+      workouts: workoutsForEvent,
+      heats,
+      judges,
+      rotations,
+      activeAssignments,
+      versionHistoryByWorkout,
+      activeVersionByWorkout,
+    },
+  }
+}
+
+export async function saveCrewJudgeRotationsForVolunteer(
+  data: SaveCrewJudgeRotationsInput,
+) {
+  requireCrewJudgeRotationsAccess()
+
+  const db = getDb()
+  const event = await requireCrewJudgeEvent(data.eventId)
+  await requireCrewJudgeWorkout(event.id, data.trackWorkoutId)
+  await requireCrewJudgeMembership(event.competitionTeamId, data.membershipId)
+
+  const normalizedRotations = data.rotations.map((rotation) => ({
+    membershipId: data.membershipId,
+    startingHeat: rotation.startingHeat,
+    startingLane: rotation.startingLane,
+    heatsCount: rotation.heatsCount,
+    laneShiftPattern: data.laneShiftPattern,
+    notes: normalizeOptionalText(rotation.notes),
+  }))
+
+  if (normalizedRotations.length > 0) {
+    const heats = (await loadCrewJudgeHeats(event.id)).filter(
+      (heat) => heat.trackWorkoutId === data.trackWorkoutId,
+    )
+    const otherRotations = await db
+      .select()
+      .from(competitionJudgeRotationsTable)
+      .where(
+        and(
+          eq(
+            competitionJudgeRotationsTable.trackWorkoutId,
+            data.trackWorkoutId,
+          ),
+          ne(competitionJudgeRotationsTable.membershipId, data.membershipId),
+        ),
+      )
+    const occupiedSlots = expandCrewJudgeRotationDrafts({
+      heats,
+      rotations: otherRotations.map(toCrewJudgeRotationDraft),
+    })
+    const issues = validateCrewJudgeRotationDrafts({
+      heats,
+      occupiedSlots,
+      rotations: normalizedRotations.map((rotation) => ({
+        membershipId: rotation.membershipId,
+        startingHeat: rotation.startingHeat,
+        startingLane: rotation.startingLane,
+        heatsCount: rotation.heatsCount,
+        laneShiftPattern: rotation.laneShiftPattern,
+      })),
+    })
+
+    if (hasCrewJudgeRotationErrors(issues)) {
+      throw new Error(
+        issues
+          .filter((issue) => issue.severity === "error")
+          .map((issue) => issue.message)
+          .join(" "),
+      )
+    }
+  }
+
+  await db.transaction(async (tx) => {
+    const existingRotations = await tx
+      .select({ id: competitionJudgeRotationsTable.id })
+      .from(competitionJudgeRotationsTable)
+      .where(
+        and(
+          eq(
+            competitionJudgeRotationsTable.trackWorkoutId,
+            data.trackWorkoutId,
+          ),
+          eq(competitionJudgeRotationsTable.membershipId, data.membershipId),
+        ),
+      )
+
+    const existingRotationIds = existingRotations.map((rotation) => rotation.id)
+    if (existingRotationIds.length > 0) {
+      await tx
+        .update(judgeHeatAssignmentsTable)
+        .set({ rotationId: null, updatedAt: new Date() })
+        .where(
+          inArray(judgeHeatAssignmentsTable.rotationId, existingRotationIds),
+        )
+
+      await tx
+        .delete(competitionJudgeRotationsTable)
+        .where(inArray(competitionJudgeRotationsTable.id, existingRotationIds))
+    }
+
+    if (normalizedRotations.length > 0) {
+      await tx.insert(competitionJudgeRotationsTable).values(
+        normalizedRotations.map((rotation) => ({
+          id: createJudgeRotationId(),
+          competitionId: event.id,
+          trackWorkoutId: data.trackWorkoutId,
+          membershipId: data.membershipId,
+          startingHeat: rotation.startingHeat,
+          startingLane: rotation.startingLane,
+          heatsCount: rotation.heatsCount,
+          laneShiftPattern: rotation.laneShiftPattern,
+          notes: rotation.notes,
+        })),
+      )
+    }
+  })
+
+  return {
+    success: true,
+    rotations: await loadCrewJudgeRotations([data.trackWorkoutId]),
+  }
+}
+
+export async function publishCrewJudgeRotations(
+  data: PublishCrewJudgeRotationsInput,
+): Promise<{ version: JudgeAssignmentVersion }> {
+  requireCrewJudgeRotationsAccess()
+
+  const db = getDb()
+  const event = await requireCrewJudgeEvent(data.eventId)
+  await requireCrewJudgeWorkout(event.id, data.trackWorkoutId)
+  await assertCrewJudgeRotationsPublishable(event.id, data.trackWorkoutId)
+  const session = await getSessionFromCookie().catch(() => null)
+  const version = await publishMaterializedJudgeAssignmentsVersion(
+    db,
+    {
+      trackWorkoutId: data.trackWorkoutId,
+      publishedBy: session?.userId ?? null,
+      notes: normalizeOptionalText(data.notes),
+    },
+    (tx) => materializeCrewJudgeRotations(tx, data.trackWorkoutId),
+  )
+
+  return { version }
+}
+
+async function requireCrewJudgeEvent(eventId: string): Promise<CrewJudgeEvent> {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      name: competitionsTable.name,
+      slug: competitionsTable.slug,
+      organizingTeamId: competitionsTable.organizingTeamId,
+      competitionTeamId: competitionsTable.competitionTeamId,
+      startDate: competitionsTable.startDate,
+      endDate: competitionsTable.endDate,
+      timezone: competitionsTable.timezone,
+      competitionType: competitionsTable.competitionType,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  if (!event.competitionTeamId) {
+    throw new Error("Crew event does not have a competition team")
+  }
+
+  return {
+    ...event,
+    competitionTeamId: event.competitionTeamId,
+  }
+}
+
+async function requireCrewJudgeWorkout(
+  eventId: string,
+  trackWorkoutId: string,
+) {
+  const db = getDb()
+  const [workout] = await db
+    .select({ id: trackWorkoutsTable.id })
+    .from(trackWorkoutsTable)
+    .innerJoin(
+      programmingTracksTable,
+      eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+    )
+    .where(
+      and(
+        eq(trackWorkoutsTable.id, trackWorkoutId),
+        eq(programmingTracksTable.competitionId, eventId),
+      ),
+    )
+    .limit(1)
+
+  if (!workout) {
+    throw new Error("Judge rotation workout not found for this Crew event")
+  }
+}
+
+async function requireCrewJudgeMembership(
+  competitionTeamId: string,
+  membershipId: string,
+) {
+  const db = getDb()
+  const [membership] = await db
+    .select({
+      id: teamMembershipTable.id,
+      metadata: teamMembershipTable.metadata,
+    })
+    .from(teamMembershipTable)
+    .where(
+      and(
+        eq(teamMembershipTable.id, membershipId),
+        eq(teamMembershipTable.teamId, competitionTeamId),
+      ),
+    )
+    .limit(1)
+
+  if (!membership) {
+    throw new Error("Judge membership not found for this Crew event")
+  }
+
+  if (
+    !isJudgeRole(
+      getCrewRosterRoleTypes(
+        parseVolunteerMetadata(membership.metadata)?.volunteerRoleTypes,
+      ),
+    )
+  ) {
+    throw new Error("Selected volunteer is not marked as a judge")
+  }
+}
+
+async function loadCrewJudgeWorkouts(
+  eventId: string,
+): Promise<CrewJudgeWorkout[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: trackWorkoutsTable.id,
+      trackOrder: trackWorkoutsTable.trackOrder,
+      eventStatus: trackWorkoutsTable.eventStatus,
+      heatStatus: trackWorkoutsTable.heatStatus,
+      defaultHeatsCount: trackWorkoutsTable.defaultHeatsCount,
+      defaultLaneShiftPattern: trackWorkoutsTable.defaultLaneShiftPattern,
+      minHeatBuffer: trackWorkoutsTable.minHeatBuffer,
+      workoutId: workouts.id,
+      workoutName: workouts.name,
+    })
+    .from(trackWorkoutsTable)
+    .innerJoin(
+      programmingTracksTable,
+      eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+    )
+    .innerJoin(workouts, eq(trackWorkoutsTable.workoutId, workouts.id))
+    .where(eq(programmingTracksTable.competitionId, eventId))
+    .orderBy(asc(trackWorkoutsTable.trackOrder))
+
+  return rows.map((row) => ({
+    id: row.id,
+    trackOrder: row.trackOrder,
+    eventStatus: row.eventStatus,
+    heatStatus: row.heatStatus,
+    defaultHeatsCount: row.defaultHeatsCount,
+    defaultLaneShiftPattern: row.defaultLaneShiftPattern as LaneShiftPattern,
+    minHeatBuffer: row.minHeatBuffer,
+    workout: {
+      id: row.workoutId,
+      name: row.workoutName,
+    },
+  }))
+}
+
+async function loadCrewJudgeHeats(eventId: string): Promise<CrewJudgeHeat[]> {
+  const db = getDb()
+  const heatRows = await db
+    .select({
+      id: competitionHeatsTable.id,
+      trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+      heatNumber: competitionHeatsTable.heatNumber,
+      scheduledTime: competitionHeatsTable.scheduledTime,
+      durationMinutes: competitionHeatsTable.durationMinutes,
+      venueName: competitionVenuesTable.name,
+      venueLaneCount: competitionVenuesTable.laneCount,
+    })
+    .from(competitionHeatsTable)
+    .leftJoin(
+      competitionVenuesTable,
+      eq(competitionHeatsTable.venueId, competitionVenuesTable.id),
+    )
+    .where(eq(competitionHeatsTable.competitionId, eventId))
+    .orderBy(
+      asc(competitionHeatsTable.trackWorkoutId),
+      asc(competitionHeatsTable.heatNumber),
+    )
+
+  const heatIds = heatRows.map((heat) => heat.id)
+  const heatAssignmentRows =
+    heatIds.length > 0
+      ? await db
+          .select({
+            heatId: competitionHeatAssignmentsTable.heatId,
+            laneNumber: competitionHeatAssignmentsTable.laneNumber,
+          })
+          .from(competitionHeatAssignmentsTable)
+          .where(inArray(competitionHeatAssignmentsTable.heatId, heatIds))
+      : []
+  const occupiedLanesByHeat = new Map<string, Set<number>>()
+
+  for (const assignment of heatAssignmentRows) {
+    if (!assignment.laneNumber) continue
+    const lanes = occupiedLanesByHeat.get(assignment.heatId) ?? new Set()
+    lanes.add(assignment.laneNumber)
+    occupiedLanesByHeat.set(assignment.heatId, lanes)
+  }
+
+  return heatRows.map((heat) => {
+    const occupiedLanes = Array.from(
+      occupiedLanesByHeat.get(heat.id) ?? [],
+    ).sort((a, b) => a - b)
+    const laneCount = Math.max(
+      heat.venueLaneCount ?? 10,
+      occupiedLanes.length > 0 ? Math.max(...occupiedLanes) : 0,
+      1,
+    )
+
+    return {
+      id: heat.id,
+      trackWorkoutId: heat.trackWorkoutId,
+      heatNumber: heat.heatNumber,
+      scheduledTime: heat.scheduledTime,
+      durationMinutes: heat.durationMinutes,
+      venueName: heat.venueName,
+      laneCount,
+      occupiedLanes,
+    }
+  })
+}
+
+async function loadCrewJudgeVolunteers(
+  competitionTeamId: string,
+): Promise<CrewJudgeVolunteer[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      membershipId: teamMembershipTable.id,
+      userId: teamMembershipTable.userId,
+      metadata: teamMembershipTable.metadata,
+      firstName: userTable.firstName,
+      lastName: userTable.lastName,
+      email: userTable.email,
+      avatar: userTable.avatar,
+    })
+    .from(teamMembershipTable)
+    .innerJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(eq(teamMembershipTable.teamId, competitionTeamId))
+
+  return rows
+    .map((row) => {
+      const metadata = parseVolunteerMetadata(row.metadata)
+      const volunteerRoleTypes = getCrewRosterRoleTypes(
+        metadata?.volunteerRoleTypes,
+      )
+
+      return {
+        membershipId: row.membershipId,
+        userId: row.userId,
+        firstName: row.firstName,
+        lastName: row.lastName,
+        email: row.email,
+        avatar: row.avatar,
+        volunteerRoleTypes,
+        credentials: metadata?.credentials,
+        availability: metadata?.availability,
+        availabilityNotes: metadata?.availabilityNotes,
+      }
+    })
+    .filter((volunteer) => isJudgeRole(volunteer.volunteerRoleTypes))
+    .sort((a, b) => getJudgeName(a).localeCompare(getJudgeName(b)))
+}
+
+async function loadCrewJudgeRotations(trackWorkoutIds: string[]) {
+  if (trackWorkoutIds.length === 0) return []
+
+  const db = getDb()
+  return db.query.competitionJudgeRotationsTable.findMany({
+    where: inArray(
+      competitionJudgeRotationsTable.trackWorkoutId,
+      trackWorkoutIds,
+    ),
+    orderBy: [
+      asc(competitionJudgeRotationsTable.trackWorkoutId),
+      asc(competitionJudgeRotationsTable.startingHeat),
+      asc(competitionJudgeRotationsTable.startingLane),
+    ],
+  })
+}
+
+async function loadCrewJudgeAssignmentVersions(trackWorkoutIds: string[]) {
+  if (trackWorkoutIds.length === 0) return []
+
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: judgeAssignmentVersionsTable.id,
+      trackWorkoutId: judgeAssignmentVersionsTable.trackWorkoutId,
+      version: judgeAssignmentVersionsTable.version,
+      publishedAt: judgeAssignmentVersionsTable.publishedAt,
+      publishedBy: judgeAssignmentVersionsTable.publishedBy,
+      notes: judgeAssignmentVersionsTable.notes,
+      isActive: judgeAssignmentVersionsTable.isActive,
+      publisherFirstName: userTable.firstName,
+      publisherLastName: userTable.lastName,
+      publisherEmail: userTable.email,
+    })
+    .from(judgeAssignmentVersionsTable)
+    .leftJoin(
+      userTable,
+      eq(judgeAssignmentVersionsTable.publishedBy, userTable.id),
+    )
+    .where(
+      inArray(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutIds),
+    )
+    .orderBy(
+      asc(judgeAssignmentVersionsTable.trackWorkoutId),
+      desc(judgeAssignmentVersionsTable.version),
+    )
+
+  return rows.map((row): CrewJudgeAssignmentVersion => {
+    const publisherName = [row.publisherFirstName, row.publisherLastName]
+      .filter(Boolean)
+      .join(" ")
+
+    return {
+      id: row.id,
+      trackWorkoutId: row.trackWorkoutId,
+      version: row.version,
+      publishedAt: row.publishedAt,
+      publishedBy: row.publishedBy,
+      notes: row.notes,
+      isActive: row.isActive,
+      publisherName: publisherName || row.publisherEmail || null,
+    }
+  })
+}
+
+async function loadCrewJudgeActiveAssignments(
+  activeVersionIds: string[],
+  judges: CrewJudgeVolunteer[],
+): Promise<CrewJudgeHeatAssignment[]> {
+  if (activeVersionIds.length === 0) return []
+
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: judgeHeatAssignmentsTable.id,
+      heatId: judgeHeatAssignmentsTable.heatId,
+      trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+      heatNumber: competitionHeatsTable.heatNumber,
+      membershipId: judgeHeatAssignmentsTable.membershipId,
+      rotationId: judgeHeatAssignmentsTable.rotationId,
+      versionId: judgeHeatAssignmentsTable.versionId,
+      laneNumber: judgeHeatAssignmentsTable.laneNumber,
+      position: judgeHeatAssignmentsTable.position,
+      isManualOverride: judgeHeatAssignmentsTable.isManualOverride,
+    })
+    .from(judgeHeatAssignmentsTable)
+    .innerJoin(
+      competitionHeatsTable,
+      eq(judgeHeatAssignmentsTable.heatId, competitionHeatsTable.id),
+    )
+    .where(inArray(judgeHeatAssignmentsTable.versionId, activeVersionIds))
+    .orderBy(
+      asc(competitionHeatsTable.trackWorkoutId),
+      asc(competitionHeatsTable.heatNumber),
+      asc(judgeHeatAssignmentsTable.laneNumber),
+    )
+  const judgeByMembershipId = new Map(
+    judges.map((judge) => [judge.membershipId, judge]),
+  )
+
+  return rows.map((row) => ({
+    ...row,
+    volunteer: judgeByMembershipId.get(row.membershipId) ?? null,
+  }))
+}
+
+function groupVersionsByWorkout(
+  trackWorkoutIds: string[],
+  versions: CrewJudgeAssignmentVersion[],
+) {
+  const grouped: Record<string, CrewJudgeAssignmentVersion[]> =
+    Object.fromEntries(
+      trackWorkoutIds.map((trackWorkoutId) => [trackWorkoutId, []]),
+    )
+
+  for (const version of versions) {
+    grouped[version.trackWorkoutId]?.push(version)
+  }
+
+  return grouped
+}
+
+async function assertCrewJudgeRotationsPublishable(
+  eventId: string,
+  trackWorkoutId: string,
+) {
+  const [heats, rotations] = await Promise.all([
+    loadCrewJudgeHeats(eventId),
+    loadCrewJudgeRotations([trackWorkoutId]),
+  ])
+  const eventHeats = heats.filter(
+    (heat) => heat.trackWorkoutId === trackWorkoutId,
+  )
+  const issues = validateCrewJudgeRotationDrafts({
+    heats: eventHeats,
+    rotations: rotations.map(toCrewJudgeRotationDraft),
+  })
+
+  if (hasCrewJudgeRotationErrors(issues)) {
+    throw new Error(
+      issues
+        .filter((issue) => issue.severity === "error")
+        .map((issue) => issue.message)
+        .join(" "),
+    )
+  }
+}
+
+async function materializeCrewJudgeRotations(
+  db: RotationQueryDb,
+  trackWorkoutId: string,
+): Promise<MaterializedJudgeAssignmentForVersion[]> {
+  const [heats, rotations] = await Promise.all([
+    loadCrewJudgeHeatsForTrackWorkout(db, trackWorkoutId),
+    db.query.competitionJudgeRotationsTable.findMany({
+      where: eq(competitionJudgeRotationsTable.trackWorkoutId, trackWorkoutId),
+    }),
+  ])
+  const heatByNumber = new Map(heats.map((heat) => [heat.heatNumber, heat]))
+  const seen = new Set<string>()
+  const assignments: MaterializedJudgeAssignmentForVersion[] = []
+
+  for (const rotation of rotations) {
+    for (let heatIndex = 0; heatIndex < rotation.heatsCount; heatIndex++) {
+      const heatNumber = rotation.startingHeat + heatIndex
+      const heat = heatByNumber.get(heatNumber)
+      if (!heat) continue
+
+      const laneNumber = getCrewJudgeRotationLane({
+        startingLane: rotation.startingLane,
+        heatIndex,
+        laneCount: heat.laneCount,
+        laneShiftPattern: rotation.laneShiftPattern,
+      })
+      if (laneNumber < 1 || laneNumber > heat.laneCount) continue
+
+      const key = `${heat.id}:${rotation.membershipId}`
+      if (seen.has(key)) continue
+      seen.add(key)
+
+      assignments.push({
+        heatId: heat.id,
+        membershipId: rotation.membershipId,
+        rotationId: rotation.id,
+        laneNumber,
+        position: VOLUNTEER_ROLE_TYPES.JUDGE,
+      })
+    }
+  }
+
+  return assignments
+}
+
+async function loadCrewJudgeHeatsForTrackWorkout(
+  db: RotationQueryDb,
+  trackWorkoutId: string,
+): Promise<CrewJudgeHeat[]> {
+  const heatRows = await db
+    .select({
+      id: competitionHeatsTable.id,
+      trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+      heatNumber: competitionHeatsTable.heatNumber,
+      scheduledTime: competitionHeatsTable.scheduledTime,
+      durationMinutes: competitionHeatsTable.durationMinutes,
+      venueName: competitionVenuesTable.name,
+      venueLaneCount: competitionVenuesTable.laneCount,
+    })
+    .from(competitionHeatsTable)
+    .leftJoin(
+      competitionVenuesTable,
+      eq(competitionHeatsTable.venueId, competitionVenuesTable.id),
+    )
+    .where(eq(competitionHeatsTable.trackWorkoutId, trackWorkoutId))
+    .orderBy(asc(competitionHeatsTable.heatNumber))
+
+  return heatRows.map((heat) => ({
+    id: heat.id,
+    trackWorkoutId: heat.trackWorkoutId,
+    heatNumber: heat.heatNumber,
+    scheduledTime: heat.scheduledTime,
+    durationMinutes: heat.durationMinutes,
+    venueName: heat.venueName,
+    laneCount: Math.max(heat.venueLaneCount ?? 10, 1),
+    occupiedLanes: [],
+  }))
+}
+
+function toCrewJudgeRotationDraft(
+  rotation: Pick<
+    CompetitionJudgeRotation,
+    | "id"
+    | "membershipId"
+    | "startingHeat"
+    | "startingLane"
+    | "heatsCount"
+    | "laneShiftPattern"
+  >,
+): CrewJudgeRotationDraft {
+  return {
+    id: rotation.id,
+    membershipId: rotation.membershipId,
+    startingHeat: rotation.startingHeat,
+    startingLane: rotation.startingLane,
+    heatsCount: rotation.heatsCount,
+    laneShiftPattern: rotation.laneShiftPattern,
+  }
+}
+
+function parseVolunteerMetadata(
+  metadata: string | null,
+): VolunteerMembershipMetadata | null {
+  if (!metadata) return null
+
+  try {
+    return JSON.parse(metadata) as VolunteerMembershipMetadata
+  } catch {
+    return null
+  }
+}
+
+function isJudgeRole(roleTypes: VolunteerRoleType[]) {
+  return (
+    roleTypes.includes(VOLUNTEER_ROLE_TYPES.JUDGE) ||
+    roleTypes.includes(VOLUNTEER_ROLE_TYPES.HEAD_JUDGE)
+  )
+}
+
+export function getJudgeName(judge: {
+  firstName: string | null
+  lastName: string | null
+  email?: string | null
+}) {
+  return (
+    [judge.firstName, judge.lastName].filter(Boolean).join(" ") ||
+    judge.email ||
+    "Unknown judge"
+  )
+}
+
+function normalizeOptionalText(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+export const CREW_JUDGE_LANE_SHIFT_PATTERNS = [
+  LANE_SHIFT_PATTERN.STAY,
+  LANE_SHIFT_PATTERN.SHIFT_RIGHT,
+] as const

--- a/apps/crew/src/server/judge-assignment-versioning.server.test.ts
+++ b/apps/crew/src/server/judge-assignment-versioning.server.test.ts
@@ -1,0 +1,79 @@
+// @lat: [[crew#Judge Rotations]]
+// @lat: [[crew#Judge Assignment Version Publishing]]
+import { describe, expect, it } from "vitest"
+import {
+  cloneJudgeAssignmentsForRevision,
+  findClonedJudgeAssignmentOrThrow,
+  getNextJudgeAssignmentVersionNumber,
+  toJudgeHeatAssignmentInserts,
+} from "./judge-assignment-versioning.server"
+
+describe("Crew judge assignment versioning", () => {
+  it("allocates the next version from the maximum existing version", () => {
+    expect(
+      getNextJudgeAssignmentVersionNumber([
+        { version: 1 },
+        { version: 4 },
+        { version: 2 },
+      ]),
+    ).toBe(5)
+  })
+
+  it("tracks source assignment ids when cloning an active version", () => {
+    const cloned = cloneJudgeAssignmentsForRevision(
+      [
+        {
+          id: "hvol_source",
+          heatId: "cheat_1",
+          membershipId: "tmem_judge",
+          rotationId: "jrot_1",
+          versionId: "jver_old",
+          laneNumber: 2,
+          position: "judge",
+          instructions: "Stay right",
+          isManualOverride: false,
+          createdAt: new Date("2026-06-20T00:00:00.000Z"),
+          updatedAt: new Date("2026-06-20T00:00:00.000Z"),
+          updateCounter: null,
+        },
+      ],
+      "jver_new",
+      () => "hvol_clone",
+    )
+
+    expect(cloned).toEqual([
+      expect.objectContaining({
+        id: "hvol_clone",
+        sourceAssignmentId: "hvol_source",
+        versionId: "jver_new",
+        heatId: "cheat_1",
+        membershipId: "tmem_judge",
+      }),
+    ])
+    expect(toJudgeHeatAssignmentInserts(cloned)).toEqual([
+      expect.not.objectContaining({ sourceAssignmentId: "hvol_source" }),
+    ])
+  })
+
+  it("fails loudly when an edit references a stale assignment id", () => {
+    expect(() =>
+      findClonedJudgeAssignmentOrThrow(
+        [
+          {
+            id: "hvol_clone",
+            sourceAssignmentId: "hvol_active",
+            heatId: "cheat_1",
+            membershipId: "tmem_judge",
+            rotationId: "jrot_1",
+            versionId: "jver_new",
+            laneNumber: 1,
+            position: "judge",
+            instructions: null,
+            isManualOverride: false,
+          },
+        ],
+        "hvol_stale",
+      ),
+    ).toThrow("Judge assignment not found in the active version")
+  })
+})

--- a/apps/crew/src/server/judge-assignment-versioning.server.test.ts
+++ b/apps/crew/src/server/judge-assignment-versioning.server.test.ts
@@ -1,10 +1,12 @@
 // @lat: [[crew#Judge Rotations]]
 // @lat: [[crew#Judge Assignment Version Publishing]]
+import { FakeDrizzleDb } from "@repo/test-utils"
 import { describe, expect, it } from "vitest"
 import {
   cloneJudgeAssignmentsForRevision,
   findClonedJudgeAssignmentOrThrow,
   getNextJudgeAssignmentVersionNumber,
+  publishMaterializedJudgeAssignmentsVersion,
   toJudgeHeatAssignmentInserts,
 } from "./judge-assignment-versioning.server"
 
@@ -75,5 +77,33 @@ describe("Crew judge assignment versioning", () => {
         "hvol_stale",
       ),
     ).toThrow("Judge assignment not found in the active version")
+  })
+
+  it("uses a transaction-scoped row lock when publishing a new version", async () => {
+    const db = new FakeDrizzleDb()
+    const timestamp = new Date("2026-06-20T00:00:00.000Z")
+    db.registerTable("judgeAssignmentVersionsTable")
+    db.setMockReturnValue([{ id: "tw_event1", version: 0 }])
+    db.setMockSingleValue({
+      id: "jver_new",
+      trackWorkoutId: "tw_event1",
+      version: 1,
+      publishedAt: timestamp,
+      publishedBy: null,
+      notes: null,
+      isActive: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      updateCounter: null,
+    })
+
+    await publishMaterializedJudgeAssignmentsVersion(
+      db as Parameters<typeof publishMaterializedJudgeAssignmentsVersion>[0],
+      { trackWorkoutId: "tw_event1" },
+      async () => [],
+    )
+
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+    expect(db.getChainMock().for).toHaveBeenCalledWith("update")
   })
 })

--- a/apps/crew/src/server/judge-assignment-versioning.server.ts
+++ b/apps/crew/src/server/judge-assignment-versioning.server.ts
@@ -1,0 +1,296 @@
+// @lat: [[crew#Judge Assignment Version Publishing]]
+// @lat: [[crew#Judge Rotations]]
+import { and, desc, eq, sql } from "drizzle-orm"
+import type { getDb } from "../db"
+import {
+  judgeAssignmentVersionsTable,
+  judgeHeatAssignmentsTable,
+} from "../db/schema"
+import {
+  createHeatVolunteerId,
+  createJudgeAssignmentVersionId,
+} from "../db/schemas/common"
+import { getFirstExecuteValue } from "../server-fns/db-execute"
+
+type DbClient = ReturnType<typeof getDb>
+type TransactionCallback = Parameters<DbClient["transaction"]>[0]
+type TransactionClient = Parameters<TransactionCallback>[0]
+type JudgeAssignmentVersionRow =
+  typeof judgeAssignmentVersionsTable.$inferSelect
+type JudgeHeatAssignmentRow = typeof judgeHeatAssignmentsTable.$inferSelect
+type JudgeHeatAssignmentInsert = typeof judgeHeatAssignmentsTable.$inferInsert
+
+type AdvisoryLockDb = {
+  execute(query: unknown): Promise<unknown>
+}
+
+export type ClonedJudgeAssignmentForRevision = JudgeHeatAssignmentInsert & {
+  id: string
+  sourceAssignmentId: string | null
+}
+
+export interface PublishedJudgeAssignmentRevision {
+  version: JudgeAssignmentVersionRow
+  resultAssignmentIds: string[]
+}
+
+export type MaterializedJudgeAssignmentForVersion = Pick<
+  JudgeHeatAssignmentInsert,
+  "heatId" | "membershipId" | "rotationId" | "laneNumber" | "position"
+>
+
+export interface PublishMaterializedJudgeAssignmentsVersionParams {
+  trackWorkoutId: string
+  publishedBy?: string | null
+  notes?: string | null
+}
+
+export function getNextJudgeAssignmentVersionNumber(
+  versions: Pick<JudgeAssignmentVersionRow, "version">[],
+) {
+  const currentMax = versions.reduce(
+    (max, version) => Math.max(max, version.version),
+    0,
+  )
+  return currentMax + 1
+}
+
+export function cloneJudgeAssignmentsForRevision(
+  activeAssignments: JudgeHeatAssignmentRow[],
+  versionId: string,
+  createId: () => string = createHeatVolunteerId,
+): ClonedJudgeAssignmentForRevision[] {
+  return activeAssignments.map((assignment) => ({
+    id: createId(),
+    sourceAssignmentId: assignment.id,
+    heatId: assignment.heatId,
+    membershipId: assignment.membershipId,
+    rotationId: assignment.rotationId,
+    versionId,
+    laneNumber: assignment.laneNumber,
+    position: assignment.position,
+    instructions: assignment.instructions,
+    isManualOverride: assignment.isManualOverride,
+  }))
+}
+
+export function findClonedJudgeAssignmentOrThrow(
+  assignments: ClonedJudgeAssignmentForRevision[],
+  sourceAssignmentId: string,
+) {
+  const assignment = assignments.find(
+    (candidate) => candidate.sourceAssignmentId === sourceAssignmentId,
+  )
+  if (!assignment) {
+    throw new Error("Judge assignment not found in the active version")
+  }
+  return assignment
+}
+
+export function toJudgeHeatAssignmentInserts(
+  assignments: ClonedJudgeAssignmentForRevision[],
+): JudgeHeatAssignmentInsert[] {
+  return assignments.map(
+    ({ sourceAssignmentId: _sourceAssignmentId, ...row }) => row,
+  )
+}
+
+export async function withJudgeAssignmentVersionLock<T>(
+  db: AdvisoryLockDb,
+  trackWorkoutId: string,
+  callback: () => Promise<T>,
+) {
+  let acquired = false
+  let callbackFailed = false
+  const lockName = await createJudgeAssignmentVersionLockName(trackWorkoutId)
+
+  try {
+    const result = await db.execute(
+      sql`SELECT GET_LOCK(${lockName}, 5) FROM dual`,
+    )
+    acquired = Number(getFirstExecuteValue(result) ?? 0) === 1
+    if (!acquired) {
+      throw new Error("Judge assignment version could not be published")
+    }
+
+    try {
+      return await callback()
+    } catch (error) {
+      callbackFailed = true
+      throw error
+    }
+  } finally {
+    if (acquired) {
+      try {
+        await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
+      } catch (releaseError) {
+        if (callbackFailed) {
+          console.warn(
+            "Failed to release judge assignment version lock after callback error",
+            releaseError,
+          )
+        } else {
+          console.warn(
+            "Failed to release judge assignment version lock",
+            releaseError,
+          )
+        }
+      }
+    }
+  }
+}
+
+export async function publishMaterializedJudgeAssignmentsVersion(
+  db: DbClient,
+  params: PublishMaterializedJudgeAssignmentsVersionParams,
+  materializeAssignments: (
+    tx: TransactionClient,
+  ) => Promise<MaterializedJudgeAssignmentForVersion[]>,
+) {
+  return withJudgeAssignmentVersionLock(db, params.trackWorkoutId, async () =>
+    db.transaction(async (tx) => {
+      const versions = await tx.query.judgeAssignmentVersionsTable.findMany({
+        where: eq(
+          judgeAssignmentVersionsTable.trackWorkoutId,
+          params.trackWorkoutId,
+        ),
+        orderBy: desc(judgeAssignmentVersionsTable.version),
+      })
+      const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
+      const newVersionId = createJudgeAssignmentVersionId()
+      const materializedAssignments = await materializeAssignments(tx)
+      const timestamp = new Date()
+
+      await tx
+        .update(judgeAssignmentVersionsTable)
+        .set({ isActive: false, updatedAt: timestamp })
+        .where(
+          eq(
+            judgeAssignmentVersionsTable.trackWorkoutId,
+            params.trackWorkoutId,
+          ),
+        )
+
+      await tx.insert(judgeAssignmentVersionsTable).values({
+        id: newVersionId,
+        trackWorkoutId: params.trackWorkoutId,
+        version: nextVersion,
+        publishedBy: params.publishedBy ?? null,
+        notes: params.notes ?? null,
+        isActive: true,
+      })
+
+      const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
+        where: eq(judgeAssignmentVersionsTable.id, newVersionId),
+      })
+
+      if (!version) {
+        throw new Error("Failed to create judge assignment version")
+      }
+
+      if (materializedAssignments.length > 0) {
+        await tx.insert(judgeHeatAssignmentsTable).values(
+          materializedAssignments.map((assignment) => ({
+            heatId: assignment.heatId,
+            membershipId: assignment.membershipId,
+            rotationId: assignment.rotationId,
+            laneNumber: assignment.laneNumber,
+            position: assignment.position,
+            versionId: version.id,
+            isManualOverride: false,
+          })),
+        )
+      }
+
+      return version
+    }),
+  )
+}
+
+export async function createPublishedJudgeAssignmentRevision(
+  db: DbClient,
+  trackWorkoutId: string,
+  editClonedAssignments: (
+    assignments: ClonedJudgeAssignmentForRevision[],
+    versionId: string,
+  ) => {
+    assignments: ClonedJudgeAssignmentForRevision[]
+    resultAssignmentIds?: string[]
+  },
+): Promise<PublishedJudgeAssignmentRevision | null> {
+  return withJudgeAssignmentVersionLock(db, trackWorkoutId, async () =>
+    db.transaction(async (tx) => {
+      const activeVersion =
+        await tx.query.judgeAssignmentVersionsTable.findFirst({
+          where: and(
+            eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
+            eq(judgeAssignmentVersionsTable.isActive, true),
+          ),
+        })
+
+      if (!activeVersion) {
+        return null
+      }
+
+      const versions = await tx.query.judgeAssignmentVersionsTable.findMany({
+        where: eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
+        orderBy: desc(judgeAssignmentVersionsTable.version),
+      })
+      const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
+      const newVersionId = createJudgeAssignmentVersionId()
+      const activeAssignments =
+        await tx.query.judgeHeatAssignmentsTable.findMany({
+          where: eq(judgeHeatAssignmentsTable.versionId, activeVersion.id),
+        })
+      const clonedAssignments = cloneJudgeAssignmentsForRevision(
+        activeAssignments,
+        newVersionId,
+      )
+      const edited = editClonedAssignments(clonedAssignments, newVersionId)
+      const timestamp = new Date()
+
+      await tx
+        .update(judgeAssignmentVersionsTable)
+        .set({ isActive: false, updatedAt: timestamp })
+        .where(eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId))
+
+      await tx.insert(judgeAssignmentVersionsTable).values({
+        id: newVersionId,
+        trackWorkoutId,
+        version: nextVersion,
+        publishedBy: null,
+        notes: "Manual judge assignment edit",
+        isActive: true,
+      })
+
+      if (edited.assignments.length > 0) {
+        await tx
+          .insert(judgeHeatAssignmentsTable)
+          .values(toJudgeHeatAssignmentInserts(edited.assignments))
+      }
+
+      const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
+        where: eq(judgeAssignmentVersionsTable.id, newVersionId),
+      })
+      if (!version) {
+        throw new Error("Failed to create judge assignment version")
+      }
+
+      return {
+        version,
+        resultAssignmentIds: edited.resultAssignmentIds ?? [],
+      }
+    }),
+  )
+}
+
+async function createJudgeAssignmentVersionLockName(trackWorkoutId: string) {
+  const encoded = new TextEncoder().encode(
+    `judge-assignment-version:${trackWorkoutId}`,
+  )
+  const digest = await crypto.subtle.digest("SHA-256", encoded)
+  const hex = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")
+  return `jav:${hex.slice(0, 60)}`
+}

--- a/apps/crew/src/server/judge-assignment-versioning.server.ts
+++ b/apps/crew/src/server/judge-assignment-versioning.server.ts
@@ -1,16 +1,16 @@
 // @lat: [[crew#Judge Assignment Version Publishing]]
 // @lat: [[crew#Judge Rotations]]
-import { and, desc, eq, sql } from "drizzle-orm"
+import { and, desc, eq } from "drizzle-orm"
 import type { getDb } from "../db"
 import {
   judgeAssignmentVersionsTable,
   judgeHeatAssignmentsTable,
+  trackWorkoutsTable,
 } from "../db/schema"
 import {
   createHeatVolunteerId,
   createJudgeAssignmentVersionId,
 } from "../db/schemas/common"
-import { getFirstExecuteValue } from "../server-fns/db-execute"
 
 type DbClient = ReturnType<typeof getDb>
 type TransactionCallback = Parameters<DbClient["transaction"]>[0]
@@ -19,10 +19,6 @@ type JudgeAssignmentVersionRow =
   typeof judgeAssignmentVersionsTable.$inferSelect
 type JudgeHeatAssignmentRow = typeof judgeHeatAssignmentsTable.$inferSelect
 type JudgeHeatAssignmentInsert = typeof judgeHeatAssignmentsTable.$inferInsert
-
-type AdvisoryLockDb = {
-  execute(query: unknown): Promise<unknown>
-}
 
 export type ClonedJudgeAssignmentForRevision = JudgeHeatAssignmentInsert & {
   id: string
@@ -95,51 +91,6 @@ export function toJudgeHeatAssignmentInserts(
   )
 }
 
-export async function withJudgeAssignmentVersionLock<T>(
-  db: AdvisoryLockDb,
-  trackWorkoutId: string,
-  callback: () => Promise<T>,
-) {
-  let acquired = false
-  let callbackFailed = false
-  const lockName = await createJudgeAssignmentVersionLockName(trackWorkoutId)
-
-  try {
-    const result = await db.execute(
-      sql`SELECT GET_LOCK(${lockName}, 5) FROM dual`,
-    )
-    acquired = Number(getFirstExecuteValue(result) ?? 0) === 1
-    if (!acquired) {
-      throw new Error("Judge assignment version could not be published")
-    }
-
-    try {
-      return await callback()
-    } catch (error) {
-      callbackFailed = true
-      throw error
-    }
-  } finally {
-    if (acquired) {
-      try {
-        await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
-      } catch (releaseError) {
-        if (callbackFailed) {
-          console.warn(
-            "Failed to release judge assignment version lock after callback error",
-            releaseError,
-          )
-        } else {
-          console.warn(
-            "Failed to release judge assignment version lock",
-            releaseError,
-          )
-        }
-      }
-    }
-  }
-}
-
 export async function publishMaterializedJudgeAssignmentsVersion(
   db: DbClient,
   params: PublishMaterializedJudgeAssignmentsVersionParams,
@@ -147,64 +98,61 @@ export async function publishMaterializedJudgeAssignmentsVersion(
     tx: TransactionClient,
   ) => Promise<MaterializedJudgeAssignmentForVersion[]>,
 ) {
-  return withJudgeAssignmentVersionLock(db, params.trackWorkoutId, async () =>
-    db.transaction(async (tx) => {
-      const versions = await tx.query.judgeAssignmentVersionsTable.findMany({
-        where: eq(
-          judgeAssignmentVersionsTable.trackWorkoutId,
-          params.trackWorkoutId,
-        ),
-        orderBy: desc(judgeAssignmentVersionsTable.version),
-      })
-      const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
-      const newVersionId = createJudgeAssignmentVersionId()
-      const materializedAssignments = await materializeAssignments(tx)
-      const timestamp = new Date()
+  return db.transaction(async (tx) => {
+    await lockJudgeAssignmentVersionScope(tx, params.trackWorkoutId)
 
-      await tx
-        .update(judgeAssignmentVersionsTable)
-        .set({ isActive: false, updatedAt: timestamp })
-        .where(
-          eq(
-            judgeAssignmentVersionsTable.trackWorkoutId,
-            params.trackWorkoutId,
-          ),
-        )
+    const versions = await tx.query.judgeAssignmentVersionsTable.findMany({
+      where: eq(
+        judgeAssignmentVersionsTable.trackWorkoutId,
+        params.trackWorkoutId,
+      ),
+      orderBy: desc(judgeAssignmentVersionsTable.version),
+    })
+    const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
+    const newVersionId = createJudgeAssignmentVersionId()
+    const materializedAssignments = await materializeAssignments(tx)
+    const timestamp = new Date()
 
-      await tx.insert(judgeAssignmentVersionsTable).values({
-        id: newVersionId,
-        trackWorkoutId: params.trackWorkoutId,
-        version: nextVersion,
-        publishedBy: params.publishedBy ?? null,
-        notes: params.notes ?? null,
-        isActive: true,
-      })
+    await tx
+      .update(judgeAssignmentVersionsTable)
+      .set({ isActive: false, updatedAt: timestamp })
+      .where(
+        eq(judgeAssignmentVersionsTable.trackWorkoutId, params.trackWorkoutId),
+      )
 
-      const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
-        where: eq(judgeAssignmentVersionsTable.id, newVersionId),
-      })
+    await tx.insert(judgeAssignmentVersionsTable).values({
+      id: newVersionId,
+      trackWorkoutId: params.trackWorkoutId,
+      version: nextVersion,
+      publishedBy: params.publishedBy ?? null,
+      notes: params.notes ?? null,
+      isActive: true,
+    })
 
-      if (!version) {
-        throw new Error("Failed to create judge assignment version")
-      }
+    const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
+      where: eq(judgeAssignmentVersionsTable.id, newVersionId),
+    })
 
-      if (materializedAssignments.length > 0) {
-        await tx.insert(judgeHeatAssignmentsTable).values(
-          materializedAssignments.map((assignment) => ({
-            heatId: assignment.heatId,
-            membershipId: assignment.membershipId,
-            rotationId: assignment.rotationId,
-            laneNumber: assignment.laneNumber,
-            position: assignment.position,
-            versionId: version.id,
-            isManualOverride: false,
-          })),
-        )
-      }
+    if (!version) {
+      throw new Error("Failed to create judge assignment version")
+    }
 
-      return version
-    }),
-  )
+    if (materializedAssignments.length > 0) {
+      await tx.insert(judgeHeatAssignmentsTable).values(
+        materializedAssignments.map((assignment) => ({
+          heatId: assignment.heatId,
+          membershipId: assignment.membershipId,
+          rotationId: assignment.rotationId,
+          laneNumber: assignment.laneNumber,
+          position: assignment.position,
+          versionId: version.id,
+          isManualOverride: false,
+        })),
+      )
+    }
+
+    return version
+  })
 }
 
 export async function createPublishedJudgeAssignmentRevision(
@@ -218,79 +166,86 @@ export async function createPublishedJudgeAssignmentRevision(
     resultAssignmentIds?: string[]
   },
 ): Promise<PublishedJudgeAssignmentRevision | null> {
-  return withJudgeAssignmentVersionLock(db, trackWorkoutId, async () =>
-    db.transaction(async (tx) => {
-      const activeVersion =
-        await tx.query.judgeAssignmentVersionsTable.findFirst({
-          where: and(
-            eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
-            eq(judgeAssignmentVersionsTable.isActive, true),
-          ),
-        })
+  return db.transaction(async (tx) => {
+    await lockJudgeAssignmentVersionScope(tx, trackWorkoutId)
 
-      if (!activeVersion) {
-        return null
-      }
+    const activeVersion = await tx.query.judgeAssignmentVersionsTable.findFirst(
+      {
+        where: and(
+          eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
+          eq(judgeAssignmentVersionsTable.isActive, true),
+        ),
+      },
+    )
 
-      const versions = await tx.query.judgeAssignmentVersionsTable.findMany({
-        where: eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
-        orderBy: desc(judgeAssignmentVersionsTable.version),
-      })
-      const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
-      const newVersionId = createJudgeAssignmentVersionId()
-      const activeAssignments =
-        await tx.query.judgeHeatAssignmentsTable.findMany({
-          where: eq(judgeHeatAssignmentsTable.versionId, activeVersion.id),
-        })
-      const clonedAssignments = cloneJudgeAssignmentsForRevision(
-        activeAssignments,
-        newVersionId,
-      )
-      const edited = editClonedAssignments(clonedAssignments, newVersionId)
-      const timestamp = new Date()
+    if (!activeVersion) {
+      return null
+    }
 
+    const versions = await tx.query.judgeAssignmentVersionsTable.findMany({
+      where: eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId),
+      orderBy: desc(judgeAssignmentVersionsTable.version),
+    })
+    const nextVersion = getNextJudgeAssignmentVersionNumber(versions)
+    const newVersionId = createJudgeAssignmentVersionId()
+    const activeAssignments = await tx.query.judgeHeatAssignmentsTable.findMany(
+      {
+        where: eq(judgeHeatAssignmentsTable.versionId, activeVersion.id),
+      },
+    )
+    const clonedAssignments = cloneJudgeAssignmentsForRevision(
+      activeAssignments,
+      newVersionId,
+    )
+    const edited = editClonedAssignments(clonedAssignments, newVersionId)
+    const timestamp = new Date()
+
+    await tx
+      .update(judgeAssignmentVersionsTable)
+      .set({ isActive: false, updatedAt: timestamp })
+      .where(eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId))
+
+    await tx.insert(judgeAssignmentVersionsTable).values({
+      id: newVersionId,
+      trackWorkoutId,
+      version: nextVersion,
+      publishedBy: null,
+      notes: "Manual judge assignment edit",
+      isActive: true,
+    })
+
+    if (edited.assignments.length > 0) {
       await tx
-        .update(judgeAssignmentVersionsTable)
-        .set({ isActive: false, updatedAt: timestamp })
-        .where(eq(judgeAssignmentVersionsTable.trackWorkoutId, trackWorkoutId))
+        .insert(judgeHeatAssignmentsTable)
+        .values(toJudgeHeatAssignmentInserts(edited.assignments))
+    }
 
-      await tx.insert(judgeAssignmentVersionsTable).values({
-        id: newVersionId,
-        trackWorkoutId,
-        version: nextVersion,
-        publishedBy: null,
-        notes: "Manual judge assignment edit",
-        isActive: true,
-      })
+    const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
+      where: eq(judgeAssignmentVersionsTable.id, newVersionId),
+    })
+    if (!version) {
+      throw new Error("Failed to create judge assignment version")
+    }
 
-      if (edited.assignments.length > 0) {
-        await tx
-          .insert(judgeHeatAssignmentsTable)
-          .values(toJudgeHeatAssignmentInserts(edited.assignments))
-      }
-
-      const version = await tx.query.judgeAssignmentVersionsTable.findFirst({
-        where: eq(judgeAssignmentVersionsTable.id, newVersionId),
-      })
-      if (!version) {
-        throw new Error("Failed to create judge assignment version")
-      }
-
-      return {
-        version,
-        resultAssignmentIds: edited.resultAssignmentIds ?? [],
-      }
-    }),
-  )
+    return {
+      version,
+      resultAssignmentIds: edited.resultAssignmentIds ?? [],
+    }
+  })
 }
 
-async function createJudgeAssignmentVersionLockName(trackWorkoutId: string) {
-  const encoded = new TextEncoder().encode(
-    `judge-assignment-version:${trackWorkoutId}`,
-  )
-  const digest = await crypto.subtle.digest("SHA-256", encoded)
-  const hex = Array.from(new Uint8Array(digest), (byte) =>
-    byte.toString(16).padStart(2, "0"),
-  ).join("")
-  return `jav:${hex.slice(0, 60)}`
+async function lockJudgeAssignmentVersionScope(
+  tx: TransactionClient,
+  trackWorkoutId: string,
+) {
+  const [workout] = await tx
+    .select({ id: trackWorkoutsTable.id })
+    .from(trackWorkoutsTable)
+    .where(eq(trackWorkoutsTable.id, trackWorkoutId))
+    .for("update")
+    .limit(1)
+
+  if (!workout) {
+    throw new Error("Judge assignment version workout not found")
+  }
 }

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -56,6 +56,18 @@ Editing an active published judge schedule creates a new active version, clones 
 
 Per-event publishing uses an advisory lock before allocating the next version number so frequent day-of edits do not race the `(trackWorkoutId, version)` uniqueness boundary. Edits against assignment IDs that are not present in the active version fail instead of silently mutating an inactive version or producing an empty revision.
 
+## Judge Rotations
+
+Crew judge rotations adapt the existing judge scheduling model into a local-operator event surface.
+
+[[apps/crew/src/routes/events/$eventId/judges.tsx]] renders workout selection, judge selection, per-judge rotation replacement, coverage preview, active published assignments, and version history.
+
+[[apps/crew/src/server-fns/crew-judge-rotations-fns.ts]] keeps route imports lightweight while [[apps/crew/src/server/crew-judge-rotations.server.ts]] owns Crew event hydration, scoped rotation writes, and publishing through the versioned assignment helper.
+
+[[apps/crew/src/lib/crew/judge-rotations.ts]] keeps rotation expansion, validation, lane conflicts, and coverage summaries deterministic for the route and server.
+
+Publishing rotations creates a new active `judge_assignment_versions` row and materializes `judge_heat_assignments` under the advisory-lock flow from [[crew#Judge Assignment Version Publishing]].
+
 ## Manual Volunteer Intake
 
 Manual volunteer intake lets Crew operators build the roster from [[apps/crew/src/routes/events/$eventId/volunteers.tsx|the event volunteer page]] without leaving the existing volunteer primitives.


### PR DESCRIPTION
## Summary

- Adds a Crew `/events/$eventId/judges` route and event-shell navigation entry for judge rotation planning.
- Adds route-safe `createServerFn` wrappers backed by a server-only Crew judge rotations module for event hydration, per-judge rotation replacement, and publishing.
- Adds Crew rotation helper coverage plus a Crew copy of the hardened judge assignment versioning helper so publishing materializes a new active version under an advisory lock.
- Adds LAT anchor `crew#Judge Rotations`.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/judge-rotations.test.ts src/server/judge-assignment-versioning.server.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0 with existing unrelated warnings)
- `pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Judge Rotations'`
- `git diff --check`
- `git diff --cached --check`

## Notes

- Crew judge rotations remain local-operator guarded until Crew auth is wired, matching the current Crew operator surfaces.
- This slice does not add AI scheduling, day-of operations, exports, reminders, queues, assignment automation, schema, migrations, or production data changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds judge rotation planning to Crew with a Judges page for per‑judge rotations, inline validation/coverage preview, and publishing versioned assignments with notes. Publishing is advisory‑locked and blocks unsafe replacement when assignments are referenced.

- **New Features**
  - Added `/events/$eventId/judges` and EventShell nav entry.
  - Rotation editor with lane‑shift pattern, add/reset rows, notes; shows active version, published assignments, and history; publish with notes.
  - Route‑safe server fns via `@tanstack/react-start` with Zod input validation; server handles hydration, save, and publish.
  - Deterministic helpers for rotation expansion, validation, and coverage with tests; access limited to local Crew operators (LAT `crew#Judge Rotations`).

- **Bug Fixes**
  - Block rotation replacement when judge assignments reference those rotations; require publishing a new version.
  - Make coverage summaries deterministic and derive lane capacity from occupied lanes when they exceed venue lane count.

<sup>Written for commit cd306a8b069d6b4643776d23e540c51ba0d38831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Judges management page to event navigation with draft/publish rotation workflows
  * Rotation editor with lane shift pattern selection and real-time validation
  * Coverage preview showing judge and lane occupancy by heat
  * Published assignment history and version tracking per workout

* **Tests**
  * Added test coverage for rotation validation and assignment versioning

* **Documentation**
  * Added Judge Rotations section to architecture guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->