### PR TITLE
feat(crew): add department leads

### DIFF
--- a/apps/crew/src/components/crew-department-leads/crew-department-leads-panel.tsx
+++ b/apps/crew/src/components/crew-department-leads/crew-department-leads-panel.tsx
@@ -187,6 +187,7 @@ export function CrewDepartmentLeadsPanel({
         </div>
 
         <form
+          key={editingLead?.id ?? "new"}
           onSubmit={handleSubmit}
           className="space-y-4 rounded-md border p-4"
         >

--- a/apps/crew/src/components/crew-department-leads/crew-department-leads-panel.tsx
+++ b/apps/crew/src/components/crew-department-leads/crew-department-leads-panel.tsx
@@ -1,0 +1,367 @@
+// @lat: [[crew#Department Leads]]
+import type { FormEvent, ReactNode } from "react"
+import { useMemo, useState } from "react"
+import { Ban, Pencil, ShieldCheck, UserRoundPlus } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { VOLUNTEER_ROLE_OPTIONS } from "@/db/schemas/volunteers"
+import type {
+  CrewDepartmentLeadListItem,
+  CrewDepartmentLeadsPageData,
+} from "@/server-fns/crew-department-lead-fns"
+
+type DepartmentLeadSubmitData = {
+  leadId?: string
+  eventId: string
+  email: string | null
+  name: string | null
+  membershipId: string | null
+  roleType: CrewDepartmentLeadListItem["roleType"]
+  floor: string | null
+  startsAt: string | null
+  endsAt: string | null
+  status: CrewDepartmentLeadListItem["status"]
+  notes: string | null
+}
+
+export function CrewDepartmentLeadsPanel({
+  pageData,
+  onCreate,
+  onUpdate,
+  onRevoke,
+}: {
+  pageData: CrewDepartmentLeadsPageData
+  onCreate: (data: DepartmentLeadSubmitData) => Promise<void>
+  onUpdate: (
+    data: DepartmentLeadSubmitData & { leadId: string },
+  ) => Promise<void>
+  onRevoke: (leadId: string) => Promise<void>
+}) {
+  const [editingLead, setEditingLead] =
+    useState<CrewDepartmentLeadListItem | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [revokingId, setRevokingId] = useState<string | null>(null)
+  const roleOptions = useMemo(() => VOLUNTEER_ROLE_OPTIONS, [])
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = event.currentTarget
+    const formData = new FormData(form)
+    const payload: DepartmentLeadSubmitData = {
+      eventId: pageData.event.id,
+      email: getFormString(formData, "email"),
+      name: getFormString(formData, "name"),
+      membershipId: getFormString(formData, "membershipId"),
+      roleType: getFormString(
+        formData,
+        "roleType",
+      ) as CrewDepartmentLeadListItem["roleType"],
+      floor: getFormString(formData, "floor"),
+      startsAt: getFormString(formData, "startsAt"),
+      endsAt: getFormString(formData, "endsAt"),
+      status: getFormString(
+        formData,
+        "status",
+      ) as CrewDepartmentLeadListItem["status"],
+      notes: getFormString(formData, "notes"),
+    }
+
+    setIsSubmitting(true)
+    try {
+      if (editingLead) {
+        await onUpdate({ ...payload, leadId: editingLead.id })
+        setEditingLead(null)
+      } else {
+        await onCreate(payload)
+        form.reset()
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  async function handleRevoke(leadId: string) {
+    setRevokingId(leadId)
+    try {
+      await onRevoke(leadId)
+      if (editingLead?.id === leadId) setEditingLead(null)
+    } finally {
+      setRevokingId(null)
+    }
+  }
+
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Department leads</h2>
+          <p className="text-sm text-muted-foreground">
+            {pageData.leads.length} scoped leads
+          </p>
+        </div>
+        {editingLead ? (
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setEditingLead(null)}
+          >
+            <UserRoundPlus />
+            New lead
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="mt-5 grid gap-5 lg:grid-cols-[minmax(0,1fr)_minmax(22rem,28rem)]">
+        <div className="overflow-hidden rounded-md border">
+          {pageData.leads.length > 0 ? (
+            <table className="w-full min-w-[720px] text-sm">
+              <thead className="border-b bg-muted/50 text-left text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Lead</th>
+                  <th className="px-4 py-3 font-medium">Scope</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pageData.leads.map((lead) => (
+                  <tr key={lead.id} className="border-b last:border-0">
+                    <td className="px-4 py-3">
+                      <div className="font-medium">
+                        {lead.name || lead.email || lead.membershipId}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {lead.email ?? lead.membershipId}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">
+                      <div>{getRoleLabel(lead.roleType)}</div>
+                      <div className="text-xs">
+                        {[lead.floor, formatWindow(lead)]
+                          .filter(Boolean)
+                          .join(" · ") || "All floors and times"}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3">
+                      <span className="inline-flex rounded-md border px-2 py-1 text-xs font-medium capitalize">
+                        {lead.status.replace("_", " ")}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          onClick={() => setEditingLead(lead)}
+                        >
+                          <Pencil />
+                          Edit
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          disabled={
+                            lead.status === "revoked" || revokingId === lead.id
+                          }
+                          onClick={() => void handleRevoke(lead.id)}
+                        >
+                          <Ban />
+                          Revoke
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          ) : (
+            <div className="p-8 text-center">
+              <ShieldCheck className="mx-auto size-8 text-muted-foreground" />
+              <h3 className="mt-3 font-semibold">No department leads</h3>
+            </div>
+          )}
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4 rounded-md border p-4"
+        >
+          <h3 className="font-semibold">
+            {editingLead ? "Edit lead" : "Add lead"}
+          </h3>
+          <Field label="Volunteer" htmlFor="department-lead-membership">
+            <select
+              id="department-lead-membership"
+              name="membershipId"
+              defaultValue={editingLead?.membershipId ?? ""}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              disabled={isSubmitting}
+            >
+              <option value="">Email invite</option>
+              {pageData.volunteerOptions.map((volunteer) => (
+                <option
+                  key={volunteer.membershipId}
+                  value={volunteer.membershipId}
+                >
+                  {volunteer.name} ({volunteer.email})
+                </option>
+              ))}
+            </select>
+          </Field>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label="Email" htmlFor="department-lead-email">
+              <Input
+                id="department-lead-email"
+                name="email"
+                type="email"
+                defaultValue={editingLead?.email ?? ""}
+                disabled={isSubmitting}
+              />
+            </Field>
+            <Field label="Name" htmlFor="department-lead-name">
+              <Input
+                id="department-lead-name"
+                name="name"
+                defaultValue={editingLead?.name ?? ""}
+                disabled={isSubmitting}
+              />
+            </Field>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label="Role" htmlFor="department-lead-role">
+              <select
+                id="department-lead-role"
+                name="roleType"
+                required
+                defaultValue={editingLead?.roleType ?? "general"}
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+                disabled={isSubmitting}
+              >
+                {roleOptions.map((role) => (
+                  <option key={role.value} value={role.value}>
+                    {role.label}
+                  </option>
+                ))}
+              </select>
+            </Field>
+            <Field label="Floor" htmlFor="department-lead-floor">
+              <Input
+                id="department-lead-floor"
+                name="floor"
+                defaultValue={editingLead?.floor ?? ""}
+                disabled={isSubmitting}
+              />
+            </Field>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field label="Starts" htmlFor="department-lead-starts">
+              <Input
+                id="department-lead-starts"
+                name="startsAt"
+                type="datetime-local"
+                defaultValue={toDateTimeLocal(editingLead?.startsAt)}
+                disabled={isSubmitting}
+              />
+            </Field>
+            <Field label="Ends" htmlFor="department-lead-ends">
+              <Input
+                id="department-lead-ends"
+                name="endsAt"
+                type="datetime-local"
+                defaultValue={toDateTimeLocal(editingLead?.endsAt)}
+                disabled={isSubmitting}
+              />
+            </Field>
+          </div>
+          <Field label="Status" htmlFor="department-lead-status">
+            <select
+              id="department-lead-status"
+              name="status"
+              defaultValue={editingLead?.status ?? "invited"}
+              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              disabled={isSubmitting}
+            >
+              <option value="invited">Invited</option>
+              <option value="active">Active</option>
+              <option value="revoked">Revoked</option>
+            </select>
+          </Field>
+          <Field label="Notes" htmlFor="department-lead-notes">
+            <Textarea
+              id="department-lead-notes"
+              name="notes"
+              defaultValue={editingLead?.notes ?? ""}
+              disabled={isSubmitting}
+            />
+          </Field>
+          <Button type="submit" disabled={isSubmitting}>
+            <ShieldCheck />
+            {editingLead ? "Save lead" : "Add lead"}
+          </Button>
+        </form>
+      </div>
+    </section>
+  )
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string
+  htmlFor: string
+  children: ReactNode
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+    </div>
+  )
+}
+
+function getFormString(formData: FormData, key: string) {
+  const value = formData.get(key)
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+function getRoleLabel(roleType: CrewDepartmentLeadListItem["roleType"]) {
+  return (
+    VOLUNTEER_ROLE_OPTIONS.find((role) => role.value === roleType)?.label ??
+    roleType
+  )
+}
+
+function formatWindow(lead: CrewDepartmentLeadListItem) {
+  if (!lead.startsAt && !lead.endsAt) return null
+  return `${formatDate(lead.startsAt) || "Any start"} to ${
+    formatDate(lead.endsAt) || "Any end"
+  }`
+}
+
+function formatDate(value: Date | string | null) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  })
+}
+
+function toDateTimeLocal(value: Date | string | null | undefined) {
+  if (!value) return ""
+  const date = value instanceof Date ? value : new Date(value)
+  if (Number.isNaN(date.getTime())) return ""
+  const timezoneOffsetMs = date.getTimezoneOffset() * 60_000
+  return new Date(date.getTime() - timezoneOffsetMs).toISOString().slice(0, 16)
+}

--- a/apps/crew/src/lib/crew/department-leads.test.ts
+++ b/apps/crew/src/lib/crew/department-leads.test.ts
@@ -1,0 +1,127 @@
+// @lat: [[crew#Department Leads]]
+import { describe, expect, it } from "vitest"
+import {
+  assertCrewDepartmentLeadCanManageRosterTarget,
+  assertCrewDepartmentLeadCanManageShift,
+  crewDepartmentLeadCanManageShift,
+  filterCrewDepartmentLeadRoster,
+  filterCrewDepartmentLeadShifts,
+  normalizeCrewDepartmentLeadScope,
+  type CrewDepartmentLeadAccess,
+} from "./department-leads"
+
+describe("Crew department lead scope helpers", () => {
+  const judgeNorthMorningScope = normalizeCrewDepartmentLeadScope({
+    id: "cdlead_judge_north",
+    roleType: "judge",
+    startsAt: "2026-07-01T14:00:00.000Z",
+    endsAt: "2026-07-01T18:00:00.000Z",
+    scope: { floors: ["North Floor"] },
+  })
+  const access: CrewDepartmentLeadAccess = {
+    kind: "department_lead",
+    scopes: [judgeNorthMorningScope],
+  }
+
+  it("matches shifts by role, floor, and overlapping time window", () => {
+    expect(
+      crewDepartmentLeadCanManageShift(judgeNorthMorningScope, {
+        id: "vshf_match",
+        roleType: "judge",
+        location: " north floor ",
+        startTime: "2026-07-01T15:00:00.000Z",
+        endTime: "2026-07-01T16:00:00.000Z",
+      }),
+    ).toBe(true)
+
+    expect(
+      crewDepartmentLeadCanManageShift(judgeNorthMorningScope, {
+        id: "vshf_wrong_role",
+        roleType: "medical",
+        location: "North Floor",
+        startTime: "2026-07-01T15:00:00.000Z",
+        endTime: "2026-07-01T16:00:00.000Z",
+      }),
+    ).toBe(false)
+
+    expect(
+      crewDepartmentLeadCanManageShift(judgeNorthMorningScope, {
+        id: "vshf_wrong_floor",
+        roleType: "judge",
+        location: "South Floor",
+        startTime: "2026-07-01T15:00:00.000Z",
+        endTime: "2026-07-01T16:00:00.000Z",
+      }),
+    ).toBe(false)
+
+    expect(
+      crewDepartmentLeadCanManageShift(judgeNorthMorningScope, {
+        id: "vshf_after_window",
+        roleType: "judge",
+        location: "North Floor",
+        startTime: "2026-07-01T18:00:00.000Z",
+        endTime: "2026-07-01T19:00:00.000Z",
+      }),
+    ).toBe(false)
+  })
+
+  it("filters shift and roster reads without leaking the full roster", () => {
+    const visibleShift = {
+      id: "vshf_visible",
+      roleType: "judge" as const,
+      location: "North Floor",
+      startTime: new Date("2026-07-01T15:00:00.000Z"),
+      endTime: new Date("2026-07-01T16:00:00.000Z"),
+      assignments: [{ membershipId: "tmem_assigned_medical" }],
+    }
+    const hiddenShift = {
+      id: "vshf_hidden",
+      roleType: "judge" as const,
+      location: "South Floor",
+      startTime: new Date("2026-07-01T15:00:00.000Z"),
+      endTime: new Date("2026-07-01T16:00:00.000Z"),
+      assignments: [{ membershipId: "tmem_hidden" }],
+    }
+    const scopedShifts = filterCrewDepartmentLeadShifts(
+      [visibleShift, hiddenShift],
+      access,
+    )
+    const scopedRoster = filterCrewDepartmentLeadRoster(
+      [
+        { membershipId: "tmem_judge", roleTypes: ["judge" as const] },
+        {
+          membershipId: "tmem_assigned_medical",
+          roleTypes: ["medical" as const],
+        },
+        { membershipId: "tmem_hidden", roleTypes: ["medical" as const] },
+      ],
+      access,
+      scopedShifts,
+    )
+
+    expect(scopedShifts.map((shift) => shift.id)).toEqual(["vshf_visible"])
+    expect(scopedRoster.map((volunteer) => volunteer.membershipId)).toEqual([
+      "tmem_judge",
+      "tmem_assigned_medical",
+    ])
+  })
+
+  it("denies out-of-scope shift and roster mutations", () => {
+    expect(() =>
+      assertCrewDepartmentLeadCanManageShift(access, {
+        id: "vshf_wrong_time",
+        roleType: "judge",
+        location: "North Floor",
+        startTime: "2026-07-01T19:00:00.000Z",
+        endTime: "2026-07-01T20:00:00.000Z",
+      }),
+    ).toThrow("Department lead scope")
+
+    expect(() =>
+      assertCrewDepartmentLeadCanManageRosterTarget(access, {
+        membershipId: "tmem_medical",
+        roleTypes: ["medical"],
+      }),
+    ).toThrow("Department lead scope")
+  })
+})

--- a/apps/crew/src/lib/crew/department-leads.test.ts
+++ b/apps/crew/src/lib/crew/department-leads.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it } from "vitest"
 import {
   assertCrewDepartmentLeadCanManageRosterTarget,
   assertCrewDepartmentLeadCanManageShift,
+  buildCrewDepartmentLeadScopePayload,
   crewDepartmentLeadCanManageShift,
   filterCrewDepartmentLeadRoster,
   filterCrewDepartmentLeadShifts,
+  getCrewDepartmentLeadFloorFromScope,
   normalizeCrewDepartmentLeadScope,
+  parseCrewDepartmentLeadDateTimeLocal,
   type CrewDepartmentLeadAccess,
 } from "./department-leads"
 
@@ -123,5 +126,35 @@ describe("Crew department lead scope helpers", () => {
         roleTypes: ["medical"],
       }),
     ).toThrow("Department lead scope")
+  })
+
+  it("writes canonical floor scope and reads legacy floor shapes", () => {
+    expect(buildCrewDepartmentLeadScopePayload(" North Floor ")).toEqual({
+      floorNames: ["North Floor"],
+    })
+    expect(getCrewDepartmentLeadFloorFromScope({ floorNames: ["North"] })).toBe(
+      "North",
+    )
+    expect(getCrewDepartmentLeadFloorFromScope({ floors: ["Legacy"] })).toBe(
+      "Legacy",
+    )
+    expect(getCrewDepartmentLeadFloorFromScope({ locations: ["Lane 1"] })).toBe(
+      "Lane 1",
+    )
+  })
+
+  it("parses department lead datetime-local values in the event timezone", () => {
+    expect(
+      parseCrewDepartmentLeadDateTimeLocal(
+        "2026-07-01T09:30",
+        "America/Denver",
+      )?.toISOString(),
+    ).toBe("2026-07-01T15:30:00.000Z")
+    expect(
+      parseCrewDepartmentLeadDateTimeLocal(
+        "2026-07-01T09:30:00.000Z",
+        "America/Denver",
+      )?.toISOString(),
+    ).toBe("2026-07-01T09:30:00.000Z")
   })
 })

