### PR TITLE
[codex] feat(crew): add day-of operations board

### DIFF
--- a/apps/crew/src/lib/crew/day-of-operations.test.ts
+++ b/apps/crew/src/lib/crew/day-of-operations.test.ts
@@ -1,0 +1,258 @@
+// @lat: [[crew#Day Of Operations Board]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+} from "../../db/schemas/crew-imports"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_ROLE_TYPES,
+} from "../../db/schemas/volunteers"
+import { buildCrewDayOfOperationsBoard } from "./day-of-operations"
+import {
+  buildCrewStaffingMatrix,
+  buildCrewStaffingReport,
+  type CrewStaffingMatrixInput,
+} from "./staffing"
+
+describe("Crew day-of operations helpers", () => {
+  it("derives current and next blocks from shifts and heats", () => {
+    const board = buildBoard()
+
+    expect(board.currentBlocks.map((block) => block.timeBlockId)).toEqual([
+      "shift:vshf_checkin",
+      "heat:heat_current",
+    ])
+    expect(board.nextBlocks.map((block) => block.timeBlockId)).toEqual([
+      "shift:vshf_equipment",
+      "heat:heat_next",
+    ])
+  })
+
+  it("prioritizes critical gaps and due-soon no-responses", () => {
+    const board = buildBoard()
+
+    expect(board.summary.openRoles).toBe(2)
+    expect(board.criticalGaps.map((gap) => gap.roleType)).toEqual([
+      VOLUNTEER_ROLE_TYPES.CHECK_IN,
+      VOLUNTEER_ROLE_TYPES.JUDGE,
+    ])
+    expect(board.noResponsesDueSoon).toHaveLength(3)
+    expect(board.noResponsesDueSoon[0]).toMatchObject({
+      volunteerName: "Casey Check-In",
+      reason: "no_response",
+      timing: "current",
+    })
+    expect(board.noResponsesDueSoon.slice(1)).toEqual([
+      expect.objectContaining({
+        volunteerName: "Jules Judge",
+        reason: "missing_confirmation",
+        timing: "next",
+      }),
+      expect.objectContaining({
+        volunteerName: "Jules Judge",
+        reason: "missing_confirmation",
+        timing: "next",
+      }),
+    ])
+  })
+
+  it("separates decision and no-show replacement queues", () => {
+    const board = buildBoard()
+
+    expect(board.decisionQueue).toEqual([
+      expect.objectContaining({
+        volunteerName: "Jules Judge",
+        reason: "declined",
+        timing: "current",
+      }),
+    ])
+    expect(board.noShowReplacementQueue).toEqual([
+      expect.objectContaining({
+        volunteerName: "Riley Equipment",
+        reason: "replaced",
+        timing: "next",
+      }),
+    ])
+    expect(board.stateSummary).toMatchObject({
+      checkedInTracked: false,
+      noShow: 0,
+      replaced: 1,
+    })
+  })
+
+  it("summarizes active judge coverage without mutating versions", () => {
+    const board = buildBoard()
+
+    expect(board.judgeCoverage).toMatchObject({
+      heatBlocks: 2,
+      activeHeatBlocks: 2,
+      lanesNeeded: 4,
+      lanesFilled: 3,
+      openLanes: 1,
+    })
+    expect(
+      board.judgeCoverage.currentAndNext.map((block) => block.open),
+    ).toEqual([1, 0])
+  })
+})
+
+function buildBoard() {
+  const input = createStaffingInput()
+  const matrix = buildCrewStaffingMatrix(input)
+  const report = buildCrewStaffingReport(input, matrix)
+  return buildCrewDayOfOperationsBoard({
+    matrix,
+    report,
+    now: new Date("2026-06-20T15:00:00.000Z"),
+  })
+}
+
+function createStaffingInput(): CrewStaffingMatrixInput {
+  return {
+    event: {
+      id: "comp_day_of",
+      name: "Day-of Test",
+      timezone: "UTC",
+      startDate: "2026-06-20",
+      endDate: "2026-06-20",
+    },
+    venues: [
+      {
+        id: "venue_floor_1",
+        name: "Floor 1",
+        laneCount: 2,
+        sortOrder: 1,
+      },
+    ],
+    workouts: [
+      {
+        id: "tw_event_1",
+        name: "Workout 1",
+        sortOrder: 1,
+      },
+    ],
+    heats: [
+      {
+        id: "heat_current",
+        trackWorkoutId: "tw_event_1",
+        heatNumber: 1,
+        venueId: "venue_floor_1",
+        scheduledTime: new Date("2026-06-20T15:00:00.000Z"),
+        durationMinutes: 20,
+      },
+      {
+        id: "heat_next",
+        trackWorkoutId: "tw_event_1",
+        heatNumber: 2,
+        venueId: "venue_floor_1",
+        scheduledTime: new Date("2026-06-20T16:00:00.000Z"),
+        durationMinutes: 20,
+      },
+    ],
+    heatLaneAssignments: [
+      { heatId: "heat_current", laneNumber: 1 },
+      { heatId: "heat_current", laneNumber: 2 },
+      { heatId: "heat_next", laneNumber: 1 },
+      { heatId: "heat_next", laneNumber: 2 },
+    ],
+    roster: [
+      {
+        membershipId: "tmem_checkin",
+        name: "Casey Check-In",
+        roleTypes: [VOLUNTEER_ROLE_TYPES.CHECK_IN],
+        availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+        isActive: true,
+      },
+      {
+        membershipId: "tmem_judge",
+        name: "Jules Judge",
+        roleTypes: [VOLUNTEER_ROLE_TYPES.JUDGE],
+        availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+        isActive: true,
+      },
+      {
+        membershipId: "tmem_equipment",
+        name: "Riley Equipment",
+        roleTypes: [VOLUNTEER_ROLE_TYPES.EQUIPMENT],
+        availability: VOLUNTEER_AVAILABILITY.ALL_DAY,
+        isActive: true,
+      },
+    ],
+    shifts: [
+      {
+        id: "vshf_checkin",
+        name: "Check-in desk",
+        roleType: VOLUNTEER_ROLE_TYPES.CHECK_IN,
+        startTime: new Date("2026-06-20T14:30:00.000Z"),
+        endTime: new Date("2026-06-20T15:30:00.000Z"),
+        capacity: 2,
+        location: "Front desk",
+        assignments: [
+          {
+            id: "vsha_checkin_1",
+            membershipId: "tmem_checkin",
+            confirmation: {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+              sentAt: new Date("2026-06-18T15:00:00.000Z"),
+            },
+          },
+        ],
+      },
+      {
+        id: "vshf_equipment",
+        name: "Equipment reset",
+        roleType: VOLUNTEER_ROLE_TYPES.EQUIPMENT,
+        startTime: new Date("2026-06-20T16:00:00.000Z"),
+        endTime: new Date("2026-06-20T17:00:00.000Z"),
+        capacity: 1,
+        location: "Floor 1",
+        assignments: [
+          {
+            id: "vsha_equipment_1",
+            membershipId: "tmem_equipment",
+            confirmation: {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+              sentAt: new Date("2026-06-18T15:00:00.000Z"),
+              respondedAt: new Date("2026-06-19T15:00:00.000Z"),
+            },
+          },
+        ],
+      },
+    ],
+    judgeAssignments: [
+      {
+        id: "jha_current_1",
+        heatId: "heat_current",
+        membershipId: "tmem_judge",
+        laneNumber: 1,
+        position: VOLUNTEER_ROLE_TYPES.JUDGE,
+        versionId: "jver_active",
+        confirmation: {
+          type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+          sentAt: new Date("2026-06-18T15:00:00.000Z"),
+          respondedAt: new Date("2026-06-19T15:00:00.000Z"),
+        },
+      },
+      {
+        id: "jha_next_1",
+        heatId: "heat_next",
+        membershipId: "tmem_judge",
+        laneNumber: 1,
+        position: VOLUNTEER_ROLE_TYPES.JUDGE,
+        versionId: "jver_active",
+      },
+      {
+        id: "jha_next_2",
+        heatId: "heat_next",
+        membershipId: "tmem_judge",
+        laneNumber: 2,
+        position: VOLUNTEER_ROLE_TYPES.JUDGE,
+        versionId: "jver_active",
+      },
+    ],
+  }
+}

