### PR TITLE
[codex] Add benchmark competition capabilities

### DIFF
--- a/apps/wodsmith-start/src/lib/competitions/capabilities.ts
+++ b/apps/wodsmith-start/src/lib/competitions/capabilities.ts
@@ -3,18 +3,21 @@ export type CompetitionCapability =
   | "videoSubmissions"
   | "submissionWindows"
   | "optInResultPublishing"
+  | "perpetual"
   | "heatScheduling"
   | "dayOfCheckIn"
   | "physicalVenue"
   | "volunteerScheduling"
   | "organizerEntersResults"
 
+export type RegisteredCompetitionTypeId = "in-person" | "online" | "benchmark"
+export type CompetitionTypeId = Exclude<RegisteredCompetitionTypeId, "benchmark">
 export type LeaderboardVariant = "standard" | "online"
 export type ResultsEntryMode = "organizer-entered" | "athlete-submitted"
 export type ResultsNavLabel = "Results" | "Submissions"
 
 export interface CompetitionTypeDef {
-  id: string
+  id: RegisteredCompetitionTypeId
   label: string
   createPickerDescription: string
   capabilities: ReadonlySet<CompetitionCapability>
@@ -32,7 +35,7 @@ export interface CompetitionTypePickerOption {
 const EMPTY_CAPABILITIES: ReadonlySet<CompetitionCapability> = new Set()
 
 export const COMPETITION_TYPE_REGISTRY: Readonly<
-  Record<"in-person" | "online", CompetitionTypeDef>
+  Record<RegisteredCompetitionTypeId, CompetitionTypeDef>
 > = {
   "in-person": {
     id: "in-person",
@@ -60,9 +63,15 @@ export const COMPETITION_TYPE_REGISTRY: Readonly<
       "optInResultPublishing",
     ]),
   },
+  benchmark: {
+    id: "benchmark",
+    label: "Benchmark",
+    createPickerDescription: "Perpetual benchmark board with video submissions",
+    leaderboardVariant: "online",
+    selectableOnCreate: false,
+    capabilities: new Set(["videoSubmissions", "perpetual"]),
+  },
 }