--- a/apps/crew/src/lib/crew/department-leads.ts
+++ b/apps/crew/src/lib/crew/department-leads.ts
@@ -1,0 +1,210 @@
+// @lat: [[crew#Department Leads]]
+import type { VolunteerRoleType } from "@/db/schemas/volunteers"
+
+export interface CrewDepartmentLeadScopeRecord {
+  id: string
+  roleType?: VolunteerRoleType | null
+  venueId?: string | null
+  startsAt?: Date | string | null
+  endsAt?: Date | string | null
+  scope?: Record<string, unknown> | null
+}
+
+export interface CrewDepartmentLeadScope {
+  id: string
+  roleTypes: VolunteerRoleType[]
+  floorNames: string[]
+  venueIds: string[]
+  startsAt: Date | null
+  endsAt: Date | null
+}
+
+export interface CrewDepartmentLeadShiftTarget {
+  id?: string
+  roleType: VolunteerRoleType
+  location?: string | null
+  venueId?: string | null
+  startTime: Date | string
+  endTime: Date | string
+}
+
+export interface CrewDepartmentLeadRosterTarget {
+  membershipId?: string | null
+  roleTypes: VolunteerRoleType[]
+}
+
+export interface CrewDepartmentLeadAccess {
+  kind: "full" | "department_lead"
+  scopes: CrewDepartmentLeadScope[]
+}
+
+export function normalizeCrewDepartmentLeadScope(
+  record: CrewDepartmentLeadScopeRecord,
+): CrewDepartmentLeadScope {
+  const scope = isRecord(record.scope) ? record.scope : {}
+  const roleTypes = uniqueStrings([
+    ...parseStringList(scope.roleTypes),
+    ...parseStringList(scope.roles),
+    ...(record.roleType ? [record.roleType] : []),
+  ]) as VolunteerRoleType[]
+  const floorNames = uniqueStrings([
+    ...parseStringList(scope.floorNames),
+    ...parseStringList(scope.floors),
+    ...parseStringList(scope.locations),
+  ]).map(normalizeDepartmentLeadText)
+  const venueIds = uniqueStrings([
+    ...parseStringList(scope.venueIds),
+    ...(record.venueId ? [record.venueId] : []),
+  ])
+
+  return {
+    id: record.id,
+    roleTypes,
+    floorNames,
+    venueIds,
+    startsAt: toValidDate(record.startsAt),
+    endsAt: toValidDate(record.endsAt),
+  }
+}
+
+export function crewDepartmentLeadCanManageShift(
+  scope: CrewDepartmentLeadScope,
+  shift: CrewDepartmentLeadShiftTarget,
+): boolean {
+  if (scope.roleTypes.length > 0 && !scope.roleTypes.includes(shift.roleType)) {
+    return false
+  }
+
+  if (
+    scope.venueIds.length > 0 &&
+    !scope.venueIds.includes(shift.venueId ?? "")
+  ) {
+    return false
+  }
+
+  if (scope.floorNames.length > 0) {
+    const location = normalizeDepartmentLeadText(shift.location)
+    if (!location || !scope.floorNames.includes(location)) {
+      return false
+    }
+  }
+
+  const startTime = toValidDate(shift.startTime)
+  const endTime = toValidDate(shift.endTime)
+  if (!startTime || !endTime) return false
+
+  if (scope.startsAt && endTime <= scope.startsAt) return false
+  if (scope.endsAt && startTime >= scope.endsAt) return false
+
+  return true
+}
+
+export function crewDepartmentLeadCanManageRosterTarget(
+  scope: CrewDepartmentLeadScope,
+  target: CrewDepartmentLeadRosterTarget,
+): boolean {
+  if (scope.roleTypes.length === 0) return true
+  return target.roleTypes.some((roleType) => scope.roleTypes.includes(roleType))
+}
+
+export function filterCrewDepartmentLeadShifts<
+  T extends CrewDepartmentLeadShiftTarget,
+>(shifts: T[], access: CrewDepartmentLeadAccess): T[] {
+  if (access.kind === "full") return shifts
+  return shifts.filter((shift) =>
+    access.scopes.some((scope) =>
+      crewDepartmentLeadCanManageShift(scope, shift),
+    ),
+  )
+}
+
+export function filterCrewDepartmentLeadRoster<
+  T extends CrewDepartmentLeadRosterTarget,
+>(
+  roster: T[],
+  access: CrewDepartmentLeadAccess,
+  visibleShiftAssignments: Array<{
+    assignments: Array<{ membershipId: string }>
+  }>,
+): T[] {
+  if (access.kind === "full") return roster
+
+  const visibleMembershipIds = new Set(
+    visibleShiftAssignments.flatMap((shift) =>
+      shift.assignments.map((assignment) => assignment.membershipId),
+    ),
+  )
+
+  return roster.filter((volunteer) => {
+    if (
+      volunteer.membershipId &&
+      visibleMembershipIds.has(volunteer.membershipId)
+    ) {
+      return true
+    }
+
+    return access.scopes.some((scope) =>
+      crewDepartmentLeadCanManageRosterTarget(scope, volunteer),
+    )
+  })
+}
+
+export function assertCrewDepartmentLeadCanManageShift(
+  access: CrewDepartmentLeadAccess,
+  shift: CrewDepartmentLeadShiftTarget,
+) {
+  if (access.kind === "full") return
+  if (
+    access.scopes.some((scope) =>
+      crewDepartmentLeadCanManageShift(scope, shift),
+    )
+  ) {
+    return
+  }
+
+  throw new Error("Department lead scope does not include this shift.")
+}
+
+export function assertCrewDepartmentLeadCanManageRosterTarget(
+  access: CrewDepartmentLeadAccess,
+  target: CrewDepartmentLeadRosterTarget,
+) {
+  if (access.kind === "full") return
+  if (
+    access.scopes.some((scope) =>
+      crewDepartmentLeadCanManageRosterTarget(scope, target),
+    )
+  ) {
+    return
+  }
+
+  throw new Error("Department lead scope does not include this volunteer.")
+}
+
+export function normalizeDepartmentLeadText(value: unknown) {
+  return typeof value === "string"
+    ? value.trim().toLowerCase().replace(/\s+/g, " ")
+    : ""
+}
+
+function parseStringList(value: unknown) {
+  if (typeof value === "string") return value.trim() ? [value.trim()] : []
+  if (!Array.isArray(value)) return []
+  return value.flatMap((item) =>
+    typeof item === "string" && item.trim() ? [item.trim()] : [],
+  )
+}
+
+function uniqueStrings(values: string[]) {
+  return [...new Set(values)]
+}
+
+function toValidDate(value: Date | string | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}

--- a/apps/crew/src/lib/crew/department-leads.ts
+++ b/apps/crew/src/lib/crew/department-leads.ts
@@ -1,5 +1,9 @@
 // @lat: [[crew#Department Leads]]
 import type { VolunteerRoleType } from "@/db/schemas/volunteers"
