### PR TITLE
feat(crew): add guided setup state

### DIFF
--- a/apps/crew/src/components/crew-guided-setup/guided-setup-shell.tsx
+++ b/apps/crew/src/components/crew-guided-setup/guided-setup-shell.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 // @lat: [[crew#Guided Setup State]]
 import { Link } from "@tanstack/react-router"
 import {
@@ -132,8 +134,17 @@ export function GuidedSetupShell({
           </div>
 
           <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
-            {activeStep.details.map((detail) => (
-              <li key={detail}>{detail}</li>
+            {activeStep.details.map((detail, detailIndex) => (
+              <li
+                key={getDetailKey(
+                  activeStep.key,
+                  activeStep.details,
+                  detail,
+                  detailIndex,
+                )}
+              >
+                {detail}
+              </li>
             ))}
           </ul>
 
@@ -269,6 +280,19 @@ function ProgressBar({ value }: { value: number }) {
       />
     </div>
   )
+}
+
+function getDetailKey(
+  stepKey: CrewGuidedSetupStepKey,
+  details: string[],
+  detail: string,
+  detailIndex: number,
+) {
+  const duplicateOrdinal = details
+    .slice(0, detailIndex)
+    .filter((candidate) => candidate === detail).length
+
+  return `${stepKey}:${detail}:${duplicateOrdinal}`
 }
 
 function statusBadgeClass(status: CrewGuidedSetupStatus) {

--- a/apps/crew/src/components/crew-guided-setup/guided-setup-shell.tsx
+++ b/apps/crew/src/components/crew-guided-setup/guided-setup-shell.tsx
@@ -1,0 +1,292 @@
+// @lat: [[crew#Guided Setup State]]
+import { Link } from "@tanstack/react-router"
+import {
+  AlertCircle,
+  CheckCircle2,
+  Circle,
+  CircleDot,
+  Save,
+} from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import {
+  crewGuidedSetupStatusLabels,
+  type CrewGuidedSetupOperatorStatus,
+  type CrewGuidedSetupState,
+  type CrewGuidedSetupStatus,
+  type CrewGuidedSetupStep,
+  type CrewGuidedSetupStepKey,
+} from "@/lib/crew/guided-setup"
+
+type StatusControlValue = CrewGuidedSetupOperatorStatus | "system"
+
+interface GuidedSetupShellProps {
+  eventId: string
+  guidedSetup: CrewGuidedSetupState
+  onUpdate: (input: {
+    stepKey: CrewGuidedSetupStepKey
+    status: CrewGuidedSetupOperatorStatus | null
+    note: string
+  }) => Promise<void>
+}
+
+const statusOptions: Array<{
+  value: StatusControlValue
+  label: string
+}> = [
+  { value: "system", label: "Use source state" },
+  { value: "not_started", label: "Not started" },
+  { value: "in_progress", label: "In progress" },
+  { value: "blocked", label: "Blocked" },
+  { value: "complete", label: "Complete" },
+]
+
+export function GuidedSetupShell({
+  eventId,
+  guidedSetup,
+  onUpdate,
+}: GuidedSetupShellProps) {
+  const [activeStepKey, setActiveStepKey] = useState<CrewGuidedSetupStepKey>(
+    guidedSetup.activeStep,
+  )
+  const activeStep = useMemo(
+    () =>
+      guidedSetup.steps.find((step) => step.key === activeStepKey) ??
+      guidedSetup.steps[0],
+    [activeStepKey, guidedSetup.steps],
+  )
+  const [status, setStatus] = useState<StatusControlValue>(
+    activeStep.operatorStatus ?? "system",
+  )
+  const [note, setNote] = useState(activeStep.note)
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    setActiveStepKey(guidedSetup.activeStep)
+  }, [guidedSetup.activeStep])
+
+  useEffect(() => {
+    setStatus(activeStep.operatorStatus ?? "system")
+    setNote(activeStep.note)
+  }, [activeStep])
+
+  async function handleSave() {
+    setIsSaving(true)
+    try {
+      await onUpdate({
+        stepKey: activeStep.key,
+        status: status === "system" ? null : status,
+        note,
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Guided setup</h2>
+          <p className="text-sm text-muted-foreground">
+            {guidedSetup.summary.complete}/{guidedSetup.summary.total} steps
+            complete
+          </p>
+        </div>
+        <StatusBadge status={guidedSetup.summary.highestStatus} />
+      </div>
+
+      <div className="mt-5">
+        <div className="flex items-center justify-between gap-4 text-sm">
+          <span className="font-medium">Progress</span>
+          <span className="text-muted-foreground">
+            {guidedSetup.summary.progressPercent}%
+          </span>
+        </div>
+        <ProgressBar value={guidedSetup.summary.progressPercent} />
+      </div>
+
+      <div className="mt-5 grid gap-5 lg:grid-cols-[18rem_1fr]">
+        <div className="grid gap-2">
+          {guidedSetup.steps.map((step) => (
+            <StepButton
+              key={step.key}
+              step={step}
+              active={step.key === activeStep.key}
+              onClick={() => setActiveStepKey(step.key)}
+            />
+          ))}
+        </div>
+
+        <section className="rounded-md border bg-background p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <StatusIcon status={activeStep.status} />
+                <h3 className="font-semibold">{activeStep.label}</h3>
+              </div>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {activeStep.summary}
+              </p>
+            </div>
+            <StatusBadge status={activeStep.status} compact />
+          </div>
+
+          <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+            {activeStep.details.map((detail) => (
+              <li key={detail}>{detail}</li>
+            ))}
+          </ul>
+
+          <div className="mt-5 grid gap-4 md:grid-cols-[minmax(12rem,16rem)_1fr]">
+            <label className="space-y-2">
+              <span className="text-sm font-medium">Operator state</span>
+              <select
+                value={status}
+                onChange={(event) =>
+                  setStatus(event.target.value as StatusControlValue)
+                }
+                className="h-10 w-full rounded-md border bg-card px-3 text-sm"
+              >
+                {statusOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="space-y-2">
+              <span className="text-sm font-medium">Note</span>
+              <input
+                value={note}
+                maxLength={2000}
+                onChange={(event) => setNote(event.target.value)}
+                className="h-10 w-full rounded-md border bg-card px-3 text-sm"
+              />
+            </label>
+          </div>
+
+          <div className="mt-5 flex flex-wrap gap-2">
+            <button
+              type="button"
+              disabled={isSaving}
+              onClick={handleSave}
+              className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+            >
+              <Save className="size-4" aria-hidden="true" />
+              {isSaving ? "Saving..." : "Save step"}
+            </button>
+            <Link
+              to={activeStep.action.to}
+              params={{ eventId }}
+              className="inline-flex h-10 items-center rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              {activeStep.action.label}
+            </Link>
+          </div>
+
+          {activeStep.operatorStatus &&
+          activeStep.systemStatus === "blocked" ? (
+            <p className="mt-4 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-800">
+              Source data is still blocking this step.
+            </p>
+          ) : null}
+        </section>
+      </div>
+    </section>
+  )
+}
+
+function StepButton({
+  step,
+  active,
+  onClick,
+}: {
+  step: CrewGuidedSetupStep
+  active: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      className={`flex min-h-14 items-center justify-between gap-3 rounded-md border px-3 py-2 text-left text-sm hover:bg-muted ${
+        active ? "bg-muted text-foreground" : "text-muted-foreground"
+      }`}
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <StatusIcon status={step.status} />
+        <span className="truncate font-medium">{step.label}</span>
+      </span>
+      <span className="shrink-0 text-xs">
+        {crewGuidedSetupStatusLabels[step.status]}
+      </span>
+    </button>
+  )
+}
+
+function StatusBadge({
+  status,
+  compact = false,
+}: {
+  status: CrewGuidedSetupStatus
+  compact?: boolean
+}) {
+  return (
+    <span
+      className={`inline-flex shrink-0 rounded-md border px-2 py-1 text-xs font-medium ${statusBadgeClass(status)} ${compact ? "" : "self-start"}`}
+    >
+      {crewGuidedSetupStatusLabels[status]}
+    </span>
+  )
+}
+
+function StatusIcon({ status }: { status: CrewGuidedSetupStatus }) {
+  const Icon =
+    status === "complete"
+      ? CheckCircle2
+      : status === "blocked"
+        ? AlertCircle
+        : status === "in_progress"
+          ? CircleDot
+          : Circle
+
+  return (
+    <Icon
+      className={`size-4 shrink-0 ${statusIconClass(status)}`}
+      aria-hidden="true"
+    />
+  )
+}
+
+function ProgressBar({ value }: { value: number }) {
+  return (
+    <div className="mt-2 h-2 overflow-hidden rounded-full bg-muted">
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  )
+}
+
+function statusBadgeClass(status: CrewGuidedSetupStatus) {
+  if (status === "complete") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "blocked") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  if (status === "in_progress") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+  }
+  return "border-muted-foreground/30 bg-muted text-muted-foreground"
+}
+
+function statusIconClass(status: CrewGuidedSetupStatus) {
+  if (status === "complete") return "text-emerald-600"
+  if (status === "blocked") return "text-destructive"
+  if (status === "in_progress") return "text-amber-600"
+  return "text-muted-foreground"
+}

--- a/apps/crew/src/lib/crew/guided-setup.test.ts
+++ b/apps/crew/src/lib/crew/guided-setup.test.ts
@@ -96,6 +96,43 @@ describe("Crew guided setup state", () => {
     expect(guidedSetup.summary.highestStatus).toBe("blocked")
   })
 
+  it("keeps days and floors blocked when venue rows have no lane capacity", () => {
+    const guidedSetup = buildCrewGuidedSetupState({
+      event: readyEvent,
+      setup: readySetup,
+      facts: {
+        ...readyFacts,
+        venues: { venueCount: 1, totalLaneCount: 0 },
+      },
+      readiness: readyReadiness,
+      persisted: {
+        activeStep: "days_floors",
+        steps: {
+          days_floors: {
+            status: "complete",
+            note: "Floor walkthrough is done.",
+            updatedAt: "2026-06-20T18:00:00.000Z",
+          },
+        },
+      },
+    })
+
+    expect(
+      guidedSetup.steps.find((step) => step.key === "days_floors"),
+    ).toMatchObject({
+      status: "blocked",
+      systemStatus: "blocked",
+      operatorStatus: "complete",
+      summary: "1 venue, 0 lanes",
+      note: "Floor walkthrough is done.",
+    })
+    expect(guidedSetup.summary).toMatchObject({
+      complete: 7,
+      blocked: 1,
+      highestStatus: "blocked",
+    })
+  })
+
   it("updates and serializes guided step progress without replacing setup settings", () => {
     const persisted = updateCrewGuidedSetupStepState(emptyPersisted, {
       stepKey: "imports",

--- a/apps/crew/src/lib/crew/guided-setup.test.ts
+++ b/apps/crew/src/lib/crew/guided-setup.test.ts
@@ -1,0 +1,237 @@
+// @lat: [[crew#Guided Setup State]]
+import { describe, expect, it } from "vitest"
+import type { CrewSetupState } from "../crew-event-setup"
+import type { CrewReadinessChecklist } from "./readiness"
+import {
+  buildCrewGuidedSetupState,
+  parseCrewGuidedSetupSettings,
+  serializeCrewGuidedSetupSettings,
+  updateCrewGuidedSetupStepState,
+  type CrewGuidedSetupFacts,
+  type CrewGuidedSetupPersistedState,
+} from "./guided-setup"
+
+describe("Crew guided setup state", () => {
+  it("derives complete self-serve steps from ready event facts", () => {
+    const guidedSetup = buildCrewGuidedSetupState({
+      event: readyEvent,
+      setup: readySetup,
+      facts: readyFacts,
+      readiness: readyReadiness,
+      persisted: emptyPersisted,
+    })
+
+    expect(guidedSetup.summary).toMatchObject({
+      total: 8,
+      complete: 8,
+      blocked: 0,
+      inProgress: 0,
+      notStarted: 0,
+      progressPercent: 100,
+      highestStatus: "complete",
+    })
+    expect(guidedSetup.steps.map((step) => step.key)).toEqual([
+      "event_basics",
+      "days_floors",
+      "imports",
+      "roles",
+      "staffing_assumptions",
+      "schedule_publish",
+      "reminders",
+      "exports",
+    ])
+  })
+
+  it("keeps source-derived blockers blocked even when an operator marks complete", () => {
+    const guidedSetup = buildCrewGuidedSetupState({
+      event: { startDate: "", endDate: "", timezone: null },
+      setup: readySetup,
+      facts: {
+        ...readyFacts,
+        venues: { venueCount: 0, totalLaneCount: 0 },
+        roster: {
+          total: 0,
+          pending: 0,
+          accepted: 0,
+          active: 0,
+          inactive: 0,
+          expired: 0,
+          assignable: 0,
+        },
+        shifts: {
+          ...readyFacts.shifts,
+          assignedSlots: 0,
+        },
+      },
+      readiness: {
+        items: [],
+        summary: {
+          total: 7,
+          ready: 2,
+          needsAttention: 1,
+          blocked: 4,
+          progressPercent: 29,
+          highestStatus: "blocked",
+        },
+      },
+      persisted: {
+        activeStep: "event_basics",
+        steps: {
+          event_basics: {
+            status: "complete",
+            note: "Confirmed elsewhere.",
+            updatedAt: "2026-06-20T17:00:00.000Z",
+          },
+        },
+      },
+    })
+
+    expect(guidedSetup.steps[0]).toMatchObject({
+      key: "event_basics",
+      status: "blocked",
+      systemStatus: "blocked",
+      operatorStatus: "complete",
+      note: "Confirmed elsewhere.",
+    })
+    expect(guidedSetup.summary.highestStatus).toBe("blocked")
+  })
+
+  it("updates and serializes guided step progress without replacing setup settings", () => {
+    const persisted = updateCrewGuidedSetupStepState(emptyPersisted, {
+      stepKey: "imports",
+      status: "in_progress",
+      note: "Awaiting heat CSV.",
+      updatedAt: "2026-06-20T17:30:00.000Z",
+    })
+    const settingsText = serializeCrewGuidedSetupSettings(
+      JSON.stringify({
+        setup: {
+          staffingLead: "Sam",
+          checklist: { staffingPlanDrafted: true },
+        },
+        arbitrary: { keep: true },
+      }),
+      persisted,
+    )
+    const parsed = JSON.parse(settingsText)
+
+    expect(parsed.setup.staffingLead).toBe("Sam")
+    expect(parsed.arbitrary.keep).toBe(true)
+    expect(parsed.guidedSetup).toMatchObject({
+      activeStep: "imports",
+      steps: {
+        imports: {
+          status: "in_progress",
+          note: "Awaiting heat CSV.",
+          updatedAt: "2026-06-20T17:30:00.000Z",
+        },
+      },
+    })
+    expect(parseCrewGuidedSetupSettings(settingsText)).toMatchObject(persisted)
+  })
+})
+
+const emptyPersisted: CrewGuidedSetupPersistedState = {
+  activeStep: null,
+  steps: {},
+}
+
+const readyEvent = {
+  startDate: "2026-08-14",
+  endDate: "2026-08-15",
+  timezone: "America/Denver",
+}
+
+const readySetup: CrewSetupState = {
+  desiredGoLiveDate: "2026-08-01",
+  sourceContactName: "Taylor",
+  sourceContactEmail: "taylor@example.com",
+  volunteerTarget: "32",
+  staffingLead: "Sam",
+  checklist: {
+    eventBasicsConfirmed: true,
+    sourceAccessConfirmed: true,
+    volunteerNeedsDrafted: true,
+    staffingPlanDrafted: true,
+    operatorHandoffReady: true,
+  },
+  internalNotes: "Use the east entrance.",
+  assumptions: "Two floors, one floater per lane.",
+}
+
+const readyFacts: CrewGuidedSetupFacts = {
+  setup: {
+    completed: 5,
+    total: 5,
+  },
+  venues: {
+    venueCount: 2,
+    totalLaneCount: 12,
+  },
+  schedule: {
+    workoutCount: 4,
+    publishedWorkoutCount: 4,
+    heatCount: 24,
+    scheduledHeatCount: 24,
+    publishedHeatCount: 24,
+  },
+  imports: {
+    volunteerImportCount: 1,
+    appliedVolunteerImportCount: 1,
+    heatScheduleImportCount: 1,
+    appliedHeatScheduleImportCount: 1,
+  },
+  roster: {
+    total: 18,
+    pending: 2,
+    accepted: 0,
+    active: 16,
+    inactive: 0,
+    expired: 0,
+    assignable: 16,
+  },
+  shifts: {
+    totalShifts: 8,
+    assignedSlots: 12,
+    capacity: 12,
+    openSlots: 0,
+    confirmationSummary: {
+      pending: 0,
+      confirmed: 12,
+      declined: 0,
+      changeRequested: 0,
+      noShow: 0,
+      cancelled: 0,
+    },
+    confirmationOperationalSummary: {
+      missing: 0,
+      pending: 0,
+      sent: 0,
+      confirmed: 12,
+      declined: 0,
+      changeRequested: 0,
+      noShow: 0,
+      replaced: 0,
+      total: 12,
+      responseNeeded: 0,
+      organizerActionNeeded: 0,
+    },
+  },
+  judge: {
+    rotationCount: 4,
+    assignmentCount: 36,
+    activeVersionCount: 1,
+  },
+}
+
+const readyReadiness: CrewReadinessChecklist = {
+  items: [],
+  summary: {
+    total: 7,
+    ready: 7,
+    needsAttention: 0,
+    blocked: 0,
+    progressPercent: 100,
+    highestStatus: "ready",
+  },
+}

--- a/apps/crew/src/lib/crew/guided-setup.ts
+++ b/apps/crew/src/lib/crew/guided-setup.ts
@@ -249,11 +249,9 @@ function buildDaysFloorsStep(
 ): CrewGuidedSetupStep {
   const { venues } = input.facts
   const status =
-    venues.venueCount === 0
+    venues.venueCount === 0 || venues.totalLaneCount === 0
       ? "blocked"
-      : venues.totalLaneCount > 0
-        ? "complete"
-        : "in_progress"
+      : "complete"
 
   return createBaseStep({
     key: "days_floors",

--- a/apps/crew/src/lib/crew/guided-setup.ts
+++ b/apps/crew/src/lib/crew/guided-setup.ts
@@ -1,0 +1,585 @@
+// @lat: [[crew#Guided Setup State]]
+import { parseCrewSettings, type CrewSetupState } from "../crew-event-setup"
+import type {
+  CrewReadinessChecklist,
+  CrewReadinessEventInput,
+  CrewReadinessImportInput,
+  CrewReadinessJudgeInput,
+  CrewReadinessScheduleInput,
+  CrewReadinessSetupInput,
+  CrewReadinessShiftInput,
+  CrewReadinessSummary,
+  CrewReadinessVenueInput,
+} from "./readiness"
+import type { CrewRosterSummary } from "./roster-shifts"
+
+export const crewGuidedSetupStepKeys = [
+  "event_basics",
+  "days_floors",
+  "imports",
+  "roles",
+  "staffing_assumptions",
+  "schedule_publish",
+  "reminders",
+  "exports",
+] as const
+
+export type CrewGuidedSetupStepKey = (typeof crewGuidedSetupStepKeys)[number]
+
+export type CrewGuidedSetupStatus =
+  | "not_started"
+  | "in_progress"
+  | "blocked"
+  | "complete"
+
+export type CrewGuidedSetupOperatorStatus = CrewGuidedSetupStatus
+
+export type CrewGuidedSetupActionTo =
+  | "/events/$eventId/setup"
+  | "/events/$eventId/schedule"
+  | "/events/$eventId/imports"
+  | "/events/$eventId/volunteers"
+  | "/events/$eventId/staffing"
+  | "/events/$eventId/shifts"
+  | "/events/$eventId/readiness"
+  | "/events/$eventId/exports"
+
+export interface CrewGuidedSetupPersistedStep {
+  status?: CrewGuidedSetupOperatorStatus
+  note: string
+  updatedAt: string | null
+}
+
+export interface CrewGuidedSetupPersistedState {
+  activeStep: CrewGuidedSetupStepKey | null
+  steps: Partial<Record<CrewGuidedSetupStepKey, CrewGuidedSetupPersistedStep>>
+}
+
+export interface CrewGuidedSetupStep {
+  key: CrewGuidedSetupStepKey
+  label: string
+  summary: string
+  details: string[]
+  action: {
+    label: string
+    to: CrewGuidedSetupActionTo
+  }
+  status: CrewGuidedSetupStatus
+  systemStatus: CrewGuidedSetupStatus
+  operatorStatus: CrewGuidedSetupOperatorStatus | null
+  note: string
+  updatedAt: string | null
+}
+
+export interface CrewGuidedSetupSummary {
+  total: number
+  complete: number
+  inProgress: number
+  blocked: number
+  notStarted: number
+  progressPercent: number
+  highestStatus: CrewGuidedSetupStatus
+}
+
+export interface CrewGuidedSetupState {
+  activeStep: CrewGuidedSetupStepKey
+  steps: CrewGuidedSetupStep[]
+  summary: CrewGuidedSetupSummary
+}
+
+export interface CrewGuidedSetupFacts {
+  setup: CrewReadinessSetupInput
+  venues: CrewReadinessVenueInput
+  schedule: CrewReadinessScheduleInput
+  imports: CrewReadinessImportInput
+  roster: CrewRosterSummary
+  shifts: CrewReadinessShiftInput
+  judge: CrewReadinessJudgeInput
+}
+
+export interface BuildCrewGuidedSetupInput {
+  event: CrewReadinessEventInput
+  setup: CrewSetupState
+  facts: CrewGuidedSetupFacts
+  readiness: CrewReadinessChecklist
+  persisted: CrewGuidedSetupPersistedState
+}
+
+export interface UpdateCrewGuidedSetupStepInput {
+  stepKey: CrewGuidedSetupStepKey
+  status: CrewGuidedSetupOperatorStatus | null
+  note?: string
+  updatedAt: string
+}
+
+export const crewGuidedSetupStatusLabels: Record<
+  CrewGuidedSetupStatus,
+  string
+> = {
+  not_started: "Not started",
+  in_progress: "In progress",
+  blocked: "Blocked",
+  complete: "Complete",
+}
+
+const defaultGuidedSetupState: CrewGuidedSetupPersistedState = {
+  activeStep: null,
+  steps: {},
+}
+
+export function parseCrewGuidedSetupSettings(
+  settingsText: string | null,
+): CrewGuidedSetupPersistedState {
+  const parsed = parseCrewSettings(settingsText)
+  return readPersistedGuidedSetup(parsed.baseSettings.guidedSetup)
+}
+
+export function serializeCrewGuidedSetupSettings(
+  settingsText: string | null,
+  guidedSetup: CrewGuidedSetupPersistedState,
+) {
+  const parsed = parseCrewSettings(settingsText)
+
+  return JSON.stringify(
+    {
+      ...parsed.baseSettings,
+      guidedSetup: normalizePersistedGuidedSetup(guidedSetup),
+    },
+    null,
+    2,
+  )
+}
+
+export function updateCrewGuidedSetupStepState(
+  state: CrewGuidedSetupPersistedState,
+  input: UpdateCrewGuidedSetupStepInput,
+): CrewGuidedSetupPersistedState {
+  const steps = { ...state.steps }
+  const current = steps[input.stepKey] ?? {
+    note: "",
+    updatedAt: null,
+  }
+  const nextStep: CrewGuidedSetupPersistedStep = {
+    ...current,
+    note: input.note !== undefined ? input.note.trim() : current.note,
+    updatedAt: input.updatedAt,
+  }
+
+  if (input.status === null) {
+    delete nextStep.status
+  } else {
+    nextStep.status = input.status
+  }
+
+  if (!nextStep.status && !nextStep.note) {
+    delete steps[input.stepKey]
+  } else {
+    steps[input.stepKey] = nextStep
+  }
+
+  return {
+    activeStep: input.stepKey,
+    steps,
+  }
+}
+
+export function buildCrewGuidedSetupState(
+  input: BuildCrewGuidedSetupInput,
+): CrewGuidedSetupState {
+  const steps = [
+    buildEventBasicsStep(input),
+    buildDaysFloorsStep(input),
+    buildImportsStep(input),
+    buildRolesStep(input),
+    buildStaffingAssumptionsStep(input),
+    buildSchedulePublishStep(input),
+    buildRemindersStep(input),
+    buildExportsStep(input),
+  ].map((step) => applyPersistedStep(step, input.persisted.steps[step.key]))
+
+  const firstOpenStep =
+    steps.find((step) => step.status !== "complete")?.key ?? steps[0].key
+  const activeStep =
+    input.persisted.activeStep &&
+    crewGuidedSetupStepKeys.includes(input.persisted.activeStep)
+      ? input.persisted.activeStep
+      : firstOpenStep
+
+  return {
+    activeStep,
+    steps,
+    summary: summarizeGuidedSetupSteps(steps),
+  }
+}
+
+function buildEventBasicsStep(
+  input: BuildCrewGuidedSetupInput,
+): CrewGuidedSetupStep {
+  const hasDates = Boolean(input.event.startDate && input.event.endDate)
+  const hasTimezone = Boolean(input.event.timezone)
+  const eventBasicsConfirmed =
+    input.setup.checklist.eventBasicsConfirmed === true
+  const status = !hasDates
+    ? "blocked"
+    : hasTimezone && eventBasicsConfirmed
+      ? "complete"
+      : "in_progress"
+
+  return createBaseStep({
+    key: "event_basics",
+    label: "Event basics",
+    status,
+    summary: hasDates
+      ? `${input.event.startDate} to ${input.event.endDate}`
+      : "Event dates are missing.",
+    details: [
+      hasTimezone
+        ? `Timezone: ${input.event.timezone}`
+        : "Timezone is not set.",
+      eventBasicsConfirmed
+        ? "Operator basics check is complete."
+        : "Confirm dates, timezone, source contact, and Crew-only plan.",
+    ],
+    action: { label: "Edit setup", to: "/events/$eventId/setup" },
+  })
+}
+
+function buildDaysFloorsStep(
+  input: BuildCrewGuidedSetupInput,
+): CrewGuidedSetupStep {
+  const { venues } = input.facts
+  const status =
+    venues.venueCount === 0
+      ? "blocked"
+      : venues.totalLaneCount > 0
+        ? "complete"
+        : "in_progress"
+
+  return createBaseStep({
+    key: "days_floors",
+    label: "Days and floors",
+    status,
+    summary:
+      venues.venueCount > 0
+        ? `${venues.venueCount} venue${plural(venues.venueCount)}, ${venues.totalLaneCount} lane${plural(venues.totalLaneCount)}`
+        : "No venues or floors are configured.",
+    details: [
+      venues.totalLaneCount > 0
+        ? "Floor and lane counts are available for shift planning."
+        : "Add floors or venue lane counts before staffing the event.",
+    ],
+    action: { label: "Open schedule", to: "/events/$eventId/schedule" },
+  })
+}
+
+function buildImportsStep(
+  input: BuildCrewGuidedSetupInput,
+): CrewGuidedSetupStep {
+  const { imports, roster, schedule } = input.facts
+  const hasVolunteerSource =
+    roster.total > 0 || imports.appliedVolunteerImportCount > 0
+  const hasScheduleSource =
+    schedule.heatCount > 0 || imports.appliedHeatScheduleImportCount > 0
+  const totalImports =
+    imports.volunteerImportCount + imports.heatScheduleImportCount
+  const appliedImports =
+    imports.appliedVolunteerImportCount + imports.appliedHeatScheduleImportCount
+  const status =
+    hasVolunteerSource && hasScheduleSource
+      ? "complete"
+      : totalImports === 0 && roster.total === 0 && schedule.heatCount === 0
+        ? "not_started"
+        : "in_progress"
+
+  return createBaseStep({
+    key: "imports",
+    label: "Imports",
+    status,
+    summary: `${appliedImports}/${totalImports} imports applied`,
+    details: [
+      `${imports.appliedVolunteerImportCount}/${imports.volunteerImportCount} volunteer imports applied.`,
+      `${imports.appliedHeatScheduleImportCount}/${imports.heatScheduleImportCount} heat schedule imports applied.`,
+      `${roster.total} volunteer${plural(roster.total)} and ${schedule.heatCount} heat${plural(schedule.heatCount)} available after import or manual setup.`,
+    ],
+    action: { label: "Review imports", to: "/events/$eventId/imports" },
+  })
+}
+
+function buildRolesStep(input: BuildCrewGuidedSetupInput): CrewGuidedSetupStep {
+  const { roster, shifts } = input.facts
+  const status =
+    roster.total === 0
+      ? "blocked"
+      : roster.assignable > 0 && shifts.totalShifts > 0
+        ? "complete"
+        : "in_progress"
+
+  return createBaseStep({
+    key: "roles",
+    label: "Roles",
+    status,
+    summary: `${roster.assignable}/${roster.total} assignable volunteers, ${shifts.totalShifts} shift${plural(shifts.totalShifts)}`,
+    details: [
+      `${roster.active} active, ${roster.pending} pending, ${roster.accepted} accepted.`,
+      shifts.totalShifts > 0
+        ? "Role shifts exist for staffing."
+        : "Create shifts for the roles this event needs.",
+    ],
+    action: { label: "Open staffing", to: "/events/$eventId/staffing" },
+  })
+}
+
+function buildStaffingAssumptionsStep(
+  input: BuildCrewGuidedSetupInput,
+): CrewGuidedSetupStep {
+  const hasAssumptions = input.setup.assumptions.trim().length > 0
+  const hasOwnerOrTarget = Boolean(
+    input.setup.staffingLead.trim() || input.setup.volunteerTarget.trim(),
+  )
+  const hasChecklist = input.setup.checklist.staffingPlanDrafted === true
+  const status =
+    hasAssumptions && hasOwnerOrTarget && hasChecklist
+      ? "complete"
+      : hasAssumptions || hasOwnerOrTarget || hasChecklist
+        ? "in_progress"
+        : "not_started"
+
+  return createBaseStep({
+    key: "staffing_assumptions",
+    label: "Staffing assumptions",
+    status,
+    summary: hasOwnerOrTarget
+      ? "Staffing owner or volunteer target recorded."
+      : "No staffing owner or target is recorded.",
+    details: [
+      hasAssumptions
+        ? "Assumptions are recorded for handoff."
+        : "Record staffing assumptions before template or role decisions.",
+      hasChecklist
+        ? "Operator staffing plan check is complete."
+        : "Mark the staffing plan check when the assumptions are usable.",
+    ],
+    action: { label: "Edit setup", to: "/events/$eventId/setup" },
+  })
+}
+
+function buildSchedulePublishStep(
+  input: BuildCrewGuidedSetupInput,
+): CrewGuidedSetupStep {
+  const { schedule } = input.facts
+  const hasCoreSchedule = schedule.workoutCount > 0 && schedule.heatCount > 0
+  const allPublished =
+    hasCoreSchedule &&
+    schedule.publishedWorkoutCount === schedule.workoutCount &&
+    schedule.scheduledHeatCount === schedule.heatCount &&
+    schedule.publishedHeatCount === schedule.heatCount
+  const status = !hasCoreSchedule
+    ? "blocked"
+    : allPublished
+      ? "complete"
+      : "in_progress"
+
+  return createBaseStep({
+    key: "schedule_publish",
+    label: "Schedule publish",
+    status,
+    summary: `${schedule.publishedWorkoutCount}/${schedule.workoutCount} workouts, ${schedule.publishedHeatCount}/${schedule.heatCount} heat schedules published`,
+    details: [
+      `${schedule.scheduledHeatCount}/${schedule.heatCount} heats scheduled.`,
+      `${schedule.publishedHeatCount}/${schedule.heatCount} heat schedules published.`,
+    ],
+    action: { label: "Open schedule", to: "/events/$eventId/schedule" },
+  })
+}
+
+function buildRemindersStep(
+  input: BuildCrewGuidedSetupInput,
+): CrewGuidedSetupStep {
+  const { shifts } = input.facts
+  const operational = shifts.confirmationOperationalSummary
+  const confirmations = shifts.confirmationSummary
+  const notSent = operational.missing + operational.pending
+  const responseIssues =
+    notSent +
+    operational.sent +
+    confirmations.declined +
+    confirmations.changeRequested +
+    confirmations.noShow +
+    operational.replaced
+  const status =
+    shifts.assignedSlots === 0
+      ? "blocked"
+      : responseIssues === 0
+        ? "complete"
+        : "in_progress"
+
+  return createBaseStep({
+    key: "reminders",
+    label: "Reminders",
+    status,
+    summary: `${confirmations.confirmed}/${shifts.assignedSlots} assignments confirmed`,
+    details: [
+      `${notSent} assignment${plural(notSent)} not sent.`,
+      `${operational.sent} sent confirmation${plural(operational.sent)} awaiting response.`,
+      `${confirmations.declined + confirmations.changeRequested + confirmations.noShow} response issue${plural(confirmations.declined + confirmations.changeRequested + confirmations.noShow)}.`,
+    ],
+    action: { label: "Review shifts", to: "/events/$eventId/shifts" },
+  })
+}
+
+function buildExportsStep(
+  input: BuildCrewGuidedSetupInput,
+): CrewGuidedSetupStep {
+  const readinessSummary = input.readiness.summary
+  const status = mapReadinessSummaryToSetupStatus(readinessSummary)
+
+  return createBaseStep({
+    key: "exports",
+    label: "Exports",
+    status,
+    summary: `${readinessSummary.ready}/${readinessSummary.total} readiness checks ready`,
+    details: [
+      `${readinessSummary.blocked} blocked readiness check${plural(readinessSummary.blocked)}.`,
+      `${readinessSummary.needsAttention} readiness check${plural(readinessSummary.needsAttention)} needs attention.`,
+      `${input.facts.judge.activeVersionCount} active judge assignment version${plural(input.facts.judge.activeVersionCount)}.`,
+    ],
+    action: { label: "Open exports", to: "/events/$eventId/exports" },
+  })
+}
+
+function createBaseStep(
+  step: Pick<
+    CrewGuidedSetupStep,
+    "key" | "label" | "summary" | "details" | "action" | "status"
+  >,
+): CrewGuidedSetupStep {
+  return {
+    ...step,
+    systemStatus: step.status,
+    operatorStatus: null,
+    note: "",
+    updatedAt: null,
+  }
+}
+
+function applyPersistedStep(
+  step: CrewGuidedSetupStep,
+  persisted: CrewGuidedSetupPersistedStep | undefined,
+): CrewGuidedSetupStep {
+  if (!persisted) return step
+
+  const operatorStatus = persisted.status ?? null
+  return {
+    ...step,
+    status:
+      step.systemStatus === "blocked"
+        ? "blocked"
+        : (operatorStatus ?? step.systemStatus),
+    operatorStatus,
+    note: persisted.note,
+    updatedAt: persisted.updatedAt,
+  }
+}
+
+function summarizeGuidedSetupSteps(
+  steps: CrewGuidedSetupStep[],
+): CrewGuidedSetupSummary {
+  const complete = steps.filter((step) => step.status === "complete").length
+  const inProgress = steps.filter(
+    (step) => step.status === "in_progress",
+  ).length
+  const blocked = steps.filter((step) => step.status === "blocked").length
+  const notStarted = steps.filter(
+    (step) => step.status === "not_started",
+  ).length
+  const total = steps.length
+
+  return {
+    total,
+    complete,
+    inProgress,
+    blocked,
+    notStarted,
+    progressPercent: total === 0 ? 0 : Math.round((complete / total) * 100),
+    highestStatus:
+      blocked > 0
+        ? "blocked"
+        : inProgress > 0
+          ? "in_progress"
+          : notStarted > 0
+            ? "not_started"
+            : "complete",
+  }
+}
+
+function mapReadinessSummaryToSetupStatus(
+  summary: CrewReadinessSummary,
+): CrewGuidedSetupStatus {
+  if (summary.blocked > 0) return "blocked"
+  if (summary.needsAttention > 0) return "in_progress"
+  return "complete"
+}
+
+function readPersistedGuidedSetup(
+  value: unknown,
+): CrewGuidedSetupPersistedState {
+  if (!isPlainObject(value)) return { ...defaultGuidedSetupState }
+
+  const activeStep = isCrewGuidedSetupStepKey(value.activeStep)
+    ? value.activeStep
+    : null
+  const rawSteps = isPlainObject(value.steps) ? value.steps : {}
+  const steps: CrewGuidedSetupPersistedState["steps"] = {}
+
+  for (const stepKey of crewGuidedSetupStepKeys) {
+    const rawStep = rawSteps[stepKey]
+    if (!isPlainObject(rawStep)) continue
+
+    const status = isCrewGuidedSetupStatus(rawStep.status)
+      ? rawStep.status
+      : undefined
+    const note = typeof rawStep.note === "string" ? rawStep.note : ""
+    const updatedAt =
+      typeof rawStep.updatedAt === "string" ? rawStep.updatedAt : null
+
+    if (status || note || updatedAt) {
+      steps[stepKey] = { status, note, updatedAt }
+    }
+  }
+
+  return { activeStep, steps }
+}
+
+function normalizePersistedGuidedSetup(
+  state: CrewGuidedSetupPersistedState,
+): CrewGuidedSetupPersistedState {
+  return readPersistedGuidedSetup(state)
+}
+
+function isCrewGuidedSetupStepKey(
+  value: unknown,
+): value is CrewGuidedSetupStepKey {
+  return (
+    typeof value === "string" &&
+    crewGuidedSetupStepKeys.includes(value as CrewGuidedSetupStepKey)
+  )
+}
+
+function isCrewGuidedSetupStatus(
+  value: unknown,
+): value is CrewGuidedSetupStatus {
+  return (
+    value === "not_started" ||
+    value === "in_progress" ||
+    value === "blocked" ||
+    value === "complete"
+  )
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function plural(count: number) {
+  return count === 1 ? "" : "s"
+}

--- a/apps/crew/src/routes/events/$eventId/setup.tsx
+++ b/apps/crew/src/routes/events/$eventId/setup.tsx
@@ -3,6 +3,11 @@ import { useEffect, useState } from "react"
 import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
 import { Save } from "lucide-react"
 import { toast } from "sonner"
+import { GuidedSetupShell } from "@/components/crew-guided-setup/guided-setup-shell"
+import type {
+  CrewGuidedSetupOperatorStatus,
+  CrewGuidedSetupStepKey,
+} from "@/lib/crew/guided-setup"
 import {
   crewSetupChecklistItems,
   parseCrewSettings,
@@ -10,17 +15,25 @@ import {
   type CrewSetupChecklistKey,
 } from "@/lib/crew-event-setup"
 import { updateCrewEventSettingsFn } from "@/server-fns/crew-event-settings-fns"
+import {
+  getCrewGuidedSetupPageFn,
+  updateCrewGuidedSetupStepFn,
+} from "@/server-fns/crew-guided-setup-fns"
 
 export const Route = createFileRoute("/events/$eventId/setup")({
+  loader: async ({ params }) =>
+    await getCrewGuidedSetupPageFn({ data: { eventId: params.eventId } }),
   component: EventSetupPage,
 })
 
 const parentRoute = getRouteApi("/events/$eventId")
 
 // @lat: [[crew#Event Setup Dashboard]]
+// @lat: [[crew#Guided Setup State]]
 function EventSetupPage() {
   const router = useRouter()
   const { event } = parentRoute.useLoaderData()
+  const { guidedSetup } = Route.useLoaderData()
   const parsedSettings = parseCrewSettings(event.settings.settings)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [crewOnly, setCrewOnly] = useState(event.settings.crewOnly)
@@ -102,332 +115,362 @@ function EventSetupPage() {
     }))
   }
 
+  async function handleGuidedSetupUpdate(data: {
+    eventId: string
+    stepKey: CrewGuidedSetupStepKey
+    status: CrewGuidedSetupOperatorStatus | null
+    note: string
+  }) {
+    try {
+      await updateCrewGuidedSetupStepFn({ data })
+      toast.success("Guided setup step saved")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to save setup step",
+      )
+    }
+  }
+
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="grid gap-6 lg:grid-cols-[1fr_20rem]"
-    >
-      <section className="space-y-6">
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h2 className="text-xl font-semibold">Setup</h2>
-              <p className="text-sm text-muted-foreground">
-                Manage lifecycle, concierge status, source details, and operator
-                assumptions.
-              </p>
+    <section className="space-y-6">
+      <GuidedSetupShell
+        eventId={event.competition.id}
+        guidedSetup={guidedSetup}
+        onUpdate={(data) =>
+          handleGuidedSetupUpdate({
+            eventId: event.competition.id,
+            ...data,
+          })
+        }
+      />
+
+      <form
+        onSubmit={handleSubmit}
+        className="grid gap-6 lg:grid-cols-[1fr_20rem]"
+      >
+        <section className="space-y-6">
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h2 className="text-xl font-semibold">Setup</h2>
+                <p className="text-sm text-muted-foreground">
+                  Manage lifecycle, concierge status, source details, and
+                  operator assumptions.
+                </p>
+              </div>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  checked={crewOnly}
+                  onChange={(changeEvent) =>
+                    setCrewOnly(changeEvent.target.checked)
+                  }
+                  className="size-4"
+                />
+                Crew-only
+              </label>
             </div>
-            <label className="flex items-center gap-2 text-sm">
-              <input
-                type="checkbox"
-                checked={crewOnly}
-                onChange={(changeEvent) =>
-                  setCrewOnly(changeEvent.target.checked)
-                }
-                className="size-4"
-              />
-              Crew-only
-            </label>
-          </div>
 
-          <div className="mt-5 grid gap-4 sm:grid-cols-2">
-            <Field label="Lifecycle" htmlFor="crew-settings-lifecycle">
-              <select
-                id="crew-settings-lifecycle"
-                value={lifecycle}
-                onChange={(changeEvent) =>
-                  setLifecycle(
-                    changeEvent.target.value as
-                      | "draft"
-                      | "setup"
-                      | "importing"
-                      | "ready"
-                      | "archived",
-                  )
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+            <div className="mt-5 grid gap-4 sm:grid-cols-2">
+              <Field label="Lifecycle" htmlFor="crew-settings-lifecycle">
+                <select
+                  id="crew-settings-lifecycle"
+                  value={lifecycle}
+                  onChange={(changeEvent) =>
+                    setLifecycle(
+                      changeEvent.target.value as
+                        | "draft"
+                        | "setup"
+                        | "importing"
+                        | "ready"
+                        | "archived",
+                    )
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value="draft">Draft</option>
+                  <option value="setup">Setup</option>
+                  <option value="importing">Importing</option>
+                  <option value="ready">Ready</option>
+                  <option value="archived">Archived</option>
+                </select>
+              </Field>
+              <Field
+                label="Concierge status"
+                htmlFor="crew-settings-concierge-status"
               >
-                <option value="draft">Draft</option>
-                <option value="setup">Setup</option>
-                <option value="importing">Importing</option>
-                <option value="ready">Ready</option>
-                <option value="archived">Archived</option>
-              </select>
-            </Field>
-            <Field
-              label="Concierge status"
-              htmlFor="crew-settings-concierge-status"
-            >
-              <select
-                id="crew-settings-concierge-status"
-                value={conciergeStatus}
-                onChange={(changeEvent) =>
-                  setConciergeStatus(
-                    changeEvent.target.value as
-                      | "not_started"
-                      | "in_progress"
-                      | "ready"
-                      | "blocked",
-                  )
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                <select
+                  id="crew-settings-concierge-status"
+                  value={conciergeStatus}
+                  onChange={(changeEvent) =>
+                    setConciergeStatus(
+                      changeEvent.target.value as
+                        | "not_started"
+                        | "in_progress"
+                        | "ready"
+                        | "blocked",
+                    )
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value="not_started">Not started</option>
+                  <option value="in_progress">In progress</option>
+                  <option value="ready">Ready</option>
+                  <option value="blocked">Blocked</option>
+                </select>
+              </Field>
+              <Field label="Crew plan" htmlFor="crew-settings-plan">
+                <select
+                  id="crew-settings-plan"
+                  value={crewPlan}
+                  onChange={(changeEvent) =>
+                    setCrewPlan(
+                      changeEvent.target.value as
+                        | "self_serve"
+                        | "concierge"
+                        | "full_platform",
+                    )
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                >
+                  <option value="self_serve">Self serve</option>
+                  <option value="concierge">Concierge</option>
+                  <option value="full_platform">Full platform</option>
+                </select>
+              </Field>
+              <Field
+                label="Full platform credit cents"
+                htmlFor="crew-settings-credit-cents"
               >
-                <option value="not_started">Not started</option>
-                <option value="in_progress">In progress</option>
-                <option value="ready">Ready</option>
-                <option value="blocked">Blocked</option>
-              </select>
-            </Field>
-            <Field label="Crew plan" htmlFor="crew-settings-plan">
-              <select
-                id="crew-settings-plan"
-                value={crewPlan}
-                onChange={(changeEvent) =>
-                  setCrewPlan(
-                    changeEvent.target.value as
-                      | "self_serve"
-                      | "concierge"
-                      | "full_platform",
-                  )
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                <input
+                  id="crew-settings-credit-cents"
+                  type="number"
+                  min="0"
+                  value={fullPlatformCreditCents}
+                  onChange={(changeEvent) =>
+                    setFullPlatformCreditCents(changeEvent.target.value)
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+            </div>
+          </section>
+
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <h2 className="text-xl font-semibold">Source</h2>
+            <div className="mt-5 grid gap-4 sm:grid-cols-2">
+              <Field
+                label="Source platform"
+                htmlFor="crew-settings-source-platform"
               >
-                <option value="self_serve">Self serve</option>
-                <option value="concierge">Concierge</option>
-                <option value="full_platform">Full platform</option>
-              </select>
-            </Field>
-            <Field
-              label="Full platform credit cents"
-              htmlFor="crew-settings-credit-cents"
-            >
-              <input
-                id="crew-settings-credit-cents"
-                type="number"
-                min="0"
-                value={fullPlatformCreditCents}
-                onChange={(changeEvent) =>
-                  setFullPlatformCreditCents(changeEvent.target.value)
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-          </div>
+                <input
+                  id="crew-settings-source-platform"
+                  value={sourcePlatform}
+                  onChange={(changeEvent) =>
+                    setSourcePlatform(changeEvent.target.value)
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+              <Field
+                label="Acquisition source"
+                htmlFor="crew-settings-acquisition-source"
+              >
+                <input
+                  id="crew-settings-acquisition-source"
+                  value={acquisitionSource}
+                  onChange={(changeEvent) =>
+                    setAcquisitionSource(changeEvent.target.value)
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+              <Field
+                label="Source event URL"
+                htmlFor="crew-settings-source-event-url"
+                wide
+              >
+                <input
+                  id="crew-settings-source-event-url"
+                  value={sourceEventUrl}
+                  onChange={(changeEvent) =>
+                    setSourceEventUrl(changeEvent.target.value)
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+              <Field
+                label="External registration URL"
+                htmlFor="crew-settings-external-registration-url"
+                wide
+              >
+                <input
+                  id="crew-settings-external-registration-url"
+                  value={externalRegistrationUrl}
+                  onChange={(changeEvent) =>
+                    setExternalRegistrationUrl(changeEvent.target.value)
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+            </div>
+          </section>
+
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <h2 className="text-xl font-semibold">Concierge notes</h2>
+            <div className="mt-5 grid gap-4 sm:grid-cols-2">
+              <Field
+                label="Desired go-live date"
+                htmlFor="crew-setup-go-live-date"
+              >
+                <input
+                  id="crew-setup-go-live-date"
+                  type="date"
+                  value={setup.desiredGoLiveDate}
+                  onChange={(changeEvent) =>
+                    setSetup((current) => ({
+                      ...current,
+                      desiredGoLiveDate: changeEvent.target.value,
+                    }))
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+              <Field
+                label="Volunteer target"
+                htmlFor="crew-setup-volunteer-target"
+              >
+                <input
+                  id="crew-setup-volunteer-target"
+                  value={setup.volunteerTarget}
+                  onChange={(changeEvent) =>
+                    setSetup((current) => ({
+                      ...current,
+                      volunteerTarget: changeEvent.target.value,
+                    }))
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+              <Field label="Staffing lead" htmlFor="crew-setup-staffing-lead">
+                <input
+                  id="crew-setup-staffing-lead"
+                  value={setup.staffingLead}
+                  onChange={(changeEvent) =>
+                    setSetup((current) => ({
+                      ...current,
+                      staffingLead: changeEvent.target.value,
+                    }))
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+              <Field
+                label="Source contact name"
+                htmlFor="crew-setup-source-contact-name"
+              >
+                <input
+                  id="crew-setup-source-contact-name"
+                  value={setup.sourceContactName}
+                  onChange={(changeEvent) =>
+                    setSetup((current) => ({
+                      ...current,
+                      sourceContactName: changeEvent.target.value,
+                    }))
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+              <Field
+                label="Source contact email"
+                htmlFor="crew-setup-source-contact-email"
+                wide
+              >
+                <input
+                  id="crew-setup-source-contact-email"
+                  type="email"
+                  value={setup.sourceContactEmail}
+                  onChange={(changeEvent) =>
+                    setSetup((current) => ({
+                      ...current,
+                      sourceContactEmail: changeEvent.target.value,
+                    }))
+                  }
+                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                />
+              </Field>
+              <Field label="Assumptions" htmlFor="crew-setup-assumptions" wide>
+                <textarea
+                  id="crew-setup-assumptions"
+                  value={setup.assumptions}
+                  onChange={(changeEvent) =>
+                    setSetup((current) => ({
+                      ...current,
+                      assumptions: changeEvent.target.value,
+                    }))
+                  }
+                  className="min-h-28 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                />
+              </Field>
+              <Field label="Internal notes" htmlFor="crew-setup-notes" wide>
+                <textarea
+                  id="crew-setup-notes"
+                  value={setup.internalNotes}
+                  onChange={(changeEvent) =>
+                    setSetup((current) => ({
+                      ...current,
+                      internalNotes: changeEvent.target.value,
+                    }))
+                  }
+                  className="min-h-32 w-full rounded-md border bg-background px-3 py-2 text-sm"
+                />
+              </Field>
+            </div>
+          </section>
         </section>
 
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <h2 className="text-xl font-semibold">Source</h2>
-          <div className="mt-5 grid gap-4 sm:grid-cols-2">
-            <Field
-              label="Source platform"
-              htmlFor="crew-settings-source-platform"
-            >
-              <input
-                id="crew-settings-source-platform"
-                value={sourcePlatform}
-                onChange={(changeEvent) =>
-                  setSourcePlatform(changeEvent.target.value)
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-            <Field
-              label="Acquisition source"
-              htmlFor="crew-settings-acquisition-source"
-            >
-              <input
-                id="crew-settings-acquisition-source"
-                value={acquisitionSource}
-                onChange={(changeEvent) =>
-                  setAcquisitionSource(changeEvent.target.value)
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-            <Field
-              label="Source event URL"
-              htmlFor="crew-settings-source-event-url"
-              wide
-            >
-              <input
-                id="crew-settings-source-event-url"
-                value={sourceEventUrl}
-                onChange={(changeEvent) =>
-                  setSourceEventUrl(changeEvent.target.value)
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-            <Field
-              label="External registration URL"
-              htmlFor="crew-settings-external-registration-url"
-              wide
-            >
-              <input
-                id="crew-settings-external-registration-url"
-                value={externalRegistrationUrl}
-                onChange={(changeEvent) =>
-                  setExternalRegistrationUrl(changeEvent.target.value)
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
+        <aside className="h-fit rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+            Setup checklist
+          </h2>
+          <div className="mt-4 space-y-3">
+            {crewSetupChecklistItems.map((item) => (
+              <label
+                key={item.key}
+                className="flex items-start gap-3 rounded-md border bg-background px-3 py-2 text-sm"
+              >
+                <input
+                  type="checkbox"
+                  checked={setup.checklist[item.key]}
+                  onChange={(changeEvent) =>
+                    updateChecklist(item.key, changeEvent.target.checked)
+                  }
+                  className="mt-0.5 size-4"
+                />
+                <span>{item.label}</span>
+              </label>
+            ))}
           </div>
-        </section>
 
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <h2 className="text-xl font-semibold">Concierge notes</h2>
-          <div className="mt-5 grid gap-4 sm:grid-cols-2">
-            <Field
-              label="Desired go-live date"
-              htmlFor="crew-setup-go-live-date"
-            >
-              <input
-                id="crew-setup-go-live-date"
-                type="date"
-                value={setup.desiredGoLiveDate}
-                onChange={(changeEvent) =>
-                  setSetup((current) => ({
-                    ...current,
-                    desiredGoLiveDate: changeEvent.target.value,
-                  }))
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-            <Field
-              label="Volunteer target"
-              htmlFor="crew-setup-volunteer-target"
-            >
-              <input
-                id="crew-setup-volunteer-target"
-                value={setup.volunteerTarget}
-                onChange={(changeEvent) =>
-                  setSetup((current) => ({
-                    ...current,
-                    volunteerTarget: changeEvent.target.value,
-                  }))
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-            <Field label="Staffing lead" htmlFor="crew-setup-staffing-lead">
-              <input
-                id="crew-setup-staffing-lead"
-                value={setup.staffingLead}
-                onChange={(changeEvent) =>
-                  setSetup((current) => ({
-                    ...current,
-                    staffingLead: changeEvent.target.value,
-                  }))
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-            <Field
-              label="Source contact name"
-              htmlFor="crew-setup-source-contact-name"
-            >
-              <input
-                id="crew-setup-source-contact-name"
-                value={setup.sourceContactName}
-                onChange={(changeEvent) =>
-                  setSetup((current) => ({
-                    ...current,
-                    sourceContactName: changeEvent.target.value,
-                  }))
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-            <Field
-              label="Source contact email"
-              htmlFor="crew-setup-source-contact-email"
-              wide
-            >
-              <input
-                id="crew-setup-source-contact-email"
-                type="email"
-                value={setup.sourceContactEmail}
-                onChange={(changeEvent) =>
-                  setSetup((current) => ({
-                    ...current,
-                    sourceContactEmail: changeEvent.target.value,
-                  }))
-                }
-                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-              />
-            </Field>
-            <Field label="Assumptions" htmlFor="crew-setup-assumptions" wide>
-              <textarea
-                id="crew-setup-assumptions"
-                value={setup.assumptions}
-                onChange={(changeEvent) =>
-                  setSetup((current) => ({
-                    ...current,
-                    assumptions: changeEvent.target.value,
-                  }))
-                }
-                className="min-h-28 w-full rounded-md border bg-background px-3 py-2 text-sm"
-              />
-            </Field>
-            <Field label="Internal notes" htmlFor="crew-setup-notes" wide>
-              <textarea
-                id="crew-setup-notes"
-                value={setup.internalNotes}
-                onChange={(changeEvent) =>
-                  setSetup((current) => ({
-                    ...current,
-                    internalNotes: changeEvent.target.value,
-                  }))
-                }
-                className="min-h-32 w-full rounded-md border bg-background px-3 py-2 text-sm"
-              />
-            </Field>
-          </div>
-        </section>
-      </section>
+          {parsedSettings.parseError ? (
+            <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              Existing settings JSON is invalid. Saving will preserve the raw
+              text as legacySettingsText.
+            </p>
+          ) : null}
 
-      <aside className="h-fit rounded-md border bg-card p-5 shadow-sm">
-        <h2 className="text-sm font-semibold uppercase text-muted-foreground">
-          Setup checklist
-        </h2>
-        <div className="mt-4 space-y-3">
-          {crewSetupChecklistItems.map((item) => (
-            <label
-              key={item.key}
-              className="flex items-start gap-3 rounded-md border bg-background px-3 py-2 text-sm"
-            >
-              <input
-                type="checkbox"
-                checked={setup.checklist[item.key]}
-                onChange={(changeEvent) =>
-                  updateChecklist(item.key, changeEvent.target.checked)
-                }
-                className="mt-0.5 size-4"
-              />
-              <span>{item.label}</span>
-            </label>
-          ))}
-        </div>
-
-        {parsedSettings.parseError ? (
-          <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-            Existing settings JSON is invalid. Saving will preserve the raw text
-            as legacySettingsText.
-          </p>
-        ) : null}
-
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
-        >
-          <Save className="size-4" aria-hidden="true" />
-          {isSubmitting ? "Saving..." : "Save setup"}
-        </button>
-      </aside>
-    </form>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+          >
+            <Save className="size-4" aria-hidden="true" />
+            {isSubmitting ? "Saving..." : "Save setup"}
+          </button>
+        </aside>
+      </form>
+    </section>
   )
 }
 

--- a/apps/crew/src/server-fns/crew-guided-setup-fns.ts
+++ b/apps/crew/src/server-fns/crew-guided-setup-fns.ts
@@ -1,0 +1,47 @@
+// @lat: [[crew#Guided Setup State]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import { crewGuidedSetupStepKeys } from "../lib/crew/guided-setup"
+
+export type { CrewGuidedSetupPageData } from "../server/crew-guided-setup.server"
+
+const guidedSetupStatusSchema = z.enum([
+  "not_started",
+  "in_progress",
+  "blocked",
+  "complete",
+])
+
+const getCrewGuidedSetupPageInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+const updateCrewGuidedSetupStepInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  stepKey: z.enum(crewGuidedSetupStepKeys),
+  status: guidedSetupStatusSchema.nullable(),
+  note: z.string().max(2000).optional(),
+})
+
+export const getCrewGuidedSetupPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    getCrewGuidedSetupPageInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewGuidedSetupPage } = await import(
+      "../server/crew-guided-setup.server"
+    )
+    return getCrewGuidedSetupPage(data)
+  })
+
+export const updateCrewGuidedSetupStepFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    updateCrewGuidedSetupStepInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { updateCrewGuidedSetupStep } = await import(
+      "../server/crew-guided-setup.server"
+    )
+    return updateCrewGuidedSetupStep(data)
+  })

--- a/apps/crew/src/server/crew-guided-setup.server.ts
+++ b/apps/crew/src/server/crew-guided-setup.server.ts
@@ -1,0 +1,86 @@
+// @lat: [[crew#Guided Setup State]]
+import {
+  buildCrewGuidedSetupState,
+  parseCrewGuidedSetupSettings,
+  serializeCrewGuidedSetupSettings,
+  updateCrewGuidedSetupStepState,
+  type CrewGuidedSetupOperatorStatus,
+  type CrewGuidedSetupState,
+  type CrewGuidedSetupStepKey,
+} from "../lib/crew/guided-setup"
+import { parseCrewSettings } from "../lib/crew-event-setup"
+import {
+  getCrewEvent,
+  updateCrewEventSettings,
+} from "./crew-event-settings.server"
+import { getCrewReadinessPage } from "./crew-readiness.server"
+
+export interface CrewGuidedSetupPageData {
+  guidedSetup: CrewGuidedSetupState
+}
+
+interface GetCrewGuidedSetupPageInput {
+  eventId: string
+}
+
+interface UpdateCrewGuidedSetupStepInput {
+  eventId: string
+  stepKey: CrewGuidedSetupStepKey
+  status: CrewGuidedSetupOperatorStatus | null
+  note?: string
+}
+
+export async function getCrewGuidedSetupPage(
+  data: GetCrewGuidedSetupPageInput,
+): Promise<CrewGuidedSetupPageData> {
+  const [{ event }, readinessPage] = await Promise.all([
+    getCrewEvent({ eventId: data.eventId }),
+    getCrewReadinessPage({ eventId: data.eventId }),
+  ])
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  const parsedSettings = parseCrewSettings(event.settings.settings)
+  const persisted = parseCrewGuidedSetupSettings(event.settings.settings)
+
+  return {
+    guidedSetup: buildCrewGuidedSetupState({
+      event: {
+        startDate: event.competition.startDate,
+        endDate: event.competition.endDate,
+        timezone: event.competition.timezone,
+      },
+      setup: parsedSettings.setup,
+      facts: readinessPage.facts,
+      readiness: readinessPage.readiness,
+      persisted,
+    }),
+  }
+}
+
+export async function updateCrewGuidedSetupStep(
+  data: UpdateCrewGuidedSetupStepInput,
+): Promise<CrewGuidedSetupPageData> {
+  const { event } = await getCrewEvent({ eventId: data.eventId })
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  const current = parseCrewGuidedSetupSettings(event.settings.settings)
+  const next = updateCrewGuidedSetupStepState(current, {
+    stepKey: data.stepKey,
+    status: data.status,
+    note: data.note,
+    updatedAt: new Date().toISOString(),
+  })
+
+  await updateCrewEventSettings({
+    competitionId: data.eventId,
+    settings: serializeCrewGuidedSetupSettings(event.settings.settings, next),
+  })
+
+  return getCrewGuidedSetupPage(data)
+}

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -192,6 +192,16 @@ Self-serve Crew setup keeps reusable setup memory in shared DB tables owned by `
 
 `crew_department_leads` stores event-scoped delegation records for role, floor, and time-slice access without expanding the broad team permission model. IDs use the `cdlead_` prefix.
 
+## Guided Setup State
+
+Guided setup turns Crew readiness facts and operator overrides into a per-event self-serve checklist stored in `crew_event_settings.settings`.
+
+[[apps/crew/src/lib/crew/guided-setup.ts]] derives event basics, days/floors, imports, roles, staffing assumptions, schedule publish, reminders, and exports steps from existing setup settings plus readiness facts. Source-data blockers remain blocked even when an operator records a manual override.
+
+[[apps/crew/src/server-fns/crew-guided-setup-fns.ts]] exposes thin route-safe read/update wrappers, while [[apps/crew/src/server/crew-guided-setup.server.ts]] keeps DB and readiness hydration server-only. Updates write only the `guidedSetup` JSON subtree and preserve existing concierge setup notes.
+
+[[apps/crew/src/components/crew-guided-setup/guided-setup-shell.tsx]] renders the compact wizard shell on [[apps/crew/src/routes/events/$eventId/setup.tsx]]. It records an operator status and note per step without adding template apply, import-mapping memory, department-lead enforcement, volunteer self-service, export-packet, queue, or schema work.
+
 ## Assignment Confirmation Responses
 
 Crew assignment confirmation links are token-only volunteer surfaces. Raw tokens are generated only while creating links, stored only as hashes, and used by [[apps/crew/src/routes/e/$slug/confirm/$token.tsx]] and [[apps/crew/src/routes/e/$slug/schedule/$token.tsx]] to show safe confirm, decline, and change-request flows without requiring a session.


### PR DESCRIPTION
## Summary

- Add a pure guided setup state model that derives self-serve Crew steps from existing setup settings, readiness facts, and persisted operator overrides.
- Add route-safe read/update server functions that persist only the `guidedSetup` subtree in `crew_event_settings.settings` behind the existing local operator guard pattern.
- Render a compact guided setup shell on `/events/$eventId/setup` and document the `crew#Guided Setup State` LAT anchor.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/guided-setup.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (passes with existing unrelated warning backlog)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Guided Setup State'`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a guided setup for Crew that turns readiness facts and setup settings into a simple, per-event checklist. It ships a compact wizard on /events/$eventId/setup with server APIs to read and update progress.

- **New Features**
  - Pure state model that derives eight steps: event basics, days/floors, imports, roles, staffing assumptions, schedule publish, reminders, and exports. System blockers stay blocked even if an operator marks a step complete.
  - Persisted operator status and note per step. Only the `guidedSetup` subtree is written in `crew_event_settings.settings` with `updatedAt` tracking.
  - Route-safe server functions: `getCrewGuidedSetupPageFn` and `updateCrewGuidedSetupStepFn` (zod-validated) with server-only hydration.
  - New `GuidedSetupShell` UI on the setup page: progress, step list, per-step status/notes, and quick links. Loader fetches guided state; saves invalidate the route.
  - Tests and docs: unit tests cover derivation, blocking rules, and serialization; LAT docs add “Guided Setup State”.

- **Bug Fixes**
  - Days/floors step stays blocked when venues have zero lane capacity.
  - Marked `GuidedSetupShell` as a client component to avoid hydration issues.

<sup>Written for commit 195744289fcdbbf2e996141b8f0892da75de9ba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided setup wizard to help organize and track essential crew event setup tasks
  * Step-by-step progress tracking with visual status indicators (not started, in progress, complete, blocked)
  * Ability to add notes to individual setup steps for team reference
  * Contextual guidance with warnings when setup steps are blocked or require attention

<!-- end of auto-generated comment: release notes by coderabbit.ai -->