### PR TITLE
feat(crew): edit roster volunteer details

### DIFF
--- a/apps/crew/src/lib/crew/manual-volunteer-intake.ts
+++ b/apps/crew/src/lib/crew/manual-volunteer-intake.ts
@@ -55,6 +55,7 @@ export interface ExistingManualVolunteerInvitation {
   id: string
   email: string
   acceptedAt?: Date | string | null
+  expiresAt?: Date | string | null
   status?: string | null
   metadata?: string | null
 }

--- a/apps/crew/src/lib/crew/roster-shifts.test.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.test.ts
@@ -277,6 +277,32 @@ describe("Crew roster helpers", () => {
     })
   })
 
+  it("ignores non-string metadata emails when checking edit collisions", () => {
+    const collision = findCrewRosterVolunteerEmailCollision({
+      source: "team_membership",
+      sourceId: "tmem_current",
+      email: "ada@example.com",
+      invitations: [
+        {
+          id: "tinv_corrupt",
+          email: "pending@example.com",
+          status: "pending",
+          metadata: JSON.stringify({ signupEmail: 42 }),
+        },
+      ],
+      memberships: [
+        {
+          id: "tmem_current",
+          email: "ada@example.com",
+          isActive: true,
+          metadata: JSON.stringify({ signupEmail: { value: "ada" } }),
+        },
+      ],
+    })
+
+    expect(collision).toBeNull()
+  })
+
   it("does not treat accepted invitations hidden by a membership as edit collisions", () => {
     expect(
       findCrewRosterVolunteerEmailCollision({

--- a/apps/crew/src/lib/crew/roster-shifts.test.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.test.ts
@@ -1,9 +1,14 @@
 // @lat: [[crew#Roster Shifts Assignments]]
+// @lat: [[crew#Roster Volunteer Editing]]
 import { describe, expect, it } from "vitest"
 import {
   buildCrewRoster,
+  buildCrewRosterVolunteerMetadataUpdate,
+  findCrewRosterVolunteerEmailCollision,
   getCrewRosterRoleTypes,
   normalizeCrewShiftTimes,
+  parseCrewRosterMetadata,
+  shouldUpdateCrewRosterInvitationEmail,
   summarizeCrewRoster,
   validateShiftAssignment,
   validateShiftCapacityUpdate,
@@ -170,6 +175,224 @@ describe("Crew roster helpers", () => {
     )
 
     expect(roster[0]?.email).toBe("member@example.com")
+  })
+
+  it("merges imported roster metadata without losing import audit details", () => {
+    const metadata = buildCrewRosterVolunteerMetadataUpdate(
+      JSON.stringify({
+        crewImportId: "cimp_1",
+        crewSignupSource: "competition_corner",
+        inviteSource: "direct",
+        status: "approved",
+        signupEmail: "old@example.com",
+        signupName: "Old Name",
+      }),
+      {
+        email: " ADA@Example.com ",
+        name: "Ada Lovelace",
+        phone: " 555-0100 ",
+        roleTypes: ["judge", "judge", "medical"],
+        availability: "morning",
+        availabilityNotes: "Before lunch",
+        credentials: "L1",
+        notes: "Can lead a lane",
+      },
+    )
+
+    expect(metadata).toMatchObject({
+      crewImportId: "cimp_1",
+      crewSignupSource: "competition_corner",
+      inviteSource: "direct",
+      status: "approved",
+      signupEmail: "ada@example.com",
+      signupName: "Ada Lovelace",
+      signupPhone: "555-0100",
+      volunteerRoleTypes: ["judge", "medical"],
+      availability: "morning",
+      availabilityNotes: "Before lunch",
+      credentials: "L1",
+      internalNotes: "Can lead a lane",
+    })
+  })
+
+  it("clears editable fields while preserving manual source metadata", () => {
+    const metadata = buildCrewRosterVolunteerMetadataUpdate(
+      JSON.stringify({
+        crewSignupSource: "manual_operator",
+        manualCreatedAt: "2026-06-19T12:00:00.000Z",
+        signupEmail: "old@example.com",
+        signupPhone: "555-0000",
+        credentials: "Old credential",
+        internalNotes: "Old note",
+      }),
+      {
+        email: "updated@example.com",
+        name: "",
+        phone: "",
+        roleTypes: [],
+        availability: "",
+        availabilityNotes: "",
+        credentials: "",
+        notes: "",
+      },
+    )
+
+    expect(metadata).toMatchObject({
+      crewSignupSource: "manual_operator",
+      manualCreatedAt: "2026-06-19T12:00:00.000Z",
+      signupEmail: "updated@example.com",
+      volunteerRoleTypes: ["general"],
+    })
+    expect(metadata).not.toHaveProperty("signupPhone")
+    expect(metadata).not.toHaveProperty("credentials")
+    expect(metadata).not.toHaveProperty("internalNotes")
+  })
+
+  it("detects duplicate edit emails across memberships and invitations", () => {
+    expect(
+      findCrewRosterVolunteerEmailCollision({
+        source: "team_membership",
+        sourceId: "tmem_current",
+        email: "ada@example.com",
+        invitations: [
+          {
+            id: "tinv_pending",
+            email: "pending@example.com",
+            metadata: JSON.stringify({ signupEmail: "Ada@Example.com" }),
+          },
+        ],
+        memberships: [
+          {
+            id: "tmem_current",
+            email: "ada@example.com",
+            isActive: true,
+            metadata: null,
+          },
+        ],
+      }),
+    ).toMatchObject({
+      source: "team_invitation",
+      sourceId: "tinv_pending",
+      email: "ada@example.com",
+    })
+  })
+
+  it("does not treat accepted invitations hidden by a membership as edit collisions", () => {
+    expect(
+      findCrewRosterVolunteerEmailCollision({
+        source: "team_membership",
+        sourceId: "tmem_current",
+        email: "ada@example.com",
+        invitations: [
+          {
+            id: "tinv_accepted",
+            email: "ada@example.com",
+            status: "accepted",
+            acceptedAt: "2026-06-19T12:00:00.000Z",
+            metadata: null,
+          },
+        ],
+        memberships: [
+          {
+            id: "tmem_current",
+            email: "ada@example.com",
+            isActive: true,
+            metadata: null,
+          },
+        ],
+      }),
+    ).toBeNull()
+  })
+
+  it("lets membership edits change roster email metadata without changing account email", () => {
+    const metadata = buildCrewRosterVolunteerMetadataUpdate(null, {
+      email: "ops@example.com",
+      name: "Ops Volunteer",
+      roleTypes: ["staff"],
+    })
+    const roster = buildCrewRoster(
+      [],
+      [
+        {
+          id: "tmem_member",
+          isActive: true,
+          user: {
+            firstName: "Account",
+            lastName: "Owner",
+            email: "account@example.com",
+          },
+          metadata: JSON.stringify(metadata),
+        },
+      ],
+    )
+
+    expect(roster[0]?.email).toBe("ops@example.com")
+    expect(roster[0]?.name).toBe("Ops Volunteer")
+  })
+
+  it("only updates the backing invitation email while a roster invitation is pending", () => {
+    const now = new Date("2026-06-19T12:00:00.000Z")
+
+    expect(
+      shouldUpdateCrewRosterInvitationEmail(
+        {
+          id: "tinv_pending",
+          email: "pending@example.com",
+          status: "pending",
+          expiresAt: "2026-06-20T12:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe(true)
+    expect(
+      shouldUpdateCrewRosterInvitationEmail(
+        {
+          id: "tinv_accepted",
+          email: "accepted@example.com",
+          status: "accepted",
+          acceptedAt: "2026-06-19T12:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe(false)
+    expect(
+      shouldUpdateCrewRosterInvitationEmail(
+        {
+          id: "tinv_expired",
+          email: "expired@example.com",
+          status: "pending",
+          expiresAt: "2026-06-18T12:00:00.000Z",
+        },
+        now,
+      ),
+    ).toBe(false)
+  })
+
+  it("normalizes edited pending invitation metadata for roster display", () => {
+    const metadata = buildCrewRosterVolunteerMetadataUpdate(null, {
+      email: "pending+new@example.com",
+      name: "Pending Volunteer",
+      roleTypes: ["check_in"],
+    })
+    const parsed = parseCrewRosterMetadata(JSON.stringify(metadata))
+    const roster = buildCrewRoster(
+      [
+        {
+          id: "tinv_pending",
+          email: parsed.signupEmail ?? "",
+          status: "pending",
+          metadata: JSON.stringify(metadata),
+        },
+      ],
+      [],
+    )
+
+    expect(roster[0]).toMatchObject({
+      source: "team_invitation",
+      email: "pending+new@example.com",
+      name: "Pending Volunteer",
+      roleTypes: ["check_in"],
+    })
   })
 })
 

--- a/apps/crew/src/lib/crew/roster-shifts.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Roster Shifts Assignments]]
+// @lat: [[crew#Roster Volunteer Editing]]
 import {
   INVITATION_STATUS,
   type InvitationStatus,
@@ -29,6 +30,23 @@ export interface CrewRosterMetadata
   inviteName?: string
   crewImportId?: string
   crewSignupSource?: string
+}
+
+export interface CrewRosterVolunteerMetadataInput {
+  email: string
+  name?: string
+  phone?: string
+  roleTypes?: VolunteerRoleType[]
+  availability?: VolunteerAvailability | ""
+  availabilityNotes?: string
+  credentials?: string
+  notes?: string
+}
+
+export interface CrewRosterEmailCollision {
+  source: CrewRosterVolunteer["source"]
+  sourceId: string
+  email: string
 }
 
 export interface CrewVolunteerInvitationRecord {
@@ -69,6 +87,7 @@ export interface CrewRosterVolunteer {
   availability: VolunteerAvailability | null
   availabilityNotes: string | null
   credentials: string | null
+  notes: string | null
   imported: boolean
   signupSource: string | null
   createdAt: Date | null
@@ -146,6 +165,117 @@ export function parseCrewRosterMetadata(
   } catch {
     return {}
   }
+}
+
+export function normalizeCrewRosterVolunteerEmail(value: string) {
+  return value.trim().toLowerCase()
+}
+
+export function buildCrewRosterVolunteerMetadataUpdate(
+  existingMetadata: string | null | undefined,
+  input: CrewRosterVolunteerMetadataInput,
+): CrewRosterMetadata {
+  const existing = parseCrewRosterMetadata(existingMetadata)
+  const next: CrewRosterMetadata = {
+    ...existing,
+    volunteerRoleTypes: getCrewRosterRoleTypes(input.roleTypes),
+    signupEmail: normalizeCrewRosterVolunteerEmail(input.email),
+    signupName: emptyToUndefined(input.name),
+    inviteName: undefined,
+    signupPhone: emptyToUndefined(input.phone),
+    availability: input.availability || undefined,
+    availabilityNotes: emptyToUndefined(input.availabilityNotes),
+    credentials: emptyToUndefined(input.credentials),
+    internalNotes: emptyToUndefined(input.notes),
+  }
+
+  return removeUndefined(next)
+}
+
+export function findCrewRosterVolunteerEmailCollision({
+  source,
+  sourceId,
+  email,
+  invitations,
+  memberships,
+  now = new Date(),
+}: {
+  source: CrewRosterVolunteer["source"]
+  sourceId: string
+  email: string
+  invitations: CrewVolunteerInvitationRecord[]
+  memberships: Array<CrewVolunteerMembershipRecord & { email?: string | null }>
+  now?: Date
+}): CrewRosterEmailCollision | null {
+  const normalizedEmail = normalizeCrewRosterVolunteerEmail(email)
+  if (!normalizedEmail) return null
+  const membershipEmails = new Set(
+    memberships.flatMap((membership) =>
+      getCrewRosterRecordEmails(
+        membership.email ?? membership.user?.email,
+        membership.metadata,
+      ),
+    ),
+  )
+
+  for (const membership of memberships) {
+    if (source === "team_membership" && membership.id === sourceId) {
+      continue
+    }
+
+    const emails = getCrewRosterRecordEmails(
+      membership.email ?? membership.user?.email,
+      membership.metadata,
+    )
+    if (emails.includes(normalizedEmail)) {
+      return {
+        source: "team_membership",
+        sourceId: membership.id,
+        email: normalizedEmail,
+      }
+    }
+  }
+
+  for (const invitation of invitations) {
+    if (source === "team_invitation" && invitation.id === sourceId) {
+      continue
+    }
+
+    const emails = getCrewRosterRecordEmails(
+      invitation.email,
+      invitation.metadata,
+    )
+    const status = getCrewRosterStatus(
+      { source: "team_invitation", ...invitation },
+      now,
+    )
+    if (
+      status !== "pending" &&
+      emails.some((recordEmail) => membershipEmails.has(recordEmail))
+    ) {
+      continue
+    }
+
+    if (emails.includes(normalizedEmail)) {
+      return {
+        source: "team_invitation",
+        sourceId: invitation.id,
+        email: normalizedEmail,
+      }
+    }
+  }
+
+  return null
+}
+
+export function shouldUpdateCrewRosterInvitationEmail(
+  invitation: CrewVolunteerInvitationRecord,
+  now = new Date(),
+) {
+  return (
+    getCrewRosterStatus({ source: "team_invitation", ...invitation }, now) ===
+    "pending"
+  )
 }
 
 export function normalizeCrewRosterRoleTypes(
@@ -374,6 +504,7 @@ function toInvitationRosterRow(
     availability: metadata.availability ?? null,
     availabilityNotes: metadata.availabilityNotes ?? null,
     credentials: metadata.credentials ?? null,
+    notes: metadata.internalNotes ?? null,
     imported: Boolean(metadata.crewImportId),
     signupSource: metadata.crewSignupSource ?? metadata.inviteSource ?? null,
     createdAt: toNullableDate(invitation.createdAt),
@@ -412,6 +543,7 @@ function toMembershipRosterRow(
     availability: metadata.availability ?? null,
     availabilityNotes: metadata.availabilityNotes ?? null,
     credentials: metadata.credentials ?? null,
+    notes: metadata.internalNotes ?? null,
     imported: Boolean(metadata.crewImportId),
     signupSource: metadata.crewSignupSource ?? metadata.inviteSource ?? null,
     createdAt: toNullableDate(membership.createdAt),
@@ -426,6 +558,28 @@ function getMetadataName(metadata: CrewRosterMetadata) {
 function nonBlankText(value: string | null | undefined) {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
+}
+
+function getCrewRosterRecordEmails(
+  email: string | null | undefined,
+  metadata: string | null | undefined,
+) {
+  const parsed = parseCrewRosterMetadata(metadata)
+  return [
+    normalizeCrewRosterVolunteerEmail(email ?? ""),
+    normalizeCrewRosterVolunteerEmail(parsed.signupEmail ?? ""),
+  ].filter(Boolean)
+}
+
+function emptyToUndefined(value: string | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function removeUndefined(value: CrewRosterMetadata): CrewRosterMetadata {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as CrewRosterMetadata
 }
 
 function compareCrewRosterRows(

--- a/apps/crew/src/lib/crew/roster-shifts.ts
+++ b/apps/crew/src/lib/crew/roster-shifts.ts
@@ -552,11 +552,13 @@ function toMembershipRosterRow(
 }
 
 function getMetadataName(metadata: CrewRosterMetadata) {
-  return metadata.signupName?.trim() || metadata.inviteName?.trim() || ""
+  return (
+    nonBlankText(metadata.signupName) ?? nonBlankText(metadata.inviteName) ?? ""
+  )
 }
 
-function nonBlankText(value: string | null | undefined) {
-  const trimmed = value?.trim()
+function nonBlankText(value: unknown) {
+  const trimmed = typeof value === "string" ? value.trim() : ""
   return trimmed ? trimmed : null
 }
 
@@ -567,7 +569,9 @@ function getCrewRosterRecordEmails(
   const parsed = parseCrewRosterMetadata(metadata)
   return [
     normalizeCrewRosterVolunteerEmail(email ?? ""),
-    normalizeCrewRosterVolunteerEmail(parsed.signupEmail ?? ""),
+    normalizeCrewRosterVolunteerEmail(
+      typeof parsed.signupEmail === "string" ? parsed.signupEmail : "",
+    ),
   ].filter(Boolean)
 }
 

--- a/apps/crew/src/lib/crew/shift-board-pilot-ops.test.ts
+++ b/apps/crew/src/lib/crew/shift-board-pilot-ops.test.ts
@@ -305,6 +305,7 @@ function rosterVolunteer(
     availability: overrides.availability ?? "all_day",
     availabilityNotes: null,
     credentials: overrides.credentials ?? null,
+    notes: null,
     imported: overrides.imported ?? false,
     signupSource: null,
     createdAt: null,

--- a/apps/crew/src/routes/events/$eventId/volunteers.tsx
+++ b/apps/crew/src/routes/events/$eventId/volunteers.tsx
@@ -514,6 +514,7 @@ function EditRosterVolunteerDialog({
                   type="email"
                   required
                   disabled={isSubmitting}
+                  maxLength={255}
                   defaultValue={volunteer.email}
                 />
               </Field>
@@ -522,6 +523,7 @@ function EditRosterVolunteerDialog({
                   id="edit-volunteer-name"
                   name="name"
                   disabled={isSubmitting}
+                  maxLength={200}
                   defaultValue={volunteer.name}
                 />
               </Field>
@@ -530,6 +532,7 @@ function EditRosterVolunteerDialog({
                   id="edit-volunteer-phone"
                   name="phone"
                   disabled={isSubmitting}
+                  maxLength={50}
                   defaultValue={volunteer.phone ?? ""}
                 />
               </Field>
@@ -565,6 +568,7 @@ function EditRosterVolunteerDialog({
                 id="edit-volunteer-credentials"
                 name="credentials"
                 disabled={isSubmitting}
+                maxLength={1000}
                 defaultValue={volunteer.credentials ?? ""}
               />
             </Field>
@@ -577,6 +581,7 @@ function EditRosterVolunteerDialog({
                 id="edit-volunteer-availability-notes"
                 name="availabilityNotes"
                 disabled={isSubmitting}
+                maxLength={5000}
                 defaultValue={volunteer.availabilityNotes ?? ""}
               />
             </Field>
@@ -586,6 +591,7 @@ function EditRosterVolunteerDialog({
                 id="edit-volunteer-notes"
                 name="notes"
                 disabled={isSubmitting}
+                maxLength={5000}
                 defaultValue={volunteer.notes ?? ""}
               />
             </Field>
@@ -767,6 +773,9 @@ function VolunteerRow({
   volunteer: CrewRosterVolunteer
   onEdit: () => void
 }) {
+  const editLabelTarget =
+    volunteer.name.trim() || volunteer.email.trim() || "volunteer"
+
   return (
     <tr className="border-b last:border-0">
       <td className="px-4 py-3 align-top">
@@ -822,7 +831,7 @@ function VolunteerRow({
                 size="icon"
                 className="size-8"
                 onClick={onEdit}
-                aria-label={`Edit ${volunteer.name}`}
+                aria-label={`Edit ${editLabelTarget}`}
               >
                 <Pencil className="h-4 w-4" />
               </Button>

--- a/apps/crew/src/routes/events/$eventId/volunteers.tsx
+++ b/apps/crew/src/routes/events/$eventId/volunteers.tsx
@@ -1,3 +1,4 @@
+// @lat: [[crew#Roster Volunteer Editing]]
 import type { FormEvent, ReactNode } from "react"
 import {
   createFileRoute,
@@ -6,7 +7,7 @@ import {
   useRouter,
 } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
-import { ClipboardPaste, Loader2, UserPlus } from "lucide-react"
+import { ClipboardPaste, Loader2, Pencil, UserPlus } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -20,6 +21,12 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type {
   VolunteerAvailability,
   VolunteerRoleType,
@@ -42,6 +49,7 @@ import {
   createManualCrewVolunteerFn,
   getCrewRosterPageFn,
   pasteManualCrewVolunteerEmailsFn,
+  updateCrewRosterVolunteerFn,
 } from "@/server-fns/crew-roster-shift-fns"
 
 export const Route = createFileRoute("/events/$eventId/volunteers")({
@@ -58,6 +66,8 @@ function VolunteersPage() {
   const router = useRouter()
   const [addOpen, setAddOpen] = useState(false)
   const [pasteOpen, setPasteOpen] = useState(false)
+  const [editingVolunteer, setEditingVolunteer] =
+    useState<CrewRosterVolunteer | null>(null)
   const reloadRoster = async () => {
     await router.invalidate()
   }
@@ -113,11 +123,16 @@ function VolunteersPage() {
                   <th className="px-4 py-3 font-medium">Roles</th>
                   <th className="px-4 py-3 font-medium">Availability</th>
                   <th className="px-4 py-3 font-medium">Source</th>
+                  <th className="px-4 py-3 text-right font-medium">Actions</th>
                 </tr>
               </thead>
               <tbody>
                 {roster.map((volunteer) => (
-                  <VolunteerRow key={volunteer.id} volunteer={volunteer} />
+                  <VolunteerRow
+                    key={volunteer.id}
+                    volunteer={volunteer}
+                    onEdit={() => setEditingVolunteer(volunteer)}
+                  />
                 ))}
               </tbody>
             </table>
@@ -144,6 +159,14 @@ function VolunteersPage() {
         eventId={eventId}
         onOpenChange={setPasteOpen}
         onCreated={reloadRoster}
+      />
+      <EditRosterVolunteerDialog
+        volunteer={editingVolunteer}
+        eventId={eventId}
+        onOpenChange={(open) => {
+          if (!open) setEditingVolunteer(null)
+        }}
+        onSaved={reloadRoster}
       />
     </section>
   )
@@ -411,7 +434,196 @@ function PasteVolunteerEmailsDialog({
   )
 }
 
-function RoleTypeCheckboxes({ disabled }: { disabled: boolean }) {
+function EditRosterVolunteerDialog({
+  volunteer,
+  eventId,
+  onOpenChange,
+  onSaved,
+}: {
+  volunteer: CrewRosterVolunteer | null
+  eventId: string
+  onOpenChange: (open: boolean) => void
+  onSaved: () => Promise<void>
+}) {
+  const updateVolunteer = useServerFn(updateCrewRosterVolunteerFn)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const open = volunteer !== null
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (!volunteer) return
+
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    const availability = getFormString(formData, "availability")
+
+    setIsSubmitting(true)
+    setError(null)
+    try {
+      await updateVolunteer({
+        data: {
+          eventId,
+          source: volunteer.source,
+          sourceId: volunteer.sourceId,
+          email: getFormString(formData, "email"),
+          name: getFormString(formData, "name"),
+          phone: getFormString(formData, "phone"),
+          roleTypes: getFormStringList(formData, "roleTypes"),
+          availability: availability
+            ? (availability as VolunteerAvailability)
+            : undefined,
+          availabilityNotes: getFormString(formData, "availabilityNotes"),
+          credentials: getFormString(formData, "credentials"),
+          notes: getFormString(formData, "notes"),
+        },
+      })
+      toast.success("Volunteer updated")
+      onOpenChange(false)
+      await onSaved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Volunteer update failed")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen) setError(null)
+        onOpenChange(nextOpen)
+      }}
+    >
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Edit volunteer</DialogTitle>
+        </DialogHeader>
+        {volunteer ? (
+          <form
+            key={volunteer.id}
+            onSubmit={handleSubmit}
+            className="space-y-4"
+          >
+            <div className="grid gap-4 sm:grid-cols-2">
+              <Field label="Email" htmlFor="edit-volunteer-email">
+                <Input
+                  id="edit-volunteer-email"
+                  name="email"
+                  type="email"
+                  required
+                  disabled={isSubmitting}
+                  defaultValue={volunteer.email}
+                />
+              </Field>
+              <Field label="Name" htmlFor="edit-volunteer-name">
+                <Input
+                  id="edit-volunteer-name"
+                  name="name"
+                  disabled={isSubmitting}
+                  defaultValue={volunteer.name}
+                />
+              </Field>
+              <Field label="Phone" htmlFor="edit-volunteer-phone">
+                <Input
+                  id="edit-volunteer-phone"
+                  name="phone"
+                  disabled={isSubmitting}
+                  defaultValue={volunteer.phone ?? ""}
+                />
+              </Field>
+              <Field label="Availability" htmlFor="edit-volunteer-availability">
+                <select
+                  id="edit-volunteer-availability"
+                  name="availability"
+                  className="h-10 rounded-md border bg-background px-3 text-sm"
+                  disabled={isSubmitting}
+                  defaultValue={volunteer.availability ?? ""}
+                >
+                  <option value="">Not set</option>
+                  <option value={VOLUNTEER_AVAILABILITY.MORNING}>
+                    Morning
+                  </option>
+                  <option value={VOLUNTEER_AVAILABILITY.AFTERNOON}>
+                    Afternoon
+                  </option>
+                  <option value={VOLUNTEER_AVAILABILITY.ALL_DAY}>
+                    All day
+                  </option>
+                </select>
+              </Field>
+            </div>
+
+            <RoleTypeCheckboxes
+              disabled={isSubmitting}
+              defaultValues={volunteer.roleTypes}
+            />
+
+            <Field label="Credentials" htmlFor="edit-volunteer-credentials">
+              <Input
+                id="edit-volunteer-credentials"
+                name="credentials"
+                disabled={isSubmitting}
+                defaultValue={volunteer.credentials ?? ""}
+              />
+            </Field>
+
+            <Field
+              label="Availability notes"
+              htmlFor="edit-volunteer-availability-notes"
+            >
+              <Textarea
+                id="edit-volunteer-availability-notes"
+                name="availabilityNotes"
+                disabled={isSubmitting}
+                defaultValue={volunteer.availabilityNotes ?? ""}
+              />
+            </Field>
+
+            <Field label="Notes" htmlFor="edit-volunteer-notes">
+              <Textarea
+                id="edit-volunteer-notes"
+                name="notes"
+                disabled={isSubmitting}
+                defaultValue={volunteer.notes ?? ""}
+              />
+            </Field>
+
+            {error ? (
+              <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                {error}
+              </p>
+            ) : null}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? <Loader2 className="animate-spin" /> : null}
+                Save changes
+              </Button>
+            </DialogFooter>
+          </form>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function RoleTypeCheckboxes({
+  disabled,
+  defaultValues = [],
+}: {
+  disabled: boolean
+  defaultValues?: VolunteerRoleType[]
+}) {
   return (
     <fieldset className="space-y-2">
       <legend className="text-sm font-medium">Roles</legend>
@@ -426,6 +638,7 @@ function RoleTypeCheckboxes({ disabled }: { disabled: boolean }) {
               name="roleTypes"
               value={option.value}
               disabled={disabled}
+              defaultChecked={defaultValues.includes(option.value)}
               className="size-4"
             />
             {option.label}
@@ -547,7 +760,13 @@ function getFormStringList(
     .map((value) => value as VolunteerRoleType)
 }
 
-function VolunteerRow({ volunteer }: { volunteer: CrewRosterVolunteer }) {
+function VolunteerRow({
+  volunteer,
+  onEdit,
+}: {
+  volunteer: CrewRosterVolunteer
+  onEdit: () => void
+}) {
   return (
     <tr className="border-b last:border-0">
       <td className="px-4 py-3 align-top">
@@ -571,6 +790,11 @@ function VolunteerRow({ volunteer }: { volunteer: CrewRosterVolunteer }) {
             </span>
           ))}
         </div>
+        {volunteer.credentials ? (
+          <div className="mt-2 max-w-xs text-muted-foreground">
+            {volunteer.credentials}
+          </div>
+        ) : null}
       </td>
       <td className="px-4 py-3 align-top">
         <div>{formatVolunteerAvailability(volunteer.availability)}</div>
@@ -587,6 +811,25 @@ function VolunteerRow({ volunteer }: { volunteer: CrewRosterVolunteer }) {
         {volunteer.signupSource ? (
           <div className="mt-1">{formatCrewValue(volunteer.signupSource)}</div>
         ) : null}
+      </td>
+      <td className="px-4 py-3 text-right align-top">
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-8"
+                onClick={onEdit}
+                aria-label={`Edit ${volunteer.name}`}
+              >
+                <Pencil className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Edit volunteer</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </td>
     </tr>
   )

--- a/apps/crew/src/server-fns/crew-roster-shift-fns.ts
+++ b/apps/crew/src/server-fns/crew-roster-shift-fns.ts
@@ -1,6 +1,7 @@
 // @lat: [[crew#Roster Shifts Assignments]]
 // @lat: [[crew#Server Function Runtime Boundary]]
 // @lat: [[crew#Manual Volunteer Intake]]
+// @lat: [[crew#Roster Volunteer Editing]]
 import { createServerFn } from "@tanstack/react-start"
 import {
   VOLUNTEER_AVAILABILITY,
@@ -22,6 +23,8 @@ const shiftIdSchema = z.string().startsWith("vshf_", "Invalid shift ID")
 const membershipIdSchema = z
   .string()
   .startsWith("tmem_", "Invalid membership ID")
+const rosterSourceSchema = z.enum(["team_invitation", "team_membership"])
+const rosterSourceIdSchema = z.string().min(1, "Roster volunteer ID is required")
 const roleTypeSchema = z.enum(VOLUNTEER_ROLE_TYPE_VALUES)
 const availabilitySchema = z
   .enum([
@@ -105,6 +108,36 @@ const manualVolunteerPasteInputSchema = z.object({
   pasteText: z.string().trim().min(1, "Paste at least one email").max(50000),
 })
 
+const updateRosterVolunteerInputSchema =
+  manualVolunteerMetadataInputSchema
+    .extend({
+      source: rosterSourceSchema,
+      sourceId: rosterSourceIdSchema,
+      credentials: z.string().trim().max(1000).optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (
+        data.source === "team_invitation" &&
+        !data.sourceId.startsWith("tinv_")
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["sourceId"],
+          message: "Invalid invitation roster ID",
+        })
+      }
+      if (
+        data.source === "team_membership" &&
+        !data.sourceId.startsWith("tmem_")
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["sourceId"],
+          message: "Invalid membership roster ID",
+        })
+      }
+    })
+
 export const getCrewRosterPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => eventInputSchema.parse(data))
   .handler(async ({ data }) => {
@@ -165,6 +198,17 @@ export const pasteManualCrewVolunteerEmailsFn = createServerFn({
       "../server/crew-roster-shift.server"
     )
     return pasteManualCrewVolunteerEmails(data)
+  })
+
+export const updateCrewRosterVolunteerFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    updateRosterVolunteerInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { updateCrewRosterVolunteer } = await import(
+      "../server/crew-roster-shift.server"
+    )
+    return updateCrewRosterVolunteer(data)
   })
 
 export const updateCrewShiftFn = createServerFn({ method: "POST" })

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -1,6 +1,7 @@
 // @lat: [[crew#Roster Shifts Assignments]]
 // @lat: [[crew#Manual Volunteer Intake]]
 // @lat: [[crew#Shift Board Pilot Ops]]
+// @lat: [[crew#Roster Volunteer Editing]]
 import { createId } from "@paralleldrive/cuid2"
 import { and, asc, eq, inArray, sql } from "drizzle-orm"
 import { getDb } from "../db"
@@ -43,11 +44,15 @@ import type {
   CrewRosterVolunteer,
 } from "../lib/crew/roster-shifts"
 import {
+  buildCrewRosterVolunteerMetadataUpdate,
   buildCrewRoster,
+  findCrewRosterVolunteerEmailCollision,
   formatVolunteerRole,
   getCrewRosterRoleTypes,
+  normalizeCrewRosterVolunteerEmail,
   normalizeCrewShiftTimes,
   parseCrewRosterMetadata,
+  shouldUpdateCrewRosterInvitationEmail,
   summarizeCrewRoster,
   validateShiftAssignment,
   validateShiftCapacityUpdate,
@@ -202,6 +207,19 @@ interface ManualCrewVolunteerPasteInput extends CrewEventInput {
   pasteText: string
 }
 
+interface UpdateCrewRosterVolunteerInput extends CrewEventInput {
+  source: CrewRosterVolunteer["source"]
+  sourceId: string
+  email: string
+  name?: string
+  phone?: string
+  roleTypes?: VolunteerRoleType[]
+  availability?: VolunteerAvailability
+  availabilityNotes?: string
+  credentials?: string
+  notes?: string
+}
+
 interface ManualCrewVolunteerCreateRow
   extends Omit<ManualCrewVolunteerInput, "eventId"> {
   rowNumber: number
@@ -235,6 +253,13 @@ export interface ManualCrewVolunteerMutationResult {
     skipped: number
     invalid: number
   }
+}
+
+export interface UpdateCrewRosterVolunteerResult {
+  success: true
+  source: CrewRosterVolunteer["source"]
+  sourceId: string
+  email: string
 }
 
 export async function getCrewRosterPage(
@@ -347,6 +372,125 @@ export async function pasteManualCrewVolunteerEmails(
     ],
     invalid: parsed.invalid,
   })
+}
+
+export async function updateCrewRosterVolunteer(
+  data: UpdateCrewRosterVolunteerInput,
+): Promise<UpdateCrewRosterVolunteerResult> {
+  requireLocalCrewOperatorAccess("Crew roster")
+
+  const event = await requireCrewRosterEvent(data.eventId)
+  const db = getDb()
+  const normalizedEmail = normalizeCrewRosterVolunteerEmail(data.email)
+
+  await withCrewRosterVolunteerWriteLock(
+    db,
+    event.competitionTeamId,
+    async () => {
+      await db.transaction(async (tx) => {
+        const client = tx as unknown as DbClient
+        const [existingInvitations, existingMemberships] = await Promise.all([
+          listManualVolunteerInvitations(client, event.competitionTeamId),
+          listManualVolunteerMemberships(client, event.competitionTeamId),
+        ])
+        const currentInvitation =
+          data.source === "team_invitation"
+            ? existingInvitations.find(
+                (invitation) => invitation.id === data.sourceId,
+              )
+            : null
+        const currentMembership =
+          data.source === "team_membership"
+            ? existingMemberships.find(
+                (membership) => membership.id === data.sourceId,
+              )
+            : null
+        const current = currentInvitation ?? currentMembership
+
+        if (!current) {
+          throw new Error("Roster volunteer not found")
+        }
+
+        const collision = findCrewRosterVolunteerEmailCollision({
+          source: data.source,
+          sourceId: data.sourceId,
+          email: normalizedEmail,
+          invitations: existingInvitations,
+          memberships: existingMemberships,
+        })
+
+        if (collision) {
+          throw new Error("A matching volunteer email already exists.")
+        }
+
+        const timestamp = new Date()
+        const metadata = buildCrewRosterVolunteerMetadataUpdate(
+          current.metadata,
+          {
+            email: normalizedEmail,
+            name: data.name,
+            phone: data.phone,
+            roleTypes: data.roleTypes,
+            availability: data.availability,
+            availabilityNotes: data.availabilityNotes,
+            credentials: data.credentials,
+            notes: data.notes,
+          },
+        )
+        const metadataJson = JSON.stringify(metadata)
+
+        if (currentInvitation) {
+          const updateValues: Partial<
+            typeof teamInvitationTable.$inferInsert
+          > = {
+            metadata: metadataJson,
+            updatedAt: timestamp,
+          }
+
+          if (
+            shouldUpdateCrewRosterInvitationEmail(currentInvitation, timestamp)
+          ) {
+            updateValues.email = normalizedEmail
+          }
+
+          await tx
+            .update(teamInvitationTable)
+            .set(updateValues)
+            .where(
+              and(
+                eq(teamInvitationTable.id, currentInvitation.id),
+                eq(teamInvitationTable.teamId, event.competitionTeamId),
+                eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+                eq(teamInvitationTable.isSystemRole, true),
+              ),
+            )
+          return
+        }
+
+        await tx
+          .update(teamMembershipTable)
+          .set({
+            metadata: metadataJson,
+            updatedAt: timestamp,
+          })
+          .where(
+            and(
+              eq(teamMembershipTable.id, data.sourceId),
+              eq(teamMembershipTable.teamId, event.competitionTeamId),
+              eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+              eq(teamMembershipTable.isSystemRole, true),
+            ),
+          )
+      })
+    },
+  )
+
+  return {
+    success: true,
+    source: data.source,
+    sourceId: data.sourceId,
+    email: normalizedEmail,
+  }
 }
 
 export async function createCrewShift(data: CrewShiftInput) {
@@ -715,7 +859,7 @@ async function createManualCrewVolunteerRows(
 
   // team_invitations has no team/email uniqueness constraint, so serialize
   // manual intake for this roster until the batch transaction commits.
-  await withManualVolunteerIntakeBatchLock(
+  await withCrewRosterVolunteerWriteLock(
     db,
     event.competitionTeamId,
     async () => {
@@ -786,14 +930,15 @@ async function createManualCrewVolunteerRows(
   })
 }
 
-async function withManualVolunteerIntakeBatchLock<T>(
+async function withCrewRosterVolunteerWriteLock<T>(
   db: DbClient,
   competitionTeamId: string,
   callback: () => Promise<T>,
 ) {
   let acquired = false
-  const lockName =
-    await createManualVolunteerIntakeBatchLockName(competitionTeamId)
+  const lockName = await createCrewRosterVolunteerWriteLockName(
+    competitionTeamId,
+  )
 
   try {
     const result = await db.execute(
@@ -801,7 +946,7 @@ async function withManualVolunteerIntakeBatchLock<T>(
     )
     acquired = Number(getFirstExecuteValue(result) ?? 0) === 1
     if (!acquired) {
-      throw new Error("Manual volunteer could not be saved")
+      throw new Error("Roster volunteer could not be saved")
     }
 
     return await callback()
@@ -812,11 +957,11 @@ async function withManualVolunteerIntakeBatchLock<T>(
   }
 }
 
-async function createManualVolunteerIntakeBatchLockName(
+async function createCrewRosterVolunteerWriteLockName(
   competitionTeamId: string,
 ) {
   const encoded = new TextEncoder().encode(
-    `crew-manual-volunteer:${competitionTeamId}`,
+    `crew-roster-volunteer:${competitionTeamId}`,
   )
   const digest = await crypto.subtle.digest("SHA-256", encoded)
   return Array.from(new Uint8Array(digest), (byte) =>
@@ -833,6 +978,7 @@ async function listManualVolunteerInvitations(
       id: teamInvitationTable.id,
       email: teamInvitationTable.email,
       acceptedAt: teamInvitationTable.acceptedAt,
+      expiresAt: teamInvitationTable.expiresAt,
       status: teamInvitationTable.status,
       metadata: teamInvitationTable.metadata,
     })

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -38,6 +38,14 @@ Roster shifts assignments normalize volunteer invitations, memberships, shifts, 
 
 The pure helpers preserve source identity for invitations and memberships, derive roster status, and keep role, availability, credential, import, and assignment details together so Crew pages can render staffing state without mutating event data.
 
+## Roster Volunteer Editing
+
+Roster volunteer editing lets local Crew operators correct existing volunteer contact and staffing metadata on [[apps/crew/src/routes/events/$eventId/volunteers.tsx|the volunteer roster page]].
+
+[[apps/crew/src/server-fns/crew-roster-shift-fns.ts]] exposes the route-safe edit wrapper while [[apps/crew/src/server/crew-roster-shift.server.ts]] mutates only the backing `team_invitations` or `team_memberships` metadata for the selected roster row. Pending invitations also keep `team_invitations.email` aligned with edited signup email; membership rows never mutate the linked user account email.
+
+[[apps/crew/src/lib/crew/roster-shifts.ts]] owns deterministic metadata normalization and duplicate email detection so import audit/source metadata, assignments, confirmations, and shift relationships survive roster corrections.
+
 ## Shift Board Pilot Ops
 
 Crew shift board pilot ops adapts the existing shift surface into an operator handoff board for real pilot events.


### PR DESCRIPTION
## Summary
- Add an edit action/dialog on `/events/$eventId/volunteers` for roster volunteer contact and staffing metadata.
- Add `updateCrewRosterVolunteerFn` plus server-only roster mutation with local operator guard, roster write lock, source-specific updates, and duplicate email detection.
- Preserve assignment/import/source relationships by updating only invitation or membership metadata; pending invitations also keep `team_invitations.email` aligned, while membership rows never update user account email.
- Add LAT anchor `crew#Roster Volunteer Editing` and focused helper coverage for imported/manual/member/pending-invitation edit behavior.

## Validation
- `pnpm --filter crew exec vitest run src/lib/crew/roster-shifts.test.ts src/lib/crew/manual-volunteer-intake.test.ts src/lib/crew/shift-board-pilot-ops.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; reports pre-existing warnings outside this slice)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Roster Volunteer Editing'`
- `git diff --check`

## Local note
- For local build validation only, copied the tracked Crew placeholder `apps/crew/wrangler.jsonc` into ignored `apps/crew/.alchemy/local/wrangler.jsonc` so Vite/Alchemy could load config without touching deploy infrastructure.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add roster volunteer editing on the event volunteers page so operators can fix contact and staffing details. Edits are source-aware, write-locked, enforce unique emails, and only update pending, unexpired invitation emails.

- New Features
  - Edit dialog on `/events/$eventId/volunteers` (email, name, phone, roles, availability, notes, credentials) with a pencil action; roster shows credentials and stores notes.
  - `updateCrewRosterVolunteerFn` updates only backing metadata; duplicate email checks across invitations and memberships; deterministic merge preserves import/source and dedups roles.

- Bug Fixes
  - Invitation email updates only when status is pending and not expired; accepted invites hidden by memberships aren’t treated as collisions.
  - Stricter input validation for roster source IDs and normalized email handling; collision checks tolerate corrupt/non-string metadata.

<sup>Written for commit 3fe7fc9172c3abd3195567b77aea4492d385ea28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edit volunteer details (email, roles, notes, and credentials) directly from the roster page
  * Volunteer invitations now track and display expiration dates
  * Email collision detection prevents duplicate signup emails across team invitations and memberships

* **Tests**
  * Expanded test coverage for volunteer metadata normalization, email collision detection, and roster metadata updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->