### PR TITLE
[codex] feat(crew): copy prior event setup

### DIFF
--- a/apps/crew/src/components/crew-copy-event/crew-copy-prior-event-panel.tsx
+++ b/apps/crew/src/components/crew-copy-event/crew-copy-prior-event-panel.tsx
@@ -1,0 +1,235 @@
+"use client"
+
+// @lat: [[crew#Copy Prior Event Setup]]
+import { Ban, CheckCircle2, Copy, Loader2 } from "lucide-react"
+import { useEffect, useState } from "react"
+import {
+  getCrewCopyPriorEventPageFn,
+  type CrewCopyPriorEventPageData,
+} from "@/server-fns/crew-copy-event-fns"
+
+interface CrewCopyPriorEventPanelProps {
+  eventId: string
+  pageData: CrewCopyPriorEventPageData
+  onApply: (input: { sourceEventId: string }) => Promise<void>
+}
+
+export function CrewCopyPriorEventPanel({
+  eventId,
+  pageData,
+  onApply,
+}: CrewCopyPriorEventPanelProps) {
+  const [data, setData] = useState(pageData)
+  const [selectedSourceEventId, setSelectedSourceEventId] = useState(
+    pageData.selectedSourceEventId ?? "",
+  )
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false)
+  const [isApplying, setIsApplying] = useState(false)
+
+  useEffect(() => {
+    setData(pageData)
+    setSelectedSourceEventId(pageData.selectedSourceEventId ?? "")
+  }, [pageData])
+
+  async function handleSourceChange(sourceEventId: string) {
+    setSelectedSourceEventId(sourceEventId)
+    if (!sourceEventId) return
+    setIsLoadingPreview(true)
+    try {
+      setData(
+        await getCrewCopyPriorEventPageFn({
+          data: { eventId, sourceEventId },
+        }),
+      )
+    } finally {
+      setIsLoadingPreview(false)
+    }
+  }
+
+  async function handleApply() {
+    if (!selectedSourceEventId) return
+    setIsApplying(true)
+    try {
+      await onApply({ sourceEventId: selectedSourceEventId })
+    } finally {
+      setIsApplying(false)
+    }
+  }
+
+  const preview = data.preview
+
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Copy prior event setup</h2>
+          <p className="text-sm text-muted-foreground">
+            Preview structural setup from an earlier event before applying it to
+            this draft.
+          </p>
+        </div>
+        <span className="inline-flex rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground">
+          Empty target only
+        </span>
+      </div>
+
+      {data.eligibleEvents.length === 0 ? (
+        <p className="mt-5 rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
+          No earlier Crew events from this organizing team are eligible.
+        </p>
+      ) : (
+        <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(16rem,22rem)_1fr]">
+          <div className="space-y-4">
+            <label className="space-y-2">
+              <span className="text-sm font-medium">Prior event</span>
+              <select
+                value={selectedSourceEventId}
+                onChange={(event) => handleSourceChange(event.target.value)}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              >
+                {data.eligibleEvents.map((event) => (
+                  <option key={event.id} value={event.id}>
+                    {event.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {preview ? (
+              <div className="rounded-md border bg-background p-3 text-sm">
+                <p className="font-medium">{preview.sourceEvent.name}</p>
+                <p className="mt-1 text-muted-foreground">
+                  {preview.sourceEvent.startDate ?? "No start date"} to{" "}
+                  {preview.targetEvent.startDate ?? "target date"}
+                </p>
+                <div className="mt-3 grid grid-cols-3 gap-2 text-center text-xs">
+                  <Metric
+                    label="Copy"
+                    value={
+                      preview.summary.filter((item) => item.status === "copy")
+                        .length
+                    }
+                  />
+                  <Metric
+                    label="Skip"
+                    value={
+                      preview.summary.filter((item) => item.status === "skip")
+                        .length
+                    }
+                  />
+                  <Metric
+                    label="Deny"
+                    value={
+                      preview.summary.filter((item) => item.status === "deny")
+                        .length
+                    }
+                  />
+                </div>
+              </div>
+            ) : null}
+
+            <button
+              type="button"
+              disabled={
+                isApplying ||
+                isLoadingPreview ||
+                !selectedSourceEventId ||
+                !preview?.canApply
+              }
+              onClick={handleApply}
+              className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+            >
+              {isApplying ? (
+                <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <Copy className="size-4" aria-hidden="true" />
+              )}
+              {isApplying ? "Applying..." : "Apply structural setup"}
+            </button>
+          </div>
+
+          <div className="space-y-4">
+            {isLoadingPreview ? (
+              <p className="rounded-md border bg-background px-3 py-2 text-sm text-muted-foreground">
+                Loading preview...
+              </p>
+            ) : null}
+
+            {preview ? (
+              <>
+                <div className="rounded-md border bg-background p-3 text-sm">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">Date shift</span>
+                    <span className="text-muted-foreground">
+                      {preview.dateShiftDays === null
+                        ? "Unavailable until both events have start dates"
+                        : `${preview.dateShiftDays} day${preview.dateShiftDays === 1 ? "" : "s"}`}
+                    </span>
+                  </div>
+                  {preview.settings.willCopyAssumptions ? (
+                    <p className="mt-2 text-muted-foreground">
+                      Setup assumptions will be copied because the target is
+                      empty.
+                    </p>
+                  ) : null}
+                </div>
+
+                <div className="overflow-hidden rounded-md border">
+                  <table className="w-full text-sm">
+                    <thead className="bg-muted text-left text-xs text-muted-foreground">
+                      <tr>
+                        <th className="px-3 py-2 font-medium">Area</th>
+                        <th className="px-3 py-2 font-medium">Count</th>
+                        <th className="px-3 py-2 font-medium">Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {preview.summary.map((item) => (
+                        <tr key={item.category} className="border-t">
+                          <td className="px-3 py-2">
+                            <div className="font-medium">{item.label}</div>
+                            <div className="text-xs text-muted-foreground">
+                              {item.reason}
+                            </div>
+                          </td>
+                          <td className="px-3 py-2 text-muted-foreground">
+                            {item.count}
+                          </td>
+                          <td className="px-3 py-2">
+                            <StatusPill status={item.status} />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </>
+            ) : null}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border bg-card px-2 py-2">
+      <div className="text-base font-semibold">{value}</div>
+      <div className="text-muted-foreground">{label}</div>
+    </div>
+  )
+}
+
+function StatusPill({ status }: { status: "copy" | "skip" | "deny" }) {
+  const Icon = status === "copy" ? CheckCircle2 : status === "deny" ? Ban : Copy
+  const label =
+    status === "copy" ? "Copy" : status === "deny" ? "Denied" : "Skip"
+
+  return (
+    <span className="inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground">
+      <Icon className="size-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  )
+}

--- a/apps/crew/src/lib/crew/copy-prior-event.test.ts
+++ b/apps/crew/src/lib/crew/copy-prior-event.test.ts
@@ -1,0 +1,253 @@
+// @lat: [[crew#Copy Prior Event Setup]]
+import { describe, expect, it } from "vitest"
+import {
+  buildCrewCopyPriorEventPreview,
+  filterEligibleCrewCopyPriorEvents,
+  serializeCrewCopyPriorEventSettings,
+  shiftDateTimeBetweenEvents,
+  type CrewCopyPriorEventCandidate,
+  type CrewCopyPriorEventPlanInput,
+} from "./copy-prior-event"
+
+const baseInput: CrewCopyPriorEventPlanInput = {
+  mode: "empty_target_only",
+  sourceEvent: {
+    id: "comp_source",
+    name: "Spring Throwdown",
+    organizingTeamId: "team_1",
+    startDate: "2026-03-14",
+    endDate: "2026-03-15",
+    timezone: "America/Denver",
+    settingsText: JSON.stringify({
+      guidedSetup: { steps: {} },
+      setup: { assumptions: "One floor lead and one judge per lane." },
+    }),
+  },
+  targetEvent: {
+    id: "comp_target",
+    name: "Summer Throwdown",
+    organizingTeamId: "team_1",
+    startDate: "2026-06-20",
+    endDate: "2026-06-21",
+    timezone: "America/Denver",
+    settingsText: JSON.stringify({
+      guidedSetup: { steps: { eventBasics: { note: "keep me" } } },
+      setup: { assumptions: "" },
+    }),
+  },
+  source: {
+    venues: [
+      {
+        id: "venue_source",
+        name: "Main floor",
+        laneCount: 8,
+        transitionMinutes: 4,
+        sortOrder: 1,
+      },
+    ],
+    tracks: [
+      {
+        id: "track_source",
+        name: "Competition events",
+        description: "Competition structure",
+        type: "team_owned",
+        scalingGroupId: "sgrp_1",
+        isPublic: 0,
+      },
+    ],
+    trackWorkouts: [
+      {
+        id: "trwk_source",
+        trackId: "track_source",
+        workoutId: "workout_source",
+        workoutName: "Event 1",
+        workoutDescription: "AMRAP 10",
+        workoutScope: "private",
+        workoutScheme: "rounds-reps",
+        workoutScoreType: "max",
+        workoutRepsPerRound: 20,
+        workoutRoundsToScore: 1,
+        workoutTiebreakScheme: null,
+        workoutTimeCap: 600,
+        workoutScalingGroupId: "sgrp_1",
+        parentEventId: null,
+        trackOrder: 1,
+        notes: "Briefing at 8",
+        pointsMultiplier: 100,
+        defaultHeatsCount: 4,
+        defaultLaneShiftPattern: "shift_right",
+        minHeatBuffer: 2,
+      },
+    ],
+    heats: [
+      {
+        id: "heat_source",
+        trackWorkoutId: "trwk_source",
+        venueId: "venue_source",
+        heatNumber: 1,
+        scheduledTime: new Date("2026-03-14T15:00:00.000Z"),
+        durationMinutes: 15,
+        notes: "Heat notes",
+      },
+    ],
+    shifts: [
+      {
+        id: "shift_source",
+        name: "Morning check-in",
+        roleType: "check_in",
+        startTime: new Date("2026-03-14T14:00:00.000Z"),
+        endTime: new Date("2026-03-14T16:00:00.000Z"),
+        location: "Front desk",
+        capacity: 2,
+        notes: "Bring labels",
+      },
+    ],
+    deniedCounts: {
+      volunteerIdentities: 12,
+      judgeAssignments: 24,
+      imports: 3,
+      payments: 40,
+      messages: 2,
+    },
+  },
+  targetExistingCounts: {
+    venues: 0,
+    tracks: 0,
+    heats: 0,
+    shifts: 0,
+  },
+}
+
+describe("copy prior event setup", () => {
+  it("filters eligible prior events to the same team and earlier dates", () => {
+    const target: CrewCopyPriorEventCandidate = {
+      id: "comp_target",
+      name: "Target",
+      organizingTeamId: "team_1",
+      startDate: "2026-06-20",
+      endDate: "2026-06-21",
+      timezone: "America/Denver",
+      lifecycle: "draft",
+    }
+    const candidates: CrewCopyPriorEventCandidate[] = [
+      { ...target, id: "comp_same" },
+      {
+        ...target,
+        id: "comp_other_team",
+        organizingTeamId: "team_2",
+        startDate: "2026-04-01",
+      },
+      { ...target, id: "comp_future", startDate: "2026-07-01" },
+      { ...target, id: "comp_archived", lifecycle: "archived" },
+      { ...target, id: "comp_prior", name: "Prior", startDate: "2026-03-01" },
+    ]
+
+    expect(filterEligibleCrewCopyPriorEvents(target, candidates)).toEqual([
+      {
+        ...target,
+        id: "comp_prior",
+        name: "Prior",
+        startDate: "2026-03-01",
+      },
+    ])
+  })
+
+  it("previews structural rows, date shifts them, and denies historical data", () => {
+    const preview = buildCrewCopyPriorEventPreview(baseInput)
+
+    expect(preview.dateShiftDays).toBe(98)
+    expect(preview.canApply).toBe(true)
+    expect(preview.plan.venuesToCreate).toHaveLength(1)
+    expect(preview.plan.trackWorkoutsToCreate).toHaveLength(1)
+    expect(preview.plan.heatsToCreate).toHaveLength(1)
+    expect(preview.plan.shiftsToCreate).toHaveLength(1)
+    expect(preview.plan.assumptionsToWrite).toBe(
+      "One floor lead and one judge per lane.",
+    )
+    expect(
+      preview.summary.find((item) => item.category === "volunteer_identity"),
+    ).toMatchObject({ status: "deny", count: 12 })
+    expect(
+      preview.summary.find((item) => item.category === "judge_assignments"),
+    ).toMatchObject({ status: "deny", count: 24 })
+  })
+
+  it("does not overwrite existing target structure or assumptions", () => {
+    const preview = buildCrewCopyPriorEventPreview({
+      ...baseInput,
+      targetEvent: {
+        ...baseInput.targetEvent,
+        settingsText: JSON.stringify({
+          setup: { assumptions: "Target assumption stays." },
+        }),
+      },
+      targetExistingCounts: {
+        venues: 1,
+        tracks: 1,
+        heats: 2,
+        shifts: 3,
+      },
+    })
+
+    expect(preview.canApply).toBe(false)
+    expect(preview.plan.venuesToCreate).toEqual([])
+    expect(preview.plan.trackWorkoutsToCreate).toEqual([])
+    expect(preview.plan.heatsToCreate).toEqual([])
+    expect(preview.plan.shiftsToCreate).toEqual([])
+    expect(preview.plan.assumptionsToWrite).toBeNull()
+    expect(
+      preview.summary.find((item) => item.category === "heats"),
+    ).toMatchObject({ status: "skip" })
+  })
+
+  it("shifts timestamps using event local calendar dates", () => {
+    const shifted = shiftDateTimeBetweenEvents({
+      value: new Date("2026-03-14T15:30:00.000Z"),
+      sourceEvent: {
+        startDate: "2026-03-14",
+        timezone: "America/Denver",
+      },
+      targetEvent: {
+        startDate: "2026-11-01",
+        timezone: "America/Denver",
+      },
+    })
+
+    expect(shifted?.toISOString()).toBe("2026-11-01T16:30:00.000Z")
+  })
+
+  it("preserves existing settings while recording copy metadata", () => {
+    const serialized = serializeCrewCopyPriorEventSettings(
+      JSON.stringify({
+        guidedSetup: { steps: { roles: { note: "keep guided" } } },
+        setup: { assumptions: "" },
+      }),
+      {
+        sourceEventId: "comp_source",
+        sourceEventName: "Spring Throwdown",
+        appliedAt: "2026-06-20T12:00:00.000Z",
+        mode: "empty_target_only",
+        assumptionsToWrite: "Copied assumptions",
+        counts: {
+          venues: 1,
+          tracks: 1,
+          trackWorkouts: 2,
+          heats: 6,
+          shifts: 3,
+        },
+      },
+    )
+
+    expect(JSON.parse(serialized)).toMatchObject({
+      guidedSetup: { steps: { roles: { note: "keep guided" } } },
+      setup: {
+        assumptions: "Copied assumptions",
+        checklist: { staffingPlanDrafted: true },
+      },
+      copyPriorEvent: {
+        sourceEventId: "comp_source",
+        sourceEventName: "Spring Throwdown",
+      },
+    })
+  })
+})

--- a/apps/crew/src/lib/crew/copy-prior-event.ts
+++ b/apps/crew/src/lib/crew/copy-prior-event.ts
@@ -1,0 +1,637 @@
+// @lat: [[crew#Copy Prior Event Setup]]
+import {
+  parseCrewSettings,
+  serializeCrewSettings,
+  type CrewSetupState,
+} from "../crew-event-setup"
+import {
+  formatDateTimeInTimezone,
+  parseTimeInTimezone,
+} from "../../utils/timezone-utils"
+
+export type CrewCopyPriorEventApplyMode = "empty_target_only"
+
+export type CrewCopyPriorEventCategory =
+  | "venues"
+  | "tracks"
+  | "heats"
+  | "shifts"
+  | "setup_assumptions"
+  | "judge_assignments"
+  | "volunteer_identity"
+  | "imports"
+  | "payments"
+  | "messages"
+
+export type CrewCopyPriorEventPreviewStatus = "copy" | "skip" | "deny"
+
+export interface CrewCopyPriorEventSummary {
+  category: CrewCopyPriorEventCategory
+  label: string
+  status: CrewCopyPriorEventPreviewStatus
+  count: number
+  reason: string
+}
+
+export interface CrewCopyPriorEventCandidate {
+  id: string
+  name: string
+  organizingTeamId: string
+  startDate: string | null
+  endDate: string | null
+  timezone: string
+  lifecycle: string
+}
+
+export interface CrewCopyPriorEventSettingsPreview {
+  willCopyAssumptions: boolean
+  sourceAssumptions: string
+  targetHasAssumptions: boolean
+}
+
+export interface CrewCopyPriorEventEventSnapshot {
+  id: string
+  name: string
+  organizingTeamId: string
+  startDate: string | null
+  endDate: string | null
+  timezone: string
+  settingsText: string | null
+}
+
+export interface CrewCopyPriorEventSourceVenue {
+  id: string
+  name: string
+  laneCount: number
+  transitionMinutes: number
+  sortOrder: number
+}
+
+export interface CrewCopyPriorEventSourceTrack {
+  id: string
+  name: string
+  description: string | null
+  type: string
+  scalingGroupId: string | null
+  isPublic: number
+}
+
+export interface CrewCopyPriorEventSourceTrackWorkout {
+  id: string
+  trackId: string
+  workoutId: string
+  workoutName: string
+  workoutDescription: string
+  workoutScope: string
+  workoutScheme: string
+  workoutScoreType: string | null
+  workoutRepsPerRound: number | null
+  workoutRoundsToScore: number | null
+  workoutTiebreakScheme: string | null
+  workoutTimeCap: number | null
+  workoutScalingGroupId: string | null
+  parentEventId: string | null
+  trackOrder: number
+  notes: string | null
+  pointsMultiplier: number | null
+  defaultHeatsCount: number | null
+  defaultLaneShiftPattern: string | null
+  minHeatBuffer: number | null
+}
+
+export interface CrewCopyPriorEventSourceHeat {
+  id: string
+  trackWorkoutId: string
+  venueId: string | null
+  heatNumber: number
+  scheduledTime: Date | string | null
+  durationMinutes: number | null
+  notes: string | null
+}
+
+export interface CrewCopyPriorEventSourceShift {
+  id: string
+  name: string
+  roleType: string
+  startTime: Date | string
+  endTime: Date | string
+  location: string | null
+  capacity: number
+  notes: string | null
+}
+
+export interface CrewCopyPriorEventExistingCounts {
+  venues: number
+  tracks: number
+  heats: number
+  shifts: number
+}
+
+export interface CrewCopyPriorEventDeniedCounts {
+  volunteerIdentities: number
+  judgeAssignments: number
+  imports: number
+  payments: number
+  messages: number
+}
+
+export interface CrewCopyPriorEventPlanInput {
+  mode: CrewCopyPriorEventApplyMode
+  sourceEvent: CrewCopyPriorEventEventSnapshot
+  targetEvent: CrewCopyPriorEventEventSnapshot
+  source: {
+    venues: CrewCopyPriorEventSourceVenue[]
+    tracks: CrewCopyPriorEventSourceTrack[]
+    trackWorkouts: CrewCopyPriorEventSourceTrackWorkout[]
+    heats: CrewCopyPriorEventSourceHeat[]
+    shifts: CrewCopyPriorEventSourceShift[]
+    deniedCounts: CrewCopyPriorEventDeniedCounts
+  }
+  targetExistingCounts: CrewCopyPriorEventExistingCounts
+}
+
+export interface CrewCopyPriorEventVenuePlan
+  extends CrewCopyPriorEventSourceVenue {
+  sourceVenueId: string
+}
+
+export interface CrewCopyPriorEventTrackPlan
+  extends CrewCopyPriorEventSourceTrack {
+  sourceTrackId: string
+}
+
+export interface CrewCopyPriorEventTrackWorkoutPlan
+  extends CrewCopyPriorEventSourceTrackWorkout {
+  sourceTrackWorkoutId: string
+  sourceParentEventId: string | null
+}
+
+export interface CrewCopyPriorEventHeatPlan
+  extends Omit<CrewCopyPriorEventSourceHeat, "scheduledTime"> {
+  sourceHeatId: string
+  sourceVenueId: string | null
+  sourceTrackWorkoutId: string
+  scheduledTime: Date | null
+}
+
+export interface CrewCopyPriorEventShiftPlan
+  extends Omit<CrewCopyPriorEventSourceShift, "startTime" | "endTime"> {
+  sourceShiftId: string
+  startTime: Date | null
+  endTime: Date | null
+}
+
+export interface CrewCopyPriorEventApplyPlan {
+  mode: CrewCopyPriorEventApplyMode
+  sourceEventId: string
+  targetEventId: string
+  dateShiftDays: number | null
+  venuesToCreate: CrewCopyPriorEventVenuePlan[]
+  tracksToCreate: CrewCopyPriorEventTrackPlan[]
+  trackWorkoutsToCreate: CrewCopyPriorEventTrackWorkoutPlan[]
+  heatsToCreate: CrewCopyPriorEventHeatPlan[]
+  shiftsToCreate: CrewCopyPriorEventShiftPlan[]
+  assumptionsToWrite: string | null
+}
+
+export interface CrewCopyPriorEventPreview {
+  mode: CrewCopyPriorEventApplyMode
+  sourceEvent: CrewCopyPriorEventCandidate
+  targetEvent: CrewCopyPriorEventCandidate
+  dateShiftDays: number | null
+  settings: CrewCopyPriorEventSettingsPreview
+  summary: CrewCopyPriorEventSummary[]
+  plan: CrewCopyPriorEventApplyPlan
+  canApply: boolean
+}
+
+export function filterEligibleCrewCopyPriorEvents(
+  targetEvent: CrewCopyPriorEventCandidate,
+  candidates: CrewCopyPriorEventCandidate[],
+) {
+  return candidates
+    .filter((candidate) => {
+      if (candidate.id === targetEvent.id) return false
+      if (candidate.organizingTeamId !== targetEvent.organizingTeamId) {
+        return false
+      }
+      if (candidate.lifecycle === "archived") return false
+      if (targetEvent.startDate && candidate.startDate) {
+        return candidate.startDate < targetEvent.startDate
+      }
+      return true
+    })
+    .sort((left, right) => {
+      const dateCompare = compareNullableDateDesc(
+        left.startDate,
+        right.startDate,
+      )
+      return dateCompare || left.name.localeCompare(right.name)
+    })
+}
+
+export function buildCrewCopyPriorEventPreview(
+  input: CrewCopyPriorEventPlanInput,
+): CrewCopyPriorEventPreview {
+  const plan = buildCrewCopyPriorEventApplyPlan(input)
+  const sourceSettings = parseCrewSettings(input.sourceEvent.settingsText)
+  const targetSettings = parseCrewSettings(input.targetEvent.settingsText)
+  const targetHasAssumptions =
+    targetSettings.setup.assumptions.trim().length > 0
+  const sourceAssumptions = sourceSettings.setup.assumptions.trim()
+  const summary = buildSummary(input, plan, {
+    sourceAssumptions,
+    targetHasAssumptions,
+  })
+
+  return {
+    mode: input.mode,
+    sourceEvent: eventToCandidate(input.sourceEvent, "source"),
+    targetEvent: eventToCandidate(input.targetEvent, "target"),
+    dateShiftDays: plan.dateShiftDays,
+    settings: {
+      willCopyAssumptions: plan.assumptionsToWrite !== null,
+      sourceAssumptions,
+      targetHasAssumptions,
+    },
+    summary,
+    plan,
+    canApply: summary.some((item) => item.status === "copy" && item.count > 0),
+  }
+}
+
+export function buildCrewCopyPriorEventApplyPlan(
+  input: CrewCopyPriorEventPlanInput,
+): CrewCopyPriorEventApplyPlan {
+  const dateShiftDays = diffDateStrings(
+    input.sourceEvent.startDate,
+    input.targetEvent.startDate,
+  )
+  const sourceSettings = parseCrewSettings(input.sourceEvent.settingsText)
+  const targetSettings = parseCrewSettings(input.targetEvent.settingsText)
+  const canCopyVenues = input.targetExistingCounts.venues === 0
+  const canCopyTracks = input.targetExistingCounts.tracks === 0
+  const canCopyHeats =
+    input.targetExistingCounts.heats === 0 && canCopyTracks && canCopyVenues
+  const canCopyShifts = input.targetExistingCounts.shifts === 0
+  const copiedSourceTrackIds = new Set(
+    input.source.trackWorkouts.map((trackWorkout) => trackWorkout.trackId),
+  )
+
+  return {
+    mode: input.mode,
+    sourceEventId: input.sourceEvent.id,
+    targetEventId: input.targetEvent.id,
+    dateShiftDays,
+    venuesToCreate: canCopyVenues
+      ? input.source.venues.map((venue) => ({
+          ...venue,
+          sourceVenueId: venue.id,
+        }))
+      : [],
+    tracksToCreate: canCopyTracks
+      ? input.source.tracks
+          .filter((track) => copiedSourceTrackIds.has(track.id))
+          .map((track) => ({
+            ...track,
+            sourceTrackId: track.id,
+          }))
+      : [],
+    trackWorkoutsToCreate: canCopyTracks
+      ? input.source.trackWorkouts.map((trackWorkout) => ({
+          ...trackWorkout,
+          sourceTrackWorkoutId: trackWorkout.id,
+          sourceParentEventId: trackWorkout.parentEventId,
+        }))
+      : [],
+    heatsToCreate: canCopyHeats
+      ? input.source.heats.map((heat) => ({
+          ...heat,
+          sourceHeatId: heat.id,
+          sourceVenueId: heat.venueId,
+          sourceTrackWorkoutId: heat.trackWorkoutId,
+          scheduledTime: shiftDateTimeBetweenEvents({
+            value: heat.scheduledTime,
+            sourceEvent: input.sourceEvent,
+            targetEvent: input.targetEvent,
+          }),
+        }))
+      : [],
+    shiftsToCreate: canCopyShifts
+      ? input.source.shifts.map((shift) => ({
+          ...shift,
+          sourceShiftId: shift.id,
+          startTime: shiftDateTimeBetweenEvents({
+            value: shift.startTime,
+            sourceEvent: input.sourceEvent,
+            targetEvent: input.targetEvent,
+          }),
+          endTime: shiftDateTimeBetweenEvents({
+            value: shift.endTime,
+            sourceEvent: input.sourceEvent,
+            targetEvent: input.targetEvent,
+          }),
+        }))
+      : [],
+    assumptionsToWrite:
+      targetSettings.setup.assumptions.trim().length === 0
+        ? sourceSettings.setup.assumptions.trim() || null
+        : null,
+  }
+}
+
+export function serializeCrewCopyPriorEventSettings(
+  settingsText: string | null,
+  input: {
+    sourceEventId: string
+    sourceEventName: string
+    appliedAt: string
+    mode: CrewCopyPriorEventApplyMode
+    assumptionsToWrite: string | null
+    counts: {
+      venues: number
+      tracks: number
+      trackWorkouts: number
+      heats: number
+      shifts: number
+    }
+  },
+) {
+  const parsed = parseCrewSettings(settingsText)
+  const setup: CrewSetupState = input.assumptionsToWrite
+    ? {
+        ...parsed.setup,
+        assumptions: input.assumptionsToWrite,
+        checklist: {
+          ...parsed.setup.checklist,
+          staffingPlanDrafted: true,
+        },
+      }
+    : parsed.setup
+  const serialized = JSON.parse(
+    serializeCrewSettings(settingsText, setup),
+  ) as Record<string, unknown> | null
+
+  return JSON.stringify(
+    {
+      ...(serialized ?? {}),
+      copyPriorEvent: {
+        sourceEventId: input.sourceEventId,
+        sourceEventName: input.sourceEventName,
+        appliedAt: input.appliedAt,
+        mode: input.mode,
+        counts: input.counts,
+      },
+    },
+    null,
+    2,
+  )
+}
+
+export function shiftDateTimeBetweenEvents(input: {
+  value: Date | string | null
+  sourceEvent: Pick<CrewCopyPriorEventEventSnapshot, "startDate" | "timezone">
+  targetEvent: Pick<CrewCopyPriorEventEventSnapshot, "startDate" | "timezone">
+}) {
+  const value = toDate(input.value)
+  if (!value || !input.sourceEvent.startDate || !input.targetEvent.startDate) {
+    return null
+  }
+
+  const sourceLocalDate = formatDateTimeInTimezone(
+    value,
+    input.sourceEvent.timezone,
+    "yyyy-MM-dd",
+  )
+  const sourceLocalTime = formatDateTimeInTimezone(
+    value,
+    input.sourceEvent.timezone,
+    "HH:mm",
+  )
+  const dayOffset = diffDateStrings(
+    input.sourceEvent.startDate,
+    sourceLocalDate,
+  )
+  const targetLocalDate =
+    dayOffset === null
+      ? null
+      : addDaysToDateString(input.targetEvent.startDate, dayOffset)
+
+  return parseTimeInTimezone(
+    sourceLocalTime,
+    targetLocalDate,
+    input.targetEvent.timezone,
+  )
+}
+
+function buildSummary(
+  input: CrewCopyPriorEventPlanInput,
+  plan: CrewCopyPriorEventApplyPlan,
+  settings: {
+    sourceAssumptions: string
+    targetHasAssumptions: boolean
+  },
+): CrewCopyPriorEventSummary[] {
+  return [
+    structuralSummary({
+      category: "venues",
+      label: "Venues and floors",
+      sourceCount: input.source.venues.length,
+      copiedCount: plan.venuesToCreate.length,
+      targetCount: input.targetExistingCounts.venues,
+    }),
+    structuralSummary({
+      category: "tracks",
+      label: "Workout/event structure",
+      sourceCount: input.source.trackWorkouts.length,
+      copiedCount: plan.trackWorkoutsToCreate.length,
+      targetCount: input.targetExistingCounts.tracks,
+    }),
+    structuralSummary({
+      category: "heats",
+      label: "Heat schedule shell",
+      sourceCount: input.source.heats.length,
+      copiedCount: plan.heatsToCreate.length,
+      targetCount: input.targetExistingCounts.heats,
+      blockedBy:
+        input.targetExistingCounts.venues > 0 ||
+        input.targetExistingCounts.tracks > 0
+          ? "Target already has venue or event structure, so heat rows are not merged."
+          : undefined,
+    }),
+    structuralSummary({
+      category: "shifts",
+      label: "Shift templates",
+      sourceCount: input.source.shifts.length,
+      copiedCount: plan.shiftsToCreate.length,
+      targetCount: input.targetExistingCounts.shifts,
+    }),
+    {
+      category: "setup_assumptions",
+      label: "Setup assumptions",
+      status: plan.assumptionsToWrite ? "copy" : "skip",
+      count: plan.assumptionsToWrite ? 1 : 0,
+      reason: plan.assumptionsToWrite
+        ? "Target assumptions are empty, so source setup assumptions will be copied."
+        : settings.sourceAssumptions.length === 0
+          ? "Source event has no setup assumptions to copy."
+          : settings.targetHasAssumptions
+            ? "Target setup assumptions are already filled and will not be overwritten."
+            : "No setup assumptions will be copied.",
+    },
+    deniedSummary(
+      "volunteer_identity",
+      "Volunteer identity and roster data",
+      input.source.deniedCounts.volunteerIdentities,
+    ),
+    deniedSummary(
+      "judge_assignments",
+      "Judge rotations and assignments",
+      input.source.deniedCounts.judgeAssignments,
+    ),
+    deniedSummary(
+      "imports",
+      "Import history and payloads",
+      input.source.deniedCounts.imports,
+    ),
+    deniedSummary(
+      "payments",
+      "Registrations and payments",
+      input.source.deniedCounts.payments,
+    ),
+    deniedSummary(
+      "messages",
+      "Broadcasts, reminders, and queues",
+      input.source.deniedCounts.messages,
+    ),
+  ]
+}
+
+function structuralSummary(input: {
+  category: CrewCopyPriorEventCategory
+  label: string
+  sourceCount: number
+  copiedCount: number
+  targetCount: number
+  blockedBy?: string
+}): CrewCopyPriorEventSummary {
+  if (input.copiedCount > 0) {
+    return {
+      category: input.category,
+      label: input.label,
+      status: "copy",
+      count: input.copiedCount,
+      reason: "Target has no existing rows in this category.",
+    }
+  }
+  if (input.sourceCount === 0) {
+    return {
+      category: input.category,
+      label: input.label,
+      status: "skip",
+      count: 0,
+      reason: "Source event has no rows in this category.",
+    }
+  }
+  return {
+    category: input.category,
+    label: input.label,
+    status: "skip",
+    count: input.sourceCount,
+    reason:
+      input.blockedBy ??
+      `Target already has ${input.targetCount} row${input.targetCount === 1 ? "" : "s"} in this category.`,
+  }
+}
+
+function deniedSummary(
+  category: CrewCopyPriorEventCategory,
+  label: string,
+  count: number,
+): CrewCopyPriorEventSummary {
+  return {
+    category,
+    label,
+    status: "deny",
+    count,
+    reason:
+      count > 0
+        ? "Explicitly excluded from copy-prior-event setup."
+        : "Excluded by policy; no source rows found.",
+  }
+}
+
+function eventToCandidate(
+  event: CrewCopyPriorEventEventSnapshot,
+  fallbackName: string,
+): CrewCopyPriorEventCandidate {
+  return {
+    id: event.id,
+    name: event.name || fallbackName,
+    organizingTeamId: event.organizingTeamId,
+    startDate: event.startDate,
+    endDate: event.endDate,
+    timezone: event.timezone,
+    lifecycle: "setup",
+  }
+}
+
+function diffDateStrings(
+  left: string | null | undefined,
+  right: string | null | undefined,
+) {
+  const leftDate = dateStringToUtcDay(left)
+  const rightDate = dateStringToUtcDay(right)
+  if (leftDate === null || rightDate === null) return null
+  return Math.round((rightDate - leftDate) / 86_400_000)
+}
+
+function addDaysToDateString(date: string | null | undefined, days: number) {
+  const parsed = parseDateParts(date)
+  if (!parsed) return null
+  const shifted = new Date(Date.UTC(parsed.year, parsed.month - 1, parsed.day))
+  shifted.setUTCDate(shifted.getUTCDate() + days)
+  return formatDateTimeInTimezone(shifted, "UTC", "yyyy-MM-dd")
+}
+
+function dateStringToUtcDay(date: string | null | undefined) {
+  const parsed = parseDateParts(date)
+  if (!parsed) return null
+  return Date.UTC(parsed.year, parsed.month - 1, parsed.day)
+}
+
+function parseDateParts(date: string | null | undefined) {
+  const match = date?.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!match) return null
+
+  const [, yearText, monthText, dayText] = match
+  const year = Number(yearText)
+  const month = Number(monthText)
+  const day = Number(dayText)
+  const check = new Date(Date.UTC(year, month - 1, day))
+  if (
+    check.getUTCFullYear() !== year ||
+    check.getUTCMonth() !== month - 1 ||
+    check.getUTCDate() !== day
+  ) {
+    return null
+  }
+
+  return { year, month, day }
+}
+
+function toDate(value: Date | string | null) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function compareNullableDateDesc(
+  left: string | null | undefined,
+  right: string | null | undefined,
+) {
+  if (left && right) return right.localeCompare(left)
+  if (left) return -1
+  if (right) return 1
+  return 0
+}

--- a/apps/crew/src/routes/events/$eventId/setup.tsx
+++ b/apps/crew/src/routes/events/$eventId/setup.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react"
 import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
 import { Save } from "lucide-react"
 import { toast } from "sonner"
+import { CrewCopyPriorEventPanel } from "@/components/crew-copy-event/crew-copy-prior-event-panel"
 import { GuidedSetupShell } from "@/components/crew-guided-setup/guided-setup-shell"
 import { CrewTemplatePanel } from "@/components/crew-templates/crew-template-panel"
 import type {
@@ -26,17 +27,24 @@ import {
   getCrewTemplatePageFn,
   saveCrewTemplatePresetFn,
 } from "@/server-fns/crew-template-fns"
+import {
+  applyCrewCopyPriorEventFn,
+  getCrewCopyPriorEventPageFn,
+} from "@/server-fns/crew-copy-event-fns"
 
 export const Route = createFileRoute("/events/$eventId/setup")({
   loader: async ({ params }) => {
-    const [guidedSetupPage, templatePage] = await Promise.all([
-      getCrewGuidedSetupPageFn({ data: { eventId: params.eventId } }),
-      getCrewTemplatePageFn({ data: { eventId: params.eventId } }),
-    ])
+    const [guidedSetupPage, templatePage, copyPriorEventPage] =
+      await Promise.all([
+        getCrewGuidedSetupPageFn({ data: { eventId: params.eventId } }),
+        getCrewTemplatePageFn({ data: { eventId: params.eventId } }),
+        getCrewCopyPriorEventPageFn({ data: { eventId: params.eventId } }),
+      ])
 
     return {
       ...guidedSetupPage,
       templatePage,
+      copyPriorEventPage,
     }
   },
   component: EventSetupPage,
@@ -46,10 +54,12 @@ const parentRoute = getRouteApi("/events/$eventId")
 
 // @lat: [[crew#Event Setup Dashboard]]
 // @lat: [[crew#Guided Setup State]]
+// @lat: [[crew#Copy Prior Event Setup]]
 function EventSetupPage() {
   const router = useRouter()
   const { event } = parentRoute.useLoaderData()
-  const { guidedSetup, templatePage } = Route.useLoaderData()
+  const { guidedSetup, templatePage, copyPriorEventPage } =
+    Route.useLoaderData()
   const parsedSettings = parseCrewSettings(event.settings.settings)
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [crewOnly, setCrewOnly] = useState(event.settings.crewOnly)
@@ -193,6 +203,28 @@ function EventSetupPage() {
     }
   }
 
+  async function handleCopyPriorEvent(data: { sourceEventId: string }) {
+    try {
+      const result = await applyCrewCopyPriorEventFn({
+        data: {
+          eventId: event.competition.id,
+          sourceEventId: data.sourceEventId,
+          mode: "empty_target_only",
+        },
+      })
+      toast.success(
+        `Prior event setup copied: ${result.created.venues} venues, ${result.created.trackWorkouts} events, ${result.created.heats} heats, ${result.created.shifts} shifts`,
+      )
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Failed to copy prior event setup",
+      )
+    }
+  }
+
   return (
     <section className="space-y-6">
       <GuidedSetupShell
@@ -210,6 +242,12 @@ function EventSetupPage() {
         templatePage={templatePage}
         onApply={handleApplyTemplate}
         onSavePreset={handleSaveTemplatePreset}
+      />
+
+      <CrewCopyPriorEventPanel
+        eventId={event.competition.id}
+        pageData={copyPriorEventPage}
+        onApply={handleCopyPriorEvent}
       />
 
       <form

--- a/apps/crew/src/server-fns/crew-copy-event-fns.ts
+++ b/apps/crew/src/server-fns/crew-copy-event-fns.ts
@@ -1,0 +1,44 @@
+// @lat: [[crew#Copy Prior Event Setup]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type {
+  ApplyCrewCopyPriorEventResult,
+  CrewCopyPriorEventPageData,
+} from "../server/crew-copy-event.server"
+
+const eventIdSchema = z.string().min(1, "Event ID is required")
+
+const getCrewCopyPriorEventPageInputSchema = z.object({
+  eventId: eventIdSchema,
+  sourceEventId: eventIdSchema.nullable().optional(),
+})
+
+const applyCrewCopyPriorEventInputSchema = z.object({
+  eventId: eventIdSchema,
+  sourceEventId: eventIdSchema,
+  mode: z.literal("empty_target_only"),
+})
+
+export const getCrewCopyPriorEventPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    getCrewCopyPriorEventPageInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewCopyPriorEventPage } = await import(
+      "../server/crew-copy-event.server"
+    )
+    return getCrewCopyPriorEventPage(data)
+  })
+
+export const applyCrewCopyPriorEventFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    applyCrewCopyPriorEventInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { applyCrewCopyPriorEvent } = await import(
+      "../server/crew-copy-event.server"
+    )
+    return applyCrewCopyPriorEvent(data)
+  })

--- a/apps/crew/src/server/crew-copy-event.server.ts
+++ b/apps/crew/src/server/crew-copy-event.server.ts
@@ -1,0 +1,692 @@
+// @lat: [[crew#Copy Prior Event Setup]]
+import { asc, count, desc, eq, inArray } from "drizzle-orm"
+import { getDb } from "../db"
+import {
+  createCompetitionHeatId,
+  createCompetitionVenueId,
+  createProgrammingTrackId,
+  createTrackWorkoutId,
+} from "../db/schemas/common"
+import {
+  competitionHeatAssignmentsTable,
+  competitionHeatsTable,
+  competitionRegistrationsTable,
+  competitionVenuesTable,
+  competitionsTable,
+} from "../db/schemas/competitions"
+import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import { crewImportsTable } from "../db/schemas/crew-imports"
+import {
+  programmingTracksTable,
+  trackWorkoutsTable,
+} from "../db/schemas/programming"
+import { teamInvitationTable, teamMembershipTable } from "../db/schemas/teams"
+import {
+  competitionJudgeRotationsTable,
+  judgeHeatAssignmentsTable,
+  type VolunteerRoleType,
+  volunteerShiftsTable,
+} from "../db/schemas/volunteers"
+import { workouts } from "../db/schemas/workouts"
+import { competitionBroadcastsTable } from "../db/schemas/broadcasts"
+import {
+  buildCrewCopyPriorEventPreview,
+  filterEligibleCrewCopyPriorEvents,
+  serializeCrewCopyPriorEventSettings,
+  type CrewCopyPriorEventApplyMode,
+  type CrewCopyPriorEventCandidate,
+  type CrewCopyPriorEventDeniedCounts,
+  type CrewCopyPriorEventEventSnapshot,
+  type CrewCopyPriorEventExistingCounts,
+  type CrewCopyPriorEventPreview,
+  type CrewCopyPriorEventSourceHeat,
+  type CrewCopyPriorEventSourceShift,
+  type CrewCopyPriorEventSourceTrack,
+  type CrewCopyPriorEventSourceTrackWorkout,
+  type CrewCopyPriorEventSourceVenue,
+} from "../lib/crew/copy-prior-event"
+import { DEFAULT_TIMEZONE } from "../utils/timezone-utils"
+import { requireLocalCrewOperatorAccess } from "./crew-local-access"
+
+type DbClient = ReturnType<typeof getDb>
+type NewWorkout = typeof workouts.$inferInsert
+type NewTrackWorkout = typeof trackWorkoutsTable.$inferInsert
+type NewVolunteerShift = typeof volunteerShiftsTable.$inferInsert
+
+interface CrewCopyPriorEventInput {
+  eventId: string
+  sourceEventId?: string | null
+}
+
+interface ApplyCrewCopyPriorEventInput extends CrewCopyPriorEventInput {
+  sourceEventId: string
+  mode: CrewCopyPriorEventApplyMode
+}
+
+interface CrewCopyPriorEventSnapshot {
+  event: CrewCopyPriorEventEventSnapshot & {
+    competitionTeamId: string
+    lifecycle: string
+  }
+  venues: CrewCopyPriorEventSourceVenue[]
+  tracks: CrewCopyPriorEventSourceTrack[]
+  trackWorkouts: CrewCopyPriorEventSourceTrackWorkout[]
+  heats: CrewCopyPriorEventSourceHeat[]
+  shifts: CrewCopyPriorEventSourceShift[]
+  existingCounts: CrewCopyPriorEventExistingCounts
+  deniedCounts: CrewCopyPriorEventDeniedCounts
+}
+
+export interface CrewCopyPriorEventPageData {
+  targetEvent: CrewCopyPriorEventCandidate
+  eligibleEvents: CrewCopyPriorEventCandidate[]
+  selectedSourceEventId: string | null
+  preview: CrewCopyPriorEventPreview | null
+}
+
+export interface ApplyCrewCopyPriorEventResult {
+  success: true
+  preview: CrewCopyPriorEventPreview
+  created: {
+    venues: number
+    tracks: number
+    trackWorkouts: number
+    heats: number
+    shifts: number
+    assumptions: boolean
+  }
+}
+
+export async function getCrewCopyPriorEventPage(
+  data: CrewCopyPriorEventInput,
+): Promise<CrewCopyPriorEventPageData> {
+  requireLocalCrewOperatorAccess("Copy prior event setup")
+
+  const target = await loadCopyEventSnapshot(data.eventId)
+  const eligibleEvents = filterEligibleCrewCopyPriorEvents(
+    snapshotToCandidate(target),
+    await listTeamCopyCandidates(target.event.organizingTeamId),
+  )
+  const selectedSourceEventId =
+    eligibleEvents.find((event) => event.id === data.sourceEventId)?.id ??
+    eligibleEvents[0]?.id ??
+    null
+
+  return {
+    targetEvent: snapshotToCandidate(target),
+    eligibleEvents,
+    selectedSourceEventId,
+    preview: selectedSourceEventId
+      ? await buildPreview(target, selectedSourceEventId, "empty_target_only")
+      : null,
+  }
+}
+
+export async function applyCrewCopyPriorEvent(
+  data: ApplyCrewCopyPriorEventInput,
+): Promise<ApplyCrewCopyPriorEventResult> {
+  requireLocalCrewOperatorAccess("Copy prior event setup")
+
+  if (data.mode !== "empty_target_only") {
+    throw new Error("Unsupported copy mode")
+  }
+
+  const db = getDb()
+  let result: ApplyCrewCopyPriorEventResult | null = null
+
+  await db.transaction(async (tx) => {
+    const client = tx as unknown as DbClient
+    const target = await loadCopyEventSnapshot(data.eventId, client, true)
+    const source = await loadCopyEventSnapshot(data.sourceEventId, client)
+
+    assertEligibleSource(target, source)
+
+    const preview = buildCrewCopyPriorEventPreview({
+      mode: data.mode,
+      sourceEvent: source.event,
+      targetEvent: target.event,
+      source: {
+        venues: source.venues,
+        tracks: source.tracks,
+        trackWorkouts: source.trackWorkouts,
+        heats: source.heats,
+        shifts: source.shifts,
+        deniedCounts: source.deniedCounts,
+      },
+      targetExistingCounts: target.existingCounts,
+    })
+    if (!preview.canApply) {
+      throw new Error("No empty target setup categories are available to copy")
+    }
+
+    const timestamp = new Date()
+    const created = {
+      venues: 0,
+      tracks: 0,
+      trackWorkouts: 0,
+      heats: 0,
+      shifts: 0,
+      assumptions: false,
+    }
+    const venueIdBySourceId = new Map<string, string>()
+    const trackIdBySourceId = new Map<string, string>()
+    const trackWorkoutIdBySourceId = new Map<string, string>()
+
+    for (const venue of preview.plan.venuesToCreate) {
+      const venueId = createCompetitionVenueId()
+      venueIdBySourceId.set(venue.sourceVenueId, venueId)
+      await tx.insert(competitionVenuesTable).values({
+        id: venueId,
+        competitionId: target.event.id,
+        name: venue.name,
+        laneCount: venue.laneCount,
+        transitionMinutes: venue.transitionMinutes,
+        sortOrder: venue.sortOrder,
+        addressId: null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      created.venues += 1
+    }
+
+    for (const track of preview.plan.tracksToCreate) {
+      const trackId = createProgrammingTrackId()
+      trackIdBySourceId.set(track.sourceTrackId, trackId)
+      await tx.insert(programmingTracksTable).values({
+        id: trackId,
+        name: track.name,
+        description: track.description,
+        type: track.type,
+        ownerTeamId: target.event.organizingTeamId,
+        scalingGroupId: null,
+        isPublic: 0,
+        competitionId: target.event.id,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      created.tracks += 1
+    }
+
+    for (const trackWorkout of preview.plan.trackWorkoutsToCreate) {
+      trackWorkoutIdBySourceId.set(
+        trackWorkout.sourceTrackWorkoutId,
+        createTrackWorkoutId(),
+      )
+    }
+
+    for (const trackWorkout of preview.plan.trackWorkoutsToCreate) {
+      const trackId = trackIdBySourceId.get(trackWorkout.trackId)
+      if (!trackId) continue
+
+      const workoutId = `workout_${createTrackWorkoutId().slice("trwk_".length)}`
+      const trackWorkoutId = trackWorkoutIdBySourceId.get(
+        trackWorkout.sourceTrackWorkoutId,
+      )
+      if (!trackWorkoutId) continue
+
+      const workoutValues: NewWorkout = {
+        id: workoutId,
+        name: trackWorkout.workoutName,
+        description: trackWorkout.workoutDescription,
+        scope: "private",
+        scheme: trackWorkout.workoutScheme as NewWorkout["scheme"],
+        scoreType: trackWorkout.workoutScoreType as NewWorkout["scoreType"],
+        repsPerRound: trackWorkout.workoutRepsPerRound,
+        roundsToScore: trackWorkout.workoutRoundsToScore,
+        teamId: target.event.organizingTeamId,
+        tiebreakScheme:
+          trackWorkout.workoutTiebreakScheme as NewWorkout["tiebreakScheme"],
+        timeCap: trackWorkout.workoutTimeCap,
+        sourceWorkoutId: trackWorkout.workoutId,
+        scalingGroupId: null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }
+      await tx.insert(workouts).values(workoutValues)
+
+      const trackWorkoutValues: NewTrackWorkout = {
+        id: trackWorkoutId,
+        trackId,
+        workoutId,
+        parentEventId: trackWorkout.sourceParentEventId
+          ? (trackWorkoutIdBySourceId.get(trackWorkout.sourceParentEventId) ??
+            null)
+          : null,
+        trackOrder: trackWorkout.trackOrder,
+        notes: trackWorkout.notes,
+        pointsMultiplier: trackWorkout.pointsMultiplier,
+        heatStatus: "draft",
+        eventStatus: "draft",
+        sponsorId: null,
+        defaultHeatsCount: trackWorkout.defaultHeatsCount,
+        defaultLaneShiftPattern: trackWorkout.defaultLaneShiftPattern,
+        minHeatBuffer: trackWorkout.minHeatBuffer,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }
+      await tx.insert(trackWorkoutsTable).values(trackWorkoutValues)
+      created.trackWorkouts += 1
+    }
+
+    for (const heat of preview.plan.heatsToCreate) {
+      const trackWorkoutId = trackWorkoutIdBySourceId.get(
+        heat.sourceTrackWorkoutId,
+      )
+      if (!trackWorkoutId) continue
+
+      await tx.insert(competitionHeatsTable).values({
+        id: createCompetitionHeatId(),
+        competitionId: target.event.id,
+        trackWorkoutId,
+        venueId: heat.sourceVenueId
+          ? (venueIdBySourceId.get(heat.sourceVenueId) ?? null)
+          : null,
+        heatNumber: heat.heatNumber,
+        scheduledTime: heat.scheduledTime,
+        durationMinutes: heat.durationMinutes,
+        divisionId: null,
+        notes: heat.notes,
+        schedulePublishedAt: null,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })
+      created.heats += 1
+    }
+
+    for (const shift of preview.plan.shiftsToCreate) {
+      if (!shift.startTime || !shift.endTime) continue
+      const shiftValues: NewVolunteerShift = {
+        competitionId: target.event.id,
+        name: shift.name,
+        roleType: shift.roleType as VolunteerRoleType,
+        startTime: shift.startTime,
+        endTime: shift.endTime,
+        location: shift.location,
+        capacity: shift.capacity,
+        notes: shift.notes,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }
+      await tx.insert(volunteerShiftsTable).values(shiftValues)
+      created.shifts += 1
+    }
+
+    await tx
+      .update(crewEventSettingsTable)
+      .set({
+        settings: serializeCrewCopyPriorEventSettings(
+          target.event.settingsText,
+          {
+            sourceEventId: source.event.id,
+            sourceEventName: source.event.name,
+            appliedAt: timestamp.toISOString(),
+            mode: data.mode,
+            assumptionsToWrite: preview.plan.assumptionsToWrite,
+            counts: {
+              venues: created.venues,
+              tracks: created.tracks,
+              trackWorkouts: created.trackWorkouts,
+              heats: created.heats,
+              shifts: created.shifts,
+            },
+          },
+        ),
+        updatedAt: timestamp,
+      })
+      .where(eq(crewEventSettingsTable.competitionId, target.event.id))
+    created.assumptions = preview.plan.assumptionsToWrite !== null
+
+    result = {
+      success: true,
+      preview,
+      created,
+    }
+  })
+
+  if (!result) {
+    throw new Error("Copy prior event setup did not complete")
+  }
+
+  return result
+}
+
+async function buildPreview(
+  target: CrewCopyPriorEventSnapshot,
+  sourceEventId: string,
+  mode: CrewCopyPriorEventApplyMode,
+) {
+  const source = await loadCopyEventSnapshot(sourceEventId)
+  assertEligibleSource(target, source)
+
+  return buildCrewCopyPriorEventPreview({
+    mode,
+    sourceEvent: source.event,
+    targetEvent: target.event,
+    source: {
+      venues: source.venues,
+      tracks: source.tracks,
+      trackWorkouts: source.trackWorkouts,
+      heats: source.heats,
+      shifts: source.shifts,
+      deniedCounts: source.deniedCounts,
+    },
+    targetExistingCounts: target.existingCounts,
+  })
+}
+
+async function listTeamCopyCandidates(teamId: string) {
+  const db = getDb()
+  const events = await db
+    .select({
+      id: competitionsTable.id,
+      name: competitionsTable.name,
+      organizingTeamId: competitionsTable.organizingTeamId,
+      startDate: competitionsTable.startDate,
+      endDate: competitionsTable.endDate,
+      timezone: competitionsTable.timezone,
+      lifecycle: crewEventSettingsTable.lifecycle,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(competitionsTable.organizingTeamId, teamId))
+    .orderBy(desc(competitionsTable.startDate), asc(competitionsTable.name))
+
+  return events.map((event) => ({
+    ...event,
+    timezone: event.timezone ?? DEFAULT_TIMEZONE,
+  }))
+}
+
+async function loadCopyEventSnapshot(
+  eventId: string,
+  db: DbClient = getDb(),
+  forUpdate = false,
+): Promise<CrewCopyPriorEventSnapshot> {
+  const eventQuery = db
+    .select({
+      id: competitionsTable.id,
+      name: competitionsTable.name,
+      organizingTeamId: competitionsTable.organizingTeamId,
+      competitionTeamId: competitionsTable.competitionTeamId,
+      startDate: competitionsTable.startDate,
+      endDate: competitionsTable.endDate,
+      timezone: competitionsTable.timezone,
+      settingsText: crewEventSettingsTable.settings,
+      lifecycle: crewEventSettingsTable.lifecycle,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  const [event] = forUpdate ? await eventQuery.for("update") : await eventQuery
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  const [venues, tracks, trackWorkouts, heats, shifts] = await Promise.all([
+    loadVenues(db, event.id),
+    loadTracks(db, event.id),
+    loadTrackWorkouts(db, event.id),
+    loadHeats(db, event.id),
+    loadShifts(db, event.id),
+  ])
+
+  return {
+    event: {
+      ...event,
+      timezone: event.timezone ?? DEFAULT_TIMEZONE,
+    },
+    venues,
+    tracks,
+    trackWorkouts,
+    heats,
+    shifts,
+    existingCounts: {
+      venues: venues.length,
+      tracks: tracks.length,
+      heats: heats.length,
+      shifts: shifts.length,
+    },
+    deniedCounts: await loadDeniedCounts(db, event.id, event.competitionTeamId),
+  }
+}
+
+async function loadVenues(db: DbClient, eventId: string) {
+  return await db
+    .select({
+      id: competitionVenuesTable.id,
+      name: competitionVenuesTable.name,
+      laneCount: competitionVenuesTable.laneCount,
+      transitionMinutes: competitionVenuesTable.transitionMinutes,
+      sortOrder: competitionVenuesTable.sortOrder,
+    })
+    .from(competitionVenuesTable)
+    .where(eq(competitionVenuesTable.competitionId, eventId))
+    .orderBy(
+      asc(competitionVenuesTable.sortOrder),
+      asc(competitionVenuesTable.id),
+    )
+}
+
+async function loadTracks(db: DbClient, eventId: string) {
+  return await db
+    .select({
+      id: programmingTracksTable.id,
+      name: programmingTracksTable.name,
+      description: programmingTracksTable.description,
+      type: programmingTracksTable.type,
+      scalingGroupId: programmingTracksTable.scalingGroupId,
+      isPublic: programmingTracksTable.isPublic,
+    })
+    .from(programmingTracksTable)
+    .where(eq(programmingTracksTable.competitionId, eventId))
+    .orderBy(asc(programmingTracksTable.name), asc(programmingTracksTable.id))
+}
+
+async function loadTrackWorkouts(db: DbClient, eventId: string) {
+  const rows = await db
+    .select({
+      id: trackWorkoutsTable.id,
+      trackId: trackWorkoutsTable.trackId,
+      workoutId: trackWorkoutsTable.workoutId,
+      workoutName: workouts.name,
+      workoutDescription: workouts.description,
+      workoutScope: workouts.scope,
+      workoutScheme: workouts.scheme,
+      workoutScoreType: workouts.scoreType,
+      workoutRepsPerRound: workouts.repsPerRound,
+      workoutRoundsToScore: workouts.roundsToScore,
+      workoutTiebreakScheme: workouts.tiebreakScheme,
+      workoutTimeCap: workouts.timeCap,
+      workoutScalingGroupId: workouts.scalingGroupId,
+      parentEventId: trackWorkoutsTable.parentEventId,
+      trackOrder: trackWorkoutsTable.trackOrder,
+      notes: trackWorkoutsTable.notes,
+      pointsMultiplier: trackWorkoutsTable.pointsMultiplier,
+      defaultHeatsCount: trackWorkoutsTable.defaultHeatsCount,
+      defaultLaneShiftPattern: trackWorkoutsTable.defaultLaneShiftPattern,
+      minHeatBuffer: trackWorkoutsTable.minHeatBuffer,
+    })
+    .from(trackWorkoutsTable)
+    .innerJoin(workouts, eq(trackWorkoutsTable.workoutId, workouts.id))
+    .innerJoin(
+      programmingTracksTable,
+      eq(trackWorkoutsTable.trackId, programmingTracksTable.id),
+    )
+    .where(eq(programmingTracksTable.competitionId, eventId))
+    .orderBy(asc(trackWorkoutsTable.trackOrder), asc(trackWorkoutsTable.id))
+
+  return rows.map((row) => ({
+    ...row,
+    trackOrder: Number(row.trackOrder),
+  }))
+}
+
+async function loadHeats(db: DbClient, eventId: string) {
+  return await db
+    .select({
+      id: competitionHeatsTable.id,
+      trackWorkoutId: competitionHeatsTable.trackWorkoutId,
+      venueId: competitionHeatsTable.venueId,
+      heatNumber: competitionHeatsTable.heatNumber,
+      scheduledTime: competitionHeatsTable.scheduledTime,
+      durationMinutes: competitionHeatsTable.durationMinutes,
+      notes: competitionHeatsTable.notes,
+    })
+    .from(competitionHeatsTable)
+    .where(eq(competitionHeatsTable.competitionId, eventId))
+    .orderBy(
+      asc(competitionHeatsTable.trackWorkoutId),
+      asc(competitionHeatsTable.heatNumber),
+    )
+}
+
+async function loadShifts(db: DbClient, eventId: string) {
+  return await db
+    .select({
+      id: volunteerShiftsTable.id,
+      name: volunteerShiftsTable.name,
+      roleType: volunteerShiftsTable.roleType,
+      startTime: volunteerShiftsTable.startTime,
+      endTime: volunteerShiftsTable.endTime,
+      location: volunteerShiftsTable.location,
+      capacity: volunteerShiftsTable.capacity,
+      notes: volunteerShiftsTable.notes,
+    })
+    .from(volunteerShiftsTable)
+    .where(eq(volunteerShiftsTable.competitionId, eventId))
+    .orderBy(asc(volunteerShiftsTable.startTime), asc(volunteerShiftsTable.id))
+}
+
+async function loadDeniedCounts(
+  db: DbClient,
+  eventId: string,
+  competitionTeamId: string,
+): Promise<CrewCopyPriorEventDeniedCounts> {
+  const heatIds = (
+    await db
+      .select({ id: competitionHeatsTable.id })
+      .from(competitionHeatsTable)
+      .where(eq(competitionHeatsTable.competitionId, eventId))
+  ).map((heat) => heat.id)
+
+  const [
+    invitations,
+    memberships,
+    registrations,
+    imports,
+    broadcasts,
+    rotations,
+    judgeAssignments,
+    heatLaneAssignments,
+  ] = await Promise.all([
+    readCount(
+      db
+        .select({ value: count() })
+        .from(teamInvitationTable)
+        .where(eq(teamInvitationTable.teamId, competitionTeamId)),
+    ),
+    readCount(
+      db
+        .select({ value: count() })
+        .from(teamMembershipTable)
+        .where(eq(teamMembershipTable.teamId, competitionTeamId)),
+    ),
+    readCount(
+      db
+        .select({ value: count() })
+        .from(competitionRegistrationsTable)
+        .where(eq(competitionRegistrationsTable.eventId, eventId)),
+    ),
+    readCount(
+      db
+        .select({ value: count() })
+        .from(crewImportsTable)
+        .where(eq(crewImportsTable.competitionId, eventId)),
+    ),
+    readCount(
+      db
+        .select({ value: count() })
+        .from(competitionBroadcastsTable)
+        .where(eq(competitionBroadcastsTable.competitionId, eventId)),
+    ),
+    readCount(
+      db
+        .select({ value: count() })
+        .from(competitionJudgeRotationsTable)
+        .where(eq(competitionJudgeRotationsTable.competitionId, eventId)),
+    ),
+    heatIds.length > 0
+      ? readCount(
+          db
+            .select({ value: count() })
+            .from(judgeHeatAssignmentsTable)
+            .where(inArray(judgeHeatAssignmentsTable.heatId, heatIds)),
+        )
+      : 0,
+    heatIds.length > 0
+      ? readCount(
+          db
+            .select({ value: count() })
+            .from(competitionHeatAssignmentsTable)
+            .where(inArray(competitionHeatAssignmentsTable.heatId, heatIds)),
+        )
+      : 0,
+  ])
+
+  return {
+    volunteerIdentities: invitations + memberships,
+    judgeAssignments: rotations + judgeAssignments + heatLaneAssignments,
+    imports,
+    payments: registrations,
+    messages: broadcasts,
+  }
+}
+
+async function readCount(query: Promise<Array<{ value: number }>>) {
+  const [row] = await query
+  return Number(row?.value ?? 0)
+}
+
+function snapshotToCandidate(
+  snapshot: CrewCopyPriorEventSnapshot,
+): CrewCopyPriorEventCandidate {
+  return {
+    id: snapshot.event.id,
+    name: snapshot.event.name,
+    organizingTeamId: snapshot.event.organizingTeamId,
+    startDate: snapshot.event.startDate,
+    endDate: snapshot.event.endDate,
+    timezone: snapshot.event.timezone,
+    lifecycle: snapshot.event.lifecycle,
+  }
+}
+
+function assertEligibleSource(
+  target: CrewCopyPriorEventSnapshot,
+  source: CrewCopyPriorEventSnapshot,
+) {
+  if (source.event.id === target.event.id) {
+    throw new Error("Choose a different source event")
+  }
+  if (source.event.organizingTeamId !== target.event.organizingTeamId) {
+    throw new Error("Source event is not owned by the same organizing team")
+  }
+  if (
+    target.event.startDate &&
+    source.event.startDate &&
+    source.event.startDate >= target.event.startDate
+  ) {
+    throw new Error("Source event must be earlier than the target event")
+  }
+  if (source.event.lifecycle === "archived") {
+    throw new Error("Archived Crew events cannot be copied")
+  }
+}

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -224,6 +224,16 @@ Crew role and shift templates provide typed built-in staffing patterns plus team
 
 [[apps/crew/src/lib/crew/templates]] owns deterministic built-ins, preset serialization, preview, duplicate detection, and append-only apply planning. [[apps/crew/src/server-fns/crew-template-fns.ts]] keeps route-facing wrappers thin while [[apps/crew/src/server/crew-template.server.ts]] loads saved team presets, fills empty setup assumptions only when requested, and appends only missing `volunteer_shifts`. [[apps/crew/src/components/crew-templates/crew-template-panel.tsx]] integrates preview/apply/save into the event setup page without adding a public marketplace or copy-prior-event flow.
 
+## Copy Prior Event Setup
+
+Crew copy-prior-event setup lets a local operator preview structural setup from an earlier Crew event owned by the same organizing team, then apply only empty-target draft structure into the current event.
+
+[[apps/crew/src/lib/crew/copy-prior-event.ts]] owns deterministic eligibility filtering, date-shift planning, denylist summaries, non-overwrite apply planning, and settings JSON preservation. It copies structural venues/floors, workout/event shells, heat schedule shells, shift templates, and empty setup assumptions only when the target category has no existing rows.
+
+[[apps/crew/src/server-fns/crew-copy-event-fns.ts]] exposes route-safe read/apply wrappers, while [[apps/crew/src/server/crew-copy-event.server.ts]] keeps DB/runtime imports server-only and rechecks target structure inside the apply transaction. Apply creates new target IDs, leaves source rows untouched, records `copyPriorEvent` metadata in `crew_event_settings.settings`, and does not copy volunteers, team invitations, roster memberships, confirmations, assignment responses, import history, registrations, payments, waivers, broadcasts, reminders, queues, check-in/no-show state, analytics, or published judge assignment rows.
+
+[[apps/crew/src/components/crew-copy-event/crew-copy-prior-event-panel.tsx]] renders the setup-page preview and conservative apply action on [[apps/crew/src/routes/events/$eventId/setup.tsx]].
+
 ## Assignment Confirmation Responses
 
 Crew assignment confirmation links are token-only volunteer surfaces. Raw tokens are generated only while creating links, stored only as hashes, and used by [[apps/crew/src/routes/e/$slug/confirm/$token.tsx]] and [[apps/crew/src/routes/e/$slug/schedule/$token.tsx]] to show safe confirm, decline, and change-request flows without requiring a session.


### PR DESCRIPTION
## Summary

Adds a narrow Crew copy-prior-event setup flow on the existing event setup page.

- lists eligible prior Crew events from the same organizing team and previews what will be copied, skipped, or denied
- applies only empty-target structural setup: venues/floors, copied private workout/event shells, heat schedule shells with timezone-safe date shifts, shift templates, and empty setup assumptions
- keeps DB/runtime code behind a route-safe `createServerFn` wrapper and server-only implementation
- records `copyPriorEvent` metadata in `crew_event_settings.settings` while preserving existing guided setup and concierge setup state
- explicitly excludes volunteer identity, invitations, roster memberships, confirmations, assignment responses, imports, registrations, payments, waivers, broadcasts/reminders/queues, check-in/no-show state, analytics, and published judge assignment rows

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/copy-prior-event.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (passes with pre-existing warnings)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Copy Prior Event Setup'`
- `git diff --check`

Note: fresh worktree build needed an ignored local `apps/crew/.alchemy/local/wrangler.jsonc` copied from the committed Crew `wrangler.jsonc` placeholder so Vite/Alchemy could load local bindings.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a copy‑prior‑event setup flow to the Crew event setup page so operators can preview and copy structural setup from an earlier event into a draft. Copies only when the target is empty and shifts dates/timezones safely.

- **New Features**
  - New panel lists eligible prior events from the same team and previews copy/skip/deny counts.
  - Copies empty‑target structure only: venues/floors, tracks and private workout/event shells, heat schedule shells with date shifts, shift templates, and setup assumptions if empty.
  - Excludes historical/personal data (e.g., volunteers/rosters, registrations/payments, imports, broadcasts, analytics, judge assignments).
  - Server-only runtime behind `createServerFn` wrappers; transactional apply generates new IDs and records `copyPriorEvent` in `crew_event_settings.settings` without changing guided/concierge state.
  - Added unit tests for eligibility, planning, date shifting, and settings serialization.

<sup>Written for commit 4ae5e3f94efcd4c0809ec3450d5f3632c3906f20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Copy Prior Event Setup" functionality on the event setup page, enabling users to preview and apply structural setup (venues, tracks, heats, shifts) from an earlier crew event to the current draft event when both events are owned by the same organizing team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->