+import {
+  DEFAULT_TIMEZONE,
+  parseTimeInTimezone,
+} from "../../utils/timezone-utils"
 
 export interface CrewDepartmentLeadScopeRecord {
   id: string
@@ -187,6 +191,53 @@ export function normalizeDepartmentLeadText(value: unknown) {
     : ""
 }
 
+export function buildCrewDepartmentLeadScopePayload(
+  floor: string | null | undefined,
+) {
+  const trimmedFloor = emptyToNull(floor)
+  return trimmedFloor ? { floorNames: [trimmedFloor] } : null
+}
+
+export function getCrewDepartmentLeadFloorFromScope(scope: unknown) {
+  if (!isRecord(scope)) return null
+
+  for (const key of ["floorNames", "floors", "locations"] as const) {
+    const value = scope[key]
+    if (!Array.isArray(value)) continue
+
+    const floor = value.find((item) => typeof item === "string" && item.trim())
+    if (typeof floor === "string") return floor
+  }
+
+  return null
+}
+
+export function parseCrewDepartmentLeadDateTimeLocal(
+  value: string | null | undefined,
+  timezone: string | null | undefined,
+) {
+  const trimmed = emptyToNull(value)
+  if (!trimmed) return null
+
+  if (hasExplicitTimezone(trimmed)) {
+    const date = new Date(trimmed)
+    if (Number.isNaN(date.getTime())) {
+      throw new Error("Department lead time window is invalid")
+    }
+    return date
+  }
+
+  const match = trimmed.match(/^(\d{4}-\d{2}-\d{2})T(\d{1,2}:\d{2})$/)
+  const parsed = match
+    ? parseTimeInTimezone(match[2], match[1], timezone ?? DEFAULT_TIMEZONE)
+    : null
+
+  if (!parsed) {
+    throw new Error("Department lead time window is invalid")
+  }
+  return parsed
+}
+
 function parseStringList(value: unknown) {
   if (typeof value === "string") return value.trim() ? [value.trim()] : []
   if (!Array.isArray(value)) return []
@@ -207,4 +258,13 @@ function toValidDate(value: Date | string | null | undefined) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function hasExplicitTimezone(value: string) {
+  return /(?:Z|[+-]\d{2}:?\d{2})$/i.test(value)
+}
+
+function emptyToNull(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
 }

--- a/apps/crew/src/lib/crew/staffing/department-lead-scope.test.ts
+++ b/apps/crew/src/lib/crew/staffing/department-lead-scope.test.ts
@@ -1,0 +1,109 @@
+// @lat: [[crew#Department Leads]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+} from "../../../db/schemas/crew-imports"
+import { normalizeCrewDepartmentLeadScope } from "../department-leads"
+import { buildCrewStaffingMatrix } from "./matrix"
+import { buildCrewStaffingReport } from "./report"
+import { filterCrewStaffingInputForDepartmentLead } from "./department-lead-scope"
+import type { CrewStaffingMatrixInput } from "./types"
+
+describe("Crew staffing department-lead scope", () => {
+  it("removes out-of-scope judge assignment membership and status data", () => {
+    const input: CrewStaffingMatrixInput = {
+      event: { id: "comp_1", timezone: "UTC" },
+      venues: [
+        { id: "venue_north", name: "North Floor", laneCount: 2 },
+        { id: "venue_south", name: "South Floor", laneCount: 2 },
+      ],
+      workouts: [{ id: "tw_1", name: "Workout 1", sortOrder: 1 }],
+      heats: [
+        {
+          id: "heat_south_hidden",
+          trackWorkoutId: "tw_1",
+          heatNumber: 1,
+          venueId: "venue_south",
+          scheduledTime: "2026-07-01T15:00:00.000Z",
+          durationMinutes: 30,
+        },
+      ],
+      heatLaneAssignments: [
+        { heatId: "heat_south_hidden", laneNumber: 1 },
+        { heatId: "heat_south_hidden", laneNumber: 2 },
+      ],
+      roster: [
+        {
+          membershipId: "tmem_visible",
+          name: "Visible Lead Volunteer",
+          roleTypes: ["judge"],
+          isActive: true,
+        },
+        {
+          membershipId: "tmem_hidden",
+          name: "Hidden Judge",
+          roleTypes: ["judge"],
+          isActive: true,
+        },
+      ],
+      shifts: [
+        {
+          id: "shift_north_visible",
+          name: "North judge shift",
+          roleType: "judge",
+          location: "North Floor",
+          startTime: "2026-07-01T15:00:00.000Z",
+          endTime: "2026-07-01T16:00:00.000Z",
+          capacity: 1,
+          assignments: [
+            {
+              id: "vsha_visible",
+              membershipId: "tmem_hidden",
+            },
+          ],
+        },
+      ],
+      judgeAssignments: [
+        {
+          id: "jha_hidden_declined",
+          heatId: "heat_south_hidden",
+          membershipId: "tmem_hidden",
+          laneNumber: 1,
+          position: "judge",
+          confirmation: {
+            type: CREW_ASSIGNMENT_CONFIRMATION_TYPE.JUDGE_HEAT,
+            status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+          },
+        },
+      ],
+    }
+    const scopedInput = filterCrewStaffingInputForDepartmentLead(input, {
+      kind: "department_lead",
+      scopes: [
+        normalizeCrewDepartmentLeadScope({
+          id: "cdlead_north_judge",
+          roleType: "judge",
+          startsAt: "2026-07-01T14:00:00.000Z",
+          endsAt: "2026-07-01T18:00:00.000Z",
+          scope: { floors: ["North Floor"] },
+        }),
+      ],
+    })
+    const matrix = buildCrewStaffingMatrix(scopedInput)
+    const report = buildCrewStaffingReport(scopedInput, matrix)
+
+    expect(scopedInput.heats).toEqual([])
+    expect(scopedInput.heatLaneAssignments).toEqual([])
+    expect(scopedInput.judgeAssignments).toEqual([])
+    expect(report.sourceCounts.judgeAssignments).toBe(0)
+    expect(matrix.doubleBookedVolunteers).toEqual([])
+    expect(
+      matrix.credentialWarnings.map((warning) => warning.assignmentId),
+    ).not.toContain("jha_hidden_declined")
+    expect(
+      matrix.confirmationGaps.map((gap) => gap.assignmentId),
+    ).not.toContain("jha_hidden_declined")
+    expect(matrix.summary.confirmationDeclines).toBe(0)
+  })
+})

--- a/apps/crew/src/lib/crew/staffing/department-lead-scope.ts
+++ b/apps/crew/src/lib/crew/staffing/department-lead-scope.ts
@@ -1,0 +1,59 @@
+// @lat: [[crew#Department Leads]]
+import {
+  filterCrewDepartmentLeadShifts,
+  type CrewDepartmentLeadAccess,
+} from "../department-leads"
+import type { CrewStaffingHeatInput, CrewStaffingMatrixInput } from "./types"
+
+export function filterCrewStaffingInputForDepartmentLead(
+  input: CrewStaffingMatrixInput,
+  access: CrewDepartmentLeadAccess,
+): CrewStaffingMatrixInput {
+  if (access.kind === "full") return input
+
+  const scopedShifts = filterCrewDepartmentLeadShifts(
+    input.shifts ?? [],
+    access,
+  )
+  const scopedHeats = filterCrewDepartmentLeadShifts(
+    (input.heats ?? []).map((heat) => ({
+      ...heat,
+      roleType: "judge" as const,
+      location: getHeatVenueName(input, heat),
+      startTime: heat.scheduledTime ?? "",
+      endTime: getHeatEndTime(heat) ?? heat.scheduledTime ?? "",
+    })),
+    access,
+  )
+  const scopedHeatIds = new Set(scopedHeats.map((heat) => heat.id))
+
+  return {
+    ...input,
+    heats: scopedHeats,
+    heatLaneAssignments: (input.heatLaneAssignments ?? []).filter(
+      (assignment) => scopedHeatIds.has(assignment.heatId),
+    ),
+    shifts: scopedShifts,
+    judgeAssignments: (input.judgeAssignments ?? []).filter((assignment) =>
+      scopedHeatIds.has(assignment.heatId),
+    ),
+  }
+}
+
+function getHeatVenueName(
+  input: CrewStaffingMatrixInput,
+  heat: CrewStaffingHeatInput,
+) {
+  if (!heat.venueId) return null
+  return input.venues?.find((venue) => venue.id === heat.venueId)?.name ?? null
+}
+
+function getHeatEndTime(heat: CrewStaffingHeatInput) {
+  if (!heat.scheduledTime || !heat.durationMinutes) return null
+  const startTime =
+    heat.scheduledTime instanceof Date
+      ? heat.scheduledTime
+      : new Date(heat.scheduledTime)
+  if (Number.isNaN(startTime.getTime())) return null
+  return new Date(startTime.getTime() + heat.durationMinutes * 60_000)
+}

--- a/apps/crew/src/routes/events/$eventId/setup.tsx
+++ b/apps/crew/src/routes/events/$eventId/setup.tsx
@@ -3,7 +3,9 @@ import { useEffect, useState } from "react"
 import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
 import { Save } from "lucide-react"
 import { toast } from "sonner"
+import type { VolunteerRoleType } from "@/db/schemas/volunteers"
 import { CrewCopyPriorEventPanel } from "@/components/crew-copy-event/crew-copy-prior-event-panel"
+import { CrewDepartmentLeadsPanel } from "@/components/crew-department-leads/crew-department-leads-panel"
 import { GuidedSetupShell } from "@/components/crew-guided-setup/guided-setup-shell"
 import { CrewTemplatePanel } from "@/components/crew-templates/crew-template-panel"
 import type {
@@ -31,20 +33,32 @@ import {
   applyCrewCopyPriorEventFn,
   getCrewCopyPriorEventPageFn,
 } from "@/server-fns/crew-copy-event-fns"
+import {
+  createCrewDepartmentLeadFn,
+  getCrewDepartmentLeadsPageFn,
+  revokeCrewDepartmentLeadFn,
+  updateCrewDepartmentLeadFn,
+} from "@/server-fns/crew-department-lead-fns"
 
 export const Route = createFileRoute("/events/$eventId/setup")({
   loader: async ({ params }) => {
-    const [guidedSetupPage, templatePage, copyPriorEventPage] =
-      await Promise.all([
-        getCrewGuidedSetupPageFn({ data: { eventId: params.eventId } }),
-        getCrewTemplatePageFn({ data: { eventId: params.eventId } }),
-        getCrewCopyPriorEventPageFn({ data: { eventId: params.eventId } }),
-      ])
+    const [
+      guidedSetupPage,
+      templatePage,
+      copyPriorEventPage,
+      departmentLeadsPage,
+    ] = await Promise.all([
+      getCrewGuidedSetupPageFn({ data: { eventId: params.eventId } }),
+      getCrewTemplatePageFn({ data: { eventId: params.eventId } }),
+      getCrewCopyPriorEventPageFn({ data: { eventId: params.eventId } }),
+      getCrewDepartmentLeadsPageFn({ data: { eventId: params.eventId } }),
+    ])
 
     return {
       ...guidedSetupPage,
       templatePage,
       copyPriorEventPage,
+      departmentLeadsPage,
     }
   },
   component: EventSetupPage,
@@ -58,7 +72,7 @@ const parentRoute = getRouteApi("/events/$eventId")
 function EventSetupPage() {
   const router = useRouter()
   const { event } = parentRoute.useLoaderData()
-  const { guidedSetup, templatePage, copyPriorEventPage } =
+  const { guidedSetup, templatePage, copyPriorEventPage, departmentLeadsPage } =
     Route.useLoaderData()
   const parsedSettings = parseCrewSettings(event.settings.settings)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -225,6 +239,65 @@ function EventSetupPage() {
     }
   }
 
+  async function handleCreateDepartmentLead(data: {
+    eventId: string
+    email: string | null
+    name: string | null
+    membershipId: string | null
+    roleType: VolunteerRoleType
+    floor: string | null
+    startsAt: string | null
+    endsAt: string | null
+    status: "invited" | "active" | "revoked"
+    notes: string | null
+  }) {
+    try {
+      await createCrewDepartmentLeadFn({ data })
+      toast.success("Department lead added")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to add lead")
+    }
+  }
+
+  async function handleUpdateDepartmentLead(data: {
+    leadId: string
+    eventId: string
+    email: string | null
+    name: string | null
+    membershipId: string | null
+    roleType: VolunteerRoleType
+    floor: string | null
+    startsAt: string | null
+    endsAt: string | null
+    status: "invited" | "active" | "revoked"
+    notes: string | null
+  }) {
+    try {
+      await updateCrewDepartmentLeadFn({ data })
+      toast.success("Department lead saved")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to save lead",
+      )
+    }
+  }
+
+  async function handleRevokeDepartmentLead(leadId: string) {
+    try {
+      await revokeCrewDepartmentLeadFn({
+        data: { eventId: event.competition.id, leadId },
+      })
+      toast.success("Department lead revoked")
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to revoke lead",
+      )
+    }
+  }
+
   return (
     <section className="space-y-6">
       <GuidedSetupShell
@@ -248,6 +321,13 @@ function EventSetupPage() {
         eventId={event.competition.id}
         pageData={copyPriorEventPage}
         onApply={handleCopyPriorEvent}
+      />
+
+      <CrewDepartmentLeadsPanel
+        pageData={departmentLeadsPage}
+        onCreate={handleCreateDepartmentLead}
+        onUpdate={handleUpdateDepartmentLead}
+        onRevoke={handleRevokeDepartmentLead}
       />
 
       <form

--- a/apps/crew/src/server-fns/crew-department-lead-fns.ts
+++ b/apps/crew/src/server-fns/crew-department-lead-fns.ts
@@ -1,0 +1,106 @@
+// @lat: [[crew#Department Leads]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import { CREW_DEPARTMENT_LEAD_STATUS } from "@/db/schemas/crew-self-serve-presets"
+import { VOLUNTEER_ROLE_TYPE_VALUES } from "@/db/schemas/volunteers"
+
+export type {
+  CrewDepartmentLeadListItem,
+  CrewDepartmentLeadsPageData,
+} from "../server/crew-department-lead.server"
+
+const eventIdSchema = z.string().min(1, "Event ID is required")
+const leadIdSchema = z.string().startsWith("cdlead_", "Invalid lead ID")
+const nullableTextInput = z
+  .string()
+  .trim()
+  .transform((value) => (value.length > 0 ? value : null))
+  .nullable()
+  .optional()
+const dateTimeInput = z
+  .string()
+  .trim()
+  .transform((value) => (value.length > 0 ? value : null))
+  .nullable()
+  .optional()
+
+const departmentLeadInputSchema = z
+  .object({
+    eventId: eventIdSchema,
+    email: nullableTextInput,
+    name: nullableTextInput,
+    membershipId: nullableTextInput,
+    roleType: z.enum(VOLUNTEER_ROLE_TYPE_VALUES),
+    floor: nullableTextInput,
+    startsAt: dateTimeInput,
+    endsAt: dateTimeInput,
+    status: z
+      .enum([
+        CREW_DEPARTMENT_LEAD_STATUS.INVITED,
+        CREW_DEPARTMENT_LEAD_STATUS.ACTIVE,
+        CREW_DEPARTMENT_LEAD_STATUS.REVOKED,
+      ])
+      .optional(),
+    notes: nullableTextInput,
+  })
+  .superRefine((data, ctx) => {
+    if (!data.email && !data.membershipId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["email"],
+        message: "Add an email or choose a volunteer.",
+      })
+    }
+  })
+
+const updateDepartmentLeadInputSchema = departmentLeadInputSchema.extend({
+  leadId: leadIdSchema,
+})
+
+const revokeDepartmentLeadInputSchema = z.object({
+  eventId: eventIdSchema,
+  leadId: leadIdSchema,
+})
+
+export const getCrewDepartmentLeadsPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    z.object({ eventId: eventIdSchema }).parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewDepartmentLeadsPage } = await import(
+      "../server/crew-department-lead.server"
+    )
+    return getCrewDepartmentLeadsPage(data)
+  })
+
+export const createCrewDepartmentLeadFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) => departmentLeadInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { createCrewDepartmentLead } = await import(
+      "../server/crew-department-lead.server"
+    )
+    return createCrewDepartmentLead(data)
+  })
+
+export const updateCrewDepartmentLeadFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    updateDepartmentLeadInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { updateCrewDepartmentLead } = await import(
+      "../server/crew-department-lead.server"
+    )
+    return updateCrewDepartmentLead(data)
+  })
+
+export const revokeCrewDepartmentLeadFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    revokeDepartmentLeadInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { revokeCrewDepartmentLead } = await import(
+      "../server/crew-department-lead.server"
+    )
+    return revokeCrewDepartmentLead(data)
+  })

