### PR TITLE
feat(crew): add pilot exports

### DIFF
--- a/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
@@ -9,6 +9,15 @@ import { buildCrewPilotExports } from "./pilot-exports"
 import type { CrewPilotExportInput } from "./pilot-exports"
 
 describe("Crew pilot exports", () => {
+  it("requires explicit generatedAt input for deterministic output", () => {
+    expect(() =>
+      buildCrewPilotExports({
+        ...baseInput(),
+        generatedAt: "",
+      }),
+    ).toThrow("generatedAt is required")
+  })
+
   it("builds deterministic master schedule CSV rows sorted by start time", () => {
     const exports = buildCrewPilotExports(baseInput())
 
@@ -21,6 +30,39 @@ describe("Crew pilot exports", () => {
       "shift,2026-07-01T14:00:00.000Z,2026-07-01T16:00:00.000Z,Check-in,Front desk,Check-In,2,2,0",
     )
     expect(exports.summary.masterScheduleRows).toBe(3)
+  })
+
+  it("neutralizes spreadsheet formula-leading CSV cells", () => {
+    const input = baseInput()
+    input.shifts = [
+      {
+        id: "shift_formula",
+        name: "=SUM(1,1)",
+        roleType: VOLUNTEER_ROLE_TYPES.EQUIPMENT,
+        startTime: "2026-07-01T13:00:00.000Z",
+        endTime: "2026-07-01T14:00:00.000Z",
+        capacity: 1,
+        location: " @floor",
+        assignments: [
+          {
+            id: "vsa_formula",
+            membershipId: "tm_formula",
+            volunteerName: "+Mallory",
+            email: "-mallory@example.com",
+          },
+        ],
+      },
+    ]
+    input.heats = []
+    input.heatLaneAssignments = []
+    input.judgeAssignments = []
+
+    const exports = buildCrewPilotExports(input)
+
+    expect(exports.masterScheduleCsv).toContain("shift,")
+    expect(exports.masterScheduleCsv).toContain(`,"'=SUM(1,1)",`)
+    expect(exports.masterScheduleCsv).toContain(",' @floor,")
+    expect(exports.masterScheduleCsv).toContain("'+Mallory")
   })
 
   it("groups role sheets with open shift slots and judge assignments", () => {

--- a/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
@@ -1,0 +1,188 @@
+// @lat: [[crew#Pilot Exports]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+} from "../../../db/schemas/crew-imports"
+import { VOLUNTEER_ROLE_TYPES } from "../../../db/schemas/volunteers"
+import { buildCrewPilotExports } from "./pilot-exports"
+import type { CrewPilotExportInput } from "./pilot-exports"
+
+describe("Crew pilot exports", () => {
+  it("builds deterministic master schedule CSV rows sorted by start time", () => {
+    const exports = buildCrewPilotExports(baseInput())
+
+    expect(exports.masterScheduleRows.map((row) => row.label)).toEqual([
+      "Check-in",
+      "Event 1 - Heat 1",
+      "Floor reset",
+    ])
+    expect(exports.masterScheduleCsv).toContain(
+      "shift,2026-07-01T14:00:00.000Z,2026-07-01T16:00:00.000Z,Check-in,Front desk,Check-In,2,2,0",
+    )
+    expect(exports.summary.masterScheduleRows).toBe(3)
+  })
+
+  it("groups role sheets with open shift slots and judge assignments", () => {
+    const exports = buildCrewPilotExports(baseInput())
+
+    const equipment = exports.roleSheets.find(
+      (sheet) => sheet.roleType === VOLUNTEER_ROLE_TYPES.EQUIPMENT,
+    )
+    const judges = exports.roleSheets.find(
+      (sheet) => sheet.roleType === VOLUNTEER_ROLE_TYPES.JUDGE,
+    )
+
+    expect(equipment?.rows).toMatchObject([
+      { volunteerName: "Rae Reset", blockLabel: "Floor reset" },
+      { volunteerName: "OPEN", confirmationStatus: "open" },
+    ])
+    expect(judges?.rows.map((row) => row.volunteerName)).toEqual([
+      "Jules Judge",
+      "Lane Two",
+    ])
+  })
+
+  it("derives no-response and decline rows from confirmation states", () => {
+    const exports = buildCrewPilotExports(baseInput())
+
+    expect(
+      exports.responseRows.map((row) => [
+        row.volunteerName,
+        row.status,
+        row.reason,
+      ]),
+    ).toEqual([
+      ["Casey Check", "pending", "no_response"],
+      ["Lane Two", "declined", "declined"],
+      ["Rae Reset", "missing", "missing_confirmation"],
+    ])
+    expect(exports.responseCsv).toContain(
+      "heat,jha_lane2,Lane Two,lane2@example.com",
+    )
+  })
+
+  it("generates judge heat lane sheets with open lanes", () => {
+    const exports = buildCrewPilotExports(baseInput())
+    const [sheet] = exports.judgeHeatLaneSheets
+
+    expect(sheet?.label).toBe("Event 1 - Heat 1")
+    expect(sheet?.rows.map((row) => [row.laneNumber, row.judgeName])).toEqual([
+      [1, "Jules Judge"],
+      [2, "Lane Two"],
+      [3, "OPEN"],
+    ])
+  })
+})
+
+function baseInput(): CrewPilotExportInput {
+  return {
+    event: {
+      id: "comp_1",
+      name: "Pilot Throwdown",
+      timezone: "America/Denver",
+    },
+    generatedAt: "2026-07-01T12:00:00.000Z",
+    venues: [
+      { id: "venue_floor", name: "Competition floor", laneCount: 3 },
+      { id: "venue_check", name: "Front desk", laneCount: 0 },
+    ],
+    workouts: [{ id: "tw_event1", name: "Event 1", sortOrder: 1 }],
+    heats: [
+      {
+        id: "heat_1",
+        trackWorkoutId: "tw_event1",
+        heatNumber: 1,
+        venueId: "venue_floor",
+        scheduledTime: "2026-07-01T15:00:00.000Z",
+        durationMinutes: 12,
+      },
+    ],
+    heatLaneAssignments: [
+      { heatId: "heat_1", laneNumber: 1 },
+      { heatId: "heat_1", laneNumber: 2 },
+      { heatId: "heat_1", laneNumber: 3 },
+    ],
+    shifts: [
+      {
+        id: "shift_reset",
+        name: "Floor reset",
+        roleType: VOLUNTEER_ROLE_TYPES.EQUIPMENT,
+        startTime: "2026-07-01T16:00:00.000Z",
+        endTime: "2026-07-01T17:00:00.000Z",
+        capacity: 2,
+        location: "Competition floor",
+        assignments: [
+          {
+            id: "vsa_reset",
+            membershipId: "tm_reset",
+            volunteerName: "Rae Reset",
+            email: "reset@example.com",
+          },
+        ],
+      },
+      {
+        id: "shift_check",
+        name: "Check-in",
+        roleType: VOLUNTEER_ROLE_TYPES.CHECK_IN,
+        startTime: "2026-07-01T14:00:00.000Z",
+        endTime: "2026-07-01T16:00:00.000Z",
+        capacity: 2,
+        location: "Front desk",
+        assignments: [
+          {
+            id: "vsa_check_2",
+            membershipId: "tm_check_2",
+            volunteerName: "Casey Check",
+            email: "casey@example.com",
+            confirmation: {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+              sentAt: "2026-06-30T12:00:00.000Z",
+            },
+          },
+          {
+            id: "vsa_check_1",
+            membershipId: "tm_check_1",
+            volunteerName: "Ari Arrivals",
+            email: "ari@example.com",
+            confirmation: {
+              type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+              status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+              respondedAt: "2026-06-30T14:00:00.000Z",
+            },
+          },
+        ],
+      },
+    ],
+    judgeAssignments: [
+      {
+        id: "jha_lane2",
+        membershipId: "tm_lane2",
+        volunteerName: "Lane Two",
+        email: "lane2@example.com",
+        heatId: "heat_1",
+        laneNumber: 2,
+        position: VOLUNTEER_ROLE_TYPES.JUDGE,
+        confirmation: {
+          type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+          responseNote: "Can't make it.",
+        },
+      },
+      {
+        id: "jha_lane1",
+        membershipId: "tm_judge",
+        volunteerName: "Jules Judge",
+        email: "jules@example.com",
+        heatId: "heat_1",
+        laneNumber: 1,
+        position: VOLUNTEER_ROLE_TYPES.JUDGE,
+        confirmation: {
+          type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+        },
+      },
+    ],
+  }
+}

--- a/apps/crew/src/lib/crew/exports/pilot-exports.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.ts
@@ -1,0 +1,864 @@
+// @lat: [[crew#Pilot Exports]]
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  type CrewAssignmentConfirmationStatus,
+  type CrewAssignmentConfirmationType,
+} from "../../../db/schemas/crew-imports"
+import {
+  VOLUNTEER_ROLE_LABELS,
+  VOLUNTEER_ROLE_TYPES,
+  type VolunteerRoleType,
+} from "../../../db/schemas/volunteers"
+
+export interface CrewPilotExportEventInput {
+  id: string
+  name: string
+  slug?: string | null
+  timezone?: string | null
+}
+
+export interface CrewPilotExportVenueInput {
+  id: string
+  name: string
+  laneCount?: number | null
+  sortOrder?: number | null
+}
+
+export interface CrewPilotExportWorkoutInput {
+  id: string
+  name: string
+  sortOrder?: number | null
+}
+
+export interface CrewPilotExportHeatInput {
+  id: string
+  trackWorkoutId: string
+  heatNumber: number
+  venueId?: string | null
+  scheduledTime?: Date | string | null
+  durationMinutes?: number | null
+  laneCount?: number | null
+}
+
+export interface CrewPilotExportHeatLaneInput {
+  heatId: string
+  laneNumber: number
+}
+
+export interface CrewPilotExportConfirmationInput {
+  type: CrewAssignmentConfirmationType
+  status: CrewAssignmentConfirmationStatus
+  sentAt?: Date | string | null
+  respondedAt?: Date | string | null
+  responseNote?: string | null
+}
+
+export interface CrewPilotExportAssignmentInput {
+  id: string
+  membershipId: string
+  volunteerName: string
+  email?: string | null
+  confirmation?: CrewPilotExportConfirmationInput | null
+}
+
+export interface CrewPilotExportShiftInput {
+  id: string
+  name: string
+  roleType: VolunteerRoleType
+  startTime: Date | string
+  endTime: Date | string
+  capacity: number
+  location?: string | null
+  assignments: CrewPilotExportAssignmentInput[]
+}
+
+export interface CrewPilotExportJudgeAssignmentInput
+  extends CrewPilotExportAssignmentInput {
+  heatId: string
+  laneNumber?: number | null
+  position?: VolunteerRoleType | null
+}
+
+export interface CrewPilotExportInput {
+  event: CrewPilotExportEventInput
+  generatedAt?: Date | string | null
+  shifts?: CrewPilotExportShiftInput[]
+  venues?: CrewPilotExportVenueInput[]
+  workouts?: CrewPilotExportWorkoutInput[]
+  heats?: CrewPilotExportHeatInput[]
+  heatLaneAssignments?: CrewPilotExportHeatLaneInput[]
+  judgeAssignments?: CrewPilotExportJudgeAssignmentInput[]
+}
+
+export type CrewPilotExportBlockType = "shift" | "heat"
+export type CrewPilotExportResponseReason =
+  | "missing_confirmation"
+  | "no_response"
+  | "declined"
+  | "change_requested"
+
+export interface CrewPilotMasterScheduleRow {
+  blockType: CrewPilotExportBlockType
+  blockId: string
+  startsAt: string | null
+  endsAt: string | null
+  label: string
+  location: string
+  role: string
+  needed: number
+  assigned: number
+  open: number
+  people: string
+  confirmationSummary: string
+}
+
+export interface CrewPilotRoleSheetAssignmentRow {
+  assignmentType: CrewPilotExportBlockType
+  assignmentId: string | null
+  blockId: string
+  volunteerName: string
+  email: string
+  startsAt: string | null
+  endsAt: string | null
+  location: string
+  blockLabel: string
+  confirmationStatus: string
+  responseNote: string
+}
+
+export interface CrewPilotRoleSheet {
+  roleType: VolunteerRoleType
+  roleLabel: string
+  rows: CrewPilotRoleSheetAssignmentRow[]
+}
+
+export interface CrewPilotJudgeLaneRow {
+  heatId: string
+  workoutName: string
+  heatNumber: number
+  venueName: string
+  startsAt: string | null
+  endsAt: string | null
+  laneNumber: number
+  assignmentId: string | null
+  judgeName: string
+  email: string
+  position: string
+  confirmationStatus: string
+}
+
+export interface CrewPilotJudgeHeatLaneSheet {
+  heatId: string
+  label: string
+  startsAt: string | null
+  venueName: string
+  rows: CrewPilotJudgeLaneRow[]
+}
+
+export interface CrewPilotResponseRow {
+  assignmentType: CrewPilotExportBlockType
+  assignmentId: string
+  membershipId: string
+  volunteerName: string
+  email: string
+  startsAt: string | null
+  endsAt: string | null
+  location: string
+  blockLabel: string
+  role: string
+  status: string
+  reason: CrewPilotExportResponseReason
+  responseNote: string
+}
+
+export interface CrewPilotFloorLeadSheet {
+  floorName: string
+  rows: CrewPilotMasterScheduleRow[]
+  judgeRows: CrewPilotJudgeLaneRow[]
+}
+
+export interface CrewPilotExports {
+  generatedAt: string
+  summary: {
+    masterScheduleRows: number
+    roleSheets: number
+    judgeHeatSheets: number
+    responseRows: number
+    floorLeadSheets: number
+  }
+  masterScheduleRows: CrewPilotMasterScheduleRow[]
+  masterScheduleCsv: string
+  roleSheets: CrewPilotRoleSheet[]
+  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
+  responseRows: CrewPilotResponseRow[]
+  responseCsv: string
+  floorLeadSheets: CrewPilotFloorLeadSheet[]
+}
+
+interface NormalizedHeat {
+  input: CrewPilotExportHeatInput
+  workoutName: string
+  venueName: string
+  startsAt: Date | null
+  endsAt: Date | null
+  laneNumbers: number[]
+}
+
+export function buildCrewPilotExports(
+  input: CrewPilotExportInput,
+): CrewPilotExports {
+  const generatedAt = toIsoString(input.generatedAt) ?? new Date().toISOString()
+  const venues = [...(input.venues ?? [])].sort(compareVenue)
+  const workouts = [...(input.workouts ?? [])].sort(compareWorkout)
+  const shifts = [...(input.shifts ?? [])].sort(compareShift)
+  const heats = [...(input.heats ?? [])].sort(compareHeat)
+  const heatLaneAssignments = [...(input.heatLaneAssignments ?? [])].sort(
+    compareHeatLaneAssignment,
+  )
+  const judgeAssignments = [...(input.judgeAssignments ?? [])].sort(
+    compareJudgeAssignment,
+  )
+  const venueById = new Map(venues.map((venue) => [venue.id, venue]))
+  const workoutById = new Map(workouts.map((workout) => [workout.id, workout]))
+  const judgeAssignmentsByHeatId = groupBy(
+    judgeAssignments,
+    (assignment) => assignment.heatId,
+  )
+  const normalizedHeats = heats.map((heat) =>
+    normalizeHeat(heat, {
+      venueById,
+      workoutById,
+      heatLaneAssignments,
+    }),
+  )
+  const heatById = new Map(normalizedHeats.map((heat) => [heat.input.id, heat]))
+
+  const masterScheduleRows = [
+    ...shifts.map(buildShiftMasterScheduleRow),
+    ...normalizedHeats.map((heat) =>
+      buildHeatMasterScheduleRow(
+        heat,
+        judgeAssignmentsByHeatId.get(heat.input.id) ?? [],
+      ),
+    ),
+  ].sort(compareMasterScheduleRow)
+  const roleSheets = buildRoleSheets({ shifts, judgeAssignments, heatById })
+  const judgeHeatLaneSheets = normalizedHeats.map((heat) =>
+    buildJudgeHeatLaneSheet(
+      heat,
+      judgeAssignmentsByHeatId.get(heat.input.id) ?? [],
+    ),
+  )
+  const responseRows = buildResponseRows({
+    shifts,
+    judgeAssignments,
+    heatById,
+  })
+  const floorLeadSheets = buildFloorLeadSheets({
+    masterScheduleRows,
+    judgeHeatLaneSheets,
+  })
+
+  return {
+    generatedAt,
+    summary: {
+      masterScheduleRows: masterScheduleRows.length,
+      roleSheets: roleSheets.length,
+      judgeHeatSheets: judgeHeatLaneSheets.length,
+      responseRows: responseRows.length,
+      floorLeadSheets: floorLeadSheets.length,
+    },
+    masterScheduleRows,
+    masterScheduleCsv: buildCsv(
+      [
+        "Type",
+        "Start",
+        "End",
+        "Label",
+        "Location",
+        "Role",
+        "Needed",
+        "Assigned",
+        "Open",
+        "People",
+        "Confirmations",
+      ],
+      masterScheduleRows.map((row) => [
+        row.blockType,
+        row.startsAt ?? "",
+        row.endsAt ?? "",
+        row.label,
+        row.location,
+        row.role,
+        row.needed,
+        row.assigned,
+        row.open,
+        row.people,
+        row.confirmationSummary,
+      ]),
+    ),
+    roleSheets,
+    judgeHeatLaneSheets,
+    responseRows,
+    responseCsv: buildCsv(
+      [
+        "Type",
+        "Assignment ID",
+        "Volunteer",
+        "Email",
+        "Start",
+        "End",
+        "Location",
+        "Block",
+        "Role",
+        "Status",
+        "Reason",
+        "Note",
+      ],
+      responseRows.map((row) => [
+        row.assignmentType,
+        row.assignmentId,
+        row.volunteerName,
+        row.email,
+        row.startsAt ?? "",
+        row.endsAt ?? "",
+        row.location,
+        row.blockLabel,
+        row.role,
+        row.status,
+        row.reason,
+        row.responseNote,
+      ]),
+    ),
+    floorLeadSheets,
+  }
+}
+
+function buildShiftMasterScheduleRow(
+  shift: CrewPilotExportShiftInput,
+): CrewPilotMasterScheduleRow {
+  const assigned = shift.assignments.length
+  return {
+    blockType: "shift",
+    blockId: shift.id,
+    startsAt: toIsoString(shift.startTime),
+    endsAt: toIsoString(shift.endTime),
+    label: shift.name,
+    location: shift.location || "Unassigned",
+    role: formatRole(shift.roleType),
+    needed: shift.capacity,
+    assigned,
+    open: Math.max(shift.capacity - assigned, 0),
+    people: formatPeople(shift.assignments),
+    confirmationSummary: formatConfirmationSummary(shift.assignments),
+  }
+}
+
+function buildHeatMasterScheduleRow(
+  heat: NormalizedHeat,
+  assignments: CrewPilotExportJudgeAssignmentInput[],
+): CrewPilotMasterScheduleRow {
+  const laneCount = heat.laneNumbers.length
+  const assignedLanes = new Set(
+    assignments
+      .map((assignment) => positiveIntegerOrNull(assignment.laneNumber))
+      .filter((laneNumber): laneNumber is number =>
+        laneNumber ? heat.laneNumbers.includes(laneNumber) : false,
+      ),
+  ).size
+  return {
+    blockType: "heat",
+    blockId: heat.input.id,
+    startsAt: toIsoString(heat.startsAt),
+    endsAt: toIsoString(heat.endsAt),
+    label: `${heat.workoutName} - Heat ${heat.input.heatNumber}`,
+    location: heat.venueName,
+    role: "Judge lanes",
+    needed: laneCount,
+    assigned: assignedLanes,
+    open: Math.max(laneCount - assignedLanes, 0),
+    people: formatPeople(assignments),
+    confirmationSummary: formatConfirmationSummary(assignments),
+  }
+}
+
+function buildRoleSheets(input: {
+  shifts: CrewPilotExportShiftInput[]
+  judgeAssignments: CrewPilotExportJudgeAssignmentInput[]
+  heatById: Map<string, NormalizedHeat>
+}) {
+  const rowsByRoleType = new Map<
+    VolunteerRoleType,
+    CrewPilotRoleSheetAssignmentRow[]
+  >()
+
+  for (const shift of input.shifts) {
+    const roleRows = rowsByRoleType.get(shift.roleType) ?? []
+    for (const assignment of shift.assignments) {
+      roleRows.push({
+        assignmentType: "shift",
+        assignmentId: assignment.id,
+        blockId: shift.id,
+        volunteerName: assignment.volunteerName,
+        email: assignment.email ?? "",
+        startsAt: toIsoString(shift.startTime),
+        endsAt: toIsoString(shift.endTime),
+        location: shift.location || "Unassigned",
+        blockLabel: shift.name,
+        confirmationStatus: formatConfirmationStatus(assignment.confirmation),
+        responseNote: assignment.confirmation?.responseNote ?? "",
+      })
+    }
+    for (
+      let index = shift.assignments.length;
+      index < shift.capacity;
+      index++
+    ) {
+      roleRows.push({
+        assignmentType: "shift",
+        assignmentId: null,
+        blockId: shift.id,
+        volunteerName: "OPEN",
+        email: "",
+        startsAt: toIsoString(shift.startTime),
+        endsAt: toIsoString(shift.endTime),
+        location: shift.location || "Unassigned",
+        blockLabel: shift.name,
+        confirmationStatus: "open",
+        responseNote: "",
+      })
+    }
+    rowsByRoleType.set(shift.roleType, roleRows)
+  }
+
+  for (const assignment of input.judgeAssignments) {
+    const roleType = getJudgeRoleType(assignment.position)
+    const heat = input.heatById.get(assignment.heatId)
+    const roleRows = rowsByRoleType.get(roleType) ?? []
+    roleRows.push({
+      assignmentType: "heat",
+      assignmentId: assignment.id,
+      blockId: assignment.heatId,
+      volunteerName: assignment.volunteerName,
+      email: assignment.email ?? "",
+      startsAt: toIsoString(heat?.startsAt),
+      endsAt: toIsoString(heat?.endsAt),
+      location: heat?.venueName ?? "Unassigned",
+      blockLabel: heat
+        ? `${heat.workoutName} - Heat ${heat.input.heatNumber}`
+        : assignment.heatId,
+      confirmationStatus: formatConfirmationStatus(assignment.confirmation),
+      responseNote: assignment.confirmation?.responseNote ?? "",
+    })
+    rowsByRoleType.set(roleType, roleRows)
+  }
+
+  return [...rowsByRoleType.entries()]
+    .map(([roleType, rows]) => ({
+      roleType,
+      roleLabel: formatRole(roleType),
+      rows: rows.sort(compareRoleSheetRow),
+    }))
+    .sort((left, right) => compareText(left.roleLabel, right.roleLabel))
+}
+
+function buildJudgeHeatLaneSheet(
+  heat: NormalizedHeat,
+  assignments: CrewPilotExportJudgeAssignmentInput[],
+): CrewPilotJudgeHeatLaneSheet {
+  const assignmentsByLane = new Map<
+    number,
+    CrewPilotExportJudgeAssignmentInput
+  >()
+  for (const assignment of assignments) {
+    const laneNumber = positiveIntegerOrNull(assignment.laneNumber)
+    if (!laneNumber || assignmentsByLane.has(laneNumber)) continue
+    assignmentsByLane.set(laneNumber, assignment)
+  }
+
+  const rows = heat.laneNumbers.map<CrewPilotJudgeLaneRow>((laneNumber) => {
+    const assignment = assignmentsByLane.get(laneNumber)
+    return {
+      heatId: heat.input.id,
+      workoutName: heat.workoutName,
+      heatNumber: heat.input.heatNumber,
+      venueName: heat.venueName,
+      startsAt: toIsoString(heat.startsAt),
+      endsAt: toIsoString(heat.endsAt),
+      laneNumber,
+      assignmentId: assignment?.id ?? null,
+      judgeName: assignment?.volunteerName ?? "OPEN",
+      email: assignment?.email ?? "",
+      position: formatRole(getJudgeRoleType(assignment?.position)),
+      confirmationStatus: formatConfirmationStatus(
+        assignment?.confirmation ?? null,
+      ),
+    }
+  })
+
+  return {
+    heatId: heat.input.id,
+    label: `${heat.workoutName} - Heat ${heat.input.heatNumber}`,
+    startsAt: toIsoString(heat.startsAt),
+    venueName: heat.venueName,
+    rows,
+  }
+}
+
+function buildResponseRows(input: {
+  shifts: CrewPilotExportShiftInput[]
+  judgeAssignments: CrewPilotExportJudgeAssignmentInput[]
+  heatById: Map<string, NormalizedHeat>
+}) {
+  const shiftRows = input.shifts.flatMap((shift) =>
+    shift.assignments.flatMap((assignment) => {
+      const reason = getResponseReason(assignment.confirmation)
+      if (!reason) return []
+      return {
+        assignmentType: "shift" as const,
+        assignmentId: assignment.id,
+        membershipId: assignment.membershipId,
+        volunteerName: assignment.volunteerName,
+        email: assignment.email ?? "",
+        startsAt: toIsoString(shift.startTime),
+        endsAt: toIsoString(shift.endTime),
+        location: shift.location || "Unassigned",
+        blockLabel: shift.name,
+        role: formatRole(shift.roleType),
+        status: formatConfirmationStatus(assignment.confirmation),
+        reason,
+        responseNote: assignment.confirmation?.responseNote ?? "",
+      }
+    }),
+  )
+  const judgeRows = input.judgeAssignments.flatMap((assignment) => {
+    const reason = getResponseReason(assignment.confirmation)
+    if (!reason) return []
+    const heat = input.heatById.get(assignment.heatId)
+    return {
+      assignmentType: "heat" as const,
+      assignmentId: assignment.id,
+      membershipId: assignment.membershipId,
+      volunteerName: assignment.volunteerName,
+      email: assignment.email ?? "",
+      startsAt: toIsoString(heat?.startsAt),
+      endsAt: toIsoString(heat?.endsAt),
+      location: heat?.venueName ?? "Unassigned",
+      blockLabel: heat
+        ? `${heat.workoutName} - Heat ${heat.input.heatNumber}`
+        : assignment.heatId,
+      role: formatRole(getJudgeRoleType(assignment.position)),
+      status: formatConfirmationStatus(assignment.confirmation),
+      reason,
+      responseNote: assignment.confirmation?.responseNote ?? "",
+    }
+  })
+
+  return [...shiftRows, ...judgeRows].sort(compareResponseRow)
+}
+
+function buildFloorLeadSheets(input: {
+  masterScheduleRows: CrewPilotMasterScheduleRow[]
+  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
+}) {
+  const scheduleRowsByFloor = groupBy(
+    input.masterScheduleRows,
+    (row) => row.location || "Unassigned",
+  )
+  const judgeRowsByFloor = groupBy(
+    input.judgeHeatLaneSheets.flatMap((sheet) => sheet.rows),
+    (row) => row.venueName || "Unassigned",
+  )
+  const floorNames = [
+    ...new Set([...scheduleRowsByFloor.keys(), ...judgeRowsByFloor.keys()]),
+  ].sort(compareText)
+
+  return floorNames.map((floorName) => ({
+    floorName,
+    rows: (scheduleRowsByFloor.get(floorName) ?? []).sort(
+      compareMasterScheduleRow,
+    ),
+    judgeRows: (judgeRowsByFloor.get(floorName) ?? []).sort(
+      compareJudgeLaneRow,
+    ),
+  }))
+}
+
+function normalizeHeat(
+  heat: CrewPilotExportHeatInput,
+  context: {
+    venueById: Map<string, CrewPilotExportVenueInput>
+    workoutById: Map<string, CrewPilotExportWorkoutInput>
+    heatLaneAssignments: CrewPilotExportHeatLaneInput[]
+  },
+): NormalizedHeat {
+  const venue = heat.venueId ? context.venueById.get(heat.venueId) : undefined
+  const workout = context.workoutById.get(heat.trackWorkoutId)
+  const startsAt = toDateOrNull(heat.scheduledTime)
+  const durationMinutes = positiveIntegerOrNull(heat.durationMinutes)
+  const endsAt =
+    startsAt && durationMinutes
+      ? new Date(startsAt.getTime() + durationMinutes * 60_000)
+      : null
+  const explicitLaneNumbers = context.heatLaneAssignments
+    .filter((assignment) => assignment.heatId === heat.id)
+    .map((assignment) => positiveIntegerOrNull(assignment.laneNumber))
+    .filter((laneNumber): laneNumber is number => Boolean(laneNumber))
+  const laneNumbers = explicitLaneNumbers.length
+    ? [...new Set(explicitLaneNumbers)].sort(compareNumber)
+    : Array.from(
+        {
+          length:
+            positiveIntegerOrNull(heat.laneCount) ??
+            positiveIntegerOrNull(venue?.laneCount) ??
+            0,
+        },
+        (_, index) => index + 1,
+      )
+
+  return {
+    input: heat,
+    workoutName: workout?.name ?? "Workout",
+    venueName: venue?.name ?? "Unassigned",
+    startsAt,
+    endsAt,
+    laneNumbers,
+  }
+}
+
+function getResponseReason(
+  confirmation: CrewPilotExportConfirmationInput | null | undefined,
+): CrewPilotExportResponseReason | null {
+  if (!confirmation) return "missing_confirmation"
+  if (confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING) {
+    return confirmation.sentAt ? "no_response" : "missing_confirmation"
+  }
+  if (confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED) {
+    return "declined"
+  }
+  if (
+    confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
+  ) {
+    return "change_requested"
+  }
+  return null
+}
+
+function formatConfirmationSummary(
+  assignments: CrewPilotExportAssignmentInput[],
+) {
+  if (assignments.length === 0) return "none"
+  const counts = new Map<string, number>()
+  for (const assignment of assignments) {
+    const label = formatConfirmationStatus(assignment.confirmation)
+    counts.set(label, (counts.get(label) ?? 0) + 1)
+  }
+  return [...counts.entries()]
+    .sort(([left], [right]) => compareText(left, right))
+    .map(([label, count]) => `${label}:${count}`)
+    .join("; ")
+}
+
+function formatConfirmationStatus(
+  confirmation: CrewPilotExportConfirmationInput | null | undefined,
+) {
+  return confirmation?.status ?? "missing"
+}
+
+function formatPeople(assignments: CrewPilotExportAssignmentInput[]) {
+  return assignments
+    .map((assignment) => assignment.volunteerName)
+    .filter(Boolean)
+    .sort(compareText)
+    .join("; ")
+}
+
+function formatRole(roleType: VolunteerRoleType) {
+  return VOLUNTEER_ROLE_LABELS[roleType] ?? roleType.replaceAll("_", " ")
+}
+
+function getJudgeRoleType(roleType: VolunteerRoleType | null | undefined) {
+  return roleType === VOLUNTEER_ROLE_TYPES.HEAD_JUDGE
+    ? VOLUNTEER_ROLE_TYPES.HEAD_JUDGE
+    : VOLUNTEER_ROLE_TYPES.JUDGE
+}
+
+function buildCsv(headers: string[], rows: Array<Array<unknown>>) {
+  return [
+    headers.map(csvCell).join(","),
+    ...rows.map((row) => row.map(csvCell).join(",")),
+  ].join("\n")
+}
+
+function csvCell(value: unknown): string {
+  if (value === null || value === undefined) return ""
+  const text = String(value)
+  if (!/[",\n\r]/.test(text)) return text
+  return `"${text.replaceAll('"', '""')}"`
+}
+
+function groupBy<T, K>(items: T[], getKey: (item: T) => K) {
+  const grouped = new Map<K, T[]>()
+  for (const item of items) {
+    const key = getKey(item)
+    grouped.set(key, [...(grouped.get(key) ?? []), item])
+  }
+  return grouped
+}
+
+function compareMasterScheduleRow(
+  left: CrewPilotMasterScheduleRow,
+  right: CrewPilotMasterScheduleRow,
+) {
+  return (
+    compareDateString(left.startsAt, right.startsAt) ||
+    compareText(left.blockType, right.blockType) ||
+    compareText(left.label, right.label) ||
+    compareText(left.blockId, right.blockId)
+  )
+}
+
+function compareRoleSheetRow(
+  left: CrewPilotRoleSheetAssignmentRow,
+  right: CrewPilotRoleSheetAssignmentRow,
+) {
+  return (
+    compareDateString(left.startsAt, right.startsAt) ||
+    compareText(left.location, right.location) ||
+    compareText(left.blockLabel, right.blockLabel) ||
+    Number(isOpenRoleRow(left)) - Number(isOpenRoleRow(right)) ||
+    compareText(left.volunteerName, right.volunteerName) ||
+    compareText(left.assignmentId ?? "", right.assignmentId ?? "")
+  )
+}
+
+function isOpenRoleRow(row: CrewPilotRoleSheetAssignmentRow) {
+  return row.assignmentId === null
+}
+
+function compareResponseRow(
+  left: CrewPilotResponseRow,
+  right: CrewPilotResponseRow,
+) {
+  return (
+    compareDateString(left.startsAt, right.startsAt) ||
+    compareText(left.reason, right.reason) ||
+    compareText(left.volunteerName, right.volunteerName) ||
+    compareText(left.assignmentId, right.assignmentId)
+  )
+}
+
+function compareJudgeLaneRow(
+  left: CrewPilotJudgeLaneRow,
+  right: CrewPilotJudgeLaneRow,
+) {
+  return (
+    compareDateString(left.startsAt, right.startsAt) ||
+    left.heatNumber - right.heatNumber ||
+    left.laneNumber - right.laneNumber ||
+    compareText(left.assignmentId ?? "", right.assignmentId ?? "")
+  )
+}
+
+function compareJudgeAssignment(
+  left: CrewPilotExportJudgeAssignmentInput,
+  right: CrewPilotExportJudgeAssignmentInput,
+) {
+  return (
+    compareText(left.heatId, right.heatId) ||
+    (left.laneNumber ?? Number.POSITIVE_INFINITY) -
+      (right.laneNumber ?? Number.POSITIVE_INFINITY) ||
+    compareText(left.id, right.id)
+  )
+}
+
+function compareShift(
+  left: CrewPilotExportShiftInput,
+  right: CrewPilotExportShiftInput,
+) {
+  return (
+    compareDateString(
+      toIsoString(left.startTime),
+      toIsoString(right.startTime),
+    ) ||
+    compareText(left.name, right.name) ||
+    compareText(left.id, right.id)
+  )
+}
+
+function compareHeat(
+  left: CrewPilotExportHeatInput,
+  right: CrewPilotExportHeatInput,
+) {
+  return (
+    compareDateString(
+      toIsoString(left.scheduledTime),
+      toIsoString(right.scheduledTime),
+    ) ||
+    left.heatNumber - right.heatNumber ||
+    compareText(left.id, right.id)
+  )
+}
+
+function compareVenue(
+  left: CrewPilotExportVenueInput,
+  right: CrewPilotExportVenueInput,
+) {
+  return (
+    (left.sortOrder ?? Number.POSITIVE_INFINITY) -
+      (right.sortOrder ?? Number.POSITIVE_INFINITY) ||
+    compareText(left.name, right.name) ||
+    compareText(left.id, right.id)
+  )
+}
+
+function compareWorkout(
+  left: CrewPilotExportWorkoutInput,
+  right: CrewPilotExportWorkoutInput,
+) {
+  return (
+    (left.sortOrder ?? Number.POSITIVE_INFINITY) -
+      (right.sortOrder ?? Number.POSITIVE_INFINITY) ||
+    compareText(left.name, right.name) ||
+    compareText(left.id, right.id)
+  )
+}
+
+function compareHeatLaneAssignment(
+  left: CrewPilotExportHeatLaneInput,
+  right: CrewPilotExportHeatLaneInput,
+) {
+  return (
+    compareText(left.heatId, right.heatId) || left.laneNumber - right.laneNumber
+  )
+}
+
+function compareDateString(left: string | null, right: string | null) {
+  const leftTime = left ? Date.parse(left) : Number.POSITIVE_INFINITY
+  const rightTime = right ? Date.parse(right) : Number.POSITIVE_INFINITY
+  return leftTime - rightTime
+}
+
+function compareText(left: string, right: string) {
+  return left.localeCompare(right)
+}
+
+function compareNumber(left: number, right: number) {
+  return left - right
+}
+
+function toDateOrNull(value: Date | string | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function toIsoString(value: Date | string | null | undefined) {
+  return toDateOrNull(value)?.toISOString() ?? null
+}
+
+function positiveIntegerOrNull(value: number | null | undefined) {
+  if (!Number.isFinite(value)) return null
+  const rounded = Math.floor(Number(value))
+  return rounded > 0 ? rounded : null
+}

--- a/apps/crew/src/lib/crew/exports/pilot-exports.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.ts
@@ -81,7 +81,7 @@ export interface CrewPilotExportJudgeAssignmentInput
 
 export interface CrewPilotExportInput {
   event: CrewPilotExportEventInput
-  generatedAt?: Date | string | null
+  generatedAt: Date | string
   shifts?: CrewPilotExportShiftInput[]
   venues?: CrewPilotExportVenueInput[]
   workouts?: CrewPilotExportWorkoutInput[]
@@ -113,6 +113,7 @@ export interface CrewPilotMasterScheduleRow {
 }
 
 export interface CrewPilotRoleSheetAssignmentRow {
+  rowKey: string
   assignmentType: CrewPilotExportBlockType
   assignmentId: string | null
   blockId: string
@@ -207,7 +208,11 @@ interface NormalizedHeat {
 export function buildCrewPilotExports(
   input: CrewPilotExportInput,
 ): CrewPilotExports {
-  const generatedAt = toIsoString(input.generatedAt) ?? new Date().toISOString()
+  const generatedAt = toIsoString(input.generatedAt)
+  if (!generatedAt) {
+    throw new Error("Crew pilot exports generatedAt is required")
+  }
+
   const venues = [...(input.venues ?? [])].sort(compareVenue)
   const workouts = [...(input.workouts ?? [])].sort(compareWorkout)
   const shifts = [...(input.shifts ?? [])].sort(compareShift)
@@ -396,6 +401,7 @@ function buildRoleSheets(input: {
     const roleRows = rowsByRoleType.get(shift.roleType) ?? []
     for (const assignment of shift.assignments) {
       roleRows.push({
+        rowKey: assignment.id,
         assignmentType: "shift",
         assignmentId: assignment.id,
         blockId: shift.id,
@@ -415,6 +421,7 @@ function buildRoleSheets(input: {
       index++
     ) {
       roleRows.push({
+        rowKey: `open:${shift.id}:${index}`,
         assignmentType: "shift",
         assignmentId: null,
         blockId: shift.id,
@@ -436,6 +443,7 @@ function buildRoleSheets(input: {
     const heat = input.heatById.get(assignment.heatId)
     const roleRows = rowsByRoleType.get(roleType) ?? []
     roleRows.push({
+      rowKey: assignment.id,
       assignmentType: "heat",
       assignmentId: assignment.id,
       blockId: assignment.heatId,
@@ -692,16 +700,25 @@ function buildCsv(headers: string[], rows: Array<Array<unknown>>) {
 
 function csvCell(value: unknown): string {
   if (value === null || value === undefined) return ""
-  const text = String(value)
+  const text = neutralizeCsvFormula(String(value))
   if (!/[",\n\r]/.test(text)) return text
   return `"${text.replaceAll('"', '""')}"`
+}
+
+function neutralizeCsvFormula(text: string) {
+  return /^\s*[=+\-@]/.test(text) ? `'${text}` : text
 }
 
 function groupBy<T, K>(items: T[], getKey: (item: T) => K) {
   const grouped = new Map<K, T[]>()
   for (const item of items) {
     const key = getKey(item)
-    grouped.set(key, [...(grouped.get(key) ?? []), item])
+    const group = grouped.get(key)
+    if (group) {
+      group.push(item)
+    } else {
+      grouped.set(key, [item])
+    }
   }
   return grouped
 }

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$even
 import { Route as EventsEventIdReadinessRouteImport } from './routes/events/$eventId/readiness'
 import { Route as EventsEventIdJudgesRouteImport } from './routes/events/$eventId/judges'
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
+import { Route as EventsEventIdExportsRouteImport } from './routes/events/$eventId/exports'
 import { Route as EventsEventIdDayOfRouteImport } from './routes/events/$eventId/day-of'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
@@ -99,6 +100,11 @@ const EventsEventIdImportsRoute = EventsEventIdImportsRouteImport.update({
   path: '/imports',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdExportsRoute = EventsEventIdExportsRouteImport.update({
+  id: '/exports',
+  path: '/exports',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const EventsEventIdDayOfRoute = EventsEventIdDayOfRouteImport.update({
   id: '/day-of',
   path: '/day-of',
@@ -134,6 +140,7 @@ export interface FileRoutesByFullPath {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
+  '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
@@ -154,6 +161,7 @@ export interface FileRoutesByTo {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
+  '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
@@ -176,6 +184,7 @@ export interface FileRoutesById {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
+  '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
@@ -199,6 +208,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/day-of'
+    | '/events/$eventId/exports'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
@@ -219,6 +229,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/day-of'
+    | '/events/$eventId/exports'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
@@ -240,6 +251,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/e/$slug/volunteer'
     | '/events/$eventId/day-of'
+    | '/events/$eventId/exports'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
     | '/events/$eventId/readiness'
@@ -363,6 +375,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdImportsRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/exports': {
+      id: '/events/$eventId/exports'
+      path: '/exports'
+      fullPath: '/events/$eventId/exports'
+      preLoaderRoute: typeof EventsEventIdExportsRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/events/$eventId/day-of': {
       id: '/events/$eventId/day-of'
       path: '/day-of'
@@ -403,6 +422,7 @@ declare module '@tanstack/react-router' {
 
 interface EventsEventIdRouteChildren {
   EventsEventIdDayOfRoute: typeof EventsEventIdDayOfRoute
+  EventsEventIdExportsRoute: typeof EventsEventIdExportsRoute
   EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
   EventsEventIdJudgesRoute: typeof EventsEventIdJudgesRoute
   EventsEventIdReadinessRoute: typeof EventsEventIdReadinessRoute
@@ -416,6 +436,7 @@ interface EventsEventIdRouteChildren {
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdDayOfRoute: EventsEventIdDayOfRoute,
+  EventsEventIdExportsRoute: EventsEventIdExportsRoute,
   EventsEventIdImportsRoute: EventsEventIdImportsRoute,
   EventsEventIdJudgesRoute: EventsEventIdJudgesRoute,
   EventsEventIdReadinessRoute: EventsEventIdReadinessRoute,

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -1,6 +1,7 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
 // @lat: [[crew#Staffing Page Gap Report]]
 // @lat: [[crew#Day Of Operations Board]]
+// @lat: [[crew#Pilot Exports]]
 import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
 import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
 
@@ -102,6 +103,14 @@ function EventShell() {
             className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             Day-of
+          </Link>
+          <Link
+            to="/events/$eventId/exports"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Exports
           </Link>
           <Link
             to="/events/$eventId/schedule"

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -269,28 +269,34 @@ function PrintSheets({
       <PrintSection title="Master schedule">
         <PrintTable
           headers={["Time", "Block", "Location", "Role", "Coverage", "People"]}
-          rows={exports.masterScheduleRows.map((row) => [
-            formatRange(row.startsAt, row.endsAt, timezone),
-            row.label,
-            row.location,
-            row.role,
-            `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
-            row.people || "Unassigned",
-          ])}
+          rows={exports.masterScheduleRows.map((row) => ({
+            key: `${row.blockType}:${row.blockId}`,
+            cells: [
+              formatRange(row.startsAt, row.endsAt, timezone),
+              row.label,
+              row.location,
+              row.role,
+              `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
+              row.people || "Unassigned",
+            ],
+          }))}
         />
       </PrintSection>
 
       <PrintSection title="No-response and decline list">
         <PrintTable
           headers={["Time", "Volunteer", "Block", "Role", "Status", "Note"]}
-          rows={exports.responseRows.map((row) => [
-            formatRange(row.startsAt, row.endsAt, timezone),
-            `${row.volunteerName}${row.email ? ` <${row.email}>` : ""}`,
-            row.blockLabel,
-            row.role,
-            formatCrewValue(row.reason),
-            row.responseNote,
-          ])}
+          rows={exports.responseRows.map((row) => ({
+            key: `${row.assignmentType}:${row.assignmentId}`,
+            cells: [
+              formatRange(row.startsAt, row.endsAt, timezone),
+              `${row.volunteerName}${row.email ? ` <${row.email}>` : ""}`,
+              row.blockLabel,
+              row.role,
+              formatCrewValue(row.reason),
+              row.responseNote,
+            ],
+          }))}
           empty="No missing, pending, declined, or change-requested responses."
         />
       </PrintSection>
@@ -306,14 +312,17 @@ function PrintSheets({
               "Location",
               "Status",
             ]}
-            rows={sheet.rows.map((row) => [
-              formatRange(row.startsAt, row.endsAt, timezone),
-              row.volunteerName,
-              row.email,
-              row.blockLabel,
-              row.location,
-              formatCrewValue(row.confirmationStatus),
-            ])}
+            rows={sheet.rows.map((row) => ({
+              key: row.rowKey,
+              cells: [
+                formatRange(row.startsAt, row.endsAt, timezone),
+                row.volunteerName,
+                row.email,
+                row.blockLabel,
+                row.location,
+                formatCrewValue(row.confirmationStatus),
+              ],
+            }))}
           />
         </PrintSection>
       ))}
@@ -325,13 +334,16 @@ function PrintSheets({
           </p>
           <PrintTable
             headers={["Lane", "Judge", "Email", "Position", "Status"]}
-            rows={sheet.rows.map((row) => [
-              row.laneNumber,
-              row.judgeName,
-              row.email,
-              row.position,
-              formatCrewValue(row.confirmationStatus),
-            ])}
+            rows={sheet.rows.map((row) => ({
+              key: `${row.heatId}:lane:${row.laneNumber}`,
+              cells: [
+                row.laneNumber,
+                row.judgeName,
+                row.email,
+                row.position,
+                formatCrewValue(row.confirmationStatus),
+              ],
+            }))}
           />
         </PrintSection>
       ))}
@@ -343,24 +355,30 @@ function PrintSheets({
         >
           <PrintTable
             headers={["Time", "Block", "Role", "Coverage", "People"]}
-            rows={sheet.rows.map((row) => [
-              formatRange(row.startsAt, row.endsAt, timezone),
-              row.label,
-              row.role,
-              `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
-              row.people || "Unassigned",
-            ])}
+            rows={sheet.rows.map((row) => ({
+              key: `${row.blockType}:${row.blockId}`,
+              cells: [
+                formatRange(row.startsAt, row.endsAt, timezone),
+                row.label,
+                row.role,
+                `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
+                row.people || "Unassigned",
+              ],
+            }))}
           />
           <div className="mt-4">
             <PrintTable
               headers={["Time", "Heat", "Lane", "Judge", "Status"]}
-              rows={sheet.judgeRows.map((row) => [
-                formatRange(row.startsAt, row.endsAt, timezone),
-                `${row.workoutName} heat ${row.heatNumber}`,
-                row.laneNumber,
-                row.judgeName,
-                formatCrewValue(row.confirmationStatus),
-              ])}
+              rows={sheet.judgeRows.map((row) => ({
+                key: `${row.heatId}:lane:${row.laneNumber}`,
+                cells: [
+                  formatRange(row.startsAt, row.endsAt, timezone),
+                  `${row.workoutName} heat ${row.heatNumber}`,
+                  row.laneNumber,
+                  row.judgeName,
+                  formatCrewValue(row.confirmationStatus),
+                ],
+              }))}
               empty="No judge lanes for this floor."
             />
           </div>
@@ -391,7 +409,7 @@ function PrintTable({
   empty = "No rows.",
 }: {
   headers: string[]
-  rows: Array<Array<ReactNode>>
+  rows: Array<{ key: string; cells: Array<ReactNode> }>
   empty?: string
 }) {
   if (rows.length === 0) {
@@ -411,10 +429,10 @@ function PrintTable({
       </thead>
       <tbody>
         {rows.map((row) => (
-          <tr key={row.map(toPrintKeyPart).join("|")}>
+          <tr key={row.key}>
             {headers.map((header, cellIndex) => (
               <td key={header} className="border px-2 py-1 align-top">
-                {row[cellIndex]}
+                {row.cells[cellIndex]}
               </td>
             ))}
           </tr>
@@ -422,13 +440,6 @@ function PrintTable({
       </tbody>
     </table>
   )
-}
-
-function toPrintKeyPart(value: ReactNode) {
-  if (typeof value === "string" || typeof value === "number") {
-    return String(value)
-  }
-  return ""
 }
 
 function JudgeHeatSheetPreview({
@@ -481,11 +492,8 @@ function RoleSheetPreview({
         <StatusPill>{sheet.rows.length} rows</StatusPill>
       </div>
       <div className="mt-3 grid gap-2 text-sm">
-        {sheet.rows.slice(0, 8).map((row, index) => (
-          <div
-            key={`${row.blockId}:${row.assignmentId ?? index}`}
-            className="grid gap-1 rounded-md border p-3"
-          >
+        {sheet.rows.slice(0, 8).map((row) => (
+          <div key={row.rowKey} className="grid gap-1 rounded-md border p-3">
             <div className="flex items-start justify-between gap-3">
               <p className="font-medium">{row.volunteerName}</p>
               <span className="text-muted-foreground">

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { Download, FileSpreadsheet, Printer } from "lucide-react"
 import type { ReactNode } from "react"
 import type {
+  CrewPilotExports,
   CrewPilotFloorLeadSheet,
   CrewPilotJudgeHeatLaneSheet,
   CrewPilotRoleSheet,
@@ -27,214 +28,407 @@ function EventPilotExportsPage() {
   const timezone = event.timezone ?? "America/Denver"
 
   return (
-    <section className="space-y-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="text-xl font-semibold">Pilot exports</h2>
-          <p className="text-sm text-muted-foreground">
-            {formatExportDate(exports.generatedAt, timezone)} / {timezone}
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-            onClick={() =>
-              downloadCsv(
-                `${event.slug || event.id}-master-schedule.csv`,
-                exports.masterScheduleCsv,
-              )
-            }
-          >
-            <Download className="size-4" />
-            Master CSV
-          </button>
-          <button
-            type="button"
-            className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-            onClick={() =>
-              downloadCsv(
-                `${event.slug || event.id}-responses.csv`,
-                exports.responseCsv,
-              )
-            }
-          >
-            <FileSpreadsheet className="size-4" />
-            Responses CSV
-          </button>
-          <button
-            type="button"
-            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-            onClick={() => window.print()}
-          >
-            <Printer className="size-4" />
-            Print sheets
-          </button>
-        </div>
-      </div>
-
-      <section className="grid gap-3 md:grid-cols-6">
-        <MetricPanel label="Rows" value={exports.summary.masterScheduleRows} />
-        <MetricPanel label="Role sheets" value={exports.summary.roleSheets} />
-        <MetricPanel
-          label="Judge sheets"
-          value={exports.summary.judgeHeatSheets}
-        />
-        <MetricPanel label="Responses" value={exports.summary.responseRows} />
-        <MetricPanel label="Floors" value={exports.summary.floorLeadSheets} />
-        <MetricPanel label="Versions" value={sources.activeJudgeVersions} />
-      </section>
-
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+    <>
+      <section className="space-y-5 print:hidden">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h3 className="font-semibold">Master schedule</h3>
+            <h2 className="text-xl font-semibold">Pilot exports</h2>
             <p className="text-sm text-muted-foreground">
-              {sources.shifts} shifts / {sources.heats} heats
+              {formatExportDate(exports.generatedAt, timezone)} / {timezone}
             </p>
           </div>
-          <StatusPill>{formatCrewValue(event.slug)}</StatusPill>
-        </div>
-        {exports.masterScheduleRows.length > 0 ? (
-          <div className="mt-4 overflow-x-auto">
-            <table className="w-full min-w-[900px] text-left text-sm">
-              <thead className="border-b text-xs uppercase text-muted-foreground">
-                <tr>
-                  <th className="py-2 pr-3">Time</th>
-                  <th className="py-2 pr-3">Block</th>
-                  <th className="py-2 pr-3">Location</th>
-                  <th className="py-2 pr-3">Role</th>
-                  <th className="py-2 pr-3">Coverage</th>
-                  <th className="py-2 pr-3">People</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y">
-                {exports.masterScheduleRows.map((row) => (
-                  <tr key={`${row.blockType}:${row.blockId}`}>
-                    <td className="py-3 pr-3 text-muted-foreground">
-                      {formatRange(row.startsAt, row.endsAt, timezone)}
-                    </td>
-                    <td className="py-3 pr-3 font-medium">{row.label}</td>
-                    <td className="py-3 pr-3">{row.location}</td>
-                    <td className="py-3 pr-3">{row.role}</td>
-                    <td className="py-3 pr-3">
-                      {row.assigned}/{row.needed}
-                      {row.open > 0 ? ` (${row.open} open)` : ""}
-                    </td>
-                    <td className="py-3 pr-3 text-muted-foreground">
-                      {row.people || "Unassigned"}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <EmptyState message="No shift or heat rows are ready to export." />
-        )}
-      </section>
-
-      <div className="grid gap-5 lg:grid-cols-2">
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <h3 className="font-semibold">No-response and declines</h3>
-              <p className="text-sm text-muted-foreground">
-                {sources.shiftAssignments + sources.judgeAssignments} active
-                assignments
-              </p>
-            </div>
-            <Link
-              to="/events/$eventId/day-of"
-              params={{ eventId }}
-              className="text-sm font-medium text-primary hover:underline"
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={() =>
+                downloadCsv(
+                  `${event.slug || event.id}-master-schedule.csv`,
+                  exports.masterScheduleCsv,
+                )
+              }
             >
-              Day-of
-            </Link>
+              <Download className="size-4" />
+              Master CSV
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+              onClick={() =>
+                downloadCsv(
+                  `${event.slug || event.id}-responses.csv`,
+                  exports.responseCsv,
+                )
+              }
+            >
+              <FileSpreadsheet className="size-4" />
+              Responses CSV
+            </button>
+            <button
+              type="button"
+              className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              onClick={() => window.print()}
+            >
+              <Printer className="size-4" />
+              Print sheets
+            </button>
           </div>
-          {exports.responseRows.length > 0 ? (
-            <div className="mt-4 grid gap-3">
-              {exports.responseRows.slice(0, 12).map((row) => (
-                <div
-                  key={`${row.assignmentType}:${row.assignmentId}`}
-                  className="rounded-md border p-3 text-sm"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div>
-                      <p className="font-medium">{row.volunteerName}</p>
-                      <p className="text-muted-foreground">
-                        {row.blockLabel} / {row.role}
-                      </p>
-                    </div>
-                    <StatusPill>{formatCrewValue(row.reason)}</StatusPill>
-                  </div>
-                  <p className="mt-2 text-muted-foreground">
-                    {formatRange(row.startsAt, row.endsAt, timezone)}
-                  </p>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <EmptyState message="No missing, pending, declined, or change-requested responses." />
-          )}
+        </div>
+
+        <section className="grid gap-3 md:grid-cols-6">
+          <MetricPanel
+            label="Rows"
+            value={exports.summary.masterScheduleRows}
+          />
+          <MetricPanel label="Role sheets" value={exports.summary.roleSheets} />
+          <MetricPanel
+            label="Judge sheets"
+            value={exports.summary.judgeHeatSheets}
+          />
+          <MetricPanel label="Responses" value={exports.summary.responseRows} />
+          <MetricPanel label="Floors" value={exports.summary.floorLeadSheets} />
+          <MetricPanel label="Versions" value={sources.activeJudgeVersions} />
         </section>
 
         <section className="rounded-md border bg-card p-5 shadow-sm">
-          <div className="flex items-start justify-between gap-4">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
             <div>
-              <h3 className="font-semibold">Judge heat sheets</h3>
+              <h3 className="font-semibold">Master schedule</h3>
               <p className="text-sm text-muted-foreground">
-                {sources.judgeAssignments}/{sources.heatLaneAssignments} lanes
-                assigned
+                {sources.shifts} shifts / {sources.heats} heats
               </p>
             </div>
-            <Link
-              to="/events/$eventId/judges"
-              params={{ eventId }}
-              className="text-sm font-medium text-primary hover:underline"
-            >
-              Judges
-            </Link>
+            <StatusPill>{formatCrewValue(event.slug)}</StatusPill>
           </div>
-          <div className="mt-4 grid gap-3">
-            {exports.judgeHeatLaneSheets.slice(0, 4).map((sheet) => (
-              <JudgeHeatSheetPreview
-                key={sheet.heatId}
+          {exports.masterScheduleRows.length > 0 ? (
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full min-w-[900px] text-left text-sm">
+                <thead className="border-b text-xs uppercase text-muted-foreground">
+                  <tr>
+                    <th className="py-2 pr-3">Time</th>
+                    <th className="py-2 pr-3">Block</th>
+                    <th className="py-2 pr-3">Location</th>
+                    <th className="py-2 pr-3">Role</th>
+                    <th className="py-2 pr-3">Coverage</th>
+                    <th className="py-2 pr-3">People</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y">
+                  {exports.masterScheduleRows.map((row) => (
+                    <tr key={`${row.blockType}:${row.blockId}`}>
+                      <td className="py-3 pr-3 text-muted-foreground">
+                        {formatRange(row.startsAt, row.endsAt, timezone)}
+                      </td>
+                      <td className="py-3 pr-3 font-medium">{row.label}</td>
+                      <td className="py-3 pr-3">{row.location}</td>
+                      <td className="py-3 pr-3">{row.role}</td>
+                      <td className="py-3 pr-3">
+                        {row.assigned}/{row.needed}
+                        {row.open > 0 ? ` (${row.open} open)` : ""}
+                      </td>
+                      <td className="py-3 pr-3 text-muted-foreground">
+                        {row.people || "Unassigned"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <EmptyState message="No shift or heat rows are ready to export." />
+          )}
+        </section>
+
+        <div className="grid gap-5 lg:grid-cols-2">
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="font-semibold">No-response and declines</h3>
+                <p className="text-sm text-muted-foreground">
+                  {sources.shiftAssignments + sources.judgeAssignments} active
+                  assignments
+                </p>
+              </div>
+              <Link
+                to="/events/$eventId/day-of"
+                params={{ eventId }}
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                Day-of
+              </Link>
+            </div>
+            {exports.responseRows.length > 0 ? (
+              <div className="mt-4 grid gap-3">
+                {exports.responseRows.slice(0, 12).map((row) => (
+                  <div
+                    key={`${row.assignmentType}:${row.assignmentId}`}
+                    className="rounded-md border p-3 text-sm"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-medium">{row.volunteerName}</p>
+                        <p className="text-muted-foreground">
+                          {row.blockLabel} / {row.role}
+                        </p>
+                      </div>
+                      <StatusPill>{formatCrewValue(row.reason)}</StatusPill>
+                    </div>
+                    <p className="mt-2 text-muted-foreground">
+                      {formatRange(row.startsAt, row.endsAt, timezone)}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <EmptyState message="No missing, pending, declined, or change-requested responses." />
+            )}
+          </section>
+
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="font-semibold">Judge heat sheets</h3>
+                <p className="text-sm text-muted-foreground">
+                  {sources.judgeAssignments}/{sources.heatLaneAssignments} lanes
+                  assigned
+                </p>
+              </div>
+              <Link
+                to="/events/$eventId/judges"
+                params={{ eventId }}
+                className="text-sm font-medium text-primary hover:underline"
+              >
+                Judges
+              </Link>
+            </div>
+            <div className="mt-4 grid gap-3">
+              {exports.judgeHeatLaneSheets.slice(0, 4).map((sheet) => (
+                <JudgeHeatSheetPreview
+                  key={sheet.heatId}
+                  sheet={sheet}
+                  timezone={timezone}
+                />
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <section className="space-y-4">
+          <h3 className="font-semibold">Role sheets</h3>
+          <div className="grid gap-4 lg:grid-cols-2">
+            {exports.roleSheets.map((sheet) => (
+              <RoleSheetPreview
+                key={sheet.roleType}
                 sheet={sheet}
                 timezone={timezone}
               />
             ))}
           </div>
         </section>
-      </div>
 
-      <section className="space-y-4">
-        <h3 className="font-semibold">Role sheets</h3>
-        <div className="grid gap-4 lg:grid-cols-2">
-          {exports.roleSheets.map((sheet) => (
-            <RoleSheetPreview
-              key={sheet.roleType}
-              sheet={sheet}
-              timezone={timezone}
-            />
-          ))}
-        </div>
+        <section className="space-y-4">
+          <h3 className="font-semibold">Floor lead sheets</h3>
+          <div className="grid gap-4">
+            {exports.floorLeadSheets.map((sheet) => (
+              <FloorLeadSheetPreview
+                key={sheet.floorName}
+                sheet={sheet}
+                timezone={timezone}
+              />
+            ))}
+          </div>
+        </section>
       </section>
+      <PrintSheets
+        eventName={event.name}
+        exports={exports}
+        timezone={timezone}
+      />
+    </>
+  )
+}
 
-      <section className="space-y-4">
-        <h3 className="font-semibold">Floor lead sheets</h3>
-        <div className="grid gap-4">
-          {exports.floorLeadSheets.map((sheet) => (
-            <FloorLeadSheetPreview
-              key={sheet.floorName}
-              sheet={sheet}
-              timezone={timezone}
+function PrintSheets({
+  eventName,
+  exports,
+  timezone,
+}: {
+  eventName: string
+  exports: CrewPilotExports
+  timezone: string
+}) {
+  return (
+    <section className="hidden space-y-8 bg-white text-black print:block">
+      <header className="border-b pb-4">
+        <h1 className="text-2xl font-semibold">{eventName}</h1>
+        <p className="text-sm">
+          Pilot exports / {formatExportDate(exports.generatedAt, timezone)}
+        </p>
+      </header>
+
+      <PrintSection title="Master schedule">
+        <PrintTable
+          headers={["Time", "Block", "Location", "Role", "Coverage", "People"]}
+          rows={exports.masterScheduleRows.map((row) => [
+            formatRange(row.startsAt, row.endsAt, timezone),
+            row.label,
+            row.location,
+            row.role,
+            `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
+            row.people || "Unassigned",
+          ])}
+        />
+      </PrintSection>
+
+      <PrintSection title="No-response and decline list">
+        <PrintTable
+          headers={["Time", "Volunteer", "Block", "Role", "Status", "Note"]}
+          rows={exports.responseRows.map((row) => [
+            formatRange(row.startsAt, row.endsAt, timezone),
+            `${row.volunteerName}${row.email ? ` <${row.email}>` : ""}`,
+            row.blockLabel,
+            row.role,
+            formatCrewValue(row.reason),
+            row.responseNote,
+          ])}
+          empty="No missing, pending, declined, or change-requested responses."
+        />
+      </PrintSection>
+
+      {exports.roleSheets.map((sheet) => (
+        <PrintSection key={sheet.roleType} title={`${sheet.roleLabel} sheet`}>
+          <PrintTable
+            headers={[
+              "Time",
+              "Volunteer",
+              "Email",
+              "Block",
+              "Location",
+              "Status",
+            ]}
+            rows={sheet.rows.map((row) => [
+              formatRange(row.startsAt, row.endsAt, timezone),
+              row.volunteerName,
+              row.email,
+              row.blockLabel,
+              row.location,
+              formatCrewValue(row.confirmationStatus),
+            ])}
+          />
+        </PrintSection>
+      ))}
+
+      {exports.judgeHeatLaneSheets.map((sheet) => (
+        <PrintSection key={sheet.heatId} title={`${sheet.label} judge lanes`}>
+          <p className="mb-2 text-sm">
+            {formatExportDate(sheet.startsAt, timezone)} / {sheet.venueName}
+          </p>
+          <PrintTable
+            headers={["Lane", "Judge", "Email", "Position", "Status"]}
+            rows={sheet.rows.map((row) => [
+              row.laneNumber,
+              row.judgeName,
+              row.email,
+              row.position,
+              formatCrewValue(row.confirmationStatus),
+            ])}
+          />
+        </PrintSection>
+      ))}
+
+      {exports.floorLeadSheets.map((sheet) => (
+        <PrintSection
+          key={sheet.floorName}
+          title={`${sheet.floorName} floor lead`}
+        >
+          <PrintTable
+            headers={["Time", "Block", "Role", "Coverage", "People"]}
+            rows={sheet.rows.map((row) => [
+              formatRange(row.startsAt, row.endsAt, timezone),
+              row.label,
+              row.role,
+              `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
+              row.people || "Unassigned",
+            ])}
+          />
+          <div className="mt-4">
+            <PrintTable
+              headers={["Time", "Heat", "Lane", "Judge", "Status"]}
+              rows={sheet.judgeRows.map((row) => [
+                formatRange(row.startsAt, row.endsAt, timezone),
+                `${row.workoutName} heat ${row.heatNumber}`,
+                row.laneNumber,
+                row.judgeName,
+                formatCrewValue(row.confirmationStatus),
+              ])}
+              empty="No judge lanes for this floor."
             />
-          ))}
-        </div>
-      </section>
+          </div>
+        </PrintSection>
+      ))}
     </section>
   )
+}
+
+function PrintSection({
+  title,
+  children,
+}: {
+  title: string
+  children: ReactNode
+}) {
+  return (
+    <section className="break-inside-avoid space-y-3 print:break-before-page first:print:break-before-auto">
+      <h2 className="text-xl font-semibold">{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+function PrintTable({
+  headers,
+  rows,
+  empty = "No rows.",
+}: {
+  headers: string[]
+  rows: Array<Array<ReactNode>>
+  empty?: string
+}) {
+  if (rows.length === 0) {
+    return <p className="text-sm">{empty}</p>
+  }
+
+  return (
+    <table className="w-full border-collapse text-left text-xs">
+      <thead>
+        <tr>
+          {headers.map((header) => (
+            <th key={header} className="border px-2 py-1 font-semibold">
+              {header}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.map(toPrintKeyPart).join("|")}>
+            {headers.map((header, cellIndex) => (
+              <td key={header} className="border px-2 py-1 align-top">
+                {row[cellIndex]}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function toPrintKeyPart(value: ReactNode) {
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value)
+  }
+  return ""
 }
 
 function JudgeHeatSheetPreview({

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -1,0 +1,409 @@
+// @lat: [[crew#Pilot Exports]]
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
+import { Download, FileSpreadsheet, Printer } from "lucide-react"
+import type { ReactNode } from "react"
+import type {
+  CrewPilotFloorLeadSheet,
+  CrewPilotJudgeHeatLaneSheet,
+  CrewPilotRoleSheet,
+} from "@/lib/crew/exports/pilot-exports"
+import { formatCrewValue } from "@/lib/crew-event-display"
+import { getCrewPilotExportsPageFn } from "@/server-fns/crew-pilot-export-fns"
+import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
+
+export const Route = createFileRoute("/events/$eventId/exports")({
+  loader: async ({ params }) =>
+    await getCrewPilotExportsPageFn({
+      data: { eventId: params.eventId },
+    }),
+  component: EventPilotExportsPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+function EventPilotExportsPage() {
+  const { eventId } = parentRoute.useParams()
+  const { event, exports, sources } = Route.useLoaderData()
+  const timezone = event.timezone ?? "America/Denver"
+
+  return (
+    <section className="space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Pilot exports</h2>
+          <p className="text-sm text-muted-foreground">
+            {formatExportDate(exports.generatedAt, timezone)} / {timezone}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            onClick={() =>
+              downloadCsv(
+                `${event.slug || event.id}-master-schedule.csv`,
+                exports.masterScheduleCsv,
+              )
+            }
+          >
+            <Download className="size-4" />
+            Master CSV
+          </button>
+          <button
+            type="button"
+            className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            onClick={() =>
+              downloadCsv(
+                `${event.slug || event.id}-responses.csv`,
+                exports.responseCsv,
+              )
+            }
+          >
+            <FileSpreadsheet className="size-4" />
+            Responses CSV
+          </button>
+          <button
+            type="button"
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            onClick={() => window.print()}
+          >
+            <Printer className="size-4" />
+            Print sheets
+          </button>
+        </div>
+      </div>
+
+      <section className="grid gap-3 md:grid-cols-6">
+        <MetricPanel label="Rows" value={exports.summary.masterScheduleRows} />
+        <MetricPanel label="Role sheets" value={exports.summary.roleSheets} />
+        <MetricPanel
+          label="Judge sheets"
+          value={exports.summary.judgeHeatSheets}
+        />
+        <MetricPanel label="Responses" value={exports.summary.responseRows} />
+        <MetricPanel label="Floors" value={exports.summary.floorLeadSheets} />
+        <MetricPanel label="Versions" value={sources.activeJudgeVersions} />
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h3 className="font-semibold">Master schedule</h3>
+            <p className="text-sm text-muted-foreground">
+              {sources.shifts} shifts / {sources.heats} heats
+            </p>
+          </div>
+          <StatusPill>{formatCrewValue(event.slug)}</StatusPill>
+        </div>
+        {exports.masterScheduleRows.length > 0 ? (
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full min-w-[900px] text-left text-sm">
+              <thead className="border-b text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="py-2 pr-3">Time</th>
+                  <th className="py-2 pr-3">Block</th>
+                  <th className="py-2 pr-3">Location</th>
+                  <th className="py-2 pr-3">Role</th>
+                  <th className="py-2 pr-3">Coverage</th>
+                  <th className="py-2 pr-3">People</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {exports.masterScheduleRows.map((row) => (
+                  <tr key={`${row.blockType}:${row.blockId}`}>
+                    <td className="py-3 pr-3 text-muted-foreground">
+                      {formatRange(row.startsAt, row.endsAt, timezone)}
+                    </td>
+                    <td className="py-3 pr-3 font-medium">{row.label}</td>
+                    <td className="py-3 pr-3">{row.location}</td>
+                    <td className="py-3 pr-3">{row.role}</td>
+                    <td className="py-3 pr-3">
+                      {row.assigned}/{row.needed}
+                      {row.open > 0 ? ` (${row.open} open)` : ""}
+                    </td>
+                    <td className="py-3 pr-3 text-muted-foreground">
+                      {row.people || "Unassigned"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <EmptyState message="No shift or heat rows are ready to export." />
+        )}
+      </section>
+
+      <div className="grid gap-5 lg:grid-cols-2">
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="font-semibold">No-response and declines</h3>
+              <p className="text-sm text-muted-foreground">
+                {sources.shiftAssignments + sources.judgeAssignments} active
+                assignments
+              </p>
+            </div>
+            <Link
+              to="/events/$eventId/day-of"
+              params={{ eventId }}
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              Day-of
+            </Link>
+          </div>
+          {exports.responseRows.length > 0 ? (
+            <div className="mt-4 grid gap-3">
+              {exports.responseRows.slice(0, 12).map((row) => (
+                <div
+                  key={`${row.assignmentType}:${row.assignmentId}`}
+                  className="rounded-md border p-3 text-sm"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{row.volunteerName}</p>
+                      <p className="text-muted-foreground">
+                        {row.blockLabel} / {row.role}
+                      </p>
+                    </div>
+                    <StatusPill>{formatCrewValue(row.reason)}</StatusPill>
+                  </div>
+                  <p className="mt-2 text-muted-foreground">
+                    {formatRange(row.startsAt, row.endsAt, timezone)}
+                  </p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <EmptyState message="No missing, pending, declined, or change-requested responses." />
+          )}
+        </section>
+
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h3 className="font-semibold">Judge heat sheets</h3>
+              <p className="text-sm text-muted-foreground">
+                {sources.judgeAssignments}/{sources.heatLaneAssignments} lanes
+                assigned
+              </p>
+            </div>
+            <Link
+              to="/events/$eventId/judges"
+              params={{ eventId }}
+              className="text-sm font-medium text-primary hover:underline"
+            >
+              Judges
+            </Link>
+          </div>
+          <div className="mt-4 grid gap-3">
+            {exports.judgeHeatLaneSheets.slice(0, 4).map((sheet) => (
+              <JudgeHeatSheetPreview
+                key={sheet.heatId}
+                sheet={sheet}
+                timezone={timezone}
+              />
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <section className="space-y-4">
+        <h3 className="font-semibold">Role sheets</h3>
+        <div className="grid gap-4 lg:grid-cols-2">
+          {exports.roleSheets.map((sheet) => (
+            <RoleSheetPreview
+              key={sheet.roleType}
+              sheet={sheet}
+              timezone={timezone}
+            />
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h3 className="font-semibold">Floor lead sheets</h3>
+        <div className="grid gap-4">
+          {exports.floorLeadSheets.map((sheet) => (
+            <FloorLeadSheetPreview
+              key={sheet.floorName}
+              sheet={sheet}
+              timezone={timezone}
+            />
+          ))}
+        </div>
+      </section>
+    </section>
+  )
+}
+
+function JudgeHeatSheetPreview({
+  sheet,
+  timezone,
+}: {
+  sheet: CrewPilotJudgeHeatLaneSheet
+  timezone: string
+}) {
+  return (
+    <div className="rounded-md border p-3 text-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <p className="font-medium">{sheet.label}</p>
+          <p className="text-muted-foreground">
+            {formatExportDate(sheet.startsAt, timezone)} / {sheet.venueName}
+          </p>
+        </div>
+        <StatusPill>{sheet.rows.length} lanes</StatusPill>
+      </div>
+      <div className="mt-3 grid gap-2">
+        {sheet.rows.map((row) => (
+          <div
+            key={`${sheet.heatId}:${row.laneNumber}`}
+            className="grid grid-cols-[4rem_1fr_auto] gap-2"
+          >
+            <span className="text-muted-foreground">Lane {row.laneNumber}</span>
+            <span>{row.judgeName}</span>
+            <span className="text-muted-foreground">
+              {formatCrewValue(row.confirmationStatus)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function RoleSheetPreview({
+  sheet,
+  timezone,
+}: {
+  sheet: CrewPilotRoleSheet
+  timezone: string
+}) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <h4 className="font-semibold">{sheet.roleLabel}</h4>
+        <StatusPill>{sheet.rows.length} rows</StatusPill>
+      </div>
+      <div className="mt-3 grid gap-2 text-sm">
+        {sheet.rows.slice(0, 8).map((row, index) => (
+          <div
+            key={`${row.blockId}:${row.assignmentId ?? index}`}
+            className="grid gap-1 rounded-md border p-3"
+          >
+            <div className="flex items-start justify-between gap-3">
+              <p className="font-medium">{row.volunteerName}</p>
+              <span className="text-muted-foreground">
+                {formatCrewValue(row.confirmationStatus)}
+              </span>
+            </div>
+            <p className="text-muted-foreground">
+              {row.blockLabel} / {row.location}
+            </p>
+            <p className="text-muted-foreground">
+              {formatRange(row.startsAt, row.endsAt, timezone)}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function FloorLeadSheetPreview({
+  sheet,
+  timezone,
+}: {
+  sheet: CrewPilotFloorLeadSheet
+  timezone: string
+}) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <h4 className="font-semibold">{sheet.floorName}</h4>
+        <StatusPill>
+          {sheet.rows.length} blocks / {sheet.judgeRows.length} lanes
+        </StatusPill>
+      </div>
+      <div className="mt-3 grid gap-3 lg:grid-cols-2">
+        <div className="space-y-2 text-sm">
+          {sheet.rows.slice(0, 8).map((row) => (
+            <div key={`${row.blockType}:${row.blockId}`}>
+              <p className="font-medium">{row.label}</p>
+              <p className="text-muted-foreground">
+                {formatRange(row.startsAt, row.endsAt, timezone)} / {row.role}
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-2 text-sm">
+          {sheet.judgeRows.slice(0, 8).map((row) => (
+            <div key={`${row.heatId}:${row.laneNumber}`}>
+              <p className="font-medium">
+                {row.workoutName} heat {row.heatNumber}, lane {row.laneNumber}
+              </p>
+              <p className="text-muted-foreground">{row.judgeName}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function MetricPanel({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-1 text-2xl font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function StatusPill({ children }: { children: ReactNode }) {
+  return (
+    <span className="rounded-md bg-muted px-2 py-1 text-xs font-medium text-muted-foreground">
+      {children}
+    </span>
+  )
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="rounded-md border border-dashed p-6 text-sm text-muted-foreground">
+      {message}
+    </div>
+  )
+}
+
+function formatRange(
+  startsAt: string | null,
+  endsAt: string | null,
+  timezone: string,
+) {
+  const start = formatExportDate(startsAt, timezone)
+  const end = formatExportDate(endsAt, timezone)
+  if (start && end) return `${start} - ${end}`
+  return start || end || "Unscheduled"
+}
+
+function formatExportDate(value: string | null, timezone: string) {
+  if (!value) return ""
+  const date = new Date(value)
+  return Number.isNaN(date.getTime())
+    ? ""
+    : formatDateTimeInTimezone(date, timezone)
+}
+
+function downloadCsv(filename: string, csvText: string) {
+  const blob = new Blob([csvText], { type: "text/csv;charset=utf-8" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  URL.revokeObjectURL(url)
+}

--- a/apps/crew/src/server-fns/crew-pilot-export-fns.ts
+++ b/apps/crew/src/server-fns/crew-pilot-export-fns.ts
@@ -1,0 +1,21 @@
+// @lat: [[crew#Pilot Exports]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type { CrewPilotExportsPageData } from "../server/crew-pilot-exports.server"
+
+const getCrewPilotExportsPageInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+export const getCrewPilotExportsPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    getCrewPilotExportsPageInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewPilotExportsPage } = await import(
+      "../server/crew-pilot-exports.server"
+    )
+    return getCrewPilotExportsPage(data)
+  })

--- a/apps/crew/src/server-fns/crew-staffing-fns.server.ts
+++ b/apps/crew/src/server-fns/crew-staffing-fns.server.ts
@@ -79,7 +79,7 @@ export async function getCrewStaffingReportPage(
   }
 }
 
-async function requireCrewStaffingEvent(
+export async function requireCrewStaffingEvent(
   eventId: string,
 ): Promise<CrewStaffingReportEvent> {
   const db = getDb()
@@ -108,7 +108,9 @@ async function requireCrewStaffingEvent(
   return event
 }
 
-async function loadCrewStaffingMatrixInput(event: CrewStaffingReportEvent) {
+export async function loadCrewStaffingMatrixInput(
+  event: CrewStaffingReportEvent,
+) {
   const [roster, shifts, venues, workouts, heats] = await Promise.all([
     loadCrewRoster(event.competitionTeamId),
     loadCrewShifts(event.id),

--- a/apps/crew/src/server/crew-pilot-exports.server.ts
+++ b/apps/crew/src/server/crew-pilot-exports.server.ts
@@ -1,0 +1,119 @@
+// @lat: [[crew#Pilot Exports]]
+import {
+  buildCrewPilotExports,
+  type CrewPilotExports,
+} from "../lib/crew/exports/pilot-exports"
+import {
+  loadCrewStaffingMatrixInput,
+  requireCrewStaffingEvent,
+  type CrewStaffingReportEvent,
+} from "../server-fns/crew-staffing-fns.server"
+import type {
+  CrewStaffingJudgeAssignmentInput,
+  CrewStaffingMatrixInput,
+  CrewStaffingShiftInput,
+  CrewStaffingVolunteerInput,
+} from "../lib/crew/staffing"
+
+export interface CrewPilotExportsPageData {
+  event: CrewStaffingReportEvent
+  exports: CrewPilotExports
+  sources: {
+    shifts: number
+    shiftAssignments: number
+    heats: number
+    heatLaneAssignments: number
+    judgeAssignments: number
+    activeJudgeVersions: number
+  }
+}
+
+export async function getCrewPilotExportsPage(data: {
+  eventId: string
+}): Promise<CrewPilotExportsPageData> {
+  const event = await requireCrewStaffingEvent(data.eventId)
+  const { input, activeJudgeVersions } =
+    await loadCrewStaffingMatrixInput(event)
+  const pilotExports = buildCrewPilotExports({
+    event,
+    generatedAt: new Date(),
+    venues: input.venues,
+    workouts: input.workouts,
+    heats: input.heats,
+    heatLaneAssignments: input.heatLaneAssignments,
+    shifts: toExportShifts(input),
+    judgeAssignments: toExportJudgeAssignments(input),
+  })
+
+  return {
+    event,
+    exports: pilotExports,
+    sources: {
+      shifts: input.shifts?.length ?? 0,
+      shiftAssignments:
+        input.shifts?.reduce(
+          (total, shift) => total + shift.assignments.length,
+          0,
+        ) ?? 0,
+      heats: input.heats?.length ?? 0,
+      heatLaneAssignments: pilotExports.judgeHeatLaneSheets.reduce(
+        (total, sheet) => total + sheet.rows.length,
+        0,
+      ),
+      judgeAssignments: input.judgeAssignments?.length ?? 0,
+      activeJudgeVersions,
+    },
+  }
+}
+
+function toExportShifts(input: CrewStaffingMatrixInput) {
+  const rosterByMembershipId = buildRosterByMembershipId(input.roster ?? [])
+
+  return (input.shifts ?? []).map((shift: CrewStaffingShiftInput) => ({
+    id: shift.id,
+    name: shift.name,
+    roleType: shift.roleType,
+    startTime: shift.startTime,
+    endTime: shift.endTime,
+    capacity: shift.capacity,
+    location: shift.location,
+    assignments: shift.assignments.map((assignment) => {
+      const volunteer = rosterByMembershipId.get(assignment.membershipId)
+      return {
+        id: assignment.id,
+        membershipId: assignment.membershipId,
+        volunteerName:
+          volunteer?.name || volunteer?.email || assignment.membershipId,
+        email: volunteer?.email ?? "",
+        confirmation: assignment.confirmation ?? null,
+      }
+    }),
+  }))
+}
+
+function toExportJudgeAssignments(input: CrewStaffingMatrixInput) {
+  const rosterByMembershipId = buildRosterByMembershipId(input.roster ?? [])
+
+  return (input.judgeAssignments ?? []).map(
+    (assignment: CrewStaffingJudgeAssignmentInput) => {
+      const volunteer = rosterByMembershipId.get(assignment.membershipId)
+      return {
+        id: assignment.id,
+        membershipId: assignment.membershipId,
+        volunteerName:
+          volunteer?.name || volunteer?.email || assignment.membershipId,
+        email: volunteer?.email ?? "",
+        heatId: assignment.heatId,
+        laneNumber: assignment.laneNumber,
+        position: assignment.position,
+        confirmation: assignment.confirmation ?? null,
+      }
+    },
+  )
+}
+
+function buildRosterByMembershipId(roster: CrewStaffingVolunteerInput[]) {
+  return new Map(
+    roster.map((volunteer) => [volunteer.membershipId, volunteer] as const),
+  )
+}

--- a/apps/crew/src/server/crew-pilot-exports.server.ts
+++ b/apps/crew/src/server/crew-pilot-exports.server.ts
@@ -8,6 +8,7 @@ import {
   requireCrewStaffingEvent,
   type CrewStaffingReportEvent,
 } from "../server-fns/crew-staffing-fns.server"
+import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
 import type {
   CrewStaffingJudgeAssignmentInput,
   CrewStaffingMatrixInput,
@@ -31,6 +32,8 @@ export interface CrewPilotExportsPageData {
 export async function getCrewPilotExportsPage(data: {
   eventId: string
 }): Promise<CrewPilotExportsPageData> {
+  requireLocalCrewOperatorAccess("Crew pilot exports")
+
   const event = await requireCrewStaffingEvent(data.eventId)
   const { input, activeJudgeVersions } =
     await loadCrewStaffingMatrixInput(event)

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -217,3 +217,11 @@ Crew day-of operations is a compact read-only board for current blocks, response
 [[apps/crew/src/lib/crew/day-of-operations.ts]] derives current and next blocks, critical unfilled roles, due-soon no-responses, decision queues, no-show/replaced queues, time-block status, and judge coverage.
 
 The board does not add schema, exports, queue bindings, live email sends, public token changes, assignment automation, or published judge-row mutation. Checked-in remains unavailable until a dedicated primitive exists.
+
+## Pilot Exports
+
+Crew pilot exports turn the active event staffing and judge assignment data into operator-ready packets without creating report-builder schema or mutating published assignments.
+
+[[apps/crew/src/routes/events/$eventId/exports.tsx]] renders the per-event export surface. [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]] keeps the route import light while [[apps/crew/src/server/crew-pilot-exports.server.ts]] reuses server-only staffing hydration and active judge assignment data.
+
+[[apps/crew/src/lib/crew/exports/pilot-exports.ts]] owns deterministic export derivation for master schedule CSV rows, role sheets, judge heat/lane sheets, no-response and decline lists, and printable floor lead sheets. Exports are read-only and must not send reminders, create queues, alter confirmation tokens, or mutate versioned judge assignment rows.


### PR DESCRIPTION
## Summary
- add a Crew pilot exports page at `/events/$eventId/exports` with master schedule CSV, response CSV, role sheets, judge heat/lane sheets, and floor lead previews
- add deterministic pure export builders under `apps/crew/src/lib/crew/exports` with focused tests
- reuse server-only staffing hydration and active published judge assignment data through a thin route-safe server-function wrapper
- add `crew#Pilot Exports` LAT coverage and event nav wiring

## Validation
- `pnpm --filter crew exec vitest run src/lib/crew/exports/pilot-exports.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0 with existing unrelated warnings)
- `pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Pilot Exports'`\n- `git diff --check`\n\n## Notes\n- No schema, migration, queue, email sending, public token, infra, or judge-row mutation changes.\n- Build used the established ignored local Crew config copy at `apps/crew/.alchemy/local/wrangler.jsonc`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Crew pilot exports at `/events/$eventId/exports` with master/response CSV downloads and full printable sheets, built from active staffing and judge assignments without mutating data. Access is limited to local crew operators.

- **New Features**
  - Route and nav: `/events/$eventId/exports` with master/response CSV downloads and print.
  - Deterministic builders with focused tests; require `generatedAt`, sort inputs, and neutralize formula-leading CSV cells.
  - Master schedule and responses CSVs; role sheets; judge heat/lane sheets; floor lead previews and full print sheets.
  - Server uses `requireLocalCrewOperatorAccess` and reuses staffing hydration and active judge assignment data via a route-safe server function wrapper.

<sup>Written for commit 578d337fa9fccd0e83f3a56acc47dbe9e168b16a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pilot exports feature for events with a dedicated exports page.
  * Download master schedule and response CSVs from the exports interface.
  * View summary metrics, master schedule, role sheets, judge heat lane assignments, response tracking, and floor lead sheets.
  * Print-optimized view available for exporting data.

* **Documentation**
  * Added pilot exports workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->