--- a/apps/crew/src/lib/crew/day-of-operations.ts
+++ b/apps/crew/src/lib/crew/day-of-operations.ts
@@ -1,0 +1,580 @@
+// @lat: [[crew#Day Of Operations Board]]
+import {
+  VOLUNTEER_ROLE_LABELS,
+  VOLUNTEER_ROLE_TYPES,
+  type VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+import type {
+  CrewStaffingConfirmationGap,
+  CrewStaffingCoverageRow,
+  CrewStaffingMatrix,
+  CrewStaffingReport,
+  CrewStaffingTimeBlock,
+} from "./staffing"
+
+export type CrewDayOfBlockTiming =
+  | "current"
+  | "next"
+  | "upcoming"
+  | "past"
+  | "unscheduled"
+
+export type CrewDayOfBlockStatus = "covered" | "attention" | "critical"
+
+export interface CrewDayOfOperationsBoardInput {
+  matrix: CrewStaffingMatrix
+  report: CrewStaffingReport
+  now?: Date | string
+  responseDueSoonHours?: number
+}
+
+export interface CrewDayOfBlockCoverage {
+  rowId: string
+  roleType: VolunteerRoleType
+  roleLabel: string
+  needed: number
+  filled: number
+  open: number
+}
+
+export interface CrewDayOfBlockSummary {
+  timeBlockId: string
+  source: CrewStaffingTimeBlock["source"]
+  sourceId: string
+  label: string
+  startsAt: string | null
+  endsAt: string | null
+  timing: CrewDayOfBlockTiming
+  status: CrewDayOfBlockStatus
+  needed: number
+  filled: number
+  open: number
+  responseNeeded: number
+  decisionNeeded: number
+  noShowOrReplaced: number
+  judgeLaneGaps: number
+  coverage: CrewDayOfBlockCoverage[]
+}
+
+export interface CrewDayOfCriticalGap {
+  rowId: string
+  timeBlockId: string
+  blockLabel: string
+  timing: CrewDayOfBlockTiming
+  roleType: VolunteerRoleType
+  roleLabel: string
+  needed: number
+  filled: number
+  open: number
+  startsAt: string | null
+  endsAt: string | null
+}
+
+export interface CrewDayOfResponseQueueItem {
+  assignmentId: string
+  membershipId: string
+  volunteerName: string
+  timeBlockId: string
+  blockLabel: string
+  timing: CrewDayOfBlockTiming
+  reason: CrewStaffingConfirmationGap["reason"]
+  startsAt: string | null
+  endsAt: string | null
+}
+
+export interface CrewDayOfJudgeCoverageBlock {
+  timeBlockId: string
+  heatId: string | null
+  blockLabel: string
+  timing: CrewDayOfBlockTiming
+  startsAt: string | null
+  endsAt: string | null
+  needed: number
+  filled: number
+  open: number
+  judgeLaneGaps: number
+}
+
+export interface CrewDayOfJudgeCoverageSummary {
+  heatBlocks: number
+  activeHeatBlocks: number
+  coveredHeatBlocks: number
+  lanesNeeded: number
+  lanesFilled: number
+  openLanes: number
+  currentAndNext: CrewDayOfJudgeCoverageBlock[]
+}
+
+export interface CrewDayOfStateSummary {
+  checkedInTracked: boolean
+  checkedIn: number
+  noShow: number
+  replaced: number
+}
+
+export interface CrewDayOfOperationsBoard {
+  generatedAt: string
+  responseDueSoonHours: number
+  currentBlocks: CrewDayOfBlockSummary[]
+  nextBlocks: CrewDayOfBlockSummary[]
+  timeBlocks: CrewDayOfBlockSummary[]
+  criticalGaps: CrewDayOfCriticalGap[]
+  noResponsesDueSoon: CrewDayOfResponseQueueItem[]
+  decisionQueue: CrewDayOfResponseQueueItem[]
+  noShowReplacementQueue: CrewDayOfResponseQueueItem[]
+  judgeCoverage: CrewDayOfJudgeCoverageSummary
+  stateSummary: CrewDayOfStateSummary
+  summary: {
+    openRoles: number
+    criticalBlocks: number
+    noResponsesDueSoon: number
+    decisionNeeded: number
+    noShowOrReplaced: number
+    currentBlockCount: number
+    nextBlockCount: number
+  }
+}
+
+interface NormalizedBlock {
+  block: CrewStaffingTimeBlock
+  startsAt: Date | null
+  endsAt: Date | null
+  timing: CrewDayOfBlockTiming
+  index: number
+}
+
+const DEFAULT_RESPONSE_DUE_SOON_HOURS = 48
+const DECISION_REASONS = new Set<CrewStaffingConfirmationGap["reason"]>([
+  "declined",
+  "change_requested",
+])
+const NO_SHOW_REPLACEMENT_REASONS = new Set<
+  CrewStaffingConfirmationGap["reason"]
+>(["no_show", "replaced"])
+const NO_RESPONSE_REASONS = new Set<CrewStaffingConfirmationGap["reason"]>([
+  "missing_confirmation",
+  "no_response",
+])
+
+export function buildCrewDayOfOperationsBoard(
+  input: CrewDayOfOperationsBoardInput,
+): CrewDayOfOperationsBoard {
+  const now = toValidDate(input.now) ?? new Date()
+  const responseDueSoonHours =
+    input.responseDueSoonHours ?? DEFAULT_RESPONSE_DUE_SOON_HOURS
+  const normalizedBlocks = normalizeBlocks(input.matrix.timeBlocks, now)
+  const blockSummaryById = buildBlockSummaries({
+    blocks: normalizedBlocks,
+    matrix: input.matrix,
+  })
+  const timeBlocks = normalizedBlocks.map((block) =>
+    blockSummaryById.get(block.block.id),
+  )
+  const presentTimeBlocks = timeBlocks.filter(
+    (block): block is CrewDayOfBlockSummary => Boolean(block),
+  )
+  const currentBlocks = presentTimeBlocks.filter(
+    (block) => block.timing === "current",
+  )
+  const nextBlocks = presentTimeBlocks.filter(
+    (block) => block.timing === "next",
+  )
+  const criticalGaps = buildCriticalGaps({
+    rows: input.report.underfilledRows,
+    blockSummaryById,
+  })
+  const queueItems = buildResponseQueueItems({
+    gaps: input.matrix.confirmationGaps,
+    blockSummaryById,
+  })
+  const noResponsesDueSoon = queueItems.filter((item) =>
+    isNoResponseDueSoon(item, now, responseDueSoonHours),
+  )
+  const decisionQueue = queueItems.filter((item) =>
+    DECISION_REASONS.has(item.reason),
+  )
+  const noShowReplacementQueue = queueItems.filter((item) =>
+    NO_SHOW_REPLACEMENT_REASONS.has(item.reason),
+  )
+  const judgeCoverage = buildJudgeCoverageSummary({
+    matrix: input.matrix,
+    blockSummaryById,
+  })
+
+  return {
+    generatedAt: now.toISOString(),
+    responseDueSoonHours,
+    currentBlocks,
+    nextBlocks,
+    timeBlocks: presentTimeBlocks,
+    criticalGaps,
+    noResponsesDueSoon,
+    decisionQueue,
+    noShowReplacementQueue,
+    judgeCoverage,
+    stateSummary: {
+      checkedInTracked: false,
+      checkedIn: 0,
+      noShow: input.matrix.summary.confirmationNoShows,
+      replaced: input.matrix.summary.confirmationReplaced,
+    },
+    summary: {
+      openRoles: criticalGaps.reduce((total, gap) => total + gap.open, 0),
+      criticalBlocks: presentTimeBlocks.filter(
+        (block) => block.status === "critical",
+      ).length,
+      noResponsesDueSoon: noResponsesDueSoon.length,
+      decisionNeeded: decisionQueue.length,
+      noShowOrReplaced: noShowReplacementQueue.length,
+      currentBlockCount: currentBlocks.length,
+      nextBlockCount: nextBlocks.length,
+    },
+  }
+}
+
+function normalizeBlocks(
+  timeBlocks: CrewStaffingTimeBlock[],
+  now: Date,
+): NormalizedBlock[] {
+  const withDates = timeBlocks.map((block, index) => ({
+    block,
+    startsAt: toValidDate(block.startTime),
+    endsAt: toValidDate(block.endTime),
+    timing: "unscheduled" as CrewDayOfBlockTiming,
+    index,
+  }))
+  const currentIds = new Set(
+    withDates
+      .filter(
+        ({ startsAt, endsAt }) =>
+          startsAt &&
+          startsAt.getTime() <= now.getTime() &&
+          (!endsAt || endsAt.getTime() > now.getTime()),
+      )
+      .map(({ block }) => block.id),
+  )
+  const nextStartMs = withDates
+    .filter(({ startsAt }) => startsAt && startsAt.getTime() > now.getTime())
+    .reduce<number | null>((nextMs, { startsAt }) => {
+      if (!startsAt) return nextMs
+      const startMs = startsAt.getTime()
+      return nextMs === null ? startMs : Math.min(nextMs, startMs)
+    }, null)
+
+  return withDates
+    .map((entry) => ({
+      ...entry,
+      timing: getBlockTiming(entry, currentIds, nextStartMs, now),
+    }))
+    .sort(compareNormalizedBlock)
+}
+
+function getBlockTiming(
+  entry: Omit<NormalizedBlock, "timing">,
+  currentIds: Set<string>,
+  nextStartMs: number | null,
+  now: Date,
+): CrewDayOfBlockTiming {
+  if (!entry.startsAt) return "unscheduled"
+  if (currentIds.has(entry.block.id)) return "current"
+  if (nextStartMs !== null && entry.startsAt.getTime() === nextStartMs) {
+    return "next"
+  }
+  if (entry.startsAt.getTime() > now.getTime()) return "upcoming"
+  return "past"
+}
+
+function buildBlockSummaries(input: {
+  blocks: NormalizedBlock[]
+  matrix: CrewStaffingMatrix
+}) {
+  const coverageRowsByBlockId = groupBy(
+    input.matrix.coverageRows,
+    (row) => row.timeBlockId,
+  )
+  const confirmationGapsByBlockId = groupBy(
+    input.matrix.confirmationGaps,
+    (gap) => gap.timeBlockId,
+  )
+  const judgeLaneGapsByBlockId = groupBy(
+    input.matrix.judgeLaneGaps,
+    (gap) => gap.timeBlockId,
+  )
+
+  return new Map(
+    input.blocks.map((entry) => {
+      const coverageRows = coverageRowsByBlockId.get(entry.block.id) ?? []
+      const confirmationGaps =
+        confirmationGapsByBlockId.get(entry.block.id) ?? []
+      const judgeLaneGaps = judgeLaneGapsByBlockId.get(entry.block.id) ?? []
+      const open = sum(coverageRows, "open")
+      const responseNeeded = confirmationGaps.filter((gap) =>
+        NO_RESPONSE_REASONS.has(gap.reason),
+      ).length
+      const decisionNeeded = confirmationGaps.filter((gap) =>
+        DECISION_REASONS.has(gap.reason),
+      ).length
+      const noShowOrReplaced = confirmationGaps.filter((gap) =>
+        NO_SHOW_REPLACEMENT_REASONS.has(gap.reason),
+      ).length
+      const status = getBlockStatus({
+        open,
+        judgeLaneGaps: judgeLaneGaps.length,
+        decisionNeeded,
+        noShowOrReplaced,
+        responseNeeded,
+      })
+      const summary: CrewDayOfBlockSummary = {
+        timeBlockId: entry.block.id,
+        source: entry.block.source,
+        sourceId: entry.block.sourceId,
+        label: entry.block.label,
+        startsAt: toIso(entry.startsAt),
+        endsAt: toIso(entry.endsAt),
+        timing: entry.timing,
+        status,
+        needed: sum(coverageRows, "needed"),
+        filled: sum(coverageRows, "filled"),
+        open,
+        responseNeeded,
+        decisionNeeded,
+        noShowOrReplaced,
+        judgeLaneGaps: judgeLaneGaps.length,
+        coverage: coverageRows.map(toBlockCoverage),
+      }
+      return [entry.block.id, summary] as const
+    }),
+  )
+}
+
+function getBlockStatus(params: {
+  open: number
+  judgeLaneGaps: number
+  responseNeeded: number
+  decisionNeeded: number
+  noShowOrReplaced: number
+}): CrewDayOfBlockStatus {
+  if (
+    params.open > 0 ||
+    params.judgeLaneGaps > 0 ||
+    params.decisionNeeded > 0 ||
+    params.noShowOrReplaced > 0
+  ) {
+    return "critical"
+  }
+  if (params.responseNeeded > 0) return "attention"
+  return "covered"
+}
+
+function buildCriticalGaps(input: {
+  rows: CrewStaffingCoverageRow[]
+  blockSummaryById: Map<string, CrewDayOfBlockSummary>
+}): CrewDayOfCriticalGap[] {
+  return input.rows
+    .filter((row) => row.open > 0)
+    .map((row) => {
+      const block = input.blockSummaryById.get(row.timeBlockId)
+      return {
+        rowId: row.id,
+        timeBlockId: row.timeBlockId,
+        blockLabel: block?.label ?? row.timeBlockId,
+        timing: block?.timing ?? "unscheduled",
+        roleType: row.roleType,
+        roleLabel: formatRole(row.roleType),
+        needed: row.needed,
+        filled: row.filled,
+        open: row.open,
+        startsAt: block?.startsAt ?? null,
+        endsAt: block?.endsAt ?? null,
+      }
+    })
+    .sort(compareCriticalGap)
+}
+
+function buildResponseQueueItems(input: {
+  gaps: CrewStaffingConfirmationGap[]
+  blockSummaryById: Map<string, CrewDayOfBlockSummary>
+}): CrewDayOfResponseQueueItem[] {
+  return input.gaps
+    .map((gap) => {
+      const block = input.blockSummaryById.get(gap.timeBlockId)
+      return {
+        assignmentId: gap.assignmentId,
+        membershipId: gap.membershipId,
+        volunteerName: gap.volunteerName,
+        timeBlockId: gap.timeBlockId,
+        blockLabel: block?.label ?? gap.timeBlockId,
+        timing: block?.timing ?? "unscheduled",
+        reason: gap.reason,
+        startsAt: block?.startsAt ?? null,
+        endsAt: block?.endsAt ?? null,
+      }
+    })
+    .sort(compareQueueItem)
+}
+
+function isNoResponseDueSoon(
+  item: CrewDayOfResponseQueueItem,
+  now: Date,
+  dueSoonHours: number,
+) {
+  if (!NO_RESPONSE_REASONS.has(item.reason)) return false
+  if (item.timing === "past" || !item.startsAt) return false
+  const startsAt = toValidDate(item.startsAt)
+  if (!startsAt) return false
+  const dueSoonMs = now.getTime() + dueSoonHours * 60 * 60 * 1000
+  return startsAt.getTime() <= dueSoonMs
+}
+
+function buildJudgeCoverageSummary(input: {
+  matrix: CrewStaffingMatrix
+  blockSummaryById: Map<string, CrewDayOfBlockSummary>
+}): CrewDayOfJudgeCoverageSummary {
+  const judgeRows = input.matrix.coverageRows.filter((row) => {
+    const block = input.blockSummaryById.get(row.timeBlockId)
+    return (
+      row.roleType === VOLUNTEER_ROLE_TYPES.JUDGE && block?.source === "heat"
+    )
+  })
+  const blocks = judgeRows
+    .map((row) => {
+      const block = input.blockSummaryById.get(row.timeBlockId)
+      return {
+        timeBlockId: row.timeBlockId,
+        heatId: block?.source === "heat" ? block.sourceId : null,
+        blockLabel: block?.label ?? row.timeBlockId,
+        timing: block?.timing ?? "unscheduled",
+        startsAt: block?.startsAt ?? null,
+        endsAt: block?.endsAt ?? null,
+        needed: row.needed,
+        filled: row.filled,
+        open: row.open,
+        judgeLaneGaps: input.matrix.judgeLaneGaps.filter(
+          (gap) => gap.timeBlockId === row.timeBlockId,
+        ).length,
+      } satisfies CrewDayOfJudgeCoverageBlock
+    })
+    .sort(compareJudgeCoverageBlock)
+
+  return {
+    heatBlocks: blocks.length,
+    activeHeatBlocks: blocks.filter(
+      (block) => block.timing === "current" || block.timing === "next",
+    ).length,
+    coveredHeatBlocks: blocks.filter((block) => block.open === 0).length,
+    lanesNeeded: sum(blocks, "needed"),
+    lanesFilled: sum(blocks, "filled"),
+    openLanes: sum(blocks, "open"),
+    currentAndNext: blocks.filter(
+      (block) => block.timing === "current" || block.timing === "next",
+    ),
+  }
+}
+
+function toBlockCoverage(row: CrewStaffingCoverageRow): CrewDayOfBlockCoverage {
+  return {
+    rowId: row.id,
+    roleType: row.roleType,
+    roleLabel: formatRole(row.roleType),
+    needed: row.needed,
+    filled: row.filled,
+    open: row.open,
+  }
+}
+
+function compareNormalizedBlock(left: NormalizedBlock, right: NormalizedBlock) {
+  return (
+    timingRank(left.timing) - timingRank(right.timing) ||
+    compareNullableDate(left.startsAt, right.startsAt) ||
+    left.index - right.index ||
+    left.block.id.localeCompare(right.block.id)
+  )
+}
+
+function compareCriticalGap(
+  left: CrewDayOfCriticalGap,
+  right: CrewDayOfCriticalGap,
+) {
+  return (
+    timingRank(left.timing) - timingRank(right.timing) ||
+    compareNullableIso(left.startsAt, right.startsAt) ||
+    right.open - left.open ||
+    left.roleLabel.localeCompare(right.roleLabel) ||
+    left.rowId.localeCompare(right.rowId)
+  )
+}
+
+function compareQueueItem(
+  left: CrewDayOfResponseQueueItem,
+  right: CrewDayOfResponseQueueItem,
+) {
+  return (
+    timingRank(left.timing) - timingRank(right.timing) ||
+    compareNullableIso(left.startsAt, right.startsAt) ||
+    left.volunteerName.localeCompare(right.volunteerName) ||
+    left.assignmentId.localeCompare(right.assignmentId)
+  )
+}
+
+function compareJudgeCoverageBlock(
+  left: CrewDayOfJudgeCoverageBlock,
+  right: CrewDayOfJudgeCoverageBlock,
+) {
+  return (
+    timingRank(left.timing) - timingRank(right.timing) ||
+    compareNullableIso(left.startsAt, right.startsAt) ||
+    left.blockLabel.localeCompare(right.blockLabel) ||
+    left.timeBlockId.localeCompare(right.timeBlockId)
+  )
+}
+
+function timingRank(timing: CrewDayOfBlockTiming) {
+  if (timing === "current") return 0
+  if (timing === "next") return 1
+  if (timing === "upcoming") return 2
+  if (timing === "unscheduled") return 3
+  return 4
+}
+
+function groupBy<T, K>(items: T[], keyFn: (item: T) => K) {
+  const grouped = new Map<K, T[]>()
+  for (const item of items) {
+    const key = keyFn(item)
+    const existing = grouped.get(key) ?? []
+    existing.push(item)
+    grouped.set(key, existing)
+  }
+  return grouped
+}
+
+function sum<T>(items: T[], key: keyof T) {
+  return items.reduce((total, item) => {
+    const value = item[key]
+    return total + (typeof value === "number" ? value : 0)
+  }, 0)
+}
+
+function formatRole(roleType: VolunteerRoleType) {
+  return VOLUNTEER_ROLE_LABELS[roleType] ?? roleType
+}
+
+function toValidDate(value: Date | string | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function toIso(date: Date | null) {
+  return date ? date.toISOString() : null
+}
+
+function compareNullableDate(left: Date | null, right: Date | null) {
+  if (left && right) return left.getTime() - right.getTime()
+  if (left) return -1
+  if (right) return 1
+  return 0
+}
+
+function compareNullableIso(left: string | null, right: string | null) {
+  return compareNullableDate(toValidDate(left), toValidDate(right))
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$even
 import { Route as EventsEventIdReadinessRouteImport } from './routes/events/$eventId/readiness'
 import { Route as EventsEventIdJudgesRouteImport } from './routes/events/$eventId/judges'
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
+import { Route as EventsEventIdDayOfRouteImport } from './routes/events/$eventId/day-of'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
 import { Route as ESlugScheduleTokenRouteImport } from './routes/e/$slug/schedule/$token'
@@ -98,6 +99,11 @@ const EventsEventIdImportsRoute = EventsEventIdImportsRouteImport.update({
   path: '/imports',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdDayOfRoute = EventsEventIdDayOfRouteImport.update({
+  id: '/day-of',
+  path: '/day-of',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const ESlugVolunteerRoute = ESlugVolunteerRouteImport.update({
   id: '/e/$slug/volunteer',
   path: '/e/$slug/volunteer',
@@ -127,6 +133,7 @@ export interface FileRoutesByFullPath {
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
@@ -146,6 +153,7 @@ export interface FileRoutesByTo {
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
@@ -167,6 +175,7 @@ export interface FileRoutesById {
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
@@ -189,6 +198,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/api/crew/import'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/day-of'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
@@ -208,6 +218,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/api/crew/import'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/day-of'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
@@ -228,6 +239,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/api/crew/import'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/day-of'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
@@ -351,6 +363,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdImportsRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/day-of': {
+      id: '/events/$eventId/day-of'
+      path: '/day-of'
+      fullPath: '/events/$eventId/day-of'
+      preLoaderRoute: typeof EventsEventIdDayOfRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/e/$slug/volunteer': {
       id: '/e/$slug/volunteer'
       path: '/e/$slug/volunteer'
@@ -383,6 +402,7 @@ declare module '@tanstack/react-router' {
 }
 
 interface EventsEventIdRouteChildren {
+  EventsEventIdDayOfRoute: typeof EventsEventIdDayOfRoute
   EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
   EventsEventIdJudgesRoute: typeof EventsEventIdJudgesRoute
   EventsEventIdReadinessRoute: typeof EventsEventIdReadinessRoute
@@ -395,6 +415,7 @@ interface EventsEventIdRouteChildren {
 }
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
+  EventsEventIdDayOfRoute: EventsEventIdDayOfRoute,
   EventsEventIdImportsRoute: EventsEventIdImportsRoute,
   EventsEventIdJudgesRoute: EventsEventIdJudgesRoute,
   EventsEventIdReadinessRoute: EventsEventIdReadinessRoute,

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -1,5 +1,6 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
 // @lat: [[crew#Staffing Page Gap Report]]
+// @lat: [[crew#Day Of Operations Board]]
 import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
 import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
 
@@ -93,6 +94,14 @@ function EventShell() {
             className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             Judges
+          </Link>
+          <Link
+            to="/events/$eventId/day-of"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Day-of
           </Link>
           <Link
             to="/events/$eventId/schedule"

--- a/apps/crew/src/routes/events/$eventId/day-of.tsx
+++ b/apps/crew/src/routes/events/$eventId/day-of.tsx
@@ -1,0 +1,552 @@
+// @lat: [[crew#Day Of Operations Board]]
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle2,
+  Clock3,
+  RadioTower,
+  UserCheck,
+  UserX,
+} from "lucide-react"
+import type { ReactNode } from "react"
+import type {
+  CrewDayOfBlockSummary,
+  CrewDayOfCriticalGap,
+  CrewDayOfResponseQueueItem,
+} from "@/lib/crew/day-of-operations"
+import { formatCrewValue } from "@/lib/crew-event-display"
+import { getCrewDayOfOperationsPageFn } from "@/server-fns/crew-day-of-fns"
+import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
+
+export const Route = createFileRoute("/events/$eventId/day-of")({
+  loader: async ({ params }) =>
+    await getCrewDayOfOperationsPageFn({
+      data: { eventId: params.eventId },
+    }),
+  component: EventDayOfOperationsPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+function EventDayOfOperationsPage() {
+  const { eventId } = parentRoute.useParams()
+  const { event, board, sources } = Route.useLoaderData()
+  const timezone = event.timezone ?? "America/Denver"
+  const leadBlocks =
+    board.currentBlocks.length > 0 ? board.currentBlocks : board.nextBlocks
+  const visibleTimeBlocks = board.timeBlocks
+    .filter((block) => block.timing !== "past")
+    .slice(0, 12)
+
+  return (
+    <section className="space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Day-of operations</h2>
+          <p className="text-sm text-muted-foreground">
+            {formatGeneratedAt(board.generatedAt, timezone)} / {timezone}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Link
+            to="/events/$eventId/shifts"
+            params={{ eventId }}
+            className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <UserCheck className="size-4" />
+            Shifts
+          </Link>
+          <Link
+            to="/events/$eventId/judges"
+            params={{ eventId }}
+            className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            <RadioTower className="size-4" />
+            Judges
+          </Link>
+          <Link
+            to="/events/$eventId/staffing"
+            params={{ eventId }}
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            <AlertTriangle className="size-4" />
+            Staffing
+          </Link>
+        </div>
+      </div>
+
+      <section className="grid gap-3 md:grid-cols-5">
+        <MetricPanel
+          label="Open roles"
+          value={board.summary.openRoles}
+          tone={board.summary.openRoles > 0 ? "critical" : "covered"}
+        />
+        <MetricPanel
+          label="Responses due"
+          value={board.summary.noResponsesDueSoon}
+          tone={board.summary.noResponsesDueSoon > 0 ? "warning" : "covered"}
+        />
+        <MetricPanel
+          label="Declines / changes"
+          value={board.summary.decisionNeeded}
+          tone={board.summary.decisionNeeded > 0 ? "critical" : "covered"}
+        />
+        <MetricPanel
+          label="No-show / replaced"
+          value={board.summary.noShowOrReplaced}
+          tone={board.summary.noShowOrReplaced > 0 ? "critical" : "covered"}
+        />
+        <MetricPanel
+          label="Judge lanes open"
+          value={board.judgeCoverage.openLanes}
+          tone={board.judgeCoverage.openLanes > 0 ? "critical" : "covered"}
+        />
+      </section>
+
+      <div className="grid gap-5 lg:grid-cols-[1.2fr_0.8fr]">
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="font-semibold">
+                {board.currentBlocks.length > 0 ? "Now" : "Next"}
+              </h3>
+              <p className="text-sm text-muted-foreground">
+                {board.currentBlocks.length} current / {board.nextBlocks.length}{" "}
+                next
+              </p>
+            </div>
+            <Clock3 className="size-5 text-muted-foreground" />
+          </div>
+
+          {leadBlocks.length > 0 ? (
+            <div className="mt-4 grid gap-3">
+              {leadBlocks.map((block) => (
+                <BlockPanel
+                  key={block.timeBlockId}
+                  block={block}
+                  timezone={timezone}
+                />
+              ))}
+            </div>
+          ) : (
+            <EmptyState message="No scheduled shift or heat blocks are active or upcoming." />
+          )}
+        </section>
+
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="font-semibold">State tracking</h3>
+              <p className="text-sm text-muted-foreground">
+                {board.stateSummary.checkedInTracked
+                  ? `${board.stateSummary.checkedIn} checked in`
+                  : "Check-in is not persisted yet"}
+              </p>
+            </div>
+            <UserX className="size-5 text-muted-foreground" />
+          </div>
+
+          <dl className="mt-5 grid gap-3 text-sm">
+            <Fact label="No-shows" value={board.stateSummary.noShow} />
+            <Fact label="Replaced" value={board.stateSummary.replaced} />
+            <Fact
+              label="Active judge versions"
+              value={sources.activeJudgeVersions}
+            />
+            <Fact label="Shift assignments" value={sources.shiftAssignments} />
+          </dl>
+        </section>
+      </div>
+
+      <div className="grid gap-5 lg:grid-cols-2">
+        <CriticalGapList
+          title="Critical unfilled roles"
+          gaps={board.criticalGaps}
+          timezone={timezone}
+        />
+        <QueueList
+          title={`No-responses due in ${board.responseDueSoonHours}h`}
+          items={board.noResponsesDueSoon}
+          timezone={timezone}
+          empty="No current or near-term no-responses."
+        />
+        <QueueList
+          title="Declines and change requests"
+          items={board.decisionQueue}
+          timezone={timezone}
+          empty="No declined or change-requested assignments."
+        />
+        <QueueList
+          title="No-shows and replacements"
+          items={board.noShowReplacementQueue}
+          timezone={timezone}
+          empty="No no-show or replaced assignments."
+        />
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="font-semibold">Floor and time blocks</h3>
+            <p className="text-sm text-muted-foreground">
+              {visibleTimeBlocks.length}/{board.timeBlocks.length} active or
+              upcoming blocks
+            </p>
+          </div>
+          <StatusPill tone="neutral">{formatCrewValue(event.slug)}</StatusPill>
+        </div>
+
+        {visibleTimeBlocks.length > 0 ? (
+          <div className="mt-4 grid gap-3 md:grid-cols-2">
+            {visibleTimeBlocks.map((block) => (
+              <TimeBlockRow
+                key={block.timeBlockId}
+                block={block}
+                timezone={timezone}
+              />
+            ))}
+          </div>
+        ) : (
+          <EmptyState message="No active or upcoming blocks." />
+        )}
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="font-semibold">Active judge coverage</h3>
+            <p className="text-sm text-muted-foreground">
+              {board.judgeCoverage.lanesFilled}/
+              {board.judgeCoverage.lanesNeeded} lanes filled across{" "}
+              {board.judgeCoverage.heatBlocks} heat blocks
+            </p>
+          </div>
+          <StatusPill
+            tone={board.judgeCoverage.openLanes > 0 ? "critical" : "covered"}
+          >
+            {board.judgeCoverage.openLanes} open
+          </StatusPill>
+        </div>
+
+        {board.judgeCoverage.currentAndNext.length > 0 ? (
+          <div className="mt-4 divide-y rounded-md border">
+            {board.judgeCoverage.currentAndNext.map((block) => (
+              <div
+                key={block.timeBlockId}
+                className="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <div>
+                  <p className="font-medium">{block.blockLabel}</p>
+                  <p className="text-sm text-muted-foreground">
+                    {formatTimeWindow(block, timezone)}
+                  </p>
+                </div>
+                <div className="flex items-center gap-3 text-sm">
+                  <span>
+                    {block.filled}/{block.needed}
+                  </span>
+                  <StatusPill tone={block.open > 0 ? "critical" : "covered"}>
+                    {block.open} open
+                  </StatusPill>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <EmptyState message="No current or next judge heat coverage." />
+        )}
+      </section>
+    </section>
+  )
+}
+
+function MetricPanel({
+  label,
+  value,
+  tone,
+}: {
+  label: string
+  value: number
+  tone: "covered" | "warning" | "critical"
+}) {
+  return (
+    <section className={`rounded-md border p-4 shadow-sm ${metricTone(tone)}`}>
+      <p className="text-sm opacity-80">{label}</p>
+      <p className="mt-2 text-2xl font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function BlockPanel({
+  block,
+  timezone,
+}: {
+  block: CrewDayOfBlockSummary
+  timezone: string
+}) {
+  return (
+    <article className="rounded-md border bg-background p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="font-medium">{block.label}</h4>
+            <StatusPill tone={block.status}>
+              {formatCrewValue(block.timing)}
+            </StatusPill>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {formatTimeWindow(block, timezone)}
+          </p>
+        </div>
+        <p className="text-sm font-medium">
+          {block.filled}/{block.needed}
+        </p>
+      </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-3">
+        <MiniFact label="Open" value={block.open} />
+        <MiniFact label="Responses" value={block.responseNeeded} />
+        <MiniFact label="Decisions" value={block.decisionNeeded} />
+      </div>
+
+      {block.coverage.length > 0 ? (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {block.coverage.map((coverage) => (
+            <StatusPill
+              key={coverage.rowId}
+              tone={coverage.open > 0 ? "critical" : "covered"}
+            >
+              {coverage.roleLabel}: {coverage.filled}/{coverage.needed}
+            </StatusPill>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  )
+}
+
+function CriticalGapList({
+  title,
+  gaps,
+  timezone,
+}: {
+  title: string
+  gaps: CrewDayOfCriticalGap[]
+  timezone: string
+}) {
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <ListHeader title={title} count={gaps.length} />
+      {gaps.length > 0 ? (
+        <div className="mt-4 divide-y rounded-md border">
+          {gaps.slice(0, 8).map((gap) => (
+            <div
+              key={gap.rowId}
+              className="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div>
+                <p className="font-medium">{gap.roleLabel}</p>
+                <p className="text-sm text-muted-foreground">
+                  {gap.blockLabel} / {formatTimeWindow(gap, timezone)}
+                </p>
+              </div>
+              <div className="flex items-center gap-3 text-sm">
+                <span>
+                  {gap.filled}/{gap.needed}
+                </span>
+                <StatusPill tone="critical">{gap.open} open</StatusPill>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <EmptyState message="No unfilled role rows." />
+      )}
+    </section>
+  )
+}
+
+function QueueList({
+  title,
+  items,
+  timezone,
+  empty,
+}: {
+  title: string
+  items: CrewDayOfResponseQueueItem[]
+  timezone: string
+  empty: string
+}) {
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <ListHeader title={title} count={items.length} />
+      {items.length > 0 ? (
+        <div className="mt-4 divide-y rounded-md border">
+          {items.slice(0, 8).map((item) => (
+            <div
+              key={`${item.assignmentId}:${item.reason}`}
+              className="flex flex-col gap-2 p-3 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div>
+                <p className="font-medium">{item.volunteerName}</p>
+                <p className="text-sm text-muted-foreground">
+                  {item.blockLabel} / {formatTimeWindow(item, timezone)}
+                </p>
+              </div>
+              <StatusPill
+                tone={
+                  item.reason === "missing_confirmation" ||
+                  item.reason === "no_response"
+                    ? "warning"
+                    : "critical"
+                }
+              >
+                {formatCrewValue(item.reason)}
+              </StatusPill>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <EmptyState message={empty} />
+      )}
+    </section>
+  )
+}
+
+function TimeBlockRow({
+  block,
+  timezone,
+}: {
+  block: CrewDayOfBlockSummary
+  timezone: string
+}) {
+  return (
+    <article className="rounded-md border bg-background p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h4 className="font-medium">{block.label}</h4>
+            <StatusPill tone={block.status}>
+              {formatCrewValue(block.timing)}
+            </StatusPill>
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {formatTimeWindow(block, timezone)}
+          </p>
+        </div>
+        {block.status === "covered" ? (
+          <CheckCircle2 className="size-5 text-emerald-600" />
+        ) : (
+          <ArrowRight className="size-5 text-muted-foreground" />
+        )}
+      </div>
+
+      <div className="mt-4 grid grid-cols-4 gap-2 text-sm">
+        <MiniFact label="Open" value={block.open} />
+        <MiniFact label="Resp." value={block.responseNeeded} />
+        <MiniFact label="Dec." value={block.decisionNeeded} />
+        <MiniFact label="Judge" value={block.judgeLaneGaps} />
+      </div>
+    </article>
+  )
+}
+
+function ListHeader({ title, count }: { title: string; count: number }) {
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <h3 className="font-semibold">{title}</h3>
+      <StatusPill tone={count > 0 ? "critical" : "covered"}>{count}</StatusPill>
+    </div>
+  )
+}
+
+function Fact({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 rounded-md border bg-background px-3 py-2">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function MiniFact({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border bg-card px-3 py-2">
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-base font-semibold">{value}</p>
+    </div>
+  )
+}
+
+function StatusPill({
+  tone,
+  children,
+}: {
+  tone: "covered" | "attention" | "warning" | "critical" | "neutral"
+  children: ReactNode
+}) {
+  return (
+    <span
+      className={`inline-flex min-h-7 items-center rounded-md border px-2 py-1 text-xs font-medium ${pillTone(tone)}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="mt-4 rounded-md border bg-background p-5 text-center text-sm text-muted-foreground">
+      {message}
+    </div>
+  )
+}
+
+function formatGeneratedAt(value: string, timezone: string) {
+  return `Updated ${formatDateTimeInTimezone(new Date(value), timezone, "h:mm a")}`
+}
+
+function formatTimeWindow(
+  value: {
+    startsAt: string | null
+    endsAt: string | null
+  },
+  timezone: string,
+) {
+  if (!value.startsAt) return "Unscheduled"
+  const start = formatDateTimeInTimezone(
+    new Date(value.startsAt),
+    timezone,
+    "EEE h:mm a",
+  )
+  const end = value.endsAt
+    ? formatDateTimeInTimezone(new Date(value.endsAt), timezone, "h:mm a")
+    : ""
+  return end ? `${start} to ${end}` : start
+}
+
+function metricTone(tone: "covered" | "warning" | "critical") {
+  if (tone === "covered") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-900"
+  }
+  if (tone === "warning") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-900"
+  }
+  return "border-destructive/30 bg-destructive/10 text-destructive"
+}
+
+function pillTone(
+  tone: "covered" | "attention" | "warning" | "critical" | "neutral",
+) {
+  if (tone === "covered") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (tone === "attention" || tone === "warning") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+  }
+  if (tone === "critical") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  return "border-muted bg-muted text-muted-foreground"
+}

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -1,5 +1,6 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
 // @lat: [[crew#Staffing Page Gap Report]]
+// @lat: [[crew#Day Of Operations Board]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { formatCrewValue, getSafeHttpUrl } from "@/lib/crew-event-display"
 import {
@@ -90,6 +91,25 @@ function EventOverviewPage() {
             className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             Open staffing
+          </Link>
+        </div>
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Day-of operations</h2>
+            <p className="text-sm text-muted-foreground">
+              Scan current blocks, response queues, no-shows, replacements, and
+              judge lane coverage.
+            </p>
+          </div>
+          <Link
+            to="/events/$eventId/day-of"
+            params={{ eventId }}
+            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Open day-of
           </Link>
         </div>
       </section>

--- a/apps/crew/src/server-fns/crew-day-of-fns.ts
+++ b/apps/crew/src/server-fns/crew-day-of-fns.ts
@@ -1,0 +1,21 @@
+// @lat: [[crew#Day Of Operations Board]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type { CrewDayOfOperationsPageData } from "../server/crew-day-of.server"
+
+const getCrewDayOfOperationsPageInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+export const getCrewDayOfOperationsPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    getCrewDayOfOperationsPageInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewDayOfOperationsPage } = await import(
+      "../server/crew-day-of.server"
+    )
+    return getCrewDayOfOperationsPage(data)
+  })

--- a/apps/crew/src/server/crew-day-of.server.ts
+++ b/apps/crew/src/server/crew-day-of.server.ts
@@ -1,0 +1,33 @@
+// @lat: [[crew#Day Of Operations Board]]
+import {
+  buildCrewDayOfOperationsBoard,
+  type CrewDayOfOperationsBoard,
+} from "../lib/crew/day-of-operations"
+import {
+  getCrewStaffingReportPage,
+  type CrewStaffingReportEvent,
+  type CrewStaffingReportPageData,
+} from "../server-fns/crew-staffing-fns.server"
+
+export interface CrewDayOfOperationsPageData {
+  event: CrewStaffingReportEvent
+  board: CrewDayOfOperationsBoard
+  sources: CrewStaffingReportPageData["sources"]
+}
+
+export async function getCrewDayOfOperationsPage(data: {
+  eventId: string
+}): Promise<CrewDayOfOperationsPageData> {
+  const staffing = await getCrewStaffingReportPage(data.eventId)
+  const now = new Date()
+
+  return {
+    event: staffing.event,
+    board: buildCrewDayOfOperationsBoard({
+      matrix: staffing.matrix,
+      report: staffing.report,
+      now,
+    }),
+    sources: staffing.sources,
+  }
+}

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -192,7 +192,7 @@ Crew assignment confirmation links are token-only volunteer surfaces. Raw tokens
 
 Organizer-facing assignment confirmations reuse `crew_assignment_confirmations` and keep assignments authoritative.
 
-[[apps/crew/src/lib/crew/assignment-confirmations.ts]] normalizes operational states from persisted status plus timestamps: pending, sent, confirmed, declined, change requested, no-show, and replaced. Sent is represented by pending rows with `sentAt`, and replaced is represented by cancelled confirmation rows; checked-in is intentionally not persisted until day-of operations adds a first-class primitive.
+[[apps/crew/src/lib/crew/assignment-confirmations.ts]] normalizes operational states from persisted status plus timestamps: pending, sent, confirmed, declined, change requested, no-show, and replaced. Sent is represented by pending rows with `sentAt`, and replaced is represented by cancelled confirmation rows; checked-in waits for a later first-class primitive.
 
 [[apps/crew/src/server/crew-confirmation.server.ts]] owns guarded organizer status updates for volunteer shift assignments, creating a confirmation row only when an assignment is missing one and never mutating assignment rows as part of status changes. [[apps/crew/src/server-fns/crew-confirmation-fns.ts]] keeps the createServerFn wrapper thin so DB/runtime imports stay out of route module graphs.
 
@@ -207,3 +207,13 @@ Crew confirmation email operations use `crew_assignment_confirmations` as the so
 [[apps/crew/src/server/crew-confirmation.server.ts]] loads eligible volunteer shift confirmations, mints fresh raw tokens only for the queued payload, stores only the new token hash, and builds rendered Crew email messages from [[apps/crew/src/react-email/crew/assignment-confirmation.tsx]], [[apps/crew/src/react-email/crew/reminder-48-hour.tsx]], and [[apps/crew/src/react-email/crew/reminder-24-hour.tsx]]. If the shared email queue binding is unavailable, the operation only logs preview payloads and returns preview counts.
 
 [[apps/crew/src/server-fns/crew-confirmation-fns.ts]] exposes the route-safe operation wrapper. [[apps/crew/src/routes/events/$eventId/shifts.tsx]] provides quiet operator actions for event-wide confirmation sends and reminder sends, then reports queued, previewed, and failed counts without sending live email during local validation.
+
+## Day Of Operations Board
+
+Crew day-of operations is a compact read-only board for current blocks, response queues, role gaps, no-shows, replacements, and active judge lane coverage.
+
+[[apps/crew/src/routes/events/$eventId/day-of.tsx]] renders the event board. [[apps/crew/src/server-fns/crew-day-of-fns.ts]] keeps the route import light while [[apps/crew/src/server/crew-day-of.server.ts]] reuses staffing hydration without mutating event data.
+
+[[apps/crew/src/lib/crew/day-of-operations.ts]] derives current and next blocks, critical unfilled roles, due-soon no-responses, decision queues, no-show/replaced queues, time-block status, and judge coverage.
+
+The board does not add schema, exports, queue bindings, live email sends, public token changes, assignment automation, or published judge-row mutation. Checked-in remains unavailable until a dedicated primitive exists.


### PR DESCRIPTION
## What changed

Adds a Crew day-of operations board at `/events/$eventId/day-of` with compact operator signals for current and next blocks, critical role gaps, due-soon no-responses, declines/change requests, no-show/replaced states, time-block coverage, and active judge lane coverage.

The route uses a thin `createServerFn` wrapper backed by a server-only implementation that reuses the existing staffing report hydration. The new pure helper derives board summaries from the merged staffing matrix, assignment confirmation, shift, roster, and active judge assignment primitives.

## Scope notes

This is read-only day-of visibility. It does not add schema, exports, queue/deploy config, SMS, live email sending, public-token architecture changes, assignment automation, or direct published judge-row mutation. Checked-in remains unavailable until a dedicated primitive exists; no-show/replaced are surfaced from existing confirmation statuses.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/day-of-operations.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; existing unrelated warnings remain outside this slice)
- `pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Day Of Operations Board'`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a read-only Day‑of operations board at `/events/$eventId/day-of` to surface current/next blocks, critical role gaps, response queues, and judge lane coverage. It reuses staffing hydration via a thin server function; no schema or automation changes.

- **New Features**
  - New route and navigation links from the event shell and overview.
  - Board data from `buildCrewDayOfOperationsBoard`: current/next blocks, critical unfilled roles, due‑soon no‑responses, declines/change requests, no‑show/replaced, and time‑block status.
  - Active judge lane coverage for current/next heats with open lane counts.
  - Server boundary: `getCrewDayOfOperationsPageFn` wraps a server‑only implementation that reuses the staffing report.
  - Unit tests for the board helper with `vitest`.

<sup>Written for commit 52ea5896c095255dda5fd9896437694014aea682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Day of Operations Board—a real-time dashboard showing current and upcoming time blocks, critical staffing gaps, response queues, judge coverage, and no-show/replacement tracking for event management.

* **Documentation**
  * Updated documentation to describe the Day of Operations Board feature and its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->