### PR TITLE
feat(crew): remember import mappings

### DIFF
--- a/apps/crew/src/lib/crew/imports/mapping-memory.test.ts
+++ b/apps/crew/src/lib/crew/imports/mapping-memory.test.ts
@@ -1,0 +1,176 @@
+// @lat: [[crew#Remember Import Mappings]]
+import { describe, expect, it } from "vitest"
+import {
+  buildCrewImportMappingPresetWrite,
+  computeImportHeaderFingerprint,
+  normalizeImportMappingSourcePlatform,
+  selectCrewImportMappingSuggestion,
+  type CrewImportMappingPresetCandidate,
+} from "./mapping-memory"
+
+describe("Crew import mapping memory", () => {
+  it("fingerprints headers deterministically after case and spacing normalization", () => {
+    expect(
+      computeImportHeaderFingerprint([" Email ", "First_Name", "Crew-Role"]),
+    ).toBe(computeImportHeaderFingerprint(["email", "first name", "crew role"]))
+    expect(computeImportHeaderFingerprint(["Email", "Role"])).not.toBe(
+      computeImportHeaderFingerprint(["Role", "Email"]),
+    )
+  })
+
+  it("normalizes blank source platforms to csv", () => {
+    expect(normalizeImportMappingSourcePlatform(" Competition Corner ")).toBe(
+      "competition corner",
+    )
+    expect(normalizeImportMappingSourcePlatform("")).toBe("csv")
+    expect(normalizeImportMappingSourcePlatform(null)).toBe("csv")
+  })
+
+  it("selects only matching team, source, kind, and header fingerprint suggestions", () => {
+    const headers = ["Email", "Full Name", "Crew Role"]
+    const fingerprint = computeImportHeaderFingerprint(headers)
+    const suggestion = selectCrewImportMappingSuggestion({
+      teamId: "team_1",
+      sourcePlatform: "Competition Corner",
+      kind: "volunteers",
+      headers,
+      candidates: [
+        candidate({
+          id: "cimap_wrong_team",
+          teamId: "team_2",
+          sourcePlatform: "competition corner",
+          kind: "volunteers",
+          headerFingerprint: fingerprint,
+        }),
+        candidate({
+          id: "cimap_wrong_source",
+          sourcePlatform: "csv",
+          kind: "volunteers",
+          headerFingerprint: fingerprint,
+        }),
+        candidate({
+          id: "cimap_wrong_kind",
+          sourcePlatform: "competition corner",
+          kind: "heat_schedule",
+          headerFingerprint: fingerprint,
+        }),
+        candidate({
+          id: "cimap_match",
+          sourcePlatform: "competition corner",
+          kind: "volunteers",
+          headerFingerprint: fingerprint,
+          lastUsedAt: "2026-06-20T12:00:00.000Z",
+        }),
+      ],
+    })
+
+    expect(suggestion).toMatchObject({
+      presetId: "cimap_match",
+      sourcePlatform: "competition corner",
+      kind: "volunteers",
+      matchedFieldCount: 3,
+      columnMapping: {
+        email: "Email",
+        name: "Full Name",
+        role: "Crew Role",
+      },
+    })
+  })
+
+  it("adapts a remembered mapping to current header casing before suggesting it", () => {
+    const headers = ["email address", "full name", "ROLE"]
+    const suggestion = selectCrewImportMappingSuggestion({
+      teamId: "team_1",
+      sourcePlatform: "csv",
+      kind: "volunteers",
+      headers,
+      candidates: [
+        candidate({
+          headerFingerprint: computeImportHeaderFingerprint(headers),
+          columnMapping: {
+            email: "Email Address",
+            name: "Full Name",
+            role: "Role",
+          },
+        }),
+      ],
+    })
+
+    expect(suggestion?.columnMapping).toEqual({
+      email: "email address",
+      name: "full name",
+      role: "ROLE",
+    })
+  })
+
+  it("builds a sanitized upsert payload for explicit operator saves", () => {
+    const write = buildCrewImportMappingPresetWrite({
+      teamId: "team_1",
+      competitionId: "comp_1",
+      sourcePlatform: "Csv Export",
+      kind: "heat_schedule",
+      headers: ["Workout", "Heat", "Start Time", "Ignored"],
+      columnMapping: {
+        workout: "Workout",
+        heat: "Heat",
+        scheduledTime: "Start Time",
+        role: "Ignored",
+      },
+    })
+
+    expect(write).toMatchObject({
+      teamId: "team_1",
+      competitionId: "comp_1",
+      sourcePlatform: "csv export",
+      kind: "heat_schedule",
+      name: "Heat schedule mapping",
+      columnMapping: {
+        workout: "Workout",
+        heat: "Heat",
+        scheduledTime: "Start Time",
+      },
+      metadata: {
+        schemaVersion: 1,
+        fieldCount: 3,
+        headerCount: 4,
+      },
+    })
+  })
+
+  it("refuses to build a save payload when no valid columns are mapped", () => {
+    expect(
+      buildCrewImportMappingPresetWrite({
+        teamId: "team_1",
+        competitionId: "comp_1",
+        kind: "volunteers",
+        headers: ["Email"],
+        columnMapping: { heat: "Email" },
+      }),
+    ).toBeNull()
+  })
+})
+
+function candidate(
+  overrides: Partial<CrewImportMappingPresetCandidate> = {},
+): CrewImportMappingPresetCandidate {
+  const headers = ["Email", "Full Name", "Crew Role"]
+  return {
+    id: "cimap_1",
+    teamId: "team_1",
+    kind: "volunteers",
+    sourcePlatform: "csv",
+    name: "Volunteer mapping",
+    headerFingerprint: computeImportHeaderFingerprint(headers),
+    headers,
+    columnMapping: {
+      email: "Email",
+      name: "Full Name",
+      role: "Crew Role",
+    },
+    parserVersion: "crew-csv-preview-v1",
+    lastUsedAt: null,
+    createdAt: "2026-06-20T10:00:00.000Z",
+    updatedAt: "2026-06-20T10:00:00.000Z",
+    ...overrides,
+  }
+}