--- a/apps/crew/src/server-fns/crew-staffing-fns.server.ts
+++ b/apps/crew/src/server-fns/crew-staffing-fns.server.ts
@@ -26,14 +26,13 @@ import {
   buildCrewStaffingReport,
   type CrewStaffingConfirmationInput,
   type CrewStaffingMatrix,
-  type CrewStaffingMatrixInput,
   type CrewStaffingReport,
 } from "../lib/crew/staffing"
-import type { CrewDepartmentLeadAccess } from "../lib/crew/department-leads"
 import {
   filterCrewDepartmentLeadRoster,
-  filterCrewDepartmentLeadShifts,
+  type CrewDepartmentLeadAccess,
 } from "../lib/crew/department-leads"
+import { filterCrewStaffingInputForDepartmentLead } from "../lib/crew/staffing/department-lead-scope"
 import { resolveCrewDepartmentLeadAccess } from "../server/crew-department-lead.server"
 import {
   loadCrewRoster,
@@ -127,20 +126,13 @@ export async function loadCrewStaffingMatrixInput(
     loadStaffingWorkouts(event.id),
     loadStaffingHeats(event.id),
   ])
-  const scopedShifts = filterCrewDepartmentLeadShifts(shifts, access)
-  const scopedRoster = filterCrewDepartmentLeadRoster(
-    roster,
-    access,
-    scopedShifts,
-  )
   const heatIds = heats.map((heat) => heat.id)
   const trackWorkoutIds = [...new Set(heats.map((heat) => heat.trackWorkoutId))]
   const [heatLaneAssignments, judgeData] = await Promise.all([
     loadHeatLaneAssignments(heatIds),
     loadActiveJudgeAssignments(heatIds, trackWorkoutIds),
   ])
