### PR TITLE
feat(crew): add assignment confirmations

### DIFF
--- a/apps/crew/src/lib/crew/assignment-confirmation-display.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmation-display.ts
@@ -1,8 +1,15 @@
+// @lat: [[crew#Assignment Confirmations]]
 export function getCrewAssignmentConfirmationStatusBadgeClassName(
   status: string,
 ) {
+  if (status === "missing") {
+    return "border-amber-500/30 bg-background text-amber-700"
+  }
   if (status === "pending") {
     return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+  }
+  if (status === "sent") {
+    return "border-blue-500/30 bg-blue-500/10 text-blue-700"
   }
   if (status === "confirmed") {
     return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
@@ -16,8 +23,21 @@ export function getCrewAssignmentConfirmationStatusBadgeClassName(
   if (status === "cancelled") {
     return "border-muted bg-muted text-muted-foreground"
   }
+  if (status === "replaced") {
+    return "border-muted bg-muted text-muted-foreground"
+  }
   if (status === "no_show") {
     return "border-orange-500/30 bg-orange-500/10 text-orange-700"
   }
   return "border-muted bg-background text-muted-foreground"
+}
+
+export function getCrewAssignmentConfirmationStatusLabel(status: string) {
+  if (status === "change_requested") return "Change requested"
+  if (status === "no_show") return "No-show"
+  if (status === "cancelled" || status === "replaced") return "Replaced"
+  return status
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
 }

--- a/apps/crew/src/lib/crew/assignment-confirmations.test.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.test.ts
@@ -3,9 +3,12 @@ import { CREW_ASSIGNMENT_CONFIRMATION_STATUS } from "../../db/schemas/crew-impor
 import {
   buildCrewAssignmentConfirmationUrls,
   generateCrewAssignmentConfirmationToken,
+  getCrewAssignmentConfirmationOperationalState,
   getCrewAssignmentConfirmationTokenState,
   hashCrewAssignmentConfirmationToken,
   resolveCrewAssignmentConfirmationResponse,
+  resolveCrewAssignmentConfirmationOrganizerStateUpdate,
+  summarizeCrewAssignmentConfirmationOperationalStates,
   summarizeCrewAssignmentConfirmations,
 } from "./assignment-confirmations"
 
@@ -198,6 +201,114 @@ describe("Crew assignment confirmation summaries", () => {
         "https://crew.wodsmith.com/e/friday-night-lights/confirm/abc_123",
       scheduleUrl:
         "https://crew.wodsmith.com/e/friday-night-lights/schedule/abc_123",
+    })
+  })
+})
+
+describe("Crew assignment confirmation operational states", () => {
+  it("normalizes missing, pending, sent, response, no-show, and replaced states", () => {
+    expect(getCrewAssignmentConfirmationOperationalState(null)).toBe("missing")
+    expect(
+      getCrewAssignmentConfirmationOperationalState({
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+        sentAt: null,
+      }),
+    ).toBe("pending")
+    expect(
+      getCrewAssignmentConfirmationOperationalState({
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+        sentAt: "2026-06-19T12:00:00.000Z",
+      }),
+    ).toBe("sent")
+    expect(
+      getCrewAssignmentConfirmationOperationalState({
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+      }),
+    ).toBe("confirmed")
+    expect(
+      getCrewAssignmentConfirmationOperationalState({
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.NO_SHOW,
+      }),
+    ).toBe("no_show")
+    expect(
+      getCrewAssignmentConfirmationOperationalState({
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+      }),
+    ).toBe("replaced")
+  })
+
+  it("summarizes operational states separately from persisted statuses", () => {
+    expect(
+      summarizeCrewAssignmentConfirmationOperationalStates([
+        null,
+        {
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+          sentAt: null,
+        },
+        {
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+          sentAt: "2026-06-19T12:00:00.000Z",
+        },
+        { status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED },
+        { status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED },
+        { status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED },
+        { status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.NO_SHOW },
+        { status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED },
+      ]),
+    ).toEqual({
+      missing: 1,
+      pending: 1,
+      sent: 1,
+      confirmed: 1,
+      declined: 1,
+      changeRequested: 1,
+      noShow: 1,
+      replaced: 1,
+      total: 8,
+      responseNeeded: 3,
+      organizerActionNeeded: 7,
+    })
+  })
+
+  it("builds organizer mutation payloads without inventing persisted states", () => {
+    const now = new Date("2026-06-19T12:00:00.000Z")
+
+    expect(
+      resolveCrewAssignmentConfirmationOrganizerStateUpdate(
+        "sent",
+        null,
+        now,
+      ),
+    ).toEqual({
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+      sentAt: now,
+      respondedAt: null,
+      responseNote: null,
+    })
+    expect(
+      resolveCrewAssignmentConfirmationOrganizerStateUpdate(
+        "change_requested",
+        " Need a later slot. ",
+        now,
+        { sentAt: "2026-06-19T10:00:00.000Z" },
+      ),
+    ).toEqual({
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
+      sentAt: new Date("2026-06-19T10:00:00.000Z"),
+      respondedAt: now,
+      responseNote: "Need a later slot.",
+    })
+    expect(
+      resolveCrewAssignmentConfirmationOrganizerStateUpdate(
+        "replaced",
+        "Covered by Sam.",
+        now,
+      ),
+    ).toMatchObject({
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+      sentAt: null,
+      respondedAt: null,
+      responseNote: "Covered by Sam.",
     })
   })
 })