--- a/apps/crew/src/lib/crew/imports/mapping-memory.test.ts
+++ b/apps/crew/src/lib/crew/imports/mapping-memory.test.ts
@@ -103,6 +103,31 @@ describe("Crew import mapping memory", () => {
     })
   })
 
+  it("selects the most recently used preset when multiple candidates match", () => {
+    const headers = ["Email", "Full Name", "Crew Role"]
+    const fingerprint = computeImportHeaderFingerprint(headers)
+    const suggestion = selectCrewImportMappingSuggestion({
+      teamId: "team_1",
+      sourcePlatform: "csv",
+      kind: "volunteers",
+      headers,
+      candidates: [
+        candidate({
+          id: "cimap_old",
+          headerFingerprint: fingerprint,
+          lastUsedAt: "2026-06-19T12:00:00.000Z",
+        }),
+        candidate({
+          id: "cimap_new",
+          headerFingerprint: fingerprint,
+          lastUsedAt: "2026-06-20T12:00:00.000Z",
+        }),
+      ],
+    })
+
+    expect(suggestion?.presetId).toBe("cimap_new")
+  })
+
   it("builds a sanitized upsert payload for explicit operator saves", () => {
     const write = buildCrewImportMappingPresetWrite({
       teamId: "team_1",

--- a/apps/crew/src/lib/crew/imports/mapping-memory.ts
+++ b/apps/crew/src/lib/crew/imports/mapping-memory.ts
@@ -199,8 +199,18 @@ function toDateTime(value: Date | string | null) {
 }
 
 function formatImportKind(kind: CrewImportKind) {
-  if (kind === "heat_schedule") return "Heat schedule"
-  return "Volunteer"
+  switch (kind) {
+    case "heat_schedule":
+      return "Heat schedule"
+    case "volunteers":
+      return "Volunteer"
+    default:
+      return assertNever(kind)
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unsupported Crew import kind: ${value}`)
 }
 
 function fnv1aHex(value: string) {

--- a/apps/crew/src/lib/crew/imports/mapping-memory.ts
+++ b/apps/crew/src/lib/crew/imports/mapping-memory.ts
@@ -1,0 +1,213 @@
+// @lat: [[crew#Remember Import Mappings]]
+import { normalizeHeader, sanitizeColumnMapping } from "./column-mapping"
+import { CREW_IMPORT_PARSER_VERSION } from "./types"
+import type { ColumnMapping, CrewImportKind } from "./types"
+
+export interface CrewImportMappingPresetCandidate {
+  id: string
+  teamId: string
+  kind: CrewImportKind
+  sourcePlatform: string | null
+  name: string | null
+  headerFingerprint: string
+  headers: string[]
+  columnMapping: ColumnMapping
+  parserVersion: string | null
+  lastUsedAt: Date | string | null
+  createdAt: Date | string | null
+  updatedAt: Date | string | null
+}
+
+export interface CrewImportMappingSuggestion {
+  presetId: string
+  name: string | null
+  sourcePlatform: string
+  kind: CrewImportKind
+  headerFingerprint: string
+  headers: string[]
+  columnMapping: ColumnMapping
+  matchedFieldCount: number
+  parserVersion: string | null
+  lastUsedAt: Date | string | null
+  updatedAt: Date | string | null
+}
+
+export interface CrewImportMappingPresetWrite {
+  teamId: string
+  competitionId: string
+  kind: CrewImportKind
+  sourcePlatform: string
+  name: string
+  headerFingerprint: string
+  headers: string[]
+  columnMapping: ColumnMapping
+  parserVersion: string
+  metadata: {
+    schemaVersion: 1
+    fieldCount: number
+    headerCount: number
+  }
+}
+
+export function computeImportHeaderFingerprint(headers: string[]) {
+  const normalizedHeaders = headers.map((header) => normalizeHeader(header))
+  const payload = JSON.stringify(normalizedHeaders)
+  return `v1_${fnv1aHex(payload)}_${normalizedHeaders.length}`
+}
+
+export function normalizeImportMappingSourcePlatform(
+  sourcePlatform?: string | null,
+) {
+  const normalized = normalizeHeader(sourcePlatform ?? "")
+  return normalized ? normalized.slice(0, 100) : "csv"
+}
+
+export function adaptImportMappingToHeaders({
+  columnMapping,
+  headers,
+  kind,
+}: {
+  columnMapping: ColumnMapping
+  headers: string[]
+  kind: CrewImportKind
+}) {
+  const headerByNormalized = new Map(
+    headers.map((header) => [normalizeHeader(header), header]),
+  )
+  const adapted: ColumnMapping = {}
+
+  for (const [field, header] of Object.entries(columnMapping)) {
+    const currentHeader = headerByNormalized.get(normalizeHeader(header))
+    if (currentHeader) {
+      adapted[field] = currentHeader
+    }
+  }
+
+  return sanitizeColumnMapping(adapted, headers, kind)
+}
+
+export function selectCrewImportMappingSuggestion({
+  teamId,
+  sourcePlatform,
+  kind,
+  headers,
+  candidates,
+}: {
+  teamId: string
+  sourcePlatform?: string | null
+  kind: CrewImportKind
+  headers: string[]
+  candidates: CrewImportMappingPresetCandidate[]
+}): CrewImportMappingSuggestion | null {
+  const normalizedSourcePlatform =
+    normalizeImportMappingSourcePlatform(sourcePlatform)
+  const headerFingerprint = computeImportHeaderFingerprint(headers)
+  const suggestions = candidates
+    .filter(
+      (candidate) =>
+        candidate.teamId === teamId &&
+        candidate.kind === kind &&
+        normalizeImportMappingSourcePlatform(candidate.sourcePlatform) ===
+          normalizedSourcePlatform &&
+        candidate.headerFingerprint === headerFingerprint,
+    )
+    .map((candidate) => {
+      const columnMapping = adaptImportMappingToHeaders({
+        columnMapping: candidate.columnMapping,
+        headers,
+        kind,
+      })
+      return {
+        presetId: candidate.id,
+        name: candidate.name,
+        sourcePlatform: normalizedSourcePlatform,
+        kind,
+        headerFingerprint,
+        headers,
+        columnMapping,
+        matchedFieldCount: Object.keys(columnMapping).length,
+        parserVersion: candidate.parserVersion,
+        lastUsedAt: candidate.lastUsedAt,
+        updatedAt: candidate.updatedAt,
+      } satisfies CrewImportMappingSuggestion
+    })
+    .filter((suggestion) => suggestion.matchedFieldCount > 0)
+
+  suggestions.sort((left, right) => compareSuggestionDates(right, left))
+  return suggestions[0] ?? null
+}
+
+export function buildCrewImportMappingPresetWrite({
+  teamId,
+  competitionId,
+  sourcePlatform,
+  kind,
+  headers,
+  columnMapping,
+}: {
+  teamId: string
+  competitionId: string
+  sourcePlatform?: string | null
+  kind: CrewImportKind
+  headers: string[]
+  columnMapping: ColumnMapping
+}): CrewImportMappingPresetWrite | null {
+  const sanitizedMapping = adaptImportMappingToHeaders({
+    columnMapping,
+    headers,
+    kind,
+  })
+  const fieldCount = Object.keys(sanitizedMapping).length
+  if (fieldCount === 0 || headers.length === 0) return null
+
+  const normalizedSourcePlatform =
+    normalizeImportMappingSourcePlatform(sourcePlatform)
+
+  return {
+    teamId,
+    competitionId,
+    kind,
+    sourcePlatform: normalizedSourcePlatform,
+    name: `${formatImportKind(kind)} mapping`,
+    headerFingerprint: computeImportHeaderFingerprint(headers),
+    headers: headers.map((header) => header.trim()),
+    columnMapping: sanitizedMapping,
+    parserVersion: CREW_IMPORT_PARSER_VERSION,
+    metadata: {
+      schemaVersion: 1,
+      fieldCount,
+      headerCount: headers.length,
+    },
+  }
+}
+
+function compareSuggestionDates(
+  left: CrewImportMappingSuggestion,
+  right: CrewImportMappingSuggestion,
+) {
+  return (
+    toDateTime(left.lastUsedAt) - toDateTime(right.lastUsedAt) ||
+    toDateTime(left.updatedAt) - toDateTime(right.updatedAt)
+  )
+}
+
+function toDateTime(value: Date | string | null) {
+  if (!value) return 0
+  const date = value instanceof Date ? value : new Date(value)
+  const time = date.getTime()
+  return Number.isFinite(time) ? time : 0
+}
+
+function formatImportKind(kind: CrewImportKind) {
+  if (kind === "heat_schedule") return "Heat schedule"
+  return "Volunteer"
+}
+
+function fnv1aHex(value: string) {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index++) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193) >>> 0
+  }
+  return hash.toString(16).padStart(8, "0")
+}

--- a/apps/crew/src/routes/api/crew/import.ts
+++ b/apps/crew/src/routes/api/crew/import.ts
@@ -6,7 +6,7 @@ import {
   createCrewImportPreviewRecord,
   CrewImportError,
   MAX_CREW_IMPORT_BYTES,
-} from "../../../server/crew-imports"
+} from "../../../server/crew-imports.server"
 import { CrewLocalAccessError } from "../../../server/crew-local-access"
 import type {
   ColumnMapping,

--- a/apps/crew/src/routes/events/$eventId/imports.tsx
+++ b/apps/crew/src/routes/events/$eventId/imports.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, FormEvent, ReactNode } from "react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import {
@@ -8,6 +8,7 @@ import {
   FileSpreadsheet,
   Loader2,
   PlayCircle,
+  Save,
   Upload,
 } from "lucide-react"
 import { toast } from "sonner"
@@ -24,9 +25,12 @@ import type {
   PreviewImportRow,
   VolunteerImportRow,
 } from "@/lib/crew/imports/types"
+import type { CrewImportMappingSuggestion } from "@/lib/crew/imports/mapping-memory"
 import {
   applyCrewImportFn,
+  getCrewImportMappingSuggestionFn,
   getCrewImportsPageFn,
+  saveCrewImportMappingPresetFn,
   type CrewImportApplyResult,
   type CrewImportHistoryItem,
   type CrewImportReferenceData,
@@ -201,13 +205,54 @@ function ImportUploadPanel({
   onPreviewComplete: (preview: PersistedCrewImportPreview) => void
   onHistoryRefresh: () => Promise<void>
 }) {
+  const getMappingSuggestion = useServerFn(getCrewImportMappingSuggestionFn)
+  const saveMappingPreset = useServerFn(saveCrewImportMappingPresetFn)
   const [file, setFile] = useState<File | null>(null)
   const [headers, setHeaders] = useState<string[]>([])
   const [mapping, setMapping] = useState<ColumnMapping>({})
+  const [mappingSuggestion, setMappingSuggestion] =
+    useState<CrewImportMappingSuggestion | null>(null)
   const [sourcePlatform, setSourcePlatform] = useState("")
   const [clientIssues, setClientIssues] = useState<ImportIssue[]>([])
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isLoadingMappingSuggestion, setIsLoadingMappingSuggestion] =
+    useState(false)
+  const [isSavingMapping, setIsSavingMapping] = useState(false)
   const fields = useMemo(() => getImportFields(kind), [kind])
+  const mappedFieldCount = Object.keys(mapping).length
+
+  useEffect(() => {
+    let ignore = false
+
+    if (headers.length === 0) {
+      setMappingSuggestion(null)
+      setIsLoadingMappingSuggestion(false)
+      return
+    }
+
+    setIsLoadingMappingSuggestion(true)
+    void getMappingSuggestion({
+      data: {
+        eventId,
+        kind,
+        sourcePlatform,
+        headers,
+      },
+    })
+      .then((result) => {
+        if (!ignore) setMappingSuggestion(result.suggestion)
+      })
+      .catch(() => {
+        if (!ignore) setMappingSuggestion(null)
+      })
+      .finally(() => {
+        if (!ignore) setIsLoadingMappingSuggestion(false)
+      })
+
+    return () => {
+      ignore = true
+    }
+  }, [eventId, getMappingSuggestion, headers, kind, sourcePlatform])
 
   async function handleFileChange(event: ChangeEvent<HTMLInputElement>) {
     const selectedFile = event.target.files?.[0] ?? null
@@ -216,6 +261,7 @@ function ImportUploadPanel({
     if (!selectedFile) {
       setHeaders([])
       setMapping({})
+      setMappingSuggestion(null)
       setClientIssues([])
       return
     }
@@ -233,6 +279,39 @@ function ImportUploadPanel({
       else delete next[field]
       return next
     })
+  }
+
+  function handleUseSuggestedMapping(suggestion: CrewImportMappingSuggestion) {
+    setMapping(suggestion.columnMapping)
+    toast.success("Saved mapping loaded")
+  }
+
+  async function handleSaveMapping() {
+    if (headers.length === 0 || mappedFieldCount === 0) {
+      toast.error("Map at least one column first")
+      return
+    }
+
+    setIsSavingMapping(true)
+    try {
+      const result = await saveMappingPreset({
+        data: {
+          eventId,
+          kind,
+          sourcePlatform,
+          headers,
+          columnMapping: mapping,
+        },
+      })
+      setMappingSuggestion(result.suggestion)
+      toast.success("Mapping remembered")
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to remember mapping",
+      )
+    } finally {
+      setIsSavingMapping(false)
+    }
   }
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
@@ -323,7 +402,47 @@ function ImportUploadPanel({
 
       {headers.length > 0 ? (
         <div className="mt-6 space-y-3">
-          <h4 className="text-sm font-semibold">Mapping</h4>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <h4 className="text-sm font-semibold">Mapping</h4>
+            <button
+              type="button"
+              onClick={handleSaveMapping}
+              disabled={isSavingMapping || mappedFieldCount === 0}
+              className="inline-flex h-9 w-fit items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSavingMapping ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <Save className="size-4" />
+              )}
+              Remember mapping
+            </button>
+          </div>
+          {mappingSuggestion ? (
+            <div className="rounded-md bg-muted p-3 text-sm">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="font-medium">Saved mapping available</p>
+                  <p className="text-muted-foreground">
+                    {mappingSuggestion.matchedFieldCount} fields from{" "}
+                    {mappingSuggestion.sourcePlatform}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleUseSuggestedMapping(mappingSuggestion)}
+                  className="inline-flex h-9 w-fit items-center gap-2 rounded-md border bg-background px-3 text-sm font-medium hover:bg-muted"
+                >
+                  <CheckCircle2 className="size-4" />
+                  Use saved
+                </button>
+              </div>
+            </div>
+          ) : isLoadingMappingSuggestion ? (
+            <p className="text-sm text-muted-foreground">
+              Checking saved mappings...
+            </p>
+          ) : null}
           <div className="space-y-3">
             {fields.map((field) => (
               <label
@@ -354,18 +473,20 @@ function ImportUploadPanel({
         </div>
       ) : null}
 
-      <button
-        type="submit"
-        disabled={isSubmitting}
-        className="mt-6 inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {isSubmitting ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : (
-          <Upload className="size-4" />
-        )}
-        Preview CSV
-      </button>
+      <div className="mt-6 flex flex-wrap items-center gap-3">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSubmitting ? (
+            <Loader2 className="size-4 animate-spin" />
+          ) : (
+            <Upload className="size-4" />
+          )}
+          Preview CSV
+        </button>
+      </div>
     </form>
   )
 }

--- a/apps/crew/src/routes/events/$eventId/imports.tsx
+++ b/apps/crew/src/routes/events/$eventId/imports.tsx
@@ -230,6 +230,7 @@ function ImportUploadPanel({
       return
     }
 
+    setMappingSuggestion(null)
     setIsLoadingMappingSuggestion(true)
     void getMappingSuggestion({
       data: {

--- a/apps/crew/src/server-fns/crew-import-fns.ts
+++ b/apps/crew/src/server-fns/crew-import-fns.ts
@@ -1,18 +1,18 @@
 // @lat: [[crew#Import CSV Preview#Preview Records]]
+// @lat: [[crew#Remember Import Mappings]]
+// @lat: [[crew#Server Function Runtime Boundary]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
-import {
-  applyCrewImportRecord,
-  loadCrewImportsPageData,
-} from "../server/crew-imports"
 
 export type {
   CrewImportApplyResult,
   CrewImportHistoryItem,
+  CrewImportMappingPresetSaveResult,
+  CrewImportMappingSuggestionResult,
   CrewImportReferenceData,
   CrewImportsPageData,
   PersistedCrewImportPreview,
-} from "../server/crew-imports"
+} from "../server/crew-imports.server"
 
 const getCrewImportsPageInputSchema = z.object({
   eventId: z.string().min(1, "Event ID is required"),
@@ -24,10 +24,61 @@ const applyCrewImportInputSchema = z.object({
   confirmed: z.literal(true),
 })
 
+const crewImportKindSchema = z.enum(["volunteers", "heat_schedule"])
+
+const getCrewImportMappingSuggestionInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  kind: crewImportKindSchema,
+  sourcePlatform: z.string().trim().max(100).nullable().optional(),
+  headers: z.array(z.string().trim()).min(1).max(200),
+})
+
+const saveCrewImportMappingPresetInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  kind: crewImportKindSchema,
+  sourcePlatform: z.string().trim().max(100).nullable().optional(),
+  headers: z.array(z.string().trim()).min(1).max(200),
+  columnMapping: z.record(z.string(), z.string()),
+})
+
 export const getCrewImportsPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => getCrewImportsPageInputSchema.parse(data))
-  .handler(async ({ data }) => await loadCrewImportsPageData(data.eventId))
+  .handler(async ({ data }) => {
+    const { loadCrewImportsPageData } = await import(
+      "../server/crew-imports.server"
+    )
+    return loadCrewImportsPageData(data.eventId)
+  })
 
 export const applyCrewImportFn = createServerFn({ method: "POST" })
   .inputValidator((data: unknown) => applyCrewImportInputSchema.parse(data))
-  .handler(async ({ data }) => await applyCrewImportRecord(data))
+  .handler(async ({ data }) => {
+    const { applyCrewImportRecord } = await import(
+      "../server/crew-imports.server"
+    )
+    return applyCrewImportRecord(data)
+  })
+
+export const getCrewImportMappingSuggestionFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) =>
+    getCrewImportMappingSuggestionInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewImportMappingSuggestion } = await import(
+      "../server/crew-imports.server"
+    )
+    return getCrewImportMappingSuggestion(data)
+  })
+
+export const saveCrewImportMappingPresetFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    saveCrewImportMappingPresetInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { saveCrewImportMappingPreset } = await import(
+      "../server/crew-imports.server"
+    )
+    return saveCrewImportMappingPreset(data)
+  })

--- a/apps/crew/src/server-fns/crew-import-fns.ts
+++ b/apps/crew/src/server-fns/crew-import-fns.ts
@@ -60,7 +60,7 @@ export const applyCrewImportFn = createServerFn({ method: "POST" })
   })
 
 export const getCrewImportMappingSuggestionFn = createServerFn({
-  method: "GET",
+  method: "POST",
 })
   .inputValidator((data: unknown) =>
     getCrewImportMappingSuggestionInputSchema.parse(data),

--- a/apps/crew/src/server/crew-imports.server.ts
+++ b/apps/crew/src/server/crew-imports.server.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Import CSV Preview#Preview Records]]
+// @lat: [[crew#Remember Import Mappings]]
 import { createId } from "@paralleldrive/cuid2"
 import { and, asc, desc, eq, inArray, isNull } from "drizzle-orm"
 import { z } from "zod"
@@ -15,6 +16,7 @@ import {
 import {
   createCompetitionHeatId,
   createCompetitionVenueId,
+  createCrewImportMappingPresetId,
   createCrewImportId,
   createProgrammingTrackId,
   createTeamInvitationId,
@@ -26,6 +28,10 @@ import {
   competitionsTable,
 } from "../db/schemas/competitions"
 import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import {
+  crewImportMappingPresetsTable,
+  type CrewImportMappingPreset,
+} from "../db/schemas/crew-self-serve-presets"
 import {
   PROGRAMMING_TRACK_TYPE,
   programmingTracksTable,
@@ -67,6 +73,14 @@ import {
   buildCrewImportPreview,
   defaultCrewImportRoleLabels,
 } from "../lib/crew/imports/preview"
+import {
+  buildCrewImportMappingPresetWrite,
+  computeImportHeaderFingerprint,
+  normalizeImportMappingSourcePlatform,
+  selectCrewImportMappingSuggestion,
+  type CrewImportMappingPresetCandidate,
+  type CrewImportMappingSuggestion,
+} from "../lib/crew/imports/mapping-memory"
 import {
   CREW_IMPORT_PARSER_VERSION,
   type ColumnMapping,
@@ -137,6 +151,23 @@ const applyCrewImportInputSchema = z.object({
   confirmed: z.literal(true),
 })
 
+const mappingMemoryKindSchema = z.enum([
+  CREW_IMPORT_KIND.VOLUNTEERS,
+  CREW_IMPORT_KIND.HEAT_SCHEDULE,
+])
+
+const crewImportMappingSuggestionInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+  kind: mappingMemoryKindSchema,
+  sourcePlatform: z.string().trim().max(100).nullable().optional(),
+  headers: z.array(z.string().trim()).min(1).max(200),
+})
+
+const saveCrewImportMappingPresetInputSchema =
+  crewImportMappingSuggestionInputSchema.extend({
+    columnMapping: z.record(z.string(), z.string()),
+  })
+
 export interface CrewImportHistoryItem {
   id: string
   kind: CrewImport["kind"]
@@ -194,6 +225,16 @@ export interface CrewImportsPageData {
   reference: CrewImportReferenceData
 }
 
+export interface CrewImportMappingSuggestionResult {
+  suggestion: CrewImportMappingSuggestion | null
+}
+
+export interface CrewImportMappingPresetSaveResult {
+  success: true
+  presetId: string
+  suggestion: CrewImportMappingSuggestion
+}
+
 export async function loadCrewImportsPageData(
   eventId: string,
 ): Promise<CrewImportsPageData> {
@@ -205,6 +246,109 @@ export async function loadCrewImportsPageData(
   ])
 
   return { reference, history }
+}
+
+export async function getCrewImportMappingSuggestion(input: {
+  eventId: string
+  kind: CrewImportKind
+  sourcePlatform?: string | null
+  headers: string[]
+}): Promise<CrewImportMappingSuggestionResult> {
+  requireLocalCrewOperatorAccess("Crew import mappings")
+
+  const data = crewImportMappingSuggestionInputSchema.parse(input)
+  const event = await requireCrewEvent(data.eventId)
+  const suggestion = await loadCrewImportMappingSuggestion({
+    teamId: event.organizingTeamId,
+    kind: data.kind,
+    sourcePlatform: data.sourcePlatform,
+    headers: data.headers,
+  })
+
+  return { suggestion }
+}
+
+export async function saveCrewImportMappingPreset(input: {
+  eventId: string
+  kind: CrewImportKind
+  sourcePlatform?: string | null
+  headers: string[]
+  columnMapping: ColumnMapping
+}): Promise<CrewImportMappingPresetSaveResult> {
+  requireLocalCrewOperatorAccess("Crew import mappings")
+
+  const data = saveCrewImportMappingPresetInputSchema.parse(input)
+  const event = await requireCrewEvent(data.eventId)
+  const presetWrite = buildCrewImportMappingPresetWrite({
+    teamId: event.organizingTeamId,
+    competitionId: event.id,
+    kind: data.kind,
+    sourcePlatform: data.sourcePlatform,
+    headers: data.headers,
+    columnMapping: data.columnMapping,
+  })
+
+  if (!presetWrite) {
+    throw new CrewImportError(
+      "INVALID_COLUMN_MAPPING",
+      "Map at least one Crew import field before saving this mapping.",
+      400,
+    )
+  }
+
+  const db = getDb()
+  const timestamp = new Date()
+  await db
+    .insert(crewImportMappingPresetsTable)
+    .values({
+      id: createCrewImportMappingPresetId(),
+      teamId: presetWrite.teamId,
+      competitionId: presetWrite.competitionId,
+      kind: presetWrite.kind,
+      sourcePlatform: presetWrite.sourcePlatform,
+      name: presetWrite.name,
+      headerFingerprint: presetWrite.headerFingerprint,
+      headers: presetWrite.headers,
+      columnMapping: presetWrite.columnMapping,
+      parserVersion: presetWrite.parserVersion,
+      lastUsedAt: timestamp,
+      metadata: presetWrite.metadata,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    })
+    .onDuplicateKeyUpdate({
+      set: {
+        competitionId: presetWrite.competitionId,
+        name: presetWrite.name,
+        headers: presetWrite.headers,
+        columnMapping: presetWrite.columnMapping,
+        parserVersion: presetWrite.parserVersion,
+        lastUsedAt: timestamp,
+        metadata: presetWrite.metadata,
+        updatedAt: timestamp,
+      },
+    })
+
+  const suggestion = await loadCrewImportMappingSuggestion({
+    teamId: event.organizingTeamId,
+    kind: data.kind,
+    sourcePlatform: data.sourcePlatform,
+    headers: data.headers,
+  })
+
+  if (!suggestion) {
+    throw new CrewImportError(
+      "INVALID_COLUMN_MAPPING",
+      "Saved mapping could not be loaded.",
+      500,
+    )
+  }
+
+  return {
+    success: true,
+    presetId: suggestion.presetId,
+    suggestion,
+  }
 }
 
 export async function createCrewImportPreviewRecord(input: {
@@ -1483,6 +1627,96 @@ async function listCrewImportHistory(
     .limit(25)
 }
 
+async function loadCrewImportMappingSuggestion({
+  teamId,
+  sourcePlatform,
+  kind,
+  headers,
+}: {
+  teamId: string
+  sourcePlatform?: string | null
+  kind: CrewImportKind
+  headers: string[]
+}) {
+  const db = getDb()
+  const normalizedSourcePlatform =
+    normalizeImportMappingSourcePlatform(sourcePlatform)
+  const headerFingerprint = computeImportHeaderFingerprint(headers)
+  const candidates = await db
+    .select({
+      id: crewImportMappingPresetsTable.id,
+      teamId: crewImportMappingPresetsTable.teamId,
+      kind: crewImportMappingPresetsTable.kind,
+      sourcePlatform: crewImportMappingPresetsTable.sourcePlatform,
+      name: crewImportMappingPresetsTable.name,
+      headerFingerprint: crewImportMappingPresetsTable.headerFingerprint,
+      headers: crewImportMappingPresetsTable.headers,
+      columnMapping: crewImportMappingPresetsTable.columnMapping,
+      parserVersion: crewImportMappingPresetsTable.parserVersion,
+      lastUsedAt: crewImportMappingPresetsTable.lastUsedAt,
+      createdAt: crewImportMappingPresetsTable.createdAt,
+      updatedAt: crewImportMappingPresetsTable.updatedAt,
+    })
+    .from(crewImportMappingPresetsTable)
+    .where(
+      and(
+        eq(crewImportMappingPresetsTable.teamId, teamId),
+        eq(
+          crewImportMappingPresetsTable.sourcePlatform,
+          normalizedSourcePlatform,
+        ),
+        eq(crewImportMappingPresetsTable.kind, kind),
+        eq(crewImportMappingPresetsTable.headerFingerprint, headerFingerprint),
+      ),
+    )
+    .orderBy(
+      desc(crewImportMappingPresetsTable.lastUsedAt),
+      desc(crewImportMappingPresetsTable.updatedAt),
+    )
+    .limit(5)
+
+  return selectCrewImportMappingSuggestion({
+    teamId,
+    sourcePlatform: normalizedSourcePlatform,
+    kind,
+    headers,
+    candidates: candidates.map(toCrewImportMappingPresetCandidate),
+  })
+}
+
+function toCrewImportMappingPresetCandidate(
+  preset: Pick<
+    CrewImportMappingPreset,
+    | "id"
+    | "teamId"
+    | "kind"
+    | "sourcePlatform"
+    | "name"
+    | "headerFingerprint"
+    | "headers"
+    | "columnMapping"
+    | "parserVersion"
+    | "lastUsedAt"
+    | "createdAt"
+    | "updatedAt"
+  >,
+): CrewImportMappingPresetCandidate {
+  return {
+    id: preset.id,
+    teamId: preset.teamId,
+    kind: preset.kind as CrewImportKind,
+    sourcePlatform: preset.sourcePlatform,
+    name: preset.name,
+    headerFingerprint: preset.headerFingerprint,
+    headers: toStringArray(preset.headers),
+    columnMapping: toColumnMapping(preset.columnMapping),
+    parserVersion: preset.parserVersion,
+    lastUsedAt: preset.lastUsedAt,
+    createdAt: preset.createdAt,
+    updatedAt: preset.updatedAt,
+  }
+}
+
 async function loadCrewImportReferenceData(
   eventId: string,
 ): Promise<CrewImportReferenceData> {
@@ -1607,6 +1841,24 @@ function toRecord(value: CrewImportRow["rawRow"]) {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, string>)
     : {}
+}
+
+function toStringArray(value: unknown) {
+  return Array.isArray(value)
+    ? value.flatMap((item) => (typeof item === "string" ? [item] : []))
+    : []
+}
+
+function toColumnMapping(value: unknown): ColumnMapping {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+
+  const mapping: ColumnMapping = {}
+  for (const [field, header] of Object.entries(value)) {
+    if (typeof header === "string") {
+      mapping[field] = header
+    }
+  }
+  return mapping
 }
 
 function toPayload(row: PreviewImportRow["normalizedRow"]) {

--- a/apps/crew/src/server/crew-imports.server.ts
+++ b/apps/crew/src/server/crew-imports.server.ts
@@ -298,42 +298,46 @@ export async function saveCrewImportMappingPreset(input: {
 
   const db = getDb()
   const timestamp = new Date()
-  await db
-    .insert(crewImportMappingPresetsTable)
-    .values({
-      id: createCrewImportMappingPresetId(),
-      teamId: presetWrite.teamId,
-      competitionId: presetWrite.competitionId,
-      kind: presetWrite.kind,
-      sourcePlatform: presetWrite.sourcePlatform,
-      name: presetWrite.name,
-      headerFingerprint: presetWrite.headerFingerprint,
-      headers: presetWrite.headers,
-      columnMapping: presetWrite.columnMapping,
-      parserVersion: presetWrite.parserVersion,
-      lastUsedAt: timestamp,
-      metadata: presetWrite.metadata,
-      createdAt: timestamp,
-      updatedAt: timestamp,
-    })
-    .onDuplicateKeyUpdate({
-      set: {
+  const suggestion = await db.transaction(async (tx) => {
+    const client = tx as unknown as DbClient
+    await client
+      .insert(crewImportMappingPresetsTable)
+      .values({
+        id: createCrewImportMappingPresetId(),
+        teamId: presetWrite.teamId,
         competitionId: presetWrite.competitionId,
+        kind: presetWrite.kind,
+        sourcePlatform: presetWrite.sourcePlatform,
         name: presetWrite.name,
+        headerFingerprint: presetWrite.headerFingerprint,
         headers: presetWrite.headers,
         columnMapping: presetWrite.columnMapping,
         parserVersion: presetWrite.parserVersion,
         lastUsedAt: timestamp,
         metadata: presetWrite.metadata,
+        createdAt: timestamp,
         updatedAt: timestamp,
-      },
-    })
+      })
+      .onDuplicateKeyUpdate({
+        set: {
+          competitionId: presetWrite.competitionId,
+          name: presetWrite.name,
+          headers: presetWrite.headers,
+          columnMapping: presetWrite.columnMapping,
+          parserVersion: presetWrite.parserVersion,
+          lastUsedAt: timestamp,
+          metadata: presetWrite.metadata,
+          updatedAt: timestamp,
+        },
+      })
 
-  const suggestion = await loadCrewImportMappingSuggestion({
-    teamId: event.organizingTeamId,
-    kind: data.kind,
-    sourcePlatform: data.sourcePlatform,
-    headers: data.headers,
+    return await loadCrewImportMappingSuggestion({
+      db: client,
+      teamId: event.organizingTeamId,
+      kind: data.kind,
+      sourcePlatform: data.sourcePlatform,
+      headers: data.headers,
+    })
   })
 
   if (!suggestion) {
@@ -1628,17 +1632,18 @@ async function listCrewImportHistory(
 }
 
 async function loadCrewImportMappingSuggestion({
+  db = getDb(),
   teamId,
   sourcePlatform,
   kind,
   headers,
 }: {
+  db?: DbClient
   teamId: string
   sourcePlatform?: string | null
   kind: CrewImportKind
   headers: string[]
 }) {
-  const db = getDb()
   const normalizedSourcePlatform =
     normalizeImportMappingSourcePlatform(sourcePlatform)
   const headerFingerprint = computeImportHeaderFingerprint(headers)

--- a/apps/crew/test/routes/event-import-tabs.test.tsx
+++ b/apps/crew/test/routes/event-import-tabs.test.tsx
@@ -8,7 +8,9 @@ vi.mock("@tanstack/react-start", () => ({
 
 vi.mock("@/server-fns/crew-import-fns", () => ({
   applyCrewImportFn: vi.fn(),
+  getCrewImportMappingSuggestionFn: vi.fn(),
   getCrewImportsPageFn: vi.fn(),
+  saveCrewImportMappingPresetFn: vi.fn(),
 }))
 
 const reference = {

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -200,6 +200,14 @@ Self-serve Crew setup keeps reusable setup memory in shared DB tables owned by `
 
 `crew_department_leads` stores event-scoped delegation records for role, floor, and time-slice access without expanding the broad team permission model. IDs use the `cdlead_` prefix.
 
+## Remember Import Mappings
+
+Crew import mapping memory stores confirmed CSV header mappings in `crew_import_mapping_presets` by team, source platform, import kind, and deterministic header fingerprint.
+
+[[apps/crew/src/lib/crew/imports/mapping-memory.ts]] owns pure header fingerprinting, source normalization, scoped suggestion selection, and save-payload sanitization. [[apps/crew/src/server-fns/crew-import-fns.ts]] keeps the route-facing functions thin while [[apps/crew/src/server/crew-imports.server.ts]] loads and upserts presets through the shared table.
+
+[[apps/crew/src/routes/events/$eventId/imports.tsx]] surfaces saved mappings as explicit suggestions. Operators must click to use or remember a mapping; previews and applies continue to use the currently visible mapping and never rewrite historical `crew_import_rows`.
+
 ## Guided Setup State
 
 Guided setup turns Crew readiness facts and operator overrides into a per-event self-serve checklist stored in `crew_event_settings.settings`.


### PR DESCRIPTION
## Summary
- Add deterministic Crew import mapping-memory helpers for header fingerprints, source normalization, scoped suggestion selection, and sanitized preset writes.
- Add route-safe import mapping suggestion/save server functions backed by `crew_import_mapping_presets`, with the import implementation moved behind the `*.server.ts` runtime-boundary pattern.
- Surface saved mappings on `/events/$eventId/imports` as explicit operator suggestions; presets are only used or updated when the operator clicks the corresponding action.

## Validation
- `pnpm --filter crew exec vitest run src/lib/crew/imports/mapping-memory.test.ts src/lib/crew/imports/preview.test.ts`
- `pnpm --filter crew exec vitest run test/routes/event-import-tabs.test.tsx`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (passes with pre-existing unrelated warnings)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` (passed after copying `apps/crew/wrangler.jsonc` to ignored `apps/crew/.alchemy/local/wrangler.jsonc`)
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Remember Import Mappings'`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add memory for Crew CSV import mappings so operators can save and reuse column mappings by team, source platform, and import kind. The imports UI auto-checks headers for a saved mapping and lets operators apply or save with one click.

- **New Features**
  - Deterministic header fingerprinting and source normalization to key presets (blank sources default to "csv").
  - Server-backed presets in `crew_import_mapping_presets` with safe upsert, `lastUsedAt`, and sanitized writes.
  - New server functions `getCrewImportMappingSuggestionFn` and `saveCrewImportMappingPresetFn`; suggestions pick the most recently used match and adapt to current header casing.
  - Imports page shows a saved mapping banner with “Use saved” and a “Remember mapping” action; mappings apply only when the operator clicks.

- **Refactors**
  - Moved import logic behind `crew-imports.server.ts` with lazy-loaded handlers and updated route imports.
  - Added tests for mapping memory, preview, and route behavior.

<sup>Written for commit 97f24f9fc64c7356ed4f81e5ccbbccf91f3946c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Import mappings are now remembered and automatically suggested for future CSV uploads matching the same data source and import type, eliminating repetitive manual header configuration.
  * Users can explicitly save the current column mapping to reuse across similar imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->