-
-  const input: CrewStaffingMatrixInput = {
+  const baseInput = {
     event: {
       id: event.id,
       name: event.name,
@@ -152,6 +144,24 @@ export async function loadCrewStaffingMatrixInput(
     workouts,
     heats,
     heatLaneAssignments,
+    shifts: toStaffingShifts(shifts),
+    judgeAssignments: judgeData.judgeAssignments,
+  }
+  const scopedStaffingInput = filterCrewStaffingInputForDepartmentLead(
+    baseInput,
+    access,
+  )
+  const scopedShiftIds = new Set(
+    scopedStaffingInput.shifts?.map((shift) => shift.id),
+  )
+  const scopedRoster = filterCrewDepartmentLeadRoster(
+    roster,
+    access,
+    shifts.filter((shift) => scopedShiftIds.has(shift.id)),
+  )
+
+  const input = {
+    ...scopedStaffingInput,
     roster: scopedRoster.flatMap((volunteer) => {
       if (!volunteer.membershipId) return []
       return {
@@ -164,8 +174,6 @@ export async function loadCrewStaffingMatrixInput(
         isActive: volunteer.status === "active",
       }
     }),
-    shifts: toStaffingShifts(scopedShifts),
-    judgeAssignments: judgeData.judgeAssignments,
   }
 
   return {

--- a/apps/crew/src/server-fns/crew-staffing-fns.server.ts
+++ b/apps/crew/src/server-fns/crew-staffing-fns.server.ts
@@ -29,7 +29,12 @@ import {
   type CrewStaffingMatrixInput,
   type CrewStaffingReport,
 } from "../lib/crew/staffing"
-import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
+import type { CrewDepartmentLeadAccess } from "../lib/crew/department-leads"
+import {
+  filterCrewDepartmentLeadRoster,
+  filterCrewDepartmentLeadShifts,
+} from "../lib/crew/department-leads"
+import { resolveCrewDepartmentLeadAccess } from "../server/crew-department-lead.server"
 import {
   loadCrewRoster,
   loadCrewShifts,
@@ -42,6 +47,7 @@ export interface CrewStaffingReportEvent {
   id: string
   name: string
   slug: string
+  organizingTeamId: string
   competitionTeamId: string
   timezone: string | null
   startDate: string | null
@@ -60,11 +66,12 @@ export interface CrewStaffingReportPageData {
 export async function getCrewStaffingReportPage(
   eventId: string,
 ): Promise<CrewStaffingReportPageData> {
-  requireLocalCrewOperatorAccess("Crew staffing")
-
   const event = await requireCrewStaffingEvent(eventId)
-  const { input, activeJudgeVersions } =
-    await loadCrewStaffingMatrixInput(event)
+  const access = await resolveCrewDepartmentLeadAccess(event)
+  const { input, activeJudgeVersions } = await loadCrewStaffingMatrixInput(
+    event,
+    access,
+  )
   const matrix = buildCrewStaffingMatrix(input)
   const report = buildCrewStaffingReport(input, matrix)
 
@@ -88,6 +95,7 @@ export async function requireCrewStaffingEvent(
       id: competitionsTable.id,
       name: competitionsTable.name,
       slug: competitionsTable.slug,
+      organizingTeamId: competitionsTable.organizingTeamId,
       competitionTeamId: competitionsTable.competitionTeamId,
       timezone: competitionsTable.timezone,
       startDate: competitionsTable.startDate,
@@ -110,6 +118,7 @@ export async function requireCrewStaffingEvent(
 
 export async function loadCrewStaffingMatrixInput(
   event: CrewStaffingReportEvent,
+  access: CrewDepartmentLeadAccess = { kind: "full", scopes: [] },
 ) {
   const [roster, shifts, venues, workouts, heats] = await Promise.all([
     loadCrewRoster(event.competitionTeamId),
@@ -118,6 +127,12 @@ export async function loadCrewStaffingMatrixInput(
     loadStaffingWorkouts(event.id),
     loadStaffingHeats(event.id),
   ])
+  const scopedShifts = filterCrewDepartmentLeadShifts(shifts, access)
+  const scopedRoster = filterCrewDepartmentLeadRoster(
+    roster,
+    access,
+    scopedShifts,
+  )
   const heatIds = heats.map((heat) => heat.id)
   const trackWorkoutIds = [...new Set(heats.map((heat) => heat.trackWorkoutId))]
   const [heatLaneAssignments, judgeData] = await Promise.all([
@@ -137,7 +152,7 @@ export async function loadCrewStaffingMatrixInput(
     workouts,
     heats,
     heatLaneAssignments,
-    roster: roster.flatMap((volunteer) => {
+    roster: scopedRoster.flatMap((volunteer) => {
       if (!volunteer.membershipId) return []
       return {
         membershipId: volunteer.membershipId,
@@ -149,7 +164,7 @@ export async function loadCrewStaffingMatrixInput(
         isActive: volunteer.status === "active",
       }
     }),
-    shifts: toStaffingShifts(shifts),
+    shifts: toStaffingShifts(scopedShifts),
     judgeAssignments: judgeData.judgeAssignments,
   }
 

--- a/apps/crew/src/server-fns/crew-staffing-fns.server.ts
+++ b/apps/crew/src/server-fns/crew-staffing-fns.server.ts
@@ -117,7 +117,7 @@ export async function requireCrewStaffingEvent(
 
 export async function loadCrewStaffingMatrixInput(
   event: CrewStaffingReportEvent,
-  access: CrewDepartmentLeadAccess = { kind: "full", scopes: [] },
+  access: CrewDepartmentLeadAccess,
 ) {
   const [roster, shifts, venues, workouts, heats] = await Promise.all([
     loadCrewRoster(event.competitionTeamId),

--- a/apps/crew/src/server/crew-confirmation.server.ts
+++ b/apps/crew/src/server/crew-confirmation.server.ts
@@ -56,6 +56,11 @@ import {
   type CrewAssignmentTokenState,
 } from "../lib/crew/assignment-confirmations"
 import {
+  assertCrewDepartmentLeadCanManageShift,
+  filterCrewDepartmentLeadShifts,
+  type CrewDepartmentLeadAccess,
+} from "../lib/crew/department-leads"
+import {
   formatVolunteerRole,
   getCrewRosterRoleTypes,
   parseCrewRosterMetadata,
@@ -69,7 +74,10 @@ import {
   formatDateTimeInTimezone,
 } from "../utils/timezone-utils"
 import { getFirstExecuteValue } from "../server-fns/db-execute"
-import { requireLocalCrewOperatorAccess } from "./crew-local-access"
+import {
+  requireCrewDepartmentLeadEvent,
+  resolveCrewDepartmentLeadAccess,
+} from "./crew-department-lead.server"
 
 type DbClient = ReturnType<typeof getDb>
 
@@ -190,6 +198,7 @@ interface CrewAssignmentEmailCandidate
   assignment: {
     id: string
     shiftName: string
+    roleType: VolunteerRoleType
     roleLabel: string
     startTime: Date
     endTime: Date
@@ -452,8 +461,8 @@ export async function loadCrewShiftAssignmentConfirmationMap(
 export async function updateCrewShiftAssignmentConfirmationState(
   data: UpdateCrewShiftAssignmentConfirmationStateInput,
 ) {
-  requireLocalCrewOperatorAccess("Crew assignment confirmations")
-
+  const event = await requireCrewDepartmentLeadEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const db = getDb()
   const now = new Date()
 
@@ -464,6 +473,10 @@ export async function updateCrewShiftAssignmentConfirmationState(
         shiftId: volunteerShiftAssignmentsTable.shiftId,
         membershipId: volunteerShiftAssignmentsTable.membershipId,
         competitionId: volunteerShiftsTable.competitionId,
+        shiftRoleType: volunteerShiftsTable.roleType,
+        shiftStartTime: volunteerShiftsTable.startTime,
+        shiftEndTime: volunteerShiftsTable.endTime,
+        shiftLocation: volunteerShiftsTable.location,
         membershipMetadata: teamMembershipTable.metadata,
         userEmail: userTable.email,
       })
@@ -489,6 +502,12 @@ export async function updateCrewShiftAssignmentConfirmationState(
     if (!assignment) {
       throw new Error("Shift assignment not found")
     }
+    assertCrewDepartmentLeadCanManageShift(access, {
+      roleType: assignment.shiftRoleType,
+      startTime: assignment.shiftStartTime,
+      endTime: assignment.shiftEndTime,
+      location: assignment.shiftLocation,
+    })
 
     const [latestConfirmation] = await tx
       .select({
@@ -580,11 +599,14 @@ export async function updateCrewShiftAssignmentConfirmationState(
 export async function queueCrewAssignmentConfirmationEmails(
   data: QueueCrewAssignmentConfirmationEmailsInput,
 ): Promise<QueueCrewAssignmentConfirmationEmailsResult> {
-  requireLocalCrewOperatorAccess("Crew confirmation emails")
-
+  const event = await requireCrewDepartmentLeadEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const db = getDb()
   const now = new Date()
-  const candidates = await loadCrewAssignmentEmailCandidates(data.eventId)
+  const candidates = filterCrewAssignmentEmailCandidates(
+    await loadCrewAssignmentEmailCandidates(data.eventId),
+    access,
+  )
   const plan = buildCrewAssignmentConfirmationEmailPlan({
     mode: data.mode,
     candidates,
@@ -910,12 +932,30 @@ async function loadCrewAssignmentEmailCandidates(
         id: row.confirmation.assignmentId,
         shiftName: row.shift.name,
         roleLabel: formatVolunteerRole(row.shift.roleType),
+        roleType: row.shift.roleType,
         startTime: row.shift.startTime,
         endTime: row.shift.endTime,
         location: row.shift.location,
       },
     }
   })
+}
+
+function filterCrewAssignmentEmailCandidates(
+  candidates: CrewAssignmentEmailCandidate[],
+  access: CrewDepartmentLeadAccess,
+) {
+  if (access.kind === "full") return candidates
+  return filterCrewDepartmentLeadShifts(
+    candidates.map((candidate) => ({
+      ...candidate,
+      roleType: candidate.assignment.roleType,
+      startTime: candidate.assignment.startTime,
+      endTime: candidate.assignment.endTime,
+      location: candidate.assignment.location,
+    })),
+    access,
+  )
 }
 
 async function claimCrewAssignmentEmailToken(params: {

--- a/apps/crew/src/server/crew-department-lead.server.ts
+++ b/apps/crew/src/server/crew-department-lead.server.ts
@@ -1,0 +1,407 @@
+// @lat: [[crew#Department Leads]]
+import { and, asc, eq, or, sql } from "drizzle-orm"
+import { getDb } from "@/db"
+import { createCrewDepartmentLeadId } from "@/db/schemas/common"
+import { competitionsTable } from "@/db/schemas/competitions"
+import {
+  CREW_DEPARTMENT_LEAD_STATUS,
+  crewDepartmentLeadsTable,
+  type CrewDepartmentLeadStatus,
+} from "@/db/schemas/crew-self-serve-presets"
+import { crewEventSettingsTable } from "@/db/schemas/crew-event-settings"
+import {
+  SYSTEM_ROLES_ENUM,
+  TEAM_PERMISSIONS,
+  teamMembershipTable,
+} from "@/db/schemas/teams"
+import { ROLES_ENUM, userTable } from "@/db/schemas/users"
+import type { VolunteerRoleType } from "@/db/schemas/volunteers"
+import {
+  type CrewDepartmentLeadAccess,
+  normalizeCrewDepartmentLeadScope,
+} from "@/lib/crew/department-leads"
+import { getSessionFromCookie } from "@/utils/auth"
+import { hasLocalCrewOperatorAccess } from "./crew-local-access"
+
+export interface CrewDepartmentLeadEvent {
+  id: string
+  organizingTeamId: string
+  competitionTeamId: string
+}
+
+export interface CrewDepartmentLeadListItem {
+  id: string
+  email: string | null
+  name: string | null
+  membershipId: string | null
+  roleType: VolunteerRoleType
+  floor: string | null
+  startsAt: Date | null
+  endsAt: Date | null
+  status: CrewDepartmentLeadStatus
+  notes: string | null
+}
+
+export interface CrewDepartmentLeadsPageData {
+  event: CrewDepartmentLeadEvent
+  leads: CrewDepartmentLeadListItem[]
+  volunteerOptions: Array<{
+    membershipId: string
+    name: string
+    email: string
+  }>
+}
+
+interface CrewDepartmentLeadInput {
+  eventId: string
+  email?: string | null
+  name?: string | null
+  membershipId?: string | null
+  roleType: VolunteerRoleType
+  floor?: string | null
+  startsAt?: string | null
+  endsAt?: string | null
+  status?: CrewDepartmentLeadStatus
+  notes?: string | null
+}
+
+interface UpdateCrewDepartmentLeadInput extends CrewDepartmentLeadInput {
+  leadId: string
+}
+
+interface RevokeCrewDepartmentLeadInput {
+  eventId: string
+  leadId: string
+}
+
+export async function getCrewDepartmentLeadsPage(data: {
+  eventId: string
+}): Promise<CrewDepartmentLeadsPageData> {
+  const event = await requireCrewDepartmentLeadEvent(data.eventId)
+  await requireCrewDepartmentLeadFullAccess(event)
+
+  const [leads, volunteerOptions] = await Promise.all([
+    loadCrewDepartmentLeads(event.id),
+    loadCrewDepartmentLeadVolunteerOptions(event.competitionTeamId),
+  ])
+
+  return { event, leads, volunteerOptions }
+}
+
+export async function createCrewDepartmentLead(data: CrewDepartmentLeadInput) {
+  const event = await requireCrewDepartmentLeadEvent(data.eventId)
+  await requireCrewDepartmentLeadFullAccess(event)
+
+  const now = new Date()
+  const db = getDb()
+  await db.insert(crewDepartmentLeadsTable).values({
+    id: createCrewDepartmentLeadId(),
+    teamId: event.competitionTeamId,
+    competitionId: event.id,
+    membershipId: emptyToNull(data.membershipId),
+    email: normalizeEmail(data.email),
+    name: emptyToNull(data.name),
+    roleType: data.roleType,
+    startsAt: parseOptionalDate(data.startsAt),
+    endsAt: parseOptionalDate(data.endsAt),
+    scope: buildLeadScope(data.floor),
+    status: data.status ?? CREW_DEPARTMENT_LEAD_STATUS.INVITED,
+    notes: emptyToNull(data.notes),
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  return { success: true }
+}
+
+export async function updateCrewDepartmentLead(
+  data: UpdateCrewDepartmentLeadInput,
+) {
+  const event = await requireCrewDepartmentLeadEvent(data.eventId)
+  await requireCrewDepartmentLeadFullAccess(event)
+
+  const db = getDb()
+  const result = await db
+    .update(crewDepartmentLeadsTable)
+    .set({
+      membershipId: emptyToNull(data.membershipId),
+      email: normalizeEmail(data.email),
+      name: emptyToNull(data.name),
+      roleType: data.roleType,
+      startsAt: parseOptionalDate(data.startsAt),
+      endsAt: parseOptionalDate(data.endsAt),
+      scope: buildLeadScope(data.floor),
+      status: data.status ?? CREW_DEPARTMENT_LEAD_STATUS.INVITED,
+      revokedAt:
+        data.status === CREW_DEPARTMENT_LEAD_STATUS.REVOKED ? new Date() : null,
+      notes: emptyToNull(data.notes),
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(crewDepartmentLeadsTable.id, data.leadId),
+        eq(crewDepartmentLeadsTable.competitionId, event.id),
+      ),
+    )
+
+  if (getAffectedRows(result) === 0) {
+    throw new Error("Department lead not found")
+  }
+
+  return { success: true }
+}
+
+export async function revokeCrewDepartmentLead(
+  data: RevokeCrewDepartmentLeadInput,
+) {
+  const event = await requireCrewDepartmentLeadEvent(data.eventId)
+  await requireCrewDepartmentLeadFullAccess(event)
+
+  const now = new Date()
+  const db = getDb()
+  const result = await db
+    .update(crewDepartmentLeadsTable)
+    .set({
+      status: CREW_DEPARTMENT_LEAD_STATUS.REVOKED,
+      revokedAt: now,
+      updatedAt: now,
+    })
+    .where(
+      and(
+        eq(crewDepartmentLeadsTable.id, data.leadId),
+        eq(crewDepartmentLeadsTable.competitionId, event.id),
+      ),
+    )
+
+  if (getAffectedRows(result) === 0) {
+    throw new Error("Department lead not found")
+  }
+
+  return { success: true }
+}
+
+export async function requireCrewDepartmentLeadEvent(
+  eventId: string,
+): Promise<CrewDepartmentLeadEvent> {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      organizingTeamId: competitionsTable.organizingTeamId,
+      competitionTeamId: competitionsTable.competitionTeamId,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  if (!event?.competitionTeamId) {
+    throw new Error("Crew event not found")
+  }
+
+  return {
+    id: event.id,
+    organizingTeamId: event.organizingTeamId,
+    competitionTeamId: event.competitionTeamId,
+  }
+}
+
+export async function resolveCrewDepartmentLeadAccess(
+  event: CrewDepartmentLeadEvent,
+): Promise<CrewDepartmentLeadAccess> {
+  if (hasLocalCrewOperatorAccess()) {
+    return { kind: "full", scopes: [] }
+  }
+
+  const session = await getSessionFromCookie().catch(() => null)
+  if (!session?.userId) {
+    throw new Error("NOT_AUTHORIZED: Not authenticated")
+  }
+
+  if (
+    session.user.role === ROLES_ENUM.ADMIN ||
+    session.teams?.some(
+      (team) =>
+        (team.id === event.organizingTeamId ||
+          team.id === event.competitionTeamId) &&
+        team.permissions.includes(TEAM_PERMISSIONS.MANAGE_COMPETITIONS),
+    )
+  ) {
+    return { kind: "full", scopes: [] }
+  }
+
+  const db = getDb()
+  const membershipIdentityCondition = and(
+    eq(teamMembershipTable.userId, session.userId),
+    eq(teamMembershipTable.teamId, event.competitionTeamId),
+    eq(teamMembershipTable.isActive, true),
+  )
+  const identityCondition = session.user.email
+    ? or(
+        membershipIdentityCondition,
+        sql`lower(${crewDepartmentLeadsTable.email}) = ${session.user.email.toLowerCase()}`,
+      )
+    : membershipIdentityCondition
+  const rows = await db
+    .select({
+      id: crewDepartmentLeadsTable.id,
+      roleType: crewDepartmentLeadsTable.roleType,
+      venueId: crewDepartmentLeadsTable.venueId,
+      startsAt: crewDepartmentLeadsTable.startsAt,
+      endsAt: crewDepartmentLeadsTable.endsAt,
+      scope: crewDepartmentLeadsTable.scope,
+    })
+    .from(crewDepartmentLeadsTable)
+    .leftJoin(
+      teamMembershipTable,
+      eq(crewDepartmentLeadsTable.membershipId, teamMembershipTable.id),
+    )
+    .where(
+      and(
+        eq(crewDepartmentLeadsTable.competitionId, event.id),
+        eq(crewDepartmentLeadsTable.teamId, event.competitionTeamId),
+        eq(crewDepartmentLeadsTable.status, CREW_DEPARTMENT_LEAD_STATUS.ACTIVE),
+        identityCondition,
+      ),
+    )
+
+  if (rows.length === 0) {
+    throw new Error("FORBIDDEN: Department lead access was not found")
+  }
+
+  return {
+    kind: "department_lead",
+    scopes: rows.map((row) =>
+      normalizeCrewDepartmentLeadScope({
+        ...row,
+        scope: row.scope,
+      }),
+    ),
+  }
+}
+
+export async function requireCrewDepartmentLeadFullAccess(
+  event: CrewDepartmentLeadEvent,
+) {
+  const access = await resolveCrewDepartmentLeadAccess(event)
+  if (access.kind !== "full") {
+    throw new Error("FORBIDDEN: Organizer access is required")
+  }
+}
+
+async function loadCrewDepartmentLeads(
+  competitionId: string,
+): Promise<CrewDepartmentLeadListItem[]> {
+  const db = getDb()
+  const rows = await db
+    .select({
+      id: crewDepartmentLeadsTable.id,
+      email: crewDepartmentLeadsTable.email,
+      name: crewDepartmentLeadsTable.name,
+      membershipId: crewDepartmentLeadsTable.membershipId,
+      roleType: crewDepartmentLeadsTable.roleType,
+      scope: crewDepartmentLeadsTable.scope,
+      startsAt: crewDepartmentLeadsTable.startsAt,
+      endsAt: crewDepartmentLeadsTable.endsAt,
+      status: crewDepartmentLeadsTable.status,
+      notes: crewDepartmentLeadsTable.notes,
+    })
+    .from(crewDepartmentLeadsTable)
+    .where(eq(crewDepartmentLeadsTable.competitionId, competitionId))
+    .orderBy(
+      asc(crewDepartmentLeadsTable.status),
+      asc(crewDepartmentLeadsTable.email),
+    )
+
+  return rows.map((row) => ({
+    id: row.id,
+    email: row.email,
+    name: row.name,
+    membershipId: row.membershipId,
+    roleType: row.roleType ?? "general",
+    floor: getFloorFromScope(row.scope),
+    startsAt: row.startsAt,
+    endsAt: row.endsAt,
+    status: row.status,
+    notes: row.notes,
+  }))
+}
+
+async function loadCrewDepartmentLeadVolunteerOptions(teamId: string) {
+  const db = getDb()
+  const rows = await db
+    .select({
+      membershipId: teamMembershipTable.id,
+      firstName: userTable.firstName,
+      lastName: userTable.lastName,
+      email: userTable.email,
+    })
+    .from(teamMembershipTable)
+    .innerJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(
+      and(
+        eq(teamMembershipTable.teamId, teamId),
+        eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamMembershipTable.isSystemRole, true),
+        eq(teamMembershipTable.isActive, true),
+      ),
+    )
+    .orderBy(asc(userTable.email))
+
+  return rows.map((row) => ({
+    membershipId: row.membershipId,
+    name:
+      [row.firstName, row.lastName].filter(Boolean).join(" ") ||
+      row.email ||
+      "Volunteer",
+    email: row.email ?? "",
+  }))
+}
+
+function buildLeadScope(floor: string | null | undefined) {
+  const trimmedFloor = emptyToNull(floor)
+  return trimmedFloor ? { floors: [trimmedFloor] } : null
+}
+
+function getFloorFromScope(scope: unknown) {
+  if (!scope || typeof scope !== "object" || Array.isArray(scope)) return null
+  const floors = (scope as { floors?: unknown }).floors
+  if (!Array.isArray(floors)) return null
+  const floor = floors.find(
+    (value) => typeof value === "string" && value.trim(),
+  )
+  return typeof floor === "string" ? floor : null
+}
+
+function parseOptionalDate(value: string | null | undefined) {
+  const trimmed = emptyToNull(value)
+  if (!trimmed) return null
+  const date = new Date(trimmed)
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Department lead time window is invalid")
+  }
+  return date
+}
+
+function normalizeEmail(value: string | null | undefined) {
+  return emptyToNull(value)?.toLowerCase() ?? null
+}
+
+function emptyToNull(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+function getAffectedRows(result: unknown) {
+  return Number(
+    (result as { rowsAffected?: number }).rowsAffected ??
+      (result as { affectedRows?: number }).affectedRows ??
+      (Array.isArray(result)
+        ? (result[0] as { affectedRows?: number } | undefined)?.affectedRows
+        : undefined) ??
+      0,
+  )
+}

--- a/apps/crew/src/server/crew-department-lead.server.ts
+++ b/apps/crew/src/server/crew-department-lead.server.ts
@@ -17,8 +17,11 @@ import {
 import { ROLES_ENUM, userTable } from "@/db/schemas/users"
 import type { VolunteerRoleType } from "@/db/schemas/volunteers"
 import {
+  buildCrewDepartmentLeadScopePayload,
   type CrewDepartmentLeadAccess,
+  getCrewDepartmentLeadFloorFromScope,
   normalizeCrewDepartmentLeadScope,
+  parseCrewDepartmentLeadDateTimeLocal,
 } from "@/lib/crew/department-leads"
 import { getSessionFromCookie } from "@/utils/auth"
 import { hasLocalCrewOperatorAccess } from "./crew-local-access"
@@ -27,6 +30,7 @@ export interface CrewDepartmentLeadEvent {
   id: string
   organizingTeamId: string
   competitionTeamId: string
+  timezone: string | null
 }
 
 export interface CrewDepartmentLeadListItem {
@@ -102,9 +106,12 @@ export async function createCrewDepartmentLead(data: CrewDepartmentLeadInput) {
     email: normalizeEmail(data.email),
     name: emptyToNull(data.name),
     roleType: data.roleType,
-    startsAt: parseOptionalDate(data.startsAt),
-    endsAt: parseOptionalDate(data.endsAt),
-    scope: buildLeadScope(data.floor),
+    startsAt: parseCrewDepartmentLeadDateTimeLocal(
+      data.startsAt,
+      event.timezone,
+    ),
+    endsAt: parseCrewDepartmentLeadDateTimeLocal(data.endsAt, event.timezone),
+    scope: buildCrewDepartmentLeadScopePayload(data.floor),
     status: data.status ?? CREW_DEPARTMENT_LEAD_STATUS.INVITED,
     notes: emptyToNull(data.notes),
     createdAt: now,
@@ -121,22 +128,30 @@ export async function updateCrewDepartmentLead(
   await requireCrewDepartmentLeadFullAccess(event)
 
   const db = getDb()
+  const updateValues: Partial<typeof crewDepartmentLeadsTable.$inferInsert> = {
+    membershipId: emptyToNull(data.membershipId),
+    email: normalizeEmail(data.email),
+    name: emptyToNull(data.name),
+    roleType: data.roleType,
+    startsAt: parseCrewDepartmentLeadDateTimeLocal(
+      data.startsAt,
+      event.timezone,
+    ),
+    endsAt: parseCrewDepartmentLeadDateTimeLocal(data.endsAt, event.timezone),
+    scope: buildCrewDepartmentLeadScopePayload(data.floor),
+    notes: emptyToNull(data.notes),
+    updatedAt: new Date(),
+  }
+
+  if (data.status !== undefined) {
+    updateValues.status = data.status
+    updateValues.revokedAt =
+      data.status === CREW_DEPARTMENT_LEAD_STATUS.REVOKED ? new Date() : null
+  }
+
   const result = await db
     .update(crewDepartmentLeadsTable)
-    .set({
-      membershipId: emptyToNull(data.membershipId),
-      email: normalizeEmail(data.email),
-      name: emptyToNull(data.name),
-      roleType: data.roleType,
-      startsAt: parseOptionalDate(data.startsAt),
-      endsAt: parseOptionalDate(data.endsAt),
-      scope: buildLeadScope(data.floor),
-      status: data.status ?? CREW_DEPARTMENT_LEAD_STATUS.INVITED,
-      revokedAt:
-        data.status === CREW_DEPARTMENT_LEAD_STATUS.REVOKED ? new Date() : null,
-      notes: emptyToNull(data.notes),
-      updatedAt: new Date(),
-    })
+    .set(updateValues)
     .where(
       and(
         eq(crewDepartmentLeadsTable.id, data.leadId),
@@ -189,6 +204,7 @@ export async function requireCrewDepartmentLeadEvent(
       id: competitionsTable.id,
       organizingTeamId: competitionsTable.organizingTeamId,
       competitionTeamId: competitionsTable.competitionTeamId,
+      timezone: competitionsTable.timezone,
     })
     .from(crewEventSettingsTable)
     .innerJoin(
@@ -206,6 +222,7 @@ export async function requireCrewDepartmentLeadEvent(
     id: event.id,
     organizingTeamId: event.organizingTeamId,
     competitionTeamId: event.competitionTeamId,
+    timezone: event.timezone,
   }
 }
 
@@ -322,7 +339,7 @@ async function loadCrewDepartmentLeads(
     name: row.name,
     membershipId: row.membershipId,
     roleType: row.roleType ?? "general",
-    floor: getFloorFromScope(row.scope),
+    floor: getCrewDepartmentLeadFloorFromScope(row.scope),
     startsAt: row.startsAt,
     endsAt: row.endsAt,
     status: row.status,
@@ -359,31 +376,6 @@ async function loadCrewDepartmentLeadVolunteerOptions(teamId: string) {
       "Volunteer",
     email: row.email ?? "",
   }))
-}
-
-function buildLeadScope(floor: string | null | undefined) {
-  const trimmedFloor = emptyToNull(floor)
-  return trimmedFloor ? { floors: [trimmedFloor] } : null
-}
-
-function getFloorFromScope(scope: unknown) {
-  if (!scope || typeof scope !== "object" || Array.isArray(scope)) return null
-  const floors = (scope as { floors?: unknown }).floors
-  if (!Array.isArray(floors)) return null
-  const floor = floors.find(
-    (value) => typeof value === "string" && value.trim(),
-  )
-  return typeof floor === "string" ? floor : null
-}
-
-function parseOptionalDate(value: string | null | undefined) {
-  const trimmed = emptyToNull(value)
-  if (!trimmed) return null
-  const date = new Date(trimmed)
-  if (Number.isNaN(date.getTime())) {
-    throw new Error("Department lead time window is invalid")
-  }
-  return date
 }
 
 function normalizeEmail(value: string | null | undefined) {

--- a/apps/crew/src/server/crew-event-settings.server.ts
+++ b/apps/crew/src/server/crew-event-settings.server.ts
@@ -12,10 +12,7 @@ import { type Competition, competitionsTable } from "../db/schemas/competitions"
 import { teamTable } from "../db/schemas/teams"
 import { requireLocalCrewOperatorAccess } from "./crew-local-access"
 import { generateSlug } from "../utils/slugify"
-import {
-  requireCrewDepartmentLeadFullAccess,
-  resolveCrewDepartmentLeadAccess,
-} from "./crew-department-lead.server"
+import { requireCrewDepartmentLeadFullAccess } from "./crew-department-lead.server"
 
 type CrewEventCompetition = Pick<
   Competition,
@@ -174,10 +171,11 @@ export async function getCrewEvent(
 ): Promise<{ event: CrewEventDetails | null }> {
   const event = await getCrewEventByCompetitionId(data.eventId)
   if (event) {
-    await resolveCrewDepartmentLeadAccess({
+    await requireCrewDepartmentLeadFullAccess({
       id: event.competition.id,
       organizingTeamId: event.competition.organizingTeamId,
       competitionTeamId: event.competition.competitionTeamId,
+      timezone: event.competition.timezone,
     })
   }
 
@@ -360,6 +358,7 @@ async function requireCrewDepartmentLeadEventForSettings(
       id: competitionsTable.id,
       organizingTeamId: competitionsTable.organizingTeamId,
       competitionTeamId: competitionsTable.competitionTeamId,
+      timezone: competitionsTable.timezone,
     })
     .from(competitionsTable)
     .where(eq(competitionsTable.id, competitionId))
@@ -373,5 +372,6 @@ async function requireCrewDepartmentLeadEventForSettings(
     id: event.id,
     organizingTeamId: event.organizingTeamId,
     competitionTeamId: event.competitionTeamId,
+    timezone: event.timezone,
   }
 }

--- a/apps/crew/src/server/crew-event-settings.server.ts
+++ b/apps/crew/src/server/crew-event-settings.server.ts
@@ -12,6 +12,10 @@ import { type Competition, competitionsTable } from "../db/schemas/competitions"
 import { teamTable } from "../db/schemas/teams"
 import { requireLocalCrewOperatorAccess } from "./crew-local-access"
 import { generateSlug } from "../utils/slugify"
+import {
+  requireCrewDepartmentLeadFullAccess,
+  resolveCrewDepartmentLeadAccess,
+} from "./crew-department-lead.server"
 
 type CrewEventCompetition = Pick<
   Competition,
@@ -168,9 +172,16 @@ export async function listCrewEvents(): Promise<{
 export async function getCrewEvent(
   data: GetCrewEventInput,
 ): Promise<{ event: CrewEventDetails | null }> {
-  requireLocalCrewSettingsAccess()
+  const event = await getCrewEventByCompetitionId(data.eventId)
+  if (event) {
+    await resolveCrewDepartmentLeadAccess({
+      id: event.competition.id,
+      organizingTeamId: event.competition.organizingTeamId,
+      competitionTeamId: event.competition.competitionTeamId,
+    })
+  }
 
-  return { event: await getCrewEventByCompetitionId(data.eventId) }
+  return { event }
 }
 
 export async function createCrewSettingsForCompetition(
@@ -293,8 +304,11 @@ export async function createCrewEvent(
 export async function updateCrewEventSettings(
   data: UpdateCrewEventSettingsInput,
 ): Promise<{ event: CrewEventDetails }> {
-  requireLocalCrewSettingsAccess()
   await requireCrewEventCompetition(data.competitionId)
+  const eventAccess = await requireCrewDepartmentLeadEventForSettings(
+    data.competitionId,
+  )
+  await requireCrewDepartmentLeadFullAccess(eventAccess)
 
   const updateData: Partial<typeof crewEventSettingsTable.$inferInsert> = {
     updatedAt: new Date(),
@@ -335,4 +349,29 @@ export async function updateCrewEventSettings(
   }
 
   return { event }
+}
+
+async function requireCrewDepartmentLeadEventForSettings(
+  competitionId: string,
+) {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      organizingTeamId: competitionsTable.organizingTeamId,
+      competitionTeamId: competitionsTable.competitionTeamId,
+    })
+    .from(competitionsTable)
+    .where(eq(competitionsTable.id, competitionId))
+    .limit(1)
+
+  if (!event?.competitionTeamId) {
+    throw new Error("Crew event not found")
+  }
+
+  return {
+    id: event.id,
+    organizingTeamId: event.organizingTeamId,
+    competitionTeamId: event.competitionTeamId,
+  }
 }

--- a/apps/crew/src/server/crew-local-access.ts
+++ b/apps/crew/src/server/crew-local-access.ts
@@ -2,7 +2,9 @@ import { env } from "cloudflare:workers"
 
 export class CrewLocalAccessError extends Error {
   constructor(featureName: string) {
-    super(`${featureName} access is local-operator only until Crew auth is wired.`)
+    super(
+      `${featureName} access is local-operator only until Crew auth is wired.`,
+    )
     this.name = "CrewLocalAccessError"
   }
 }
@@ -18,11 +20,13 @@ const localCrewStages = new Set(["dev", "local", "test"])
 
 // @lat: [[crew#Event Setup Dashboard]]
 // @lat: [[crew#Import CSV Preview#Private Upload Route]]
+// @lat: [[crew#Department Leads]]
 export function requireLocalCrewOperatorAccess(featureName = "Crew operator") {
   if (hasLocalCrewOperatorAccess()) return
   throw new CrewLocalAccessError(featureName)
 }
 
+// @lat: [[crew#Department Leads]]
 export function hasLocalCrewOperatorAccess() {
   const runtimeEnv = env as CrewRuntimeEnv
   const nodeEnv = runtimeEnv.NODE_ENV?.toLowerCase()

--- a/apps/crew/src/server/crew-local-access.ts
+++ b/apps/crew/src/server/crew-local-access.ts
@@ -19,6 +19,11 @@ const localCrewStages = new Set(["dev", "local", "test"])
 // @lat: [[crew#Event Setup Dashboard]]
 // @lat: [[crew#Import CSV Preview#Private Upload Route]]
 export function requireLocalCrewOperatorAccess(featureName = "Crew operator") {
+  if (hasLocalCrewOperatorAccess()) return
+  throw new CrewLocalAccessError(featureName)
+}
+
+export function hasLocalCrewOperatorAccess() {
   const runtimeEnv = env as CrewRuntimeEnv
   const nodeEnv = runtimeEnv.NODE_ENV?.toLowerCase()
   const stage = runtimeEnv.STAGE?.toLowerCase()
@@ -35,9 +40,7 @@ export function requireLocalCrewOperatorAccess(featureName = "Crew operator") {
     stage === "staging" ||
     appUrl.includes("wodsmith.com")
 
-  if (isProductionLike || (!isLocalStage && !isLocalUrl)) {
-    throw new CrewLocalAccessError(featureName)
-  }
+  return !isProductionLike && (isLocalStage || isLocalUrl)
 }
 
 function getAppHost(appUrl: string) {

--- a/apps/crew/src/server/crew-pilot-exports.server.ts
+++ b/apps/crew/src/server/crew-pilot-exports.server.ts
@@ -35,8 +35,10 @@ export async function getCrewPilotExportsPage(data: {
   requireLocalCrewOperatorAccess("Crew pilot exports")
 
   const event = await requireCrewStaffingEvent(data.eventId)
-  const { input, activeJudgeVersions } =
-    await loadCrewStaffingMatrixInput(event)
+  const { input, activeJudgeVersions } = await loadCrewStaffingMatrixInput(
+    event,
+    { kind: "full", scopes: [] },
+  )
   const pilotExports = buildCrewPilotExports({
     event,
     generatedAt: new Date(),

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -44,6 +44,13 @@ import type {
   CrewRosterVolunteer,
 } from "../lib/crew/roster-shifts"
 import {
+  assertCrewDepartmentLeadCanManageRosterTarget,
+  assertCrewDepartmentLeadCanManageShift,
+  filterCrewDepartmentLeadRoster,
+  filterCrewDepartmentLeadShifts,
+  type CrewDepartmentLeadRosterTarget,
+} from "../lib/crew/department-leads"
+import {
   buildCrewRosterVolunteerMetadataUpdate,
   buildCrewRoster,
   findCrewRosterVolunteerEmailCollision,
@@ -66,7 +73,7 @@ import {
   buildCrewStaffingMatrix,
   type CrewStaffingMatrixInput,
 } from "../lib/crew/staffing"
-import { requireLocalCrewOperatorAccess } from "../server/crew-local-access"
+import { resolveCrewDepartmentLeadAccess } from "./crew-department-lead.server"
 import {
   cancelCrewShiftAssignmentConfirmations,
   ensureCrewShiftAssignmentConfirmation,
@@ -87,6 +94,7 @@ type CrewRosterCompetition = Pick<
   | "id"
   | "name"
   | "slug"
+  | "organizingTeamId"
   | "competitionTeamId"
   | "timezone"
   | "startDate"
@@ -265,70 +273,92 @@ export interface UpdateCrewRosterVolunteerResult {
 export async function getCrewRosterPage(
   data: CrewEventInput,
 ): Promise<CrewRosterPageData> {
-  requireLocalCrewOperatorAccess("Crew roster")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const [roster, shifts] = await Promise.all([
     loadCrewRoster(event.competitionTeamId),
     loadCrewShifts(event.id),
   ])
+  const scopedShifts = filterCrewDepartmentLeadShifts(shifts, access)
+  const scopedRoster = filterCrewDepartmentLeadRoster(
+    roster,
+    access,
+    scopedShifts,
+  )
 
   return {
     event,
-    roster,
-    summary: summarizeCrewRoster(roster),
-    shiftSummary: summarizeCrewShifts(shifts),
+    roster: scopedRoster,
+    summary: summarizeCrewRoster(scopedRoster),
+    shiftSummary: summarizeCrewShifts(scopedShifts),
   }
 }
 
 export async function getCrewShiftBoard(
   data: CrewEventInput,
 ): Promise<CrewShiftBoardData> {
-  requireLocalCrewOperatorAccess("Crew shifts")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const [roster, shifts] = await Promise.all([
     loadCrewRoster(event.competitionTeamId),
     loadCrewShifts(event.id),
   ])
-  const matrixInput = buildShiftBoardStaffingMatrixInput(event, roster, shifts)
+  const scopedShifts = filterCrewDepartmentLeadShifts(shifts, access)
+  const scopedRoster = filterCrewDepartmentLeadRoster(
+    roster,
+    access,
+    scopedShifts,
+  )
+  const matrixInput = buildShiftBoardStaffingMatrixInput(
+    event,
+    scopedRoster,
+    scopedShifts,
+  )
   const matrix = buildCrewStaffingMatrix(matrixInput)
 
   return {
     event,
-    roster,
-    rosterSummary: summarizeCrewRoster(roster),
-    shifts,
-    shiftSummary: summarizeCrewShifts(shifts),
+    roster: scopedRoster,
+    rosterSummary: summarizeCrewRoster(scopedRoster),
+    shifts: scopedShifts,
+    shiftSummary: summarizeCrewShifts(scopedShifts),
     pilotOps: buildCrewShiftBoardPilotOps({
-      shifts,
-      roster,
+      shifts: scopedShifts,
+      roster: scopedRoster,
       matrix,
     }),
   }
 }
 
 export async function getCrewEventRosterShiftSummary(data: CrewEventInput) {
-  requireLocalCrewOperatorAccess("Crew dashboard")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const [roster, shifts] = await Promise.all([
     loadCrewRoster(event.competitionTeamId),
     loadCrewShifts(event.id),
   ])
+  const scopedShifts = filterCrewDepartmentLeadShifts(shifts, access)
+  const scopedRoster = filterCrewDepartmentLeadRoster(
+    roster,
+    access,
+    scopedShifts,
+  )
 
   return {
-    rosterSummary: summarizeCrewRoster(roster),
-    shiftSummary: summarizeCrewShifts(shifts),
+    rosterSummary: summarizeCrewRoster(scopedRoster),
+    shiftSummary: summarizeCrewShifts(scopedShifts),
   }
 }
 
 export async function createManualCrewVolunteer(
   data: ManualCrewVolunteerInput,
 ): Promise<ManualCrewVolunteerMutationResult> {
-  requireLocalCrewOperatorAccess("Crew roster")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
+  assertCrewDepartmentLeadCanManageRosterTarget(
+    access,
+    toRosterTarget(null, data.roleTypes),
+  )
   return createManualCrewVolunteerRows(event, [
     {
       rowNumber: 1,
@@ -346,9 +376,12 @@ export async function createManualCrewVolunteer(
 export async function pasteManualCrewVolunteerEmails(
   data: ManualCrewVolunteerPasteInput,
 ): Promise<ManualCrewVolunteerMutationResult> {
-  requireLocalCrewOperatorAccess("Crew roster")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
+  assertCrewDepartmentLeadCanManageRosterTarget(
+    access,
+    toRosterTarget(null, undefined),
+  )
   const parsed = parseManualVolunteerEmailPaste(data.pasteText)
   const result = await createManualCrewVolunteerRows(
     event,
@@ -377,9 +410,8 @@ export async function pasteManualCrewVolunteerEmails(
 export async function updateCrewRosterVolunteer(
   data: UpdateCrewRosterVolunteerInput,
 ): Promise<UpdateCrewRosterVolunteerResult> {
-  requireLocalCrewOperatorAccess("Crew roster")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const db = getDb()
   const normalizedEmail = normalizeCrewRosterVolunteerEmail(data.email)
 
@@ -410,6 +442,17 @@ export async function updateCrewRosterVolunteer(
         if (!current) {
           throw new Error("Roster volunteer not found")
         }
+        assertCrewDepartmentLeadCanManageRosterTarget(
+          access,
+          toRosterTarget(
+            currentMembership?.id ?? null,
+            parseCrewRosterMetadata(current.metadata).volunteerRoleTypes,
+          ),
+        )
+        assertCrewDepartmentLeadCanManageRosterTarget(
+          access,
+          toRosterTarget(currentMembership?.id ?? null, data.roleTypes),
+        )
 
         const collision = findCrewRosterVolunteerEmailCollision({
           source: data.source,
@@ -440,12 +483,11 @@ export async function updateCrewRosterVolunteer(
         const metadataJson = JSON.stringify(metadata)
 
         if (currentInvitation) {
-          const updateValues: Partial<
-            typeof teamInvitationTable.$inferInsert
-          > = {
-            metadata: metadataJson,
-            updatedAt: timestamp,
-          }
+          const updateValues: Partial<typeof teamInvitationTable.$inferInsert> =
+            {
+              metadata: metadataJson,
+              updatedAt: timestamp,
+            }
 
           if (
             shouldUpdateCrewRosterInvitationEmail(currentInvitation, timestamp)
@@ -494,14 +536,19 @@ export async function updateCrewRosterVolunteer(
 }
 
 export async function createCrewShift(data: CrewShiftInput) {
-  requireLocalCrewOperatorAccess("Crew shifts")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const { startTime, endTime } = normalizeCrewShiftTimes({
     date: data.date,
     startTime: data.startTime,
     endTime: data.endTime,
     timezone: event.timezone ?? DEFAULT_TIMEZONE,
+  })
+  assertCrewDepartmentLeadCanManageShift(access, {
+    roleType: data.roleType,
+    startTime,
+    endTime,
+    location: data.location,
   })
   const db = getDb()
 
@@ -520,9 +567,8 @@ export async function createCrewShift(data: CrewShiftInput) {
 }
 
 export async function updateCrewShift(data: UpdateCrewShiftInput) {
-  requireLocalCrewOperatorAccess("Crew shifts")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const db = getDb()
   await db.transaction(async (tx) => {
     const [existingShift] = await tx
@@ -587,6 +633,16 @@ export async function updateCrewShift(data: UpdateCrewShiftInput) {
     if (data.notes !== undefined) updateValues.notes = emptyToNull(data.notes)
 
     if (Object.keys(updateValues).length === 0) return
+    assertCrewDepartmentLeadCanManageShift(access, existingShift)
+    assertCrewDepartmentLeadCanManageShift(access, {
+      roleType: data.roleType ?? existingShift.roleType,
+      startTime: updateValues.startTime ?? existingShift.startTime,
+      endTime: updateValues.endTime ?? existingShift.endTime,
+      location:
+        data.location !== undefined
+          ? emptyToNull(data.location)
+          : existingShift.location,
+    })
 
     updateValues.updatedAt = new Date()
     await tx
@@ -599,10 +655,10 @@ export async function updateCrewShift(data: UpdateCrewShiftInput) {
 }
 
 export async function deleteCrewShift(data: DeleteCrewShiftInput) {
-  requireLocalCrewOperatorAccess("Crew shifts")
-
-  await requireCrewRosterEvent(data.eventId)
-  await requireCrewShift(data.eventId, data.shiftId)
+  const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
+  const shift = await requireCrewShift(event.id, data.shiftId)
+  assertCrewDepartmentLeadCanManageShift(access, shift)
   const db = getDb()
 
   await db.transaction(async (tx) => {
@@ -643,10 +699,9 @@ export async function deleteCrewShift(data: DeleteCrewShiftInput) {
 export async function assignCrewVolunteerToShift(
   data: CrewShiftAssignmentInput,
 ) {
-  requireLocalCrewOperatorAccess("Crew shifts")
-
   const db = getDb()
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
 
   return await db.transaction(async (tx) => {
     const [shift] = await tx
@@ -664,6 +719,7 @@ export async function assignCrewVolunteerToShift(
     if (!shift) {
       throw new Error("Volunteer shift not found")
     }
+    assertCrewDepartmentLeadCanManageShift(access, shift)
 
     const [assignments, membershipRows] = await Promise.all([
       tx
@@ -728,6 +784,12 @@ export async function assignCrewVolunteerToShift(
     if (!membership) {
       throw new Error("Volunteer record was not found for this event.")
     }
+    assertCrewDepartmentLeadCanManageRosterTarget(access, {
+      membershipId: membership.id,
+      roleTypes: getCrewRosterRoleTypes(
+        parseCrewRosterMetadata(membership.metadata).volunteerRoleTypes,
+      ),
+    })
 
     const assignmentId = createVolunteerShiftAssignmentId()
     const now = new Date()
@@ -758,10 +820,10 @@ export async function assignCrewVolunteerToShift(
 export async function removeCrewVolunteerShiftAssignment(
   data: CrewShiftAssignmentInput,
 ) {
-  requireLocalCrewOperatorAccess("Crew shifts")
-
   const event = await requireCrewRosterEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
   const shift = await requireCrewShift(event.id, data.shiftId)
+  assertCrewDepartmentLeadCanManageShift(access, shift)
   const db = getDb()
 
   await db.transaction(async (tx) => {
@@ -800,6 +862,7 @@ async function requireCrewRosterEvent(
       id: competitionsTable.id,
       name: competitionsTable.name,
       slug: competitionsTable.slug,
+      organizingTeamId: competitionsTable.organizingTeamId,
       competitionTeamId: competitionsTable.competitionTeamId,
       timezone: competitionsTable.timezone,
       startDate: competitionsTable.startDate,
@@ -818,6 +881,16 @@ async function requireCrewRosterEvent(
   }
 
   return event
+}
+
+function toRosterTarget(
+  membershipId: string | null,
+  roleTypes: VolunteerRoleType[] | undefined,
+): CrewDepartmentLeadRosterTarget {
+  return {
+    membershipId,
+    roleTypes: getCrewRosterRoleTypes(roleTypes),
+  }
 }
 
 export async function loadCrewRoster(competitionTeamId: string) {
@@ -936,9 +1009,8 @@ async function withCrewRosterVolunteerWriteLock<T>(
   callback: () => Promise<T>,
 ) {
   let acquired = false
-  const lockName = await createCrewRosterVolunteerWriteLockName(
-    competitionTeamId,
-  )
+  const lockName =
+    await createCrewRosterVolunteerWriteLockName(competitionTeamId)
 
   try {
     const result = await db.execute(

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -586,6 +586,7 @@ export async function updateCrewShift(data: UpdateCrewShiftInput) {
     if (!existingShift) {
       throw new Error("Volunteer shift not found")
     }
+    assertCrewDepartmentLeadCanManageShift(access, existingShift)
 
     const updateValues: Partial<typeof volunteerShiftsTable.$inferInsert> = {}
     const timezone = event.timezone ?? DEFAULT_TIMEZONE
@@ -633,7 +634,6 @@ export async function updateCrewShift(data: UpdateCrewShiftInput) {
     if (data.notes !== undefined) updateValues.notes = emptyToNull(data.notes)
 
     if (Object.keys(updateValues).length === 0) return
-    assertCrewDepartmentLeadCanManageShift(access, existingShift)
     assertCrewDepartmentLeadCanManageShift(access, {
       roleType: data.roleType ?? existingShift.roleType,
       startTime: updateValues.startTime ?? existingShift.startTime,
@@ -750,6 +750,17 @@ export async function assignCrewVolunteerToShift(
     ])
     const membership = membershipRows[0] ?? null
 
+    if (!membership) {
+      throw new Error("Volunteer record was not found for this event.")
+    }
+    const membershipRoleTypes = getCrewRosterRoleTypes(
+      parseCrewRosterMetadata(membership.metadata).volunteerRoleTypes,
+    )
+    assertCrewDepartmentLeadCanManageRosterTarget(access, {
+      membershipId: membership.id,
+      roleTypes: membershipRoleTypes,
+    })
+
     const existingAssignment = assignments.find(
       (assignment) => assignment.membershipId === data.membershipId,
     )
@@ -767,29 +778,16 @@ export async function assignCrewVolunteerToShift(
       currentAssignmentMembershipIds: assignments.map(
         (assignment) => assignment.membershipId,
       ),
-      volunteer: membership
-        ? {
-            membershipId: membership.id,
-            isActive: membership.isActive,
-            roleTypes: getCrewRosterRoleTypes(
-              parseCrewRosterMetadata(membership.metadata).volunteerRoleTypes,
-            ),
-          }
-        : null,
+      volunteer: {
+        membershipId: membership.id,
+        isActive: membership.isActive,
+        roleTypes: membershipRoleTypes,
+      },
     })
 
     if (!validation.ok) {
       throw new Error(validation.message)
     }
-    if (!membership) {
-      throw new Error("Volunteer record was not found for this event.")
-    }
-    assertCrewDepartmentLeadCanManageRosterTarget(access, {
-      membershipId: membership.id,
-      roleTypes: getCrewRosterRoleTypes(
-        parseCrewRosterMetadata(membership.metadata).volunteerRoleTypes,
-      ),
-    })
 
     const assignmentId = createVolunteerShiftAssignmentId()
     const now = new Date()

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -200,6 +200,14 @@ Self-serve Crew setup keeps reusable setup memory in shared DB tables owned by `
 
 `crew_department_leads` stores event-scoped delegation records for role, floor, and time-slice access without expanding the broad team permission model. IDs use the `cdlead_` prefix.
 
+## Department Leads
+
+Department leads let organizers delegate Crew shift-board and roster operations for a role, floor, and time window without adding broad `TEAM_PERMISSIONS`.
+
+[[apps/crew/src/lib/crew/department-leads.ts]] owns deterministic scope normalization, read filtering, and mutation guard helpers. [[apps/crew/src/server/crew-department-lead.server.ts]] loads shared `crew_department_leads` rows and resolves either full organizer/local-operator access or active department-lead scopes. [[apps/crew/src/server-fns/crew-department-lead-fns.ts]] keeps the route-safe wrappers thin.
+
+The setup surface at [[apps/crew/src/routes/events/$eventId/setup.tsx]] manages lead rows through [[apps/crew/src/components/crew-department-leads/crew-department-leads-panel.tsx]]. Existing roster, shift, staffing, day-of, and confirmation server paths apply the same server-side scope before returning data or mutating shift/assignment state.
+
 ## Remember Import Mappings
 
 Crew import mapping memory stores confirmed CSV header mappings in `crew_import_mapping_presets` by team, source platform, import kind, and deterministic header fingerprint.


### PR DESCRIPTION
## Summary
- Adds Crew department-lead management on the setup surface using the existing shared `crew_department_leads` schema.
- Adds route-safe server functions plus server-only CRUD/access resolution for department lead rows.
- Adds deterministic role/floor/time scope helpers and applies them server-side to roster, shift board, staffing/day-of derived data, confirmation queue/status updates, and touched roster/shift mutations.
- Adds LAT anchor `crew#Department Leads`.

## Validation
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm install` (exited 0; optional `better-sqlite3` node-gyp/Python 3.7 warning only)
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew exec vitest run src/lib/crew/department-leads.test.ts`
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew type-check`
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew lint` (exits 0; pre-existing unrelated warnings remain)
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` (requires ignored `.alchemy/local/wrangler.jsonc`; exits 0 with existing chunk-size warning)
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm check:schema-ownership`
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm dlx lat.md locate "crew#Department Leads"`
- `git diff --check`

## Scoped notes / deferrals
- No schema or migration changes; this reuses `@repo/wodsmith-db` ownership for `crew_department_leads`.
- No broad `TEAM_PERMISSIONS` rewrite. Full organizers/operators use existing permissions/local operator access; department leads resolve through active lead rows.
- This does not add email/SMS delivery for lead invitations or public-token architecture.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add department lead management to Crew so organizers can delegate scoped access by role, floor, and time. All roster, shifts, staffing, confirmation, and event settings paths now enforce these scopes on reads and writes.

- **New Features**
  - Setup panel to list, add, edit, and revoke leads (invite by email or select member), backed by `crew_department_leads`.
  - Route-safe server functions and a server-only access resolver for organizer/local-operator vs `department_lead` scopes; event settings are organizer-only.
  - Scope helpers to normalize role/floor/time and guard roster, shift, staffing, and confirmation operations.
  - Added LAT anchor `crew#Department Leads`. No schema changes.

- **Bug Fixes**
  - Staffing now scopes judge assignments, heats, lane assignments, and report counts to department-lead access to prevent out-of-scope data.
  - Roster/shift pages and all roster/shift mutations are filtered and validated against lead scope.
  - Confirmation emails and shift assignment updates are filtered and validated against lead scope before queuing or updating.
  - Improved floor scope compatibility (legacy `floors`/`locations`) and datetime-local parsing in the event timezone.

<sup>Written for commit 1cb06417401897861453f6c48d246d5e22a8f53c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/566?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added department leads management interface allowing organizers to create, edit, and revoke delegated lead accounts with scoped permissions (by role, floor, and time window).
* Department leads now have restricted access to manage shifts and roster entries within their assigned scope across crew management workflows.

## Documentation
* Added documentation detailing department leads scope controls and feature integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->