-
-export type CompetitionTypeId = keyof typeof COMPETITION_TYPE_REGISTRY
 
 export function competitionCan(
   type: string,

--- a/apps/wodsmith-start/src/routes/api/compete/scores/submit.ts
+++ b/apps/wodsmith-start/src/routes/api/compete/scores/submit.ts
@@ -68,10 +68,18 @@ async function checkSubmissionWindow(
     .where(eq(competitionsTable.id, competitionId))
     .limit(1)
 
-  if (
-    !competition ||
-    !competitionCan(competition.competitionType, "submissionWindows")
-  ) {
+  if (!competition) {
+    return {
+      isOpen: false,
+      reason: "Submission windows are not available for this competition type",
+    }
+  }
+
+  if (competitionCan(competition.competitionType, "perpetual")) {
+    return { isOpen: true, reason: undefined }
+  }
+
+  if (!competitionCan(competition.competitionType, "submissionWindows")) {
     return {
       isOpen: false,
       reason: "Submission windows are not available for this competition type",

--- a/apps/wodsmith-start/src/routes/api/compete/scores/window-status.ts
+++ b/apps/wodsmith-start/src/routes/api/compete/scores/window-status.ts
@@ -38,6 +38,14 @@ async function getSubmissionWindowStatus(
     }
   }
 
+  if (competitionCan(competition.competitionType, "perpetual")) {
+    return {
+      isOpen: true,
+      opensAt: null,
+      closesAt: null,
+    }
+  }
+
   if (!competitionCan(competition.competitionType, "submissionWindows")) {
     return {
       isOpen: false,

--- a/apps/wodsmith-start/src/routes/api/compete/video/submit.ts
+++ b/apps/wodsmith-start/src/routes/api/compete/video/submit.ts
@@ -85,6 +85,10 @@ async function checkVideoSubmissionWindow(
     }
   }
 
+  if (competitionCan(competition.competitionType, "perpetual")) {
+    return { allowed: true }
+  }
+
   const [event] = await db
     .select({
       submissionOpensAt: competitionEventsTable.submissionOpensAt,

--- a/apps/wodsmith-start/src/routes/compete/$slug/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/index.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/competition-workout-card"
 import { EventDetailsContent } from "@/components/event-details-content"
 import { RegistrationSidebar } from "@/components/registration-sidebar"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import {
   getPublicScheduleDataFn,
   type PublicScheduleEvent,
@@ -53,13 +54,14 @@ export const Route = createFileRoute("/compete/$slug/")({
     // Single consolidated call for workouts + division descriptions +
     // event-division mappings + the viewer's submission statuses (fetched
     // server-side in the same wave as the descriptions, only for registered
-    // athletes on online competitions).
+    // athletes on competitions that support video submissions).
     const pageData = await getPublicWorkoutsPageDataFn({
       data: {
         competitionId,
         divisionIds,
         includeSubmissionStatuses:
-          competition.competitionType === "online" && !!userRegistration,
+          competitionCan(competition.competitionType, "videoSubmissions") &&
+          !!userRegistration,
       },
     })
 
@@ -132,7 +134,7 @@ function CompetitionOverviewPage() {
   }
 
   const showScorePanel =
-    competition.competitionType === "online" &&
+    competitionCan(competition.competitionType, "videoSubmissions") &&
     isRegistered &&
     !!session &&
     userDivisions.length > 0 &&

--- a/apps/wodsmith-start/src/routes/compete/$slug/review/$eventId/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/review/$eventId/index.tsx
@@ -56,6 +56,7 @@ import {
   getCompetitionDivisionsForScoreEntryFn,
 } from "@/server-fns/competition-score-fns"
 import { getOrganizerSubmissionsFn } from "@/server-fns/video-submission-fns"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import { cn } from "@/utils/cn"
 import { isSafeUrl } from "@/utils/url"
 
@@ -97,10 +98,9 @@ export const Route = createFileRoute("/compete/$slug/review/$eventId/")({
       throw new Error("Competition not found")
     }
 
-    // Only allow for online competitions
-    if (competition.competitionType !== "online") {
+    if (!competitionCan(competition.competitionType, "videoSubmissions")) {
       throw new Error(
-        "Video submissions are only available for online competitions",
+        "Video submissions are not available for this competition type",
       )
     }
 

--- a/apps/wodsmith-start/src/routes/compete/$slug/workouts/$eventId.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/workouts/$eventId.tsx
@@ -43,6 +43,7 @@ import {
   getBatchEventVideoSubmissionsFn,
   type VideoSubmissionResult,
 } from "@/server-fns/video-submission-fns"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import { getGoogleMapsUrl, hasAddressData } from "@/utils/address"
 import { formatTrackOrder } from "@/utils/format-track-order"
 
@@ -70,7 +71,10 @@ export const Route = createFileRoute("/compete/$slug/workouts/$eventId")({
 
     const divisions = parentDivisions ?? []
     const divisionIds = divisions.map((d) => d.id)
-    const isOnline = competition.competitionType === "online"
+    const supportsVideoSubmissions = competitionCan(
+      competition.competitionType,
+      "videoSubmissions",
+    )
 
     // Athlete's registered division ids — derived from the parent route's
     // registrations (the same getUserCompetitionRegistrationsFn data the old
@@ -136,14 +140,14 @@ export const Route = createFileRoute("/compete/$slug/workouts/$eventId")({
       }
     }
 
-    // For online competitions, fetch video submissions in ONE batched call
+    // For video-submission competitions, fetch submissions in ONE batched call
     // (instead of one getVideoSubmissionFn call per child event). The target
     // events (children vs the event itself) and the mapped division only
     // emerge from the page data, so this chains off the same promise — a
     // single dependent round-trip.
     const videoDataPromise: Promise<Record<string, VideoSubmissionResult>> =
       (async () => {
-        if (!isOnline) return {}
+        if (!supportsVideoSubmissions) return {}
         const pageData = await pageDataPromise
         if (!pageData.event) return {}
 
@@ -231,9 +235,11 @@ export const Route = createFileRoute("/compete/$slug/workouts/$eventId")({
     }
 
     const videoSubmission =
-      isOnline && !hasChildEvents ? (videoResults[eventId] ?? null) : null
+      supportsVideoSubmissions && !hasChildEvents
+        ? (videoResults[eventId] ?? null)
+        : null
     const childVideoSubmissions: Record<string, VideoSubmissionResult> = {}
-    if (isOnline && hasChildEvents) {
+    if (supportsVideoSubmissions && hasChildEvents) {
       for (const child of childEvents) {
         const result = videoResults[child.id]
         if (result) {
@@ -648,8 +654,11 @@ function EventDetailsPage() {
                         )}
                       </div>
 
-                      {/* Per-sub-event submission form for online competitions */}
-                      {competition.competitionType === "online" &&
+                      {/* Per-sub-event submission form */}
+                      {competitionCan(
+                        competition.competitionType,
+                        "videoSubmissions",
+                      ) &&
                         childSubmission && (
                           <VideoSubmissionForm
                             trackWorkoutId={child.id}
@@ -676,7 +685,7 @@ function EventDetailsPage() {
 
             {/* Video & Score Submission Form - For events without sub-events */}
             {/* Only show when event is mapped to athlete's division (or no mappings configured) */}
-            {competition.competitionType === "online" &&
+            {competitionCan(competition.competitionType, "videoSubmissions") &&
               videoSubmission &&
               childEvents.length === 0 &&
               isEventMappedToAthleteDivision && (
@@ -695,8 +704,8 @@ function EventDetailsPage() {
 
       {/* Sidebar */}
       <aside className="space-y-4 lg:sticky lg:top-4 lg:self-start">
-        {/* Submission Info Card - For online competitions */}
-        {competition.competitionType === "online" &&
+        {/* Submission Info Card - For competitions with submission windows */}
+        {competitionCan(competition.competitionType, "submissionWindows") &&
           sidebarSubmission?.submissionWindow && (
             <Card>
               <CardHeader className="pb-3">

--- a/apps/wodsmith-start/src/routes/compete/$slug/workouts/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/$slug/workouts/index.tsx
@@ -31,6 +31,7 @@ import {
   getPublicWorkoutsPageDataFn,
   type PublicWorkoutVenueInfo,
 } from "@/server-fns/competition-workouts-page-fns"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import { useDeferredSchedule } from "@/utils/use-deferred-schedule"
 
 const parentRoute = getRouteApi("/compete/$slug")
@@ -78,18 +79,22 @@ export const Route = createFileRoute("/compete/$slug/workouts/")({
       parentMatch.loaderData?.userRegistration?.divisionId ?? null
 
     const divisionIds = divisions?.map((d) => d.id) ?? []
-    const isOnline = competition.competitionType === "online"
+    const supportsVideoSubmissions = competitionCan(
+      competition.competitionType,
+      "videoSubmissions",
+    )
 
     // Single consolidated call for workouts + division descriptions +
     // event-division mappings + venues + the viewer's submission statuses
     // (fetched server-side in the same wave as descriptions/venues, only
-    // for registered athletes on online competitions).
+    // for registered athletes on video-submission competitions).
     const pageData = await getPublicWorkoutsPageDataFn({
       data: {
         competitionId,
         divisionIds,
         includeVenues: true,
-        includeSubmissionStatuses: isOnline && !!athleteRegisteredDivisionId,
+        includeSubmissionStatuses:
+          supportsVideoSubmissions && !!athleteRegisteredDivisionId,
       },
     })
 

--- a/apps/wodsmith-start/src/routes/compete/cohost/$competitionId/events/$eventId/submissions/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/cohost/$competitionId/events/$eventId/submissions/index.tsx
@@ -56,6 +56,7 @@ import { cohostGetOrganizerSubmissionsFn } from "@/server-fns/cohost/cohost-subm
 import { cn } from "@/utils/cn"
 import { isSafeUrl } from "@/utils/url"
 import { getCompetitionByIdFn } from "@/server-fns/competition-detail-fns"
+import { competitionCan } from "@/lib/competitions/capabilities"
 
 const FLAGGED_THRESHOLD = 3
 
@@ -97,10 +98,9 @@ export const Route = createFileRoute(
 
     const competitionTeamId = competition.competitionTeamId!
 
-    // Only allow for online competitions
-    if (competition.competitionType !== "online") {
+    if (!competitionCan(competition.competitionType, "videoSubmissions")) {
       throw new Error(
-        "Video submissions are only available for online competitions",
+        "Video submissions are not available for this competition type",
       )
     }
 

--- a/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/events/$eventId/submissions/index.tsx
+++ b/apps/wodsmith-start/src/routes/compete/organizer/$competitionId/events/$eventId/submissions/index.tsx
@@ -56,6 +56,7 @@ import { getCompetitionByIdFn } from "@/server-fns/competition-detail-fns"
 import { getCompetitionDivisionsWithCountsFn } from "@/server-fns/competition-divisions-fns"
 import { getCompetitionEventFn } from "@/server-fns/competition-workouts-fns"
 import { getOrganizerSubmissionsFn } from "@/server-fns/video-submission-fns"
+import { competitionCan } from "@/lib/competitions/capabilities"
 import { cn } from "@/utils/cn"
 import { isSafeUrl } from "@/utils/url"
 
@@ -100,10 +101,9 @@ export const Route = createFileRoute(
       throw new Error("Competition not found")
     }
 
-    // Only allow for online competitions
-    if (competition.competitionType !== "online") {
+    if (!competitionCan(competition.competitionType, "videoSubmissions")) {
       throw new Error(
-        "Video submissions are only available for online competitions",
+        "Video submissions are not available for this competition type",
       )
     }
 

--- a/apps/wodsmith-start/src/server-fns/athlete-score-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/athlete-score-fns.ts
@@ -149,6 +149,14 @@ async function checkSubmissionWindow(
     }
   }
 
+  if (competitionCan(competition.competitionType, "perpetual")) {
+    return {
+      isOpen: true,
+      opensAt: null,
+      closesAt: null,
+    }
+  }
+
   if (!competitionCan(competition.competitionType, "submissionWindows")) {
     return {
       isOpen: false,

--- a/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
+++ b/apps/wodsmith-start/src/server-fns/video-submission-fns.ts
@@ -167,6 +167,10 @@ async function checkSubmissionWindow(
     }
   }
 
+  if (competitionCan(competition.competitionType, "perpetual")) {
+    return { allowed: true }
+  }
+
   // If no event record exists, allow submission (backward compatibility)
   if (!event) {
     return { allowed: true }
@@ -932,9 +936,13 @@ export const getBatchEventVideoSubmissionsFn = createServerFn({
         if (!competition) {
           allowed = false
           windowReason = "Competition not found"
-        } else if (competition.competitionType !== "online") {
+        } else if (
+          !competitionCan(competition.competitionType, "videoSubmissions")
+        ) {
           allowed = false
           windowReason = "Video submissions are only for online competitions"
+        } else if (competitionCan(competition.competitionType, "perpetual")) {
+          allowed = true
         } else {
           const event = eventMap.get(twId)
           // No event record / no configured window → submission allowed

--- a/apps/wodsmith-start/test/lib/competitions/capabilities.test.ts
+++ b/apps/wodsmith-start/test/lib/competitions/capabilities.test.ts
@@ -16,6 +16,7 @@ const CAPABILITIES: CompetitionCapability[] = [
 	"videoSubmissions",
 	"submissionWindows",
 	"optInResultPublishing",
+	"perpetual",
 	"heatScheduling",
 	"dayOfCheckIn",
 	"physicalVenue",
@@ -28,6 +29,7 @@ const EXPECTED = {
 		videoSubmissions: false,
 		submissionWindows: false,
 		optInResultPublishing: false,
+		perpetual: false,
 		heatScheduling: true,
 		dayOfCheckIn: true,
 		physicalVenue: true,
@@ -40,6 +42,7 @@ const EXPECTED = {
 		videoSubmissions: true,
 		submissionWindows: true,
 		optInResultPublishing: true,
+		perpetual: false,
 		heatScheduling: false,
 		dayOfCheckIn: false,
 		physicalVenue: false,
@@ -48,11 +51,24 @@ const EXPECTED = {
 		leaderboardVariant: "online",
 		selectableOnCreate: true,
 	},
+	benchmark: {
+		videoSubmissions: true,
+		submissionWindows: false,
+		optInResultPublishing: false,
+		perpetual: true,
+		heatScheduling: false,
+		dayOfCheckIn: false,
+		physicalVenue: false,
+		volunteerScheduling: false,
+		organizerEntersResults: false,
+		leaderboardVariant: "online",
+		selectableOnCreate: false,
+	},
 } as const
 
 describe("competition type capabilities", () => {
 	// @lat: [[competition-type-capabilities#Capability Truth Table Test#Current Type Matrix]]
-	it("pins every in-person and online capability to the existing behavior table", () => {
+	it("pins every registered capability to the expected behavior table", () => {
 		for (const [type, expected] of Object.entries(EXPECTED)) {
 			for (const capability of CAPABILITIES) {
 				expect(competitionCan(type, capability), `${type}:${capability}`).toBe(
@@ -68,6 +84,7 @@ describe("competition type capabilities", () => {
 	// @lat: [[competition-type-capabilities#Capability Truth Table Test#Registry Metadata Alignment]]
 	it("keeps registry metadata aligned with the supported type identities", () => {
 		expect(Object.keys(COMPETITION_TYPE_REGISTRY).sort()).toEqual([
+			"benchmark",
 			"in-person",
 			"online",
 		])
@@ -82,11 +99,11 @@ describe("competition type capabilities", () => {
 	// @lat: [[competition-type-capabilities#Capability Truth Table Test#Unknown Type Fallback]]
 	it("falls back safely for unknown competition types", () => {
 		for (const capability of CAPABILITIES) {
-			expect(competitionCan("benchmark", capability)).toBe(false)
+			expect(competitionCan("unregistered", capability)).toBe(false)
 		}
 
-		expect(leaderboardVariant("benchmark")).toBe("standard")
-		expect(isSelectableType("benchmark")).toBe(false)
+		expect(leaderboardVariant("unregistered")).toBe("standard")
+		expect(isSelectableType("unregistered")).toBe(false)
 	})
 
 	// @lat: [[competition-type-capabilities#Create Picker Selectability Test]]
@@ -102,6 +119,7 @@ describe("competition type capabilities", () => {
 			expect(isSelectableType(type.id)).toBe(true)
 			expect(isSelectableCompetitionTypeValue(type.id)).toBe(true)
 		}
+		expect(isSelectableType("benchmark")).toBe(false)
 		expect(isSelectableCompetitionTypeValue("benchmark")).toBe(false)
 		expect(isSelectableCompetitionTypeValue(null)).toBe(false)
 
@@ -128,5 +146,8 @@ describe("competition type capabilities", () => {
 
 		expect(resultsEntryMode("online")).toBe("athlete-submitted")
 		expect(resultsNavLabel("online")).toBe("Submissions")
+
+		expect(resultsEntryMode("benchmark")).toBe("athlete-submitted")
+		expect(resultsNavLabel("benchmark")).toBe("Submissions")
 	})
 })

--- a/apps/wodsmith-start/test/routes/api/compete/scores/window-status.test.ts
+++ b/apps/wodsmith-start/test/routes/api/compete/scores/window-status.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockLimit = vi.hoisted(() => vi.fn())
+
+const mockDb = vi.hoisted(() => {
+  const chain: Record<string, unknown> = {}
+
+  chain.select = vi.fn(() => chain)
+  chain.from = vi.fn(() => chain)
+  chain.where = vi.fn(() => chain)
+  chain.limit = (...args: unknown[]) => mockLimit(...args)
+
+  return chain
+})
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn(() => mockDb),
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: unknown) => config,
+}))
+
+vi.mock("@tanstack/react-start", () => ({
+  json: (data: unknown, init?: { status?: number; headers?: HeadersInit }) =>
+    new Response(JSON.stringify(data), {
+      status: init?.status ?? 200,
+      headers: { "Content-Type": "application/json", ...init?.headers },
+    }),
+}))
+
+import { Route } from "@/routes/api/compete/scores/window-status"
+
+const routeConfig = Route as unknown as {
+  server: {
+    handlers: {
+      GET: (args: { request: Request }) => Promise<Response>
+    }
+  }
+}
+
+function windowStatusRequest() {
+  return new Request(
+    "https://wodsmith.test/api/compete/scores/window-status?competitionId=comp-1&trackWorkoutId=tw-1",
+  )
+}
+
+describe("score window-status API route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLimit.mockReset()
+  })
+
+  it("keeps online competitions closed when no submission window row exists", async () => {
+    mockLimit
+      .mockResolvedValueOnce([{ competitionType: "online" }])
+      .mockResolvedValueOnce([])
+
+    const response = await routeConfig.server.handlers.GET({
+      request: windowStatusRequest(),
+    })
+    const data = (await response.json()) as {
+      isOpen: boolean
+      reason: string
+    }
+
+    expect(response.status).toBe(200)
+    expect(data).toMatchObject({
+      isOpen: false,
+      reason: "Submission window not configured",
+    })
+  })
+
+  it("treats benchmark perpetual status as open without window rows", async () => {
+    // @lat: [[competition-type-capabilities#Perpetual Window Status Test]]
+    mockLimit.mockResolvedValueOnce([{ competitionType: "benchmark" }])
+
+    const response = await routeConfig.server.handlers.GET({
+      request: windowStatusRequest(),
+    })
+    const data = (await response.json()) as {
+      isOpen: boolean
+      opensAt: string | null
+      closesAt: string | null
+    }
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({
+      isOpen: true,
+      opensAt: null,
+      closesAt: null,
+    })
+    expect(mockLimit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/wodsmith-start/test/routes/api/compete/submission-gates.test.ts
+++ b/apps/wodsmith-start/test/routes/api/compete/submission-gates.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockAuthSession = vi.hoisted(() => vi.fn())
+const mockLimit = vi.hoisted(() => vi.fn())
+
+const mockDb = vi.hoisted(() => {
+  const chain: Record<string, unknown> = {}
+  const passthrough = () => chain
+
+  chain.select = vi.fn(passthrough)
+  chain.from = vi.fn(passthrough)
+  chain.where = vi.fn(passthrough)
+  chain.innerJoin = vi.fn(passthrough)
+  chain.insert = vi.fn(passthrough)
+  chain.values = vi.fn(passthrough)
+  chain.update = vi.fn(passthrough)
+  chain.set = vi.fn(passthrough)
+  chain.limit = (...args: unknown[]) => mockLimit(...args)
+  chain.onDuplicateKeyUpdate = vi.fn(() => Promise.resolve())
+  chain.then = <T>(resolve: (value: T) => void) => {
+    resolve(undefined as T)
+    return Promise.resolve(undefined as T)
+  }
+
+  return chain
+})
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn(() => mockDb),
+}))
+
+vi.mock("@/utils/bearer-auth", () => ({
+  corsHeaders: () => ({}),
+  getSessionFromBearerOrCookie: mockAuthSession,
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: unknown) => config,
+}))
+
+vi.mock("@tanstack/react-start", () => ({
+  json: (data: unknown, init?: { status?: number; headers?: HeadersInit }) =>
+    new Response(JSON.stringify(data), {
+      status: init?.status ?? 200,
+      headers: { "Content-Type": "application/json", ...init?.headers },
+    }),
+}))
+
+import { Route as ScoreSubmitRoute } from "@/routes/api/compete/scores/submit"
+import { Route as VideoSubmitRoute } from "@/routes/api/compete/video/submit"
+
+const scoreSubmitRoute = ScoreSubmitRoute as unknown as {
+  server: {
+    handlers: {
+      POST: (args: { request: Request }) => Promise<Response>
+    }
+  }
+}
+
+const videoSubmitRoute = VideoSubmitRoute as unknown as {
+  server: {
+    handlers: {
+      POST: (args: { request: Request }) => Promise<Response>
+    }
+  }
+}
+
+function postRequest(path: string, body: Record<string, unknown>) {
+  return new Request(`https://wodsmith.test${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+}
+
+describe("submission API capability gates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLimit.mockReset()
+    mockAuthSession.mockResolvedValue({ userId: "user-1" })
+  })
+
+  it("allows benchmark score submission without submission-window rows", async () => {
+    // @lat: [[competition-type-capabilities#Perpetual Submission Gate Test]]
+    mockLimit
+      .mockResolvedValueOnce([{ id: "reg-1", divisionId: "open" }])
+      .mockResolvedValueOnce([{ competitionType: "benchmark" }])
+      .mockResolvedValueOnce([{ workoutId: "workout-1", trackId: "track-1" }])
+      .mockResolvedValueOnce([
+        {
+          scheme: "time",
+          scoreType: "min",
+          tiebreakScheme: null,
+          timeCap: null,
+        },
+      ])
+      .mockResolvedValueOnce([{ ownerTeamId: "team-1" }])
+      .mockResolvedValueOnce([{ id: "score-1" }])
+
+    const response = await scoreSubmitRoute.server.handlers.POST({
+      request: postRequest("/api/compete/scores/submit", {
+        competitionId: "comp-1",
+        trackWorkoutId: "tw-1",
+        score: "10:00",
+        status: "scored",
+      }),
+    })
+    const data = (await response.json()) as {
+      success?: boolean
+      scoreId?: string
+      error?: string
+    }
+
+    expect(response.status).toBe(200)
+    expect(data).toMatchObject({ success: true, scoreId: "score-1" })
+    expect(data.error).toBeUndefined()
+  })
+
+  it("allows benchmark video submission without submission-window rows", async () => {
+    mockLimit
+      .mockResolvedValueOnce([{ id: "reg-1", divisionId: "open" }])
+      .mockResolvedValueOnce([{ competitionType: "benchmark" }])
+      .mockResolvedValueOnce([])
+
+    const response = await videoSubmitRoute.server.handlers.POST({
+      request: postRequest("/api/compete/video/submit", {
+        competitionId: "comp-1",
+        trackWorkoutId: "tw-1",
+        videoUrl: "https://example.com/video",
+      }),
+    })
+    const data = (await response.json()) as {
+      success?: boolean
+      submissionId?: string
+      error?: string
+    }
+
+    expect(response.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(data.submissionId).toEqual(expect.any(String))
+    expect(data.error).toBeUndefined()
+  })
+})

--- a/apps/wodsmith-start/test/routes/compete/video-submission-route-gates.test.ts
+++ b/apps/wodsmith-start/test/routes/compete/video-submission-route-gates.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const routeFiles = [
+  "../../../src/routes/compete/$slug/index.tsx",
+  "../../../src/routes/compete/$slug/workouts/index.tsx",
+  "../../../src/routes/compete/$slug/workouts/$eventId.tsx",
+  "../../../src/routes/compete/$slug/review/$eventId/index.tsx",
+  "../../../src/routes/compete/organizer/$competitionId/events/$eventId/submissions/index.tsx",
+  "../../../src/routes/compete/cohost/$competitionId/events/$eventId/submissions/index.tsx",
+]
+
+describe("video submission route gates", () => {
+  // @lat: [[competition-type-capabilities#Video Submission Route Gates Test]]
+  it("uses capability gates instead of literal online checks at submission routes", () => {
+    for (const routeFile of routeFiles) {
+      const source = readFileSync(
+        fileURLToPath(new URL(routeFile, import.meta.url)),
+        "utf8",
+      )
+
+      expect(source, routeFile).not.toContain(
+        'competition.competitionType === "online"',
+      )
+      expect(source, routeFile).not.toContain(
+        'competition.competitionType !== "online"',
+      )
+    }
+  })
+})

--- a/apps/wodsmith-start/test/server-fns/athlete-score-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/athlete-score-fns.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mockSession = vi.hoisted(() => vi.fn())
+const mockLimit = vi.hoisted(() => vi.fn())
+
+const mockDb = vi.hoisted(() => {
+  const chain: Record<string, unknown> = {}
+  const passthrough = () => chain
+
+  chain.select = vi.fn(passthrough)
+  chain.from = vi.fn(passthrough)
+  chain.where = vi.fn(passthrough)
+  chain.insert = vi.fn(passthrough)
+  chain.values = vi.fn(passthrough)
+  chain.limit = (...args: unknown[]) => mockLimit(...args)
+  chain.onDuplicateKeyUpdate = vi.fn(() => Promise.resolve())
+  chain.then = <T>(resolve: (value: T) => void) => {
+    resolve(undefined as T)
+    return Promise.resolve(undefined as T)
+  }
+
+  return chain
+})
+
+vi.mock("@/db", () => ({
+  getDb: vi.fn(() => mockDb),
+}))
+
+vi.mock("@/utils/auth", () => ({
+  getSessionFromCookie: mockSession,
+}))
+
+vi.mock("@/lib/logging", () => ({
+  addRequestContextAttribute: vi.fn(),
+  logEntityUpdated: vi.fn(),
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+  logWarning: vi.fn(),
+  updateRequestContext: vi.fn(),
+}))
+
+vi.mock("@tanstack/react-start", () => ({
+  createServerFn: () => ({
+    inputValidator: (validator: (data: unknown) => unknown) => ({
+      handler: (fn: (ctx: { data: unknown }) => Promise<unknown>) => {
+        return async (ctx: { data: unknown }) => {
+          const data = validator(ctx.data)
+          return fn({ data })
+        }
+      },
+    }),
+  }),
+}))
+
+import { submitAthleteScoreFn } from "@/server-fns/athlete-score-fns"
+
+describe("athlete score submission capability gates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockLimit.mockReset()
+    mockSession.mockResolvedValue({ userId: "user-1" })
+  })
+
+  it("allows benchmark score submission without submission-window rows", async () => {
+    mockLimit
+      .mockResolvedValueOnce([{ id: "reg-1", divisionId: "open" }])
+      .mockResolvedValueOnce([{ competitionType: "benchmark" }])
+      .mockResolvedValueOnce([{ workoutId: "workout-1", trackId: "track-1" }])
+      .mockResolvedValueOnce([
+        {
+          scheme: "time",
+          scoreType: "min",
+          tiebreakScheme: null,
+          timeCap: null,
+        },
+      ])
+      .mockResolvedValueOnce([{ ownerTeamId: "team-1" }])
+      .mockResolvedValueOnce([{ id: "score-1" }])
+
+    const result = await submitAthleteScoreFn({
+      data: {
+        competitionId: "comp-1",
+        trackWorkoutId: "tw-1",
+        score: "10:00",
+        status: "scored",
+      },
+    })
+
+    expect(result).toEqual({
+      success: true,
+      scoreId: "score-1",
+      message: "Score submitted successfully",
+    })
+  })
+})

--- a/apps/wodsmith-start/test/server-fns/video-submission-fns.test.ts
+++ b/apps/wodsmith-start/test/server-fns/video-submission-fns.test.ts
@@ -4,6 +4,7 @@ import {
 	getVideoSubmissionFn,
 	submitVideoFn,
 	getBatchSubmissionStatusFn,
+	getBatchEventVideoSubmissionsFn,
 	getOrganizerSubmissionsFn,
 	getOrganizerSubmissionDetailFn,
 	markSubmissionReviewedFn,
@@ -78,7 +79,7 @@ const setMockSession = (session: unknown) => {
 function createTestCompetition(
 	overrides?: Partial<{
 		id: string
-		competitionType: "in-person" | "online"
+		competitionType: "in-person" | "online" | "benchmark"
 	}>,
 ) {
 	return {
@@ -307,6 +308,32 @@ describe("Video Submission Server Functions (TanStack)", () => {
 				.mockResolvedValueOnce([registration]) // Registration found
 				.mockResolvedValueOnce([competition]) // Competition type check
 				.mockResolvedValueOnce([event]) // Event with submission window
+				.mockResolvedValueOnce([{ teamSize: 1 }]) // getTeamSize
+				.mockResolvedValueOnce([]) // No workout details
+				.mockResolvedValueOnce([]) // No existing score
+			orderByMock.mockResolvedValueOnce([]) // No existing submission
+
+			const result = await getVideoSubmissionFn({
+				data: {
+					trackWorkoutId: "tw-1",
+					competitionId: "comp-1",
+				},
+			})
+
+			expect(result.canSubmit).toBe(true)
+			expect(result.isRegistered).toBe(true)
+		})
+
+		it("returns canSubmit true for benchmark competitions without submission windows", async () => {
+			const registration = createTestRegistration()
+			const competition = createTestCompetition({ competitionType: "benchmark" })
+
+			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
+			const orderByMock = mockDb.getChainMock().orderBy as ReturnType<typeof vi.fn>
+			limitMock
+				.mockResolvedValueOnce([registration]) // Registration found
+				.mockResolvedValueOnce([competition]) // Competition type check
+				.mockResolvedValueOnce([]) // No event row required for perpetual benchmark
 				.mockResolvedValueOnce([{ teamSize: 1 }]) // getTeamSize
 				.mockResolvedValueOnce([]) // No workout details
 				.mockResolvedValueOnce([]) // No existing score
@@ -1493,6 +1520,32 @@ describe("Video Submission Server Functions (TanStack)", () => {
 					},
 				}),
 			).rejects.toThrow()
+		})
+	})
+
+	describe("getBatchEventVideoSubmissionsFn", () => {
+		it("returns canSubmit true for benchmark competitions without submission windows", async () => {
+			const registration = createTestRegistration()
+			const competition = createTestCompetition({ competitionType: "benchmark" })
+
+			mockDb.setMockReturnValue([])
+			const limitMock = mockDb.getChainMock().limit as ReturnType<typeof vi.fn>
+			const orderByMock = mockDb.getChainMock().orderBy as ReturnType<typeof vi.fn>
+			limitMock
+				.mockResolvedValueOnce([registration]) // getAthleteRegistration
+				.mockResolvedValueOnce([{ teamSize: 1 }]) // getTeamSize
+				.mockResolvedValueOnce([competition]) // Competition type
+			orderByMock.mockResolvedValueOnce([]) // No existing submissions
+
+			const result = await getBatchEventVideoSubmissionsFn({
+				data: {
+					competitionId: "comp-1",
+					trackWorkoutIds: ["tw-1"],
+				},
+			})
+
+			expect(result.results["tw-1"]?.canSubmit).toBe(true)
+			expect(result.results["tw-1"]?.reason).toBeUndefined()
 		})
 	})
 

--- a/lat.md/competition-type-capabilities.md
+++ b/lat.md/competition-type-capabilities.md
@@ -10,23 +10,23 @@ Competition type capabilities define which product behaviors each stored competi
 
 The registry maps each competition type to named capabilities, its leaderboard variant, and create-picker selectability without adding a database field.
 
-[[apps/wodsmith-start/src/lib/competitions/capabilities.ts#COMPETITION_TYPE_REGISTRY]] keeps `competitionType` as the stored discriminator and exposes [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#competitionCan]], [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#leaderboardVariant]], and [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]] for later call-site refactors. In-person competitions retain heat scheduling, day-of check-in, physical venue, volunteer scheduling, and organizer-entered results. Online competitions retain video submissions, submission windows, opt-in result publishing, and the online leaderboard variant.
+[[apps/wodsmith-start/src/lib/competitions/capabilities.ts#COMPETITION_TYPE_REGISTRY]] keeps `competitionType` as the stored discriminator and exposes [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#competitionCan]], [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#leaderboardVariant]], and [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]] for later call-site refactors. In-person competitions retain heat scheduling, day-of check-in, physical venue, volunteer scheduling, and organizer-entered results. Online competitions retain video submissions, submission windows, opt-in result publishing, and the online leaderboard variant. Benchmark competitions retain video submissions and the online leaderboard visual variant, add the `perpetual` capability, and intentionally skip submission windows and opt-in result publishing.
 
-Server submission gates now consume the registry for the API, server-function, and leaderboard paths: score-window checks use `submissionWindows`, while video submission checks use `videoSubmissions`. The dedicated leaderboard refactor also routes the online table decision through `leaderboardVariant` and the hidden-until-published default through `optInResultPublishing`; [[apps/wodsmith-start/src/server/competition-leaderboard.ts#getCompetitionLeaderboard]] stayed minimal because GitNexus reports HIGH blast radius.
+Server submission gates now consume the registry for the API, server-function, and leaderboard paths: score-window checks use `submissionWindows`, while benchmark status checks use `perpetual` to stay open without seeded window rows. Video submission checks use `videoSubmissions`. The dedicated leaderboard refactor also routes the online table decision through `leaderboardVariant` and the hidden-until-published default through `optInResultPublishing`; [[apps/wodsmith-start/src/server/competition-leaderboard.ts#getCompetitionLeaderboard]] stayed minimal because GitNexus reports HIGH blast radius.
 
 The `scoringAlgorithm === "online"` axis remains separate from `competitionType === "online"`. Capability checks must not replace scoring-algorithm branches.
 
 ## Capability Truth Table Test
 
-The truth-table test pins every capability and leaderboard variant for in-person and online competitions before call sites are refactored.
+The truth-table test pins every capability and leaderboard variant for registered competition types while unknown values fail closed.
 
-[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies each capability for both current types, confirms registry metadata matches type identity, and covers the unknown-type fallback. This is the PR-1 safety net for the M0 competition-type capability registry.
+[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies each capability for every registered type, confirms registry metadata matches type identity, and covers the unknown-type fallback. Benchmark is registered but remains out of generic create-picker options.
 
 Focused PR-2 server-function tests pin that in-person score saves pass the submission-window gate, online score saves still honor closed windows, and in-person video submissions still reject before writes. PR-3 adds [[apps/wodsmith-start/test/components/leaderboard-page-content.test.tsx]] coverage for standard versus online leaderboard table selection plus [[apps/wodsmith-start/test/server/competition-leaderboard-capability-gates.test.ts]] coverage for opt-in result publishing defaults and the leaderboard video-submission fetch gate. PR-4 adds [[apps/wodsmith-start/test/lib/competitions/scheduling-check-in-gates.test.ts]] coverage for the heat scheduling and day-of check-in gates used by the public schedule, judge rotations, check-in routes, and check-in server functions. PR-5 adds [[apps/wodsmith-start/test/lib/competitions/venue-volunteer-gates.test.ts]] and [[apps/wodsmith-start/test/components/competition-location-card.test.tsx]] coverage for physical venue display and volunteer schedule-tab gates.
 
 ### Current Type Matrix
 
-This test verifies every current competition type keeps its existing capability, leaderboard variant, and create-selectability behavior.
+This test verifies every registered competition type keeps its expected capability, leaderboard variant, and create-selectability behavior.
 
 ### Registry Metadata Alignment
 
@@ -34,13 +34,19 @@ This test verifies registry keys, ids, labels, and capability sets stay aligned 
 
 ### Unknown Type Fallback
 
-This test verifies unknown competition types fail closed for capabilities, use the standard leaderboard variant, and stay unselectable.
+This test verifies unregistered competition types fail closed for capabilities, use the standard leaderboard variant, and stay unselectable.
 
 ## Create Picker Selectability Test
 
-The create-picker test pins that selectable competition type options are derived from registry selectability while exposing only current types.
+The create-picker test pins that selectable competition type options are derived from registry selectability while benchmark remains hidden.
 
-[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypes]] returns only in-person and online type definitions, with each entry passing [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]] and [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableCompetitionTypeValue]]. [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypeOptions]] provides the registry-backed label and description text that the generic organizer create and edit form pickers render, while the form and server schemas use the same selectable-value guard.
+[[apps/wodsmith-start/test/lib/competitions/capabilities.test.ts]] verifies [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypes]] returns only in-person and online type definitions, with each entry passing [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]] and [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableCompetitionTypeValue]]. [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#selectableCompetitionTypeOptions]] provides the registry-backed label and description text that the generic organizer create and edit form pickers render, while the form and server schemas use the same selectable-value guard that rejects benchmark for this picker.
+
+## Perpetual Window Status Test
+
+The window-status test pins benchmark as open without submission-window rows while online competitions still require configured rows.
+
+[[apps/wodsmith-start/test/routes/api/compete/scores/window-status.test.ts]] verifies the score window-status API returns open/null-window metadata for benchmark because it has `perpetual`, while online stays closed when no submission-window row exists.
 
 ## Scheduling and Check-In Gates Test
 

--- a/lat.md/competition-type-capabilities.md
+++ b/lat.md/competition-type-capabilities.md
@@ -12,7 +12,7 @@ The registry maps each competition type to named capabilities, its leaderboard v
 
 [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#COMPETITION_TYPE_REGISTRY]] keeps `competitionType` as the stored discriminator and exposes [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#competitionCan]], [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#leaderboardVariant]], and [[apps/wodsmith-start/src/lib/competitions/capabilities.ts#isSelectableType]] for later call-site refactors. In-person competitions retain heat scheduling, day-of check-in, physical venue, volunteer scheduling, and organizer-entered results. Online competitions retain video submissions, submission windows, opt-in result publishing, and the online leaderboard variant. Benchmark competitions retain video submissions and the online leaderboard visual variant, add the `perpetual` capability, and intentionally skip submission windows and opt-in result publishing.
 
-Server submission gates now consume the registry for the API, server-function, and leaderboard paths: score-window checks use `submissionWindows`, while benchmark status checks use `perpetual` to stay open without seeded window rows. Video submission checks use `videoSubmissions`. The dedicated leaderboard refactor also routes the online table decision through `leaderboardVariant` and the hidden-until-published default through `optInResultPublishing`; [[apps/wodsmith-start/src/server/competition-leaderboard.ts#getCompetitionLeaderboard]] stayed minimal because GitNexus reports HIGH blast radius.
+Server submission gates now consume the registry for API, server-function, route, and leaderboard paths: score-window checks use `submissionWindows`, while benchmark status checks use `perpetual` to stay open without seeded window rows. Video submission checks use `videoSubmissions`. The dedicated leaderboard refactor also routes the online table decision through `leaderboardVariant` and the hidden-until-published default through `optInResultPublishing`; [[apps/wodsmith-start/src/server/competition-leaderboard.ts#getCompetitionLeaderboard]] stayed minimal because GitNexus reports HIGH blast radius.
 
 The `scoringAlgorithm === "online"` axis remains separate from `competitionType === "online"`. Capability checks must not replace scoring-algorithm branches.
 
@@ -47,6 +47,18 @@ The create-picker test pins that selectable competition type options are derived
 The window-status test pins benchmark as open without submission-window rows while online competitions still require configured rows.
 
 [[apps/wodsmith-start/test/routes/api/compete/scores/window-status.test.ts]] verifies the score window-status API returns open/null-window metadata for benchmark because it has `perpetual`, while online stays closed when no submission-window row exists.
+
+## Perpetual Submission Gate Test
+
+The submission-gate tests pin benchmark write entries as open without seeded submission-window rows while preserving existing validation after the gate.
+
+[[apps/wodsmith-start/test/routes/api/compete/submission-gates.test.ts]] verifies the score and video API submit routes accept benchmark competitions through the window gate. [[apps/wodsmith-start/test/server-fns/athlete-score-fns.test.ts]] verifies the athlete score server function does the same.
+
+## Video Submission Route Gates Test
+
+The route-gate test pins public athlete and review submission routes to the `videoSubmissions` capability instead of literal online checks.
+
+[[apps/wodsmith-start/test/routes/compete/video-submission-route-gates.test.ts]] verifies the public overview, workout detail, organizer, cohost, and volunteer review submission routes do not reintroduce literal `competitionType === "online"` gates.
 
 ## Scheduling and Check-In Gates Test
 


### PR DESCRIPTION
## Summary

Implements the M0a registry slice for the benchmark leaderboard stack.

- Registers `competitionType: "benchmark"` in the existing capability registry.
- Adds the `perpetual` capability.
- Keeps benchmark out of generic create-picker options.
- Gives benchmark `videoSubmissions` + `perpetual`, but not `submissionWindows` or `optInResultPublishing`.
- Treats benchmark submission/window-status paths as open without seeded submission-window rows.
- Moves public athlete/review submission route gates from literal `online` checks to the `videoSubmissions` capability.
- Preserves the separate `scoringAlgorithm === "online"` axis.

No HillerFit-branded pages, routes, marketing surfaces, logos, theme treatments, product navigation, PDF extraction, or seed work are included in this slice.

## Verification

- `lat search "benchmark leaderboard HillerFit branded pages training guide pdf capability registry M0a"`
- `lat expand "should be explicit in stating we are not building any hillerfit branded pages, we will just build out the benchmark against the training pdf"`
- `PATH="/Users/zacjones/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm --dir apps/wodsmith-start test test/lib/competitions/capabilities.test.ts test/routes/api/compete/scores/window-status.test.ts test/server-fns/video-submission-fns.test.ts test/routes/api/compete/submission-gates.test.ts test/server-fns/athlete-score-fns.test.ts test/routes/compete/video-submission-route-gates.test.ts`
- `PATH="/Users/zacjones/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm --dir apps/wodsmith-start type-check`
- `PATH="/Users/zacjones/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm --dir apps/wodsmith-start lint` (passes with pre-existing warnings)
- `PATH="/Users/zacjones/.nvm/versions/node/v24.15.0/bin:$PATH" lat check` (known unrelated crew refs only)
- `git diff --check`
- pre-push hook: monorepo `pnpm lint` and `pnpm type-check`

Known existing LAT issue, unrelated to this slice: `lat check` still fails on pre-existing `crew` refs in `lat.md/crew.md` and `apps/crew/test/routes/event-import-tabs.test.tsx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added benchmark competition type with perpetual submission capabilities—submissions remain open without time windows
  * Video submissions now available for benchmark competitions

* **Improvements**
  * Refactored submission validation to use flexible capability-based checks, improving support across competition types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->