--- a/apps/crew/src/lib/crew/assignment-confirmations.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Assignment Confirmation Responses]]
+// @lat: [[crew#Assignment Confirmations]]
 import {
   CREW_ASSIGNMENT_CONFIRMATION_STATUS,
   type CrewAssignmentConfirmationStatus,
@@ -32,8 +33,58 @@ export interface CrewAssignmentConfirmationStatusSummary {
   cancelled: number
 }
 
+export type CrewAssignmentConfirmationOperationalState =
+  | "missing"
+  | "pending"
+  | "sent"
+  | "confirmed"
+  | "declined"
+  | "change_requested"
+  | "no_show"
+  | "replaced"
+
+export type CrewAssignmentConfirmationOrganizerState = Exclude<
+  CrewAssignmentConfirmationOperationalState,
+  "missing"
+>
+
+export interface CrewAssignmentConfirmationOperationalRecord {
+  status?: CrewAssignmentConfirmationStatus | string | null
+  sentAt?: Date | string | null
+}
+
+export interface CrewAssignmentConfirmationOperationalSummary {
+  missing: number
+  pending: number
+  sent: number
+  confirmed: number
+  declined: number
+  changeRequested: number
+  noShow: number
+  replaced: number
+  total: number
+  responseNeeded: number
+  organizerActionNeeded: number
+}
+
+export interface CrewAssignmentConfirmationOrganizerStateUpdate {
+  status: CrewAssignmentConfirmationStatus
+  sentAt: Date | null
+  respondedAt: Date | null
+  responseNote: string | null
+}
+
 export const CREW_ASSIGNMENT_CONFIRMATION_TOKEN_BYTES = 32
 export const CREW_ASSIGNMENT_CONFIRMATION_TOKEN_HASH_PREFIX = "sha256:"
+export const CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES = [
+  "pending",
+  "sent",
+  "confirmed",
+  "declined",
+  "change_requested",
+  "no_show",
+  "replaced",
+] as const satisfies CrewAssignmentConfirmationOrganizerState[]
 
 export function generateCrewAssignmentConfirmationToken(
   byteLength = CREW_ASSIGNMENT_CONFIRMATION_TOKEN_BYTES,
@@ -216,6 +267,129 @@ export function summarizeCrewAssignmentConfirmations(
   )
 }
 
+export function getCrewAssignmentConfirmationOperationalState(
+  record: CrewAssignmentConfirmationOperationalRecord | null | undefined,
+): CrewAssignmentConfirmationOperationalState {
+  if (!record?.status) return "missing"
+  if (record.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED) {
+    return "confirmed"
+  }
+  if (record.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED) {
+    return "declined"
+  }
+  if (
+    record.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+  ) {
+    return "change_requested"
+  }
+  if (record.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.NO_SHOW) {
+    return "no_show"
+  }
+  if (record.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED) {
+    return "replaced"
+  }
+  return record.sentAt ? "sent" : "pending"
+}
+
+export function summarizeCrewAssignmentConfirmationOperationalStates(
+  confirmations: Array<
+    CrewAssignmentConfirmationOperationalRecord | null | undefined
+  >,
+): CrewAssignmentConfirmationOperationalSummary {
+  return confirmations.reduce<CrewAssignmentConfirmationOperationalSummary>(
+    (summary, confirmation) => {
+      const state = getCrewAssignmentConfirmationOperationalState(confirmation)
+      if (state === "missing") summary.missing += 1
+      else if (state === "pending") summary.pending += 1
+      else if (state === "sent") summary.sent += 1
+      else if (state === "confirmed") summary.confirmed += 1
+      else if (state === "declined") summary.declined += 1
+      else if (state === "change_requested") summary.changeRequested += 1
+      else if (state === "no_show") summary.noShow += 1
+      else summary.replaced += 1
+
+      summary.total += 1
+      summary.responseNeeded =
+        summary.missing + summary.pending + summary.sent
+      summary.organizerActionNeeded =
+        summary.missing +
+        summary.pending +
+        summary.sent +
+        summary.declined +
+        summary.changeRequested +
+        summary.noShow +
+        summary.replaced
+      return summary
+    },
+    {
+      missing: 0,
+      pending: 0,
+      sent: 0,
+      confirmed: 0,
+      declined: 0,
+      changeRequested: 0,
+      noShow: 0,
+      replaced: 0,
+      total: 0,
+      responseNeeded: 0,
+      organizerActionNeeded: 0,
+    },
+  )
+}
+
+export function resolveCrewAssignmentConfirmationOrganizerStateUpdate(
+  state: CrewAssignmentConfirmationOrganizerState,
+  note: string | null | undefined,
+  now = new Date(),
+  current?: CrewAssignmentConfirmationOperationalRecord | null,
+): CrewAssignmentConfirmationOrganizerStateUpdate {
+  if (state === "pending") {
+    return {
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+      sentAt: null,
+      respondedAt: null,
+      responseNote: null,
+    }
+  }
+
+  if (state === "sent") {
+    return {
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+      sentAt: now,
+      respondedAt: null,
+      responseNote: null,
+    }
+  }
+
+  if (state === "replaced") {
+    return {
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+      sentAt: normalizeDateOrNull(current?.sentAt),
+      respondedAt: null,
+      responseNote: normalizeResponseNote(note),
+    }
+  }
+
+  const status =
+    state === "confirmed"
+      ? CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED
+      : state === "declined"
+        ? CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED
+        : state === "no_show"
+          ? CREW_ASSIGNMENT_CONFIRMATION_STATUS.NO_SHOW
+          : CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+
+  return {
+    status,
+    sentAt: normalizeDateOrNull(current?.sentAt),
+    respondedAt: now,
+    responseNote:
+      status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+        ? normalizeResponseNote(note)
+        : null,
+  }
+}
+
 export function buildCrewAssignmentConfirmationUrls(params: {
   appUrl: string
   slug: string
@@ -230,9 +404,16 @@ export function buildCrewAssignmentConfirmationUrls(params: {
   }
 }
 
-function normalizeResponseNote(value: string | null | undefined) {
+export function normalizeResponseNote(value: string | null | undefined) {
   const trimmed = value?.trim()
   return trimmed ? trimmed.slice(0, 1000) : null
+}
+
+function normalizeDateOrNull(value: Date | string | null | undefined) {
+  if (!value) return null
+  if (value instanceof Date) return value
+  const parsed = new Date(value)
+  return Number.isNaN(parsed.getTime()) ? null : parsed
 }
 
 function bytesToBase64Url(bytes: Uint8Array) {

--- a/apps/crew/src/lib/crew/readiness.test.ts
+++ b/apps/crew/src/lib/crew/readiness.test.ts
@@ -87,6 +87,19 @@ describe("Crew readiness checklist", () => {
           noShow: 0,
           cancelled: 0,
         },
+        confirmationOperationalSummary: {
+          missing: 0,
+          pending: 2,
+          sent: 0,
+          confirmed: 3,
+          declined: 1,
+          changeRequested: 1,
+          noShow: 0,
+          replaced: 0,
+          total: 7,
+          responseNeeded: 2,
+          organizerActionNeeded: 4,
+        },
       },
     })
 
@@ -97,7 +110,14 @@ describe("Crew readiness checklist", () => {
     ).toMatchObject({
       status: "needs_attention",
       summary: "3/7 assignments confirmed",
-      details: ["2 no response.", "1 declined.", "1 change requested."],
+      details: [
+        "2 not sent.",
+        "0 sent.",
+        "1 declined.",
+        "1 change requested.",
+        "0 no-show.",
+        "0 replaced.",
+      ],
     })
   })
 
@@ -167,6 +187,19 @@ const readyInput: CrewReadinessInput = {
       changeRequested: 0,
       noShow: 0,
       cancelled: 0,
+    },
+    confirmationOperationalSummary: {
+      missing: 0,
+      pending: 0,
+      sent: 0,
+      confirmed: 7,
+      declined: 0,
+      changeRequested: 0,
+      noShow: 0,
+      replaced: 0,
+      total: 7,
+      responseNeeded: 0,
+      organizerActionNeeded: 0,
     },
   },
   judge: {

--- a/apps/crew/src/lib/crew/readiness.test.ts
+++ b/apps/crew/src/lib/crew/readiness.test.ts
@@ -88,8 +88,8 @@ describe("Crew readiness checklist", () => {
           cancelled: 0,
         },
         confirmationOperationalSummary: {
-          missing: 0,
-          pending: 2,
+          missing: 1,
+          pending: 1,
           sent: 0,
           confirmed: 3,
           declined: 1,

--- a/apps/crew/src/lib/crew/readiness.ts
+++ b/apps/crew/src/lib/crew/readiness.ts
@@ -1,5 +1,8 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
-import type { CrewAssignmentConfirmationStatusSummary } from "./assignment-confirmations"
+import type {
+  CrewAssignmentConfirmationOperationalSummary,
+  CrewAssignmentConfirmationStatusSummary,
+} from "./assignment-confirmations"
 import type { CrewRosterSummary } from "./roster-shifts"
 
 export type CrewReadinessStatus = "ready" | "needs_attention" | "blocked"
@@ -80,6 +83,7 @@ export interface CrewReadinessShiftInput {
   capacity: number
   openSlots: number
   confirmationSummary: CrewAssignmentConfirmationStatusSummary
+  confirmationOperationalSummary: CrewAssignmentConfirmationOperationalSummary
 }
 
 export interface CrewReadinessJudgeInput {
@@ -314,10 +318,15 @@ function buildAssignmentConfirmationsItem(
   input: CrewReadinessInput,
 ): CrewReadinessChecklistItem {
   const confirmations = input.shifts.confirmationSummary
+  const operational = input.shifts.confirmationOperationalSummary
   const responseIssues =
-    confirmations.pending +
+    operational.missing +
+    operational.pending +
+    operational.sent +
     confirmations.declined +
-    confirmations.changeRequested
+    confirmations.changeRequested +
+    confirmations.noShow +
+    operational.replaced
   const status =
     input.shifts.assignedSlots === 0
       ? "needs_attention"
@@ -331,9 +340,12 @@ function buildAssignmentConfirmationsItem(
     status,
     summary: `${confirmations.confirmed}/${input.shifts.assignedSlots} assignments confirmed`,
     details: [
-      `${confirmations.pending} no response.`,
+      `${operational.pending} not sent.`,
+      `${operational.sent} sent.`,
       `${confirmations.declined} declined.`,
       `${confirmations.changeRequested} change requested.`,
+      `${confirmations.noShow} no-show.`,
+      `${operational.replaced} replaced.`,
     ],
     action: { label: "Review shifts", to: "/events/$eventId/shifts" },
   }

--- a/apps/crew/src/lib/crew/readiness.ts
+++ b/apps/crew/src/lib/crew/readiness.ts
@@ -319,9 +319,9 @@ function buildAssignmentConfirmationsItem(
 ): CrewReadinessChecklistItem {
   const confirmations = input.shifts.confirmationSummary
   const operational = input.shifts.confirmationOperationalSummary
+  const notSent = operational.missing + operational.pending
   const responseIssues =
-    operational.missing +
-    operational.pending +
+    notSent +
     operational.sent +
     confirmations.declined +
     confirmations.changeRequested +
@@ -340,7 +340,7 @@ function buildAssignmentConfirmationsItem(
     status,
     summary: `${confirmations.confirmed}/${input.shifts.assignedSlots} assignments confirmed`,
     details: [
-      `${operational.pending} not sent.`,
+      `${notSent} not sent.`,
       `${operational.sent} sent.`,
       `${confirmations.declined} declined.`,
       `${confirmations.changeRequested} change requested.`,

--- a/apps/crew/src/lib/crew/shift-board-pilot-ops.ts
+++ b/apps/crew/src/lib/crew/shift-board-pilot-ops.ts
@@ -1,6 +1,10 @@
 // @lat: [[crew#Shift Board Pilot Ops]]
 import type { CrewAssignmentConfirmationStatus } from "../../db/schemas/crew-imports"
 import {
+  getCrewAssignmentConfirmationOperationalState,
+  type CrewAssignmentConfirmationOperationalState,
+} from "./assignment-confirmations"
+import {
   VOLUNTEER_ROLE_LABELS,
   type VolunteerAvailability,
   type VolunteerRoleType,
@@ -55,6 +59,7 @@ export interface CrewShiftPilotOpsAssignment {
   membershipId: string
   confirmation?: {
     status: CrewAssignmentConfirmationStatus
+    sentAt?: Date | string | null
   } | null
 }
 
@@ -86,7 +91,7 @@ export interface CrewShiftPilotShiftState {
   importedAssignmentCount: number
   directAssignmentCount: number
   confirmationCounts: Record<
-    CrewAssignmentConfirmationStatus | "missing",
+    CrewAssignmentConfirmationOperationalState,
     number
   >
   warnings: CrewShiftPilotWarning[]
@@ -398,18 +403,21 @@ function countAssignmentConfirmations(
 ): CrewShiftPilotShiftState["confirmationCounts"] {
   return assignments.reduce<CrewShiftPilotShiftState["confirmationCounts"]>(
     (counts, assignment) => {
-      const status = assignment.confirmation?.status ?? "missing"
-      counts[status] += 1
+      const state = getCrewAssignmentConfirmationOperationalState(
+        assignment.confirmation ?? null,
+      )
+      counts[state] += 1
       return counts
     },
     {
       missing: 0,
       pending: 0,
+      sent: 0,
       confirmed: 0,
       declined: 0,
       change_requested: 0,
       no_show: 0,
-      cancelled: 0,
+      replaced: 0,
     },
   )
 }

--- a/apps/crew/src/lib/crew/staffing/matrix.test.ts
+++ b/apps/crew/src/lib/crew/staffing/matrix.test.ts
@@ -382,6 +382,52 @@ describe("Crew staffing matrix core", () => {
       confirmationChangeRequests: 1,
     })
   })
+
+  it("treats cancelled confirmation rows as replaced assignment gaps", () => {
+    const matrix = buildCrewStaffingMatrix({
+      event: { id: "comp_1" },
+      roster: [
+        {
+          membershipId: "tmem_staff",
+          name: "Staff One",
+          roleTypes: ["staff"],
+          isActive: true,
+        },
+      ],
+      shifts: [
+        {
+          id: "shift_staff",
+          name: "Staff block",
+          roleType: "staff",
+          startTime: "2026-07-04T15:00:00.000Z",
+          endTime: "2026-07-04T16:00:00.000Z",
+          capacity: 1,
+          assignments: [
+            {
+              id: "vsha_replaced",
+              membershipId: "tmem_staff",
+              confirmation: {
+                type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+                status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+              },
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(matrix.confirmationGaps).toMatchObject([
+      {
+        assignmentId: "vsha_replaced",
+        type: "volunteer_shift",
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+        reason: "replaced",
+      },
+    ])
+    expect(matrix.summary).toMatchObject({
+      confirmationReplaced: 1,
+    })
+  })
 })
 
 function baseInput(): CrewStaffingMatrixInput {

--- a/apps/crew/src/lib/crew/staffing/matrix.ts
+++ b/apps/crew/src/lib/crew/staffing/matrix.ts
@@ -514,6 +514,16 @@ function getConfirmationGap(params: {
       reason: "no_show",
     }
   }
+  if (
+    params.confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED
+  ) {
+    return {
+      ...base,
+      type: params.confirmation.type,
+      status: params.confirmation.status,
+      reason: "replaced",
+    }
+  }
 
   return null
 }
@@ -554,6 +564,9 @@ function summarizeMatrix(input: {
     ).length,
     confirmationNoShows: input.confirmationGaps.filter(
       (gap) => gap.reason === "no_show",
+    ).length,
+    confirmationReplaced: input.confirmationGaps.filter(
+      (gap) => gap.reason === "replaced",
     ).length,
   }
 }

--- a/apps/crew/src/lib/crew/staffing/report.ts
+++ b/apps/crew/src/lib/crew/staffing/report.ts
@@ -24,6 +24,7 @@ export type CrewStaffingReportIssueKey =
   | "confirmation_declines"
   | "confirmation_change_requests"
   | "confirmation_no_shows"
+  | "confirmation_replaced"
 
 export interface CrewStaffingRoleSummary {
   roleType: VolunteerRoleType
@@ -203,6 +204,12 @@ function buildIssueSummary(
       key: "confirmation_no_shows",
       label: "No-shows",
       count: matrix.summary.confirmationNoShows,
+      severity: "critical",
+    },
+    {
+      key: "confirmation_replaced",
+      label: "Replaced",
+      count: matrix.summary.confirmationReplaced,
       severity: "critical",
     },
     {

--- a/apps/crew/src/lib/crew/staffing/types.ts
+++ b/apps/crew/src/lib/crew/staffing/types.ts
@@ -85,6 +85,7 @@ export interface CrewStaffingJudgeAssignmentInput {
 export interface CrewStaffingConfirmationInput {
   type: CrewAssignmentConfirmationType
   status: CrewAssignmentConfirmationStatus
+  sentAt?: Date | string | null
   respondedAt?: Date | string | null
   responseNote?: string | null
 }
@@ -169,6 +170,7 @@ export interface CrewStaffingConfirmationGap {
     | "declined"
     | "change_requested"
     | "no_show"
+    | "replaced"
 }
 
 export interface CrewStaffingMatrixSummary {
@@ -187,6 +189,7 @@ export interface CrewStaffingMatrixSummary {
   confirmationDeclines: number
   confirmationChangeRequests: number
   confirmationNoShows: number
+  confirmationReplaced: number
 }
 
 export interface CrewStaffingMatrix {

--- a/apps/crew/src/routes/e/$slug/confirm/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/confirm/$token.tsx
@@ -5,8 +5,10 @@ import { useServerFn } from "@tanstack/react-start"
 import { Loader2 } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
-import { getCrewAssignmentConfirmationStatusBadgeClassName } from "@/lib/crew/assignment-confirmation-display"
-import { formatCrewValue } from "@/lib/crew-event-display"
+import {
+  getCrewAssignmentConfirmationStatusBadgeClassName,
+  getCrewAssignmentConfirmationStatusLabel,
+} from "@/lib/crew/assignment-confirmation-display"
 import {
   getCrewAssignmentConfirmationTokenFn,
   respondCrewAssignmentConfirmationTokenFn,
@@ -221,7 +223,8 @@ function CrewAssignmentConfirmationPage() {
         <section className="rounded-md border bg-card p-6 shadow-sm">
           <h2 className="text-xl font-semibold">Response recorded</h2>
           <p className="mt-2 text-muted-foreground">
-            Your current response is {formatCrewValue(confirmationStatus)}.
+            Your current response is{" "}
+            {getCrewAssignmentConfirmationStatusLabel(confirmationStatus)}.
           </p>
           {data.confirmation?.responseNote ? (
             <p className="mt-4 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm">
@@ -250,7 +253,7 @@ function StatusBadge({ status }: { status: string }) {
     <span
       className={`inline-flex w-fit rounded-md border px-2 py-1 text-xs font-medium ${className}`}
     >
-      {formatCrewValue(status)}
+      {getCrewAssignmentConfirmationStatusLabel(status)}
     </span>
   )
 }

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -6,7 +6,7 @@ import {
   type VolunteerAvailability,
   type VolunteerRoleType,
 } from "@/db/schemas/volunteers"
-import { formatCrewValue } from "@/lib/crew-event-display"
+import { getCrewAssignmentConfirmationStatusLabel } from "@/lib/crew/assignment-confirmation-display"
 import {
   getCrewAssignmentConfirmationTokenFn,
   type CrewAssignmentConfirmationTokenData,
@@ -169,7 +169,9 @@ function CrewAssignmentSchedule({
             </p>
           </div>
           <span className="inline-flex w-fit rounded-md border bg-background px-2 py-1 text-xs font-medium">
-            {formatCrewValue(data.confirmation?.status ?? "pending")}
+            {getCrewAssignmentConfirmationStatusLabel(
+              data.confirmation?.status ?? "pending",
+            )}
           </span>
         </div>
 

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -1,4 +1,5 @@
 // @lat: [[crew#Shift Board Pilot Ops]]
+// @lat: [[crew#Assignment Confirmations]]
 import type { FormEvent } from "react"
 import {
   createFileRoute,
@@ -21,7 +22,15 @@ import {
 } from "lucide-react"
 import { useMemo, useState } from "react"
 import { toast } from "sonner"
-import { getCrewAssignmentConfirmationStatusBadgeClassName } from "@/lib/crew/assignment-confirmation-display"
+import {
+  getCrewAssignmentConfirmationStatusBadgeClassName,
+  getCrewAssignmentConfirmationStatusLabel,
+} from "@/lib/crew/assignment-confirmation-display"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES,
+  getCrewAssignmentConfirmationOperationalState,
+  type CrewAssignmentConfirmationOrganizerState,
+} from "@/lib/crew/assignment-confirmations"
 import { formatCrewValue } from "@/lib/crew-event-display"
 import {
   filterCrewShiftBoardPilotShifts,
@@ -43,6 +52,7 @@ import {
   updateCrewShiftFn,
   type CrewShiftBoardItem,
 } from "@/server-fns/crew-roster-shift-fns"
+import { updateCrewShiftAssignmentConfirmationStateFn } from "@/server-fns/crew-confirmation-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 import {
   VOLUNTEER_ROLE_OPTIONS,
@@ -151,7 +161,7 @@ function EventShiftsPage() {
         />
       </div>
 
-      <div className="grid gap-4 md:grid-cols-4">
+      <div className="grid gap-4 md:grid-cols-6">
         <StatusPanel label="Active volunteers" value={rosterSummary.active} />
         <StatusPanel label="Assignable" value={rosterSummary.assignable} />
         <StatusPanel
@@ -161,6 +171,16 @@ function EventShiftsPage() {
         <StatusPanel
           label="Confirmed"
           value={shiftSummary.confirmationSummary.confirmed}
+        />
+        <StatusPanel
+          label="Sent"
+          value={shiftSummary.confirmationOperationalSummary.sent}
+        />
+        <StatusPanel
+          label="Action needed"
+          value={
+            shiftSummary.confirmationOperationalSummary.organizerActionNeeded
+          }
         />
       </div>
 
@@ -460,9 +480,15 @@ function ShiftCard({
   const removeAssignment = useServerFn(removeCrewVolunteerShiftAssignmentFn)
   const deleteShift = useServerFn(deleteCrewShiftFn)
   const updateShift = useServerFn(updateCrewShiftFn)
+  const updateConfirmationState = useServerFn(
+    updateCrewShiftAssignmentConfirmationStateFn,
+  )
   const [isAssigning, setIsAssigning] = useState(false)
   const [isUpdating, setIsUpdating] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
+  const [updatingConfirmationId, setUpdatingConfirmationId] = useState<
+    string | null
+  >(null)
   const assignedMembershipIds = new Set(
     shift.assignments.map((assignment) => assignment.membershipId),
   )
@@ -516,6 +542,41 @@ function ShiftCard({
       toast.error(
         error instanceof Error ? error.message : "Failed to remove volunteer",
       )
+    }
+  }
+
+  async function handleConfirmationStateUpdate(
+    event: FormEvent<HTMLFormElement>,
+    assignment: CrewShiftBoardItem["assignments"][number],
+  ) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const state = getFormString(formData, "state")
+    if (!isOrganizerConfirmationState(state)) {
+      toast.error("Choose a confirmation state")
+      return
+    }
+
+    setUpdatingConfirmationId(assignment.id)
+    try {
+      await updateConfirmationState({
+        data: {
+          eventId,
+          assignmentId: assignment.id,
+          state,
+          responseNote: getFormString(formData, "responseNote"),
+        },
+      })
+      toast.success("Confirmation updated")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to update confirmation",
+      )
+    } finally {
+      setUpdatingConfirmationId(null)
     }
   }
 
@@ -645,7 +706,9 @@ function ShiftCard({
                         {assignment.volunteer.name}
                       </span>
                       <ConfirmationBadge
-                        status={assignment.confirmation?.status ?? "pending"}
+                        status={getCrewAssignmentConfirmationOperationalState(
+                          assignment.confirmation,
+                        )}
                       />
                     </div>
                     <div className="text-sm text-muted-foreground">
@@ -661,6 +724,13 @@ function ShiftCard({
                         {assignment.confirmation.responseNote}
                       </div>
                     ) : null}
+                    <AssignmentConfirmationControls
+                      assignment={assignment}
+                      isUpdating={updatingConfirmationId === assignment.id}
+                      onSubmit={(event) =>
+                        handleConfirmationStateUpdate(event, assignment)
+                      }
+                    />
                   </div>
                   <button
                     type="button"
@@ -846,19 +916,37 @@ function AssignmentResponseDetail({
     return <p className="mt-2 text-xs text-amber-700">Confirmation missing</p>
   }
 
+  const state = getCrewAssignmentConfirmationOperationalState(confirmation)
+  if (state === "pending") {
+    return <p className="mt-2 text-xs text-muted-foreground">Not sent</p>
+  }
+  if (state === "sent" && confirmation.sentAt) {
+    return (
+      <p className="mt-2 text-xs text-muted-foreground">
+        Sent{" "}
+        {formatDateTimeInTimezone(
+          confirmation.sentAt,
+          timezone,
+          "MMM d h:mm a",
+        )}
+      </p>
+    )
+  }
+  if (state === "replaced") {
+    return <p className="mt-2 text-xs text-muted-foreground">Replaced</p>
+  }
+
   if (!confirmation.respondedAt) {
     return (
       <p className="mt-2 text-xs text-muted-foreground">
-        {confirmation.status === "pending"
-          ? "Awaiting response"
-          : formatCrewValue(confirmation.status)}
+        {getCrewAssignmentConfirmationStatusLabel(state)}
       </p>
     )
   }
 
   return (
     <p className="mt-2 text-xs text-muted-foreground">
-      {formatCrewValue(confirmation.status)}{" "}
+      {getCrewAssignmentConfirmationStatusLabel(state)}{" "}
       {formatDateTimeInTimezone(
         confirmation.respondedAt,
         timezone,
@@ -875,8 +963,67 @@ function ConfirmationBadge({ status }: { status: string }) {
     <span
       className={`inline-flex rounded-md border px-2 py-1 text-xs font-medium ${className}`}
     >
-      {formatCrewValue(status)}
+      {getCrewAssignmentConfirmationStatusLabel(status)}
     </span>
+  )
+}
+
+function AssignmentConfirmationControls({
+  assignment,
+  isUpdating,
+  onSubmit,
+}: {
+  assignment: CrewShiftBoardItem["assignments"][number]
+  isUpdating: boolean
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+}) {
+  const state = getCrewAssignmentConfirmationOperationalState(
+    assignment.confirmation,
+  )
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center"
+    >
+      <select
+        name="state"
+        defaultValue={state === "missing" ? "pending" : state}
+        className="h-9 min-w-0 rounded-md border bg-card px-2 text-sm"
+      >
+        {CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES.map((option) => (
+          <option key={option} value={option}>
+            {getCrewAssignmentConfirmationStatusLabel(option)}
+          </option>
+        ))}
+      </select>
+      <input
+        name="responseNote"
+        className="h-9 min-w-0 rounded-md border bg-card px-2 text-sm"
+        placeholder="Note"
+        defaultValue={assignment.confirmation?.responseNote ?? ""}
+      />
+      <button
+        type="submit"
+        disabled={isUpdating}
+        className="inline-flex h-9 w-fit items-center gap-2 rounded-md border px-3 text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isUpdating ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <CheckCircle2 className="size-4" />
+        )}
+        Save
+      </button>
+    </form>
+  )
+}
+
+function isOrganizerConfirmationState(
+  state: string,
+): state is CrewAssignmentConfirmationOrganizerState {
+  return CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES.includes(
+    state as CrewAssignmentConfirmationOrganizerState,
   )
 }
 

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -980,13 +980,19 @@ function AssignmentConfirmationControls({
   const state = getCrewAssignmentConfirmationOperationalState(
     assignment.confirmation,
   )
+  const stateInputId = `confirmation-state-${assignment.id}`
+  const noteInputId = `confirmation-note-${assignment.id}`
 
   return (
     <form
       onSubmit={onSubmit}
       className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center"
     >
+      <label className="sr-only" htmlFor={stateInputId}>
+        Confirmation state for {assignment.volunteer.name}
+      </label>
       <select
+        id={stateInputId}
         name="state"
         defaultValue={state === "missing" ? "pending" : state}
         className="h-9 min-w-0 rounded-md border bg-card px-2 text-sm"
@@ -997,7 +1003,11 @@ function AssignmentConfirmationControls({
           </option>
         ))}
       </select>
+      <label className="sr-only" htmlFor={noteInputId}>
+        Confirmation note for {assignment.volunteer.name}
+      </label>
       <input
+        id={noteInputId}
         name="responseNote"
         className="h-9 min-w-0 rounded-md border bg-card px-2 text-sm"
         placeholder="Note"

--- a/apps/crew/src/routes/events/$eventId/staffing.tsx
+++ b/apps/crew/src/routes/events/$eventId/staffing.tsx
@@ -2,7 +2,10 @@
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { AlertCircle, CheckCircle2, CircleAlert } from "lucide-react"
 import type { ReactNode } from "react"
-import { getCrewAssignmentConfirmationStatusBadgeClassName } from "@/lib/crew/assignment-confirmation-display"
+import {
+  getCrewAssignmentConfirmationStatusBadgeClassName,
+  getCrewAssignmentConfirmationStatusLabel,
+} from "@/lib/crew/assignment-confirmation-display"
 import type {
   CrewStaffingCoverageRow,
   CrewStaffingReportIssueSummary,
@@ -39,7 +42,8 @@ function EventStaffingPage() {
     matrix.summary.confirmationNoResponses +
     matrix.summary.confirmationDeclines +
     matrix.summary.confirmationChangeRequests +
-    matrix.summary.confirmationNoShows
+    matrix.summary.confirmationNoShows +
+    matrix.summary.confirmationReplaced
 
   return (
     <section className="space-y-6">
@@ -422,7 +426,7 @@ function ConfirmationBadge({ status }: { status: string }) {
     <span
       className={`rounded-md border px-2 py-1 text-xs font-medium ${getCrewAssignmentConfirmationStatusBadgeClassName(status)}`}
     >
-      {formatCrewValue(status)}
+      {getCrewAssignmentConfirmationStatusLabel(status)}
     </span>
   )
 }

--- a/apps/crew/src/server-fns/crew-confirmation-fns.ts
+++ b/apps/crew/src/server-fns/crew-confirmation-fns.ts
@@ -1,7 +1,10 @@
 // @lat: [[crew#Assignment Confirmation Responses]]
+// @lat: [[crew#Assignment Confirmations]]
 // @lat: [[crew#Server Function Runtime Boundary]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
+import { CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES } from "../lib/crew/assignment-confirmations"
+import type { UpdateCrewShiftAssignmentConfirmationStateInput } from "../server/crew-confirmation.server"
 
 export type {
   CrewAssignmentConfirmationEmailMessage,
@@ -9,6 +12,7 @@ export type {
   CrewAssignmentConfirmationTokenData,
   CrewShiftAssignmentConfirmationStatus,
   EnsureCrewShiftAssignmentConfirmationResult,
+  UpdateCrewShiftAssignmentConfirmationStateInput,
 } from "../server/crew-confirmation.server"
 
 const publicTokenInputSchema = z.object({
@@ -20,6 +24,13 @@ const publicTokenResponseInputSchema = publicTokenInputSchema.extend({
   action: z.enum(["confirm", "decline", "request_change"]),
   responseNote: z.string().trim().max(1000).optional(),
 })
+
+const updateShiftAssignmentConfirmationStateInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  assignmentId: z.string().startsWith("vsha_", "Invalid assignment ID"),
+  state: z.enum(CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES),
+  responseNote: z.string().trim().max(1000).optional(),
+}) satisfies z.ZodType<UpdateCrewShiftAssignmentConfirmationStateInput>
 
 export const getCrewAssignmentConfirmationTokenFn = createServerFn({
   method: "GET",
@@ -41,4 +52,17 @@ export const respondCrewAssignmentConfirmationTokenFn = createServerFn({
       "../server/crew-confirmation.server"
     )
     return respondCrewAssignmentConfirmationToken(data)
+  })
+
+export const updateCrewShiftAssignmentConfirmationStateFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) =>
+    updateShiftAssignmentConfirmationStateInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { updateCrewShiftAssignmentConfirmationState } = await import(
+      "../server/crew-confirmation.server"
+    )
+    return updateCrewShiftAssignmentConfirmationState(data)
   })

--- a/apps/crew/src/server-fns/crew-staffing-fns.server.ts
+++ b/apps/crew/src/server-fns/crew-staffing-fns.server.ts
@@ -316,6 +316,7 @@ async function loadJudgeAssignmentConfirmationMap(
       assignmentId: crewAssignmentConfirmationsTable.assignmentId,
       type: crewAssignmentConfirmationsTable.assignmentType,
       status: crewAssignmentConfirmationsTable.status,
+      sentAt: crewAssignmentConfirmationsTable.sentAt,
       respondedAt: crewAssignmentConfirmationsTable.respondedAt,
       responseNote: crewAssignmentConfirmationsTable.responseNote,
       updatedAt: crewAssignmentConfirmationsTable.updatedAt,
@@ -338,6 +339,7 @@ async function loadJudgeAssignmentConfirmationMap(
     byAssignment.set(row.assignmentId, {
       type: row.type,
       status: row.status,
+      sentAt: row.sentAt,
       respondedAt: row.respondedAt,
       responseNote: row.responseNote,
     })
@@ -361,6 +363,7 @@ function toStaffingShifts(shifts: CrewShiftBoardItem[]) {
         ? {
             type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
             status: assignment.confirmation.status,
+            sentAt: assignment.confirmation.sentAt,
             respondedAt: assignment.confirmation.respondedAt,
             responseNote: assignment.confirmation.responseNote,
           }

--- a/apps/crew/src/server/crew-confirmation.server.ts
+++ b/apps/crew/src/server/crew-confirmation.server.ts
@@ -1,5 +1,6 @@
 import { render } from "@react-email/render"
 // @lat: [[crew#Assignment Confirmation Responses]]
+// @lat: [[crew#Assignment Confirmations]]
 import { and, desc, eq, inArray, ne, sql } from "drizzle-orm"
 import { getDb } from "../db"
 import { competitionsTable, type Competition } from "../db/schemas/competitions"
@@ -27,8 +28,10 @@ import {
   getCrewAssignmentConfirmationTokenState,
   hashCrewAssignmentConfirmationToken,
   resolveCrewAssignmentConfirmationResponse,
+  resolveCrewAssignmentConfirmationOrganizerStateUpdate,
   statusForCrewAssignmentResponseAction,
   summarizeCrewAssignmentConfirmations,
+  type CrewAssignmentConfirmationOrganizerState,
   type CrewAssignmentConfirmationStatusSummary,
   type CrewAssignmentResponseAction,
   type CrewAssignmentTokenState,
@@ -45,6 +48,7 @@ import {
   formatDateTimeInTimezone,
 } from "../utils/timezone-utils"
 import { getFirstExecuteValue } from "../server-fns/db-execute"
+import { requireLocalCrewOperatorAccess } from "./crew-local-access"
 
 type DbClient = ReturnType<typeof getDb>
 
@@ -101,8 +105,16 @@ export interface CrewAssignmentConfirmationResponseResult
 export interface CrewShiftAssignmentConfirmationStatus {
   id: string
   status: CrewAssignmentConfirmationStatus
+  sentAt: Date | null
   respondedAt: Date | null
   responseNote: string | null
+}
+
+export interface UpdateCrewShiftAssignmentConfirmationStateInput {
+  eventId: string
+  assignmentId: string
+  state: CrewAssignmentConfirmationOrganizerState
+  responseNote?: string
 }
 
 export interface CrewAssignmentConfirmationEmailMessage {
@@ -353,6 +365,7 @@ export async function loadCrewShiftAssignmentConfirmationMap(
       assignmentId: crewAssignmentConfirmationsTable.assignmentId,
       id: crewAssignmentConfirmationsTable.id,
       status: crewAssignmentConfirmationsTable.status,
+      sentAt: crewAssignmentConfirmationsTable.sentAt,
       respondedAt: crewAssignmentConfirmationsTable.respondedAt,
       responseNote: crewAssignmentConfirmationsTable.responseNote,
       updatedAt: crewAssignmentConfirmationsTable.updatedAt,
@@ -375,11 +388,140 @@ export async function loadCrewShiftAssignmentConfirmationMap(
     byAssignment.set(row.assignmentId, {
       id: row.id,
       status: row.status,
+      sentAt: row.sentAt,
       respondedAt: row.respondedAt,
       responseNote: row.responseNote,
     })
   }
   return byAssignment
+}
+
+export async function updateCrewShiftAssignmentConfirmationState(
+  data: UpdateCrewShiftAssignmentConfirmationStateInput,
+) {
+  requireLocalCrewOperatorAccess("Crew assignment confirmations")
+
+  const db = getDb()
+  const now = new Date()
+
+  return await db.transaction(async (tx) => {
+    const [assignment] = await tx
+      .select({
+        assignmentId: volunteerShiftAssignmentsTable.id,
+        shiftId: volunteerShiftAssignmentsTable.shiftId,
+        membershipId: volunteerShiftAssignmentsTable.membershipId,
+        competitionId: volunteerShiftsTable.competitionId,
+        membershipMetadata: teamMembershipTable.metadata,
+        userEmail: userTable.email,
+      })
+      .from(volunteerShiftAssignmentsTable)
+      .innerJoin(
+        volunteerShiftsTable,
+        eq(volunteerShiftAssignmentsTable.shiftId, volunteerShiftsTable.id),
+      )
+      .leftJoin(
+        teamMembershipTable,
+        eq(volunteerShiftAssignmentsTable.membershipId, teamMembershipTable.id),
+      )
+      .leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+      .where(
+        and(
+          eq(volunteerShiftAssignmentsTable.id, data.assignmentId),
+          eq(volunteerShiftsTable.competitionId, data.eventId),
+        ),
+      )
+      .for("update")
+      .limit(1)
+
+    if (!assignment) {
+      throw new Error("Shift assignment not found")
+    }
+
+    const [latestConfirmation] = await tx
+      .select({
+        id: crewAssignmentConfirmationsTable.id,
+        status: crewAssignmentConfirmationsTable.status,
+        sentAt: crewAssignmentConfirmationsTable.sentAt,
+      })
+      .from(crewAssignmentConfirmationsTable)
+      .where(
+        and(
+          eq(
+            crewAssignmentConfirmationsTable.assignmentType,
+            CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+          ),
+          eq(
+            crewAssignmentConfirmationsTable.assignmentId,
+            assignment.assignmentId,
+          ),
+        ),
+      )
+      .orderBy(desc(crewAssignmentConfirmationsTable.updatedAt))
+      .limit(1)
+
+    let confirmation = latestConfirmation ?? null
+    if (
+      !confirmation ||
+      (confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED &&
+        data.state !== "replaced")
+    ) {
+      const metadata = parseCrewRosterMetadata(assignment.membershipMetadata)
+      const token = generateCrewAssignmentConfirmationToken()
+      const tokenHash = await hashCrewAssignmentConfirmationToken(token)
+      const confirmationId = createCrewAssignmentConfirmationId()
+
+      await tx.insert(crewAssignmentConfirmationsTable).values({
+        id: confirmationId,
+        competitionId: assignment.competitionId,
+        assignmentType: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        assignmentId: assignment.assignmentId,
+        membershipId: assignment.membershipId,
+        email:
+          normalizeConfirmationEmail(metadata.signupEmail) ??
+          normalizeConfirmationEmail(assignment.userEmail),
+        tokenHash,
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+        expiresAt: getAssignmentConfirmationExpiry(now),
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      confirmation = {
+        id: confirmationId,
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+        sentAt: null,
+      }
+    }
+
+    const update = resolveCrewAssignmentConfirmationOrganizerStateUpdate(
+      data.state,
+      data.responseNote,
+      now,
+      confirmation,
+    )
+
+    await tx
+      .update(crewAssignmentConfirmationsTable)
+      .set({
+        status: update.status,
+        sentAt: update.sentAt,
+        respondedAt: update.respondedAt,
+        responseNote: update.responseNote,
+        updatedAt: now,
+      })
+      .where(eq(crewAssignmentConfirmationsTable.id, confirmation.id))
+
+    return {
+      success: true,
+      confirmation: {
+        id: confirmation.id,
+        status: update.status,
+        sentAt: update.sentAt,
+        respondedAt: update.respondedAt,
+        responseNote: update.responseNote,
+      },
+    }
+  })
 }
 
 export function summarizeCrewShiftAssignmentConfirmations(
@@ -625,6 +767,17 @@ function toConfirmationDisplay(confirmation: {
     expiresAt: confirmation.expiresAt,
     responseNote: confirmation.responseNote,
   }
+}
+
+function getAssignmentConfirmationExpiry(now: Date) {
+  const expiresAt = new Date(now)
+  expiresAt.setDate(expiresAt.getDate() + 14)
+  return expiresAt
+}
+
+function normalizeConfirmationEmail(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
 }
 
 function getResponseSuccessMessage(action: CrewAssignmentResponseAction) {

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -52,6 +52,7 @@ import {
   validateShiftAssignment,
   validateShiftCapacityUpdate,
 } from "../lib/crew/roster-shifts"
+import { summarizeCrewAssignmentConfirmationOperationalStates } from "../lib/crew/assignment-confirmations"
 import {
   buildCrewShiftBoardPilotOps,
   type CrewShiftBoardPilotOpsData,
@@ -145,6 +146,9 @@ export interface CrewShiftSummary {
   openSlots: number
   confirmationSummary: ReturnType<
     typeof summarizeCrewShiftAssignmentConfirmations
+  >
+  confirmationOperationalSummary: ReturnType<
+    typeof summarizeCrewAssignmentConfirmationOperationalStates
   >
 }
 
@@ -999,6 +1003,7 @@ function buildShiftBoardStaffingMatrixInput(
           ? {
               type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
               status: assignment.confirmation.status,
+              sentAt: assignment.confirmation.sentAt,
               respondedAt: assignment.confirmation.respondedAt,
               responseNote: assignment.confirmation.responseNote,
             }
@@ -1039,6 +1044,10 @@ export function summarizeCrewShifts(
     confirmationSummary: summarizeCrewShiftAssignmentConfirmations(
       summary.confirmations,
     ),
+    confirmationOperationalSummary:
+      summarizeCrewAssignmentConfirmationOperationalStates(
+        summary.confirmations,
+      ),
   }
 }
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -187,3 +187,11 @@ Raw confirmation tokens are generated later for links and must not be persisted.
 Crew assignment confirmation links are token-only volunteer surfaces. Raw tokens are generated only while creating links, stored only as hashes, and used by [[apps/crew/src/routes/e/$slug/confirm/$token.tsx]] and [[apps/crew/src/routes/e/$slug/schedule/$token.tsx]] to show safe confirm, decline, and change-request flows without requiring a session.
 
 [[apps/crew/src/server-fns/crew-confirmation-fns.ts]] owns token lookup, transient email payload construction, and deterministic response transitions. [[apps/crew/src/lib/crew/assignment-confirmations.ts]] keeps the pure token and status helpers testable outside the server function layer.
+
+## Assignment Confirmations
+
+Organizer-facing assignment confirmations reuse the existing `crew_assignment_confirmations` rows and keep assignments authoritative. [[apps/crew/src/lib/crew/assignment-confirmations.ts]] normalizes operational states from persisted status plus timestamps: pending, sent, confirmed, declined, change requested, no-show, and replaced. Sent is represented by pending rows with `sentAt`, and replaced is represented by cancelled confirmation rows; checked-in is intentionally not persisted until day-of operations adds a first-class primitive.
+
+[[apps/crew/src/server/crew-confirmation.server.ts]] owns guarded organizer status updates for volunteer shift assignments, creating a confirmation row only when an assignment is missing one and never mutating assignment rows as part of status changes. [[apps/crew/src/server-fns/crew-confirmation-fns.ts]] keeps the createServerFn wrapper thin so DB/runtime imports stay out of route module graphs.
+
+[[apps/crew/src/routes/events/$eventId/shifts.tsx]] shows compact assignment-level status controls and summary counts for sent and action-needed confirmations. [[apps/crew/src/lib/crew/staffing/index.ts]], [[apps/crew/src/routes/events/$eventId/staffing.tsx]], and [[apps/crew/src/lib/crew/readiness.ts]] consume the same normalized state so staffing gaps and readiness summaries treat no-shows, change requests, declines, and replacements consistently.

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -190,7 +190,9 @@ Crew assignment confirmation links are token-only volunteer surfaces. Raw tokens
 
 ## Assignment Confirmations
 
-Organizer-facing assignment confirmations reuse the existing `crew_assignment_confirmations` rows and keep assignments authoritative. [[apps/crew/src/lib/crew/assignment-confirmations.ts]] normalizes operational states from persisted status plus timestamps: pending, sent, confirmed, declined, change requested, no-show, and replaced. Sent is represented by pending rows with `sentAt`, and replaced is represented by cancelled confirmation rows; checked-in is intentionally not persisted until day-of operations adds a first-class primitive.
+Organizer-facing assignment confirmations reuse `crew_assignment_confirmations` and keep assignments authoritative.
+
+[[apps/crew/src/lib/crew/assignment-confirmations.ts]] normalizes operational states from persisted status plus timestamps: pending, sent, confirmed, declined, change requested, no-show, and replaced. Sent is represented by pending rows with `sentAt`, and replaced is represented by cancelled confirmation rows; checked-in is intentionally not persisted until day-of operations adds a first-class primitive.
 
 [[apps/crew/src/server/crew-confirmation.server.ts]] owns guarded organizer status updates for volunteer shift assignments, creating a confirmation row only when an assignment is missing one and never mutating assignment rows as part of status changes. [[apps/crew/src/server-fns/crew-confirmation-fns.ts]] keeps the createServerFn wrapper thin so DB/runtime imports stay out of route module graphs.
 


### PR DESCRIPTION
## Summary

- Normalize Crew assignment confirmation operational states over existing confirmation rows: pending, sent, confirmed, declined, change requested, no-show, and replaced.
- Add guarded organizer status updates for volunteer shift assignments through the existing server/runtime-boundary pattern.
- Surface confirmation state controls and sent/action-needed counts on the shift board, and carry the same state into staffing gaps, readiness summaries, and token-page labels.
- Add LAT anchor `crew#Assignment Confirmations`.

## Scope notes

- No schema or migration changes.
- No live email sending, reminder queue, queue consumer, resend/idempotent reminder infrastructure, or day-of board route.
- Assignment references remain authoritative; confirmation state updates reference assignment IDs and do not mutate assignment rows.
- Checked-in is documented as not persisted yet because no existing Crew primitive represents it without adding schema.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/assignment-confirmations.test.ts src/lib/crew/shift-board-pilot-ops.test.ts src/lib/crew/staffing/matrix.test.ts src/lib/crew/staffing/report.test.ts src/lib/crew/readiness.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; existing repo warnings outside touched files remain)
- `pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Assignment Confirmations'`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds organizer-facing assignment confirmations with normalized states and inline controls on the shift board. Updates staffing and readiness to use the same states, with sent and action-needed counts to guide follow‑up.

- Normalized operational states from persisted data: missing, pending, sent, confirmed, declined, change requested, no-show, replaced (pending+sentAt → sent; cancelled → replaced).
- Shift board: status badges, friendly labels, and inline controls to set state + note; panels show Sent and Action needed.
- Server: `updateCrewShiftAssignmentConfirmationStateFn` performs access‑guarded updates, creates a confirmation if missing, and never mutates assignment rows.
- Staffing/readiness: gaps and summaries include declines, change requests, no-shows, and replacements; readiness details reflect not sent, sent, declined, change requested, no-show, replaced.
- Volunteer token pages use clearer, friendly labels for statuses.
- No schema/migration changes; email sending and reminders are out of scope.

<sup>Written for commit 25c8ddf9771ab29386e363592d5e186a79e34514. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/553?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organizer controls to update crew assignment confirmation states directly from the shift board.
  * Introduced "Sent" and "Action needed" confirmation panels in the shift summary.
  * New operational state model for normalized confirmation tracking.

* **Improvements**
  * Enhanced confirmation status labels throughout the app.
  * Added "Replaced" confirmation gap tracking to staffing reports.
  * Expanded shift summaries with confirmation operational data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->