### PR TITLE
[codex] feat(crew): harden volunteer self-service

### DIFF
--- a/apps/crew/src/lib/crew/assignment-confirmations.test.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.test.ts
@@ -140,10 +140,10 @@ describe("Crew assignment response state transitions", () => {
         {
           status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
           expiresAt: "2026-06-20T12:00:00.000Z",
-          responseNote: "Need afternoon",
+          responseNote: " Need afternoon ",
         },
         "request_change",
-        "Need afternoon",
+        "\nNeed afternoon\n",
         now,
       ),
     ).toMatchObject({

--- a/apps/crew/src/lib/crew/assignment-confirmations.test.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.test.ts
@@ -134,6 +134,23 @@ describe("Crew assignment response state transitions", () => {
       ok: false,
       reason: "already_responded",
     })
+
+    expect(
+      resolveCrewAssignmentConfirmationResponse(
+        {
+          status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
+          expiresAt: "2026-06-20T12:00:00.000Z",
+          responseNote: "Need afternoon",
+        },
+        "request_change",
+        "Need afternoon",
+        now,
+      ),
+    ).toMatchObject({
+      ok: true,
+      outcome: "idempotent",
+      responseNote: "Need afternoon",
+    })
   })
 
   it("rejects expired pending tokens", () => {

--- a/apps/crew/src/lib/crew/volunteer-self-service.test.ts
+++ b/apps/crew/src/lib/crew/volunteer-self-service.test.ts
@@ -1,0 +1,194 @@
+// @lat: [[crew#Volunteer Self Service]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  type CrewAssignmentConfirmationStatus,
+} from "../../db/schemas/crew-imports"
+import {
+  VOLUNTEER_AVAILABILITY,
+  VOLUNTEER_ROLE_TYPES,
+} from "../../db/schemas/volunteers"
+import {
+  buildCrewVolunteerSelfServiceGoogleCalendarUrl,
+  buildCrewVolunteerSelfServiceIcs,
+  buildCrewVolunteerSelfServiceIcsFilename,
+  buildCrewVolunteerSelfServiceSchedule,
+  resolveCrewVolunteerSelfServiceContactUpdate,
+  type CrewVolunteerSelfServiceAssignmentRecord,
+} from "./volunteer-self-service"
+
+describe("Crew volunteer self-service schedule", () => {
+  it("keeps token access isolated to the volunteer membership schedule", () => {
+    const schedule = buildCrewVolunteerSelfServiceSchedule({
+      membershipId: "tmem_ada",
+      tokenAssignmentId: "vsha_token",
+      assignments: [
+        assignment({
+          id: "vsha_other",
+          membershipId: "tmem_other",
+          startTime: "2026-06-20T14:00:00.000Z",
+        }),
+        assignment({
+          id: "vsha_later",
+          membershipId: "tmem_ada",
+          startTime: "2026-06-20T18:00:00.000Z",
+        }),
+        assignment({
+          id: "vsha_token",
+          membershipId: "tmem_ada",
+          startTime: "2026-06-20T15:00:00.000Z",
+          confirmationStatus: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+        }),
+        assignment({
+          id: "vsha_token",
+          membershipId: "tmem_ada",
+          startTime: "2026-06-20T15:00:00.000Z",
+          confirmationStatus: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+        }),
+      ],
+    })
+
+    expect(schedule.map((item) => item.id)).toEqual([
+      "vsha_token",
+      "vsha_later",
+    ])
+    expect(schedule.find((item) => item.id === "vsha_token")).toMatchObject({
+      isTokenAssignment: true,
+      confirmation: {
+        status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED,
+      },
+    })
+    expect(schedule.some((item) => item.id === "vsha_other")).toBe(false)
+  })
+})
+
+describe("Crew volunteer self-service contact updates", () => {
+  it("updates contact metadata without losing staffing or import audit fields", () => {
+    const result = resolveCrewVolunteerSelfServiceContactUpdate(
+      JSON.stringify({
+        volunteerRoleTypes: [VOLUNTEER_ROLE_TYPES.JUDGE],
+        crewImportId: "cimp_123",
+        crewSignupSource: "import",
+        internalNotes: "Keep at north floor",
+        signupEmail: "old@example.com",
+      }),
+      {
+        email: " ADA@Example.com ",
+        name: " Ada Lovelace ",
+        phone: " 555-0100 ",
+        availability: VOLUNTEER_AVAILABILITY.AFTERNOON,
+        availabilityNotes: " After 1pm ",
+        credentials: " L1 Judge ",
+      },
+    )
+
+    expect(result.changed).toBe(true)
+    expect(result.metadata).toMatchObject({
+      signupEmail: "ada@example.com",
+      signupName: "Ada Lovelace",
+      signupPhone: "555-0100",
+      availability: VOLUNTEER_AVAILABILITY.AFTERNOON,
+      availabilityNotes: "After 1pm",
+      credentials: "L1 Judge",
+      volunteerRoleTypes: [VOLUNTEER_ROLE_TYPES.JUDGE],
+      crewImportId: "cimp_123",
+      crewSignupSource: "import",
+      internalNotes: "Keep at north floor",
+    })
+  })
+
+  it("treats repeated contact saves as idempotent no-ops", () => {
+    const first = resolveCrewVolunteerSelfServiceContactUpdate(null, {
+      email: "ada@example.com",
+      name: "Ada Lovelace",
+      phone: "555-0100",
+    })
+    const second = resolveCrewVolunteerSelfServiceContactUpdate(
+      JSON.stringify(first.metadata),
+      {
+        email: " ada@example.com ",
+        name: " Ada Lovelace ",
+        phone: " 555-0100 ",
+      },
+    )
+
+    expect(first.changed).toBe(true)
+    expect(second.changed).toBe(false)
+  })
+})
+
+describe("Crew volunteer self-service calendar helpers", () => {
+  it("builds deterministic iCal, Google Calendar, and filename outputs", () => {
+    const [item] = buildCrewVolunteerSelfServiceSchedule({
+      membershipId: "tmem_ada",
+      tokenAssignmentId: "vsha_token",
+      assignments: [
+        assignment({
+          id: "vsha_token",
+          membershipId: "tmem_ada",
+          name: "Morning Check-In",
+          roleLabel: "Check-In",
+          startTime: "2026-06-20T15:00:00.000Z",
+          endTime: "2026-06-20T17:00:00.000Z",
+          location: "North Floor",
+          notes: "Bring clipboard",
+        }),
+      ],
+    })
+
+    expect(item).toBeDefined()
+    const ics = buildCrewVolunteerSelfServiceIcs({
+      eventName: "Friday, Night",
+      assignments: item ? [item] : [],
+      generatedAt: new Date("2026-06-20T12:00:00.000Z"),
+    })
+    const googleUrl = item
+      ? buildCrewVolunteerSelfServiceGoogleCalendarUrl({
+          eventName: "Friday Night",
+          assignment: item,
+        })
+      : ""
+    const google = new URL(googleUrl)
+
+    expect(ics).toContain("BEGIN:VCALENDAR")
+    expect(ics).toContain("DTSTART:20260620T150000Z")
+    expect(ics).toContain("SUMMARY:Friday\\, Night: Morning Check-In")
+    expect(ics).toContain("DESCRIPTION:Role: Check-In\\nNotes: Bring clipboard")
+    expect(google.searchParams.get("text")).toBe(
+      "Friday Night: Morning Check-In",
+    )
+    expect(google.searchParams.get("location")).toBe("North Floor")
+    expect(buildCrewVolunteerSelfServiceIcsFilename("Friday Night!")).toBe(
+      "friday-night-schedule.ics",
+    )
+  })
+})
+
+function assignment(
+  overrides: Partial<CrewVolunteerSelfServiceAssignmentRecord> & {
+    confirmationStatus?: CrewAssignmentConfirmationStatus
+  },
+): CrewVolunteerSelfServiceAssignmentRecord {
+  return {
+    id: overrides.id ?? "vsha_default",
+    membershipId: overrides.membershipId ?? "tmem_ada",
+    shiftId: overrides.shiftId ?? "vshf_default",
+    name: overrides.name ?? "Check-In",
+    roleType: overrides.roleType ?? VOLUNTEER_ROLE_TYPES.CHECK_IN,
+    roleLabel: overrides.roleLabel ?? "Check-In",
+    startTime: overrides.startTime ?? "2026-06-20T15:00:00.000Z",
+    endTime: overrides.endTime ?? "2026-06-20T17:00:00.000Z",
+    location: overrides.location ?? "North Floor",
+    notes: overrides.notes ?? null,
+    confirmation: {
+      id: `caconf_${overrides.id ?? "default"}`,
+      status:
+        overrides.confirmationStatus ??
+        CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+      sentAt: null,
+      respondedAt: null,
+      expiresAt: "2026-06-27T12:00:00.000Z",
+      responseNote: null,
+    },
+  }
+}

--- a/apps/crew/src/lib/crew/volunteer-self-service.ts
+++ b/apps/crew/src/lib/crew/volunteer-self-service.ts
@@ -1,0 +1,230 @@
+// @lat: [[crew#Volunteer Self Service]]
+import type { CrewAssignmentConfirmationStatus } from "../../db/schemas/crew-imports"
+import type {
+  VolunteerAvailability,
+  VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+import {
+  normalizeCrewRosterVolunteerEmail,
+  parseCrewRosterMetadata,
+  type CrewRosterMetadata,
+} from "./roster-shifts"
+
+export interface CrewVolunteerSelfServiceConfirmation {
+  id: string
+  status: CrewAssignmentConfirmationStatus
+  sentAt: Date | string | null
+  respondedAt: Date | string | null
+  expiresAt: Date | string | null
+  responseNote: string | null
+}
+
+export interface CrewVolunteerSelfServiceAssignmentRecord {
+  id: string
+  membershipId: string
+  shiftId: string
+  name: string
+  roleType: VolunteerRoleType
+  roleLabel: string
+  startTime: Date | string
+  endTime: Date | string
+  location: string | null
+  notes: string | null
+  confirmation: CrewVolunteerSelfServiceConfirmation | null
+}
+
+export interface CrewVolunteerSelfServiceScheduleItem
+  extends Omit<
+    CrewVolunteerSelfServiceAssignmentRecord,
+    "membershipId" | "startTime" | "endTime"
+  > {
+  startTime: Date
+  endTime: Date
+  isTokenAssignment: boolean
+}
+
+export interface CrewVolunteerSelfServiceContactInput {
+  email: string
+  name?: string
+  phone?: string
+  availability?: VolunteerAvailability
+  availabilityNotes?: string
+  credentials?: string
+}
+
+export function buildCrewVolunteerSelfServiceSchedule({
+  assignments,
+  membershipId,
+  tokenAssignmentId,
+}: {
+  assignments: CrewVolunteerSelfServiceAssignmentRecord[]
+  membershipId: string
+  tokenAssignmentId: string
+}): CrewVolunteerSelfServiceScheduleItem[] {
+  const byAssignmentId = new Map<string, CrewVolunteerSelfServiceScheduleItem>()
+
+  for (const assignment of assignments) {
+    if (assignment.membershipId !== membershipId) continue
+    if (byAssignmentId.has(assignment.id)) continue
+
+    const startTime = toValidDate(assignment.startTime)
+    const endTime = toValidDate(assignment.endTime)
+    if (!startTime || !endTime) continue
+
+    byAssignmentId.set(assignment.id, {
+      id: assignment.id,
+      shiftId: assignment.shiftId,
+      name: assignment.name,
+      roleType: assignment.roleType,
+      roleLabel: assignment.roleLabel,
+      startTime,
+      endTime,
+      location: assignment.location,
+      notes: assignment.notes,
+      confirmation: assignment.confirmation,
+      isTokenAssignment: assignment.id === tokenAssignmentId,
+    })
+  }
+
+  return [...byAssignmentId.values()].sort((a, b) => {
+    const timeDiff = a.startTime.getTime() - b.startTime.getTime()
+    if (timeDiff !== 0) return timeDiff
+    return a.name.localeCompare(b.name)
+  })
+}
+
+export function resolveCrewVolunteerSelfServiceContactUpdate(
+  existingMetadata: string | null | undefined,
+  input: CrewVolunteerSelfServiceContactInput,
+) {
+  const existing = removeUndefined(parseCrewRosterMetadata(existingMetadata))
+  const next: CrewRosterMetadata = removeUndefined({
+    ...existing,
+    signupEmail: normalizeCrewRosterVolunteerEmail(input.email),
+    signupName: emptyToUndefined(input.name),
+    signupPhone: emptyToUndefined(input.phone),
+    availability: input.availability,
+    availabilityNotes: emptyToUndefined(input.availabilityNotes),
+    credentials: emptyToUndefined(input.credentials),
+  })
+
+  return {
+    metadata: next,
+    changed: JSON.stringify(existing) !== JSON.stringify(next),
+  }
+}
+
+export function buildCrewVolunteerSelfServiceIcs(params: {
+  eventName: string
+  assignments: CrewVolunteerSelfServiceScheduleItem[]
+  generatedAt?: Date
+}) {
+  const generatedAt =
+    params.generatedAt ?? params.assignments[0]?.startTime ?? new Date(0)
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//WODsmith//Crew//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    `X-WR-CALNAME:${escapeIcsText(`${params.eventName} Crew Schedule`)}`,
+  ]
+
+  for (const assignment of params.assignments) {
+    lines.push(
+      "BEGIN:VEVENT",
+      `UID:${escapeIcsText(`${assignment.id}@crew.wodsmith.com`)}`,
+      `DTSTAMP:${formatIcsDate(generatedAt)}`,
+      `DTSTART:${formatIcsDate(assignment.startTime)}`,
+      `DTEND:${formatIcsDate(assignment.endTime)}`,
+      `SUMMARY:${escapeIcsText(`${params.eventName}: ${assignment.name}`)}`,
+    )
+    if (assignment.location) {
+      lines.push(`LOCATION:${escapeIcsText(assignment.location)}`)
+    }
+    lines.push(
+      `DESCRIPTION:${escapeIcsText(
+        [
+          `Role: ${assignment.roleLabel}`,
+          assignment.notes ? `Notes: ${assignment.notes}` : null,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      )}`,
+      "END:VEVENT",
+    )
+  }
+
+  lines.push("END:VCALENDAR")
+  return `${lines.join("\r\n")}\r\n`
+}
+
+export function buildCrewVolunteerSelfServiceGoogleCalendarUrl(params: {
+  eventName: string
+  assignment: CrewVolunteerSelfServiceScheduleItem
+}) {
+  const searchParams = new URLSearchParams({
+    action: "TEMPLATE",
+    text: `${params.eventName}: ${params.assignment.name}`,
+    dates: `${formatGoogleCalendarDate(
+      params.assignment.startTime,
+    )}/${formatGoogleCalendarDate(params.assignment.endTime)}`,
+    details: [
+      `Role: ${params.assignment.roleLabel}`,
+      params.assignment.notes ? `Notes: ${params.assignment.notes}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n"),
+  })
+
+  if (params.assignment.location) {
+    searchParams.set("location", params.assignment.location)
+  }
+
+  return `https://calendar.google.com/calendar/render?${searchParams.toString()}`
+}
+
+export function buildCrewVolunteerSelfServiceIcsFilename(eventName: string) {
+  const slug = eventName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+  return `${slug || "crew"}-schedule.ics`
+}
+
+function toValidDate(value: Date | string | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+function formatIcsDate(date: Date) {
+  return date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z")
+}
+
+function formatGoogleCalendarDate(date: Date) {
+  return formatIcsDate(date)
+}
+
+function escapeIcsText(value: string) {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\r?\n/g, "\\n")
+    .replace(/,/g, "\\,")
+    .replace(/;/g, "\\;")
+}
+
+function emptyToUndefined(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed || undefined
+}
+
+function removeUndefined<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entryValue]) => entryValue !== undefined),
+  ) as T
+}

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -1,16 +1,38 @@
 // @lat: [[crew#Assignment Confirmation Responses]]
-import { createFileRoute, notFound } from "@tanstack/react-router"
+// @lat: [[crew#Volunteer Self Service]]
+import { createFileRoute, notFound, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import {
+  CalendarPlus,
+  ExternalLink,
+  Loader2,
+  Mail,
+  Phone,
+  Printer,
+} from "lucide-react"
+import type { FormEvent } from "react"
+import { useMemo, useState } from "react"
+import { toast } from "sonner"
 import {
   VOLUNTEER_AVAILABILITY,
   VOLUNTEER_ROLE_LABELS,
   type VolunteerAvailability,
   type VolunteerRoleType,
 } from "@/db/schemas/volunteers"
-import { getCrewAssignmentConfirmationStatusLabel } from "@/lib/crew/assignment-confirmation-display"
+import {
+  getCrewAssignmentConfirmationStatusBadgeClassName,
+  getCrewAssignmentConfirmationStatusLabel,
+} from "@/lib/crew/assignment-confirmation-display"
 import {
   getCrewAssignmentConfirmationTokenFn,
   type CrewAssignmentConfirmationTokenData,
+  updateCrewAssignmentConfirmationContactTokenFn,
 } from "@/server-fns/crew-confirmation-fns"
+import {
+  buildCrewVolunteerSelfServiceGoogleCalendarUrl,
+  buildCrewVolunteerSelfServiceIcs,
+  buildCrewVolunteerSelfServiceIcsFilename,
+} from "@/lib/crew/volunteer-self-service"
 import { getCrewVolunteerScheduleTokenFn } from "@/server-fns/crew-volunteer-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
@@ -125,10 +147,89 @@ function CrewAssignmentSchedule({
 }: {
   data: CrewAssignmentConfirmationTokenData
 }) {
+  const { slug, token } = Route.useParams()
+  const router = useRouter()
+  const updateContact = useServerFn(
+    updateCrewAssignmentConfirmationContactTokenFn,
+  )
+  const [contactPending, setContactPending] = useState(false)
+  const schedule = useMemo(() => {
+    if (data.status !== "valid" || !data.assignment) return []
+    if (data.schedule.length > 0) return data.schedule
+    return [
+      {
+        ...data.assignment,
+        confirmation: data.confirmation,
+        isTokenAssignment: true,
+      },
+    ]
+  }, [data])
+  const tokenAssignment =
+    schedule.find((assignment) => assignment.isTokenAssignment) ?? null
+  const eventName = data.event?.name ?? "Crew"
+  const icsText = useMemo(
+    () =>
+      buildCrewVolunteerSelfServiceIcs({
+        eventName,
+        assignments: schedule,
+      }),
+    [eventName, schedule],
+  )
+  const icsHref = `data:text/calendar;charset=utf-8,${encodeURIComponent(
+    icsText,
+  )}`
+  const googleCalendarUrl = tokenAssignment
+    ? buildCrewVolunteerSelfServiceGoogleCalendarUrl({
+        eventName,
+        assignment: tokenAssignment,
+      })
+    : null
+  const confirmHref = `/e/${encodeURIComponent(slug)}/confirm/${encodeURIComponent(
+    token,
+  )}`
+
+  async function handleContactSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    setContactPending(true)
+
+    try {
+      const result = await updateContact({
+        data: {
+          slug,
+          token,
+          email: getFormString(formData, "email"),
+          name: getOptionalFormString(formData, "name"),
+          phone: getOptionalFormString(formData, "phone"),
+          availability: getOptionalFormString(formData, "availability") as
+            | VolunteerAvailability
+            | undefined,
+          availabilityNotes: getOptionalFormString(
+            formData,
+            "availabilityNotes",
+          ),
+          credentials: getOptionalFormString(formData, "credentials"),
+        },
+      })
+      if (result.success) {
+        toast.success(result.message)
+      } else {
+        toast.error(result.message)
+      }
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Contact update failed",
+      )
+    } finally {
+      setContactPending(false)
+    }
+  }
+
   if (data.status !== "valid" || !data.event || !data.assignment) {
     return (
-      <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6">
-        <section className="rounded-md border bg-card p-6 shadow-sm">
+      <main className="mx-auto max-w-3xl px-4 py-8 sm:px-6 print:max-w-none print:px-0">
+        <section className="rounded-md border bg-card p-6 shadow-sm print:border-0 print:shadow-none">
           <p className="text-sm font-medium text-muted-foreground">
             Volunteer schedule
           </p>
@@ -146,67 +247,225 @@ function CrewAssignmentSchedule({
   }
 
   const timezone = data.event.timezone ?? "America/Denver"
+  const eventDates = `${data.event.startDate} to ${data.event.endDate}`
 
   return (
-    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
-      <section className="rounded-md border bg-card p-6 shadow-sm">
-        <p className="text-sm font-medium text-muted-foreground">
-          Volunteer schedule
-        </p>
-        <h1 className="mt-2 text-3xl font-semibold">{data.event.name}</h1>
-        <p className="mt-2 text-muted-foreground">
-          {data.volunteer?.name ?? "Volunteer"} ·{" "}
-          {data.volunteer?.email ?? "No email"}
-        </p>
-      </section>
-
-      <section className="rounded-md border bg-card p-6 shadow-sm">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6 print:max-w-none print:px-0">
+      <section className="rounded-md border bg-card p-6 shadow-sm print:border-0 print:shadow-none">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold">{data.assignment.name}</h2>
+            <p className="text-sm font-medium text-muted-foreground">
+              Volunteer schedule
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold">{data.event.name}</h1>
             <p className="mt-2 text-muted-foreground">
-              {data.assignment.roleLabel}
+              {data.volunteer?.name ?? "Volunteer"} ·{" "}
+              {data.volunteer?.email ?? "No email"}
             </p>
           </div>
-          <span className="inline-flex w-fit rounded-md border bg-background px-2 py-1 text-xs font-medium">
-            {getCrewAssignmentConfirmationStatusLabel(
-              data.confirmation?.status ?? "pending",
-            )}
-          </span>
+          <div className="flex flex-wrap gap-2 print:hidden">
+            <a
+              href={icsHref}
+              download={buildCrewVolunteerSelfServiceIcsFilename(
+                data.event.name,
+              )}
+              className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+            >
+              <CalendarPlus className="size-4" />
+              iCal
+            </a>
+            {googleCalendarUrl ? (
+              <a
+                href={googleCalendarUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+              >
+                <ExternalLink className="size-4" />
+                Google
+              </a>
+            ) : null}
+            <button
+              type="button"
+              onClick={() => window.print()}
+              className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+            >
+              <Printer className="size-4" />
+              Print
+            </button>
+          </div>
         </div>
+      </section>
 
-        <dl className="mt-6 grid gap-4 text-sm sm:grid-cols-2">
-          <InfoRow
-            label="Start"
-            value={formatDateTimeInTimezone(
-              data.assignment.startTime,
-              timezone,
-              "EEE, MMM d h:mm a",
-            )}
-          />
-          <InfoRow
-            label="End"
-            value={formatDateTimeInTimezone(
-              data.assignment.endTime,
-              timezone,
-              "EEE, MMM d h:mm a",
-            )}
-          />
-          <InfoRow
-            label="Location"
-            value={data.assignment.location ?? "Not set"}
-          />
-          <InfoRow
-            label="Event dates"
-            value={`${data.event.startDate} to ${data.event.endDate}`}
-          />
-        </dl>
+      <section className="rounded-md border bg-card p-6 shadow-sm print:hidden">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="space-y-1">
+            <h2 className="text-xl font-semibold">Response</h2>
+            <p className="text-sm text-muted-foreground">
+              {tokenAssignment?.name ?? data.assignment.name} ·{" "}
+              {getCrewAssignmentConfirmationStatusLabel(
+                data.confirmation?.status ?? "pending",
+              )}
+            </p>
+          </div>
+          <a
+            href={confirmHref}
+            className="inline-flex h-10 w-fit items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            <ExternalLink className="size-4" />
+            Respond
+          </a>
+        </div>
+      </section>
 
-        {data.assignment.notes ? (
-          <p className="mt-5 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
-            {data.assignment.notes}
-          </p>
-        ) : null}
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">Assignments</h2>
+        {schedule.map((assignment) => (
+          <article
+            key={assignment.id}
+            className={`rounded-md border bg-card p-5 shadow-sm print:break-inside-avoid print:shadow-none ${
+              assignment.isTokenAssignment ? "border-primary/50" : ""
+            }`}
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold">{assignment.name}</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {assignment.roleLabel}
+                </p>
+              </div>
+              <StatusBadge status={assignment.confirmation?.status} />
+            </div>
+
+            <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2">
+              <InfoRow
+                label="Start"
+                value={formatDateTimeInTimezone(
+                  assignment.startTime,
+                  timezone,
+                  "EEE, MMM d h:mm a",
+                )}
+              />
+              <InfoRow
+                label="End"
+                value={formatDateTimeInTimezone(
+                  assignment.endTime,
+                  timezone,
+                  "EEE, MMM d h:mm a",
+                )}
+              />
+              <InfoRow
+                label="Location"
+                value={assignment.location ?? "Not set"}
+              />
+              <InfoRow label="Event dates" value={eventDates} />
+            </dl>
+
+            {assignment.notes ? (
+              <p className="mt-5 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
+                {assignment.notes}
+              </p>
+            ) : null}
+
+            {assignment.isTokenAssignment ? (
+              <a
+                href={confirmHref}
+                className="mt-5 inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted print:hidden"
+              >
+                <ExternalLink className="size-4" />
+                Update response
+              </a>
+            ) : null}
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-md border bg-card p-6 shadow-sm print:hidden">
+        <h2 className="text-xl font-semibold">Contact</h2>
+        <form onSubmit={handleContactSubmit} className="mt-5 grid gap-4">
+          <label className="grid gap-2 text-sm">
+            <span className="inline-flex items-center gap-2 font-medium">
+              <Mail className="size-4" />
+              Email
+            </span>
+            <input
+              name="email"
+              type="email"
+              required
+              defaultValue={data.volunteer?.email ?? ""}
+              className="h-10 rounded-md border bg-background px-3"
+            />
+          </label>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="grid gap-2 text-sm">
+              <span className="font-medium">Name</span>
+              <input
+                name="name"
+                defaultValue={data.volunteer?.name ?? ""}
+                className="h-10 rounded-md border bg-background px-3"
+              />
+            </label>
+            <label className="grid gap-2 text-sm">
+              <span className="inline-flex items-center gap-2 font-medium">
+                <Phone className="size-4" />
+                Phone
+              </span>
+              <input
+                name="phone"
+                defaultValue={data.volunteer?.phone ?? ""}
+                className="h-10 rounded-md border bg-background px-3"
+              />
+            </label>
+          </div>
+
+          <label className="grid gap-2 text-sm">
+            <span className="font-medium">Availability</span>
+            <select
+              name="availability"
+              defaultValue={data.volunteer?.availability ?? ""}
+              className="h-10 rounded-md border bg-background px-3"
+            >
+              <option value="">Not provided</option>
+              <option value={VOLUNTEER_AVAILABILITY.MORNING}>Morning</option>
+              <option value={VOLUNTEER_AVAILABILITY.AFTERNOON}>
+                Afternoon
+              </option>
+              <option value={VOLUNTEER_AVAILABILITY.ALL_DAY}>All day</option>
+            </select>
+          </label>
+
+          <label className="grid gap-2 text-sm">
+            <span className="font-medium">Availability notes</span>
+            <textarea
+              name="availabilityNotes"
+              rows={3}
+              defaultValue={data.volunteer?.availabilityNotes ?? ""}
+              className="rounded-md border bg-background px-3 py-2"
+            />
+          </label>
+
+          <label className="grid gap-2 text-sm">
+            <span className="font-medium">Credentials</span>
+            <textarea
+              name="credentials"
+              rows={3}
+              defaultValue={data.volunteer?.credentials ?? ""}
+              className="rounded-md border bg-background px-3 py-2"
+            />
+          </label>
+
+          <button
+            type="submit"
+            disabled={contactPending}
+            className="inline-flex h-10 w-fit items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {contactPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : null}
+            Save contact
+          </button>
+        </form>
       </section>
     </main>
   )
@@ -230,6 +489,20 @@ function InfoRow({ label, value }: { label: string; value: string }) {
   )
 }
 
+function StatusBadge({ status }: { status: string | null | undefined }) {
+  const confirmationStatus = status ?? "pending"
+  const className =
+    getCrewAssignmentConfirmationStatusBadgeClassName(confirmationStatus)
+
+  return (
+    <span
+      className={`inline-flex w-fit rounded-md border px-2 py-1 text-xs font-medium ${className}`}
+    >
+      {getCrewAssignmentConfirmationStatusLabel(confirmationStatus)}
+    </span>
+  )
+}
+
 function formatRoleTypes(roleTypes: VolunteerRoleType[]) {
   if (roleTypes.length === 0) return "General"
   return roleTypes
@@ -242,4 +515,14 @@ function formatAvailability(availability: VolunteerAvailability | null) {
   if (availability === VOLUNTEER_AVAILABILITY.AFTERNOON) return "Afternoon"
   if (availability === VOLUNTEER_AVAILABILITY.ALL_DAY) return "All day"
   return "Not provided"
+}
+
+function getFormString(formData: FormData, name: string) {
+  const value = formData.get(name)
+  return typeof value === "string" ? value.trim() : ""
+}
+
+function getOptionalFormString(formData: FormData, name: string) {
+  const value = getFormString(formData, name)
+  return value || undefined
 }

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -1,5 +1,6 @@
 // @lat: [[crew#Assignment Confirmation Responses]]
 // @lat: [[crew#Volunteer Self Service]]
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
 import { createFileRoute, notFound, useRouter } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import {
@@ -10,9 +11,10 @@ import {
   Phone,
   Printer,
 } from "lucide-react"
-import type { FormEvent } from "react"
-import { useMemo, useState } from "react"
+import { useMemo } from "react"
+import { useForm } from "react-hook-form"
 import { toast } from "sonner"
+import { z } from "zod"
 import {
   VOLUNTEER_AVAILABILITY,
   VOLUNTEER_ROLE_LABELS,
@@ -35,6 +37,25 @@ import {
 } from "@/lib/crew/volunteer-self-service"
 import { getCrewVolunteerScheduleTokenFn } from "@/server-fns/crew-volunteer-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
+
+const optionalContactString = (maxLength: number) =>
+  z.string().trim().max(maxLength).optional()
+
+const contactFormSchema = z.object({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Enter a valid email address")
+    .max(255),
+  name: optionalContactString(200),
+  phone: optionalContactString(50),
+  availability: z.union([z.enum(VOLUNTEER_AVAILABILITY), z.literal("")]),
+  availabilityNotes: optionalContactString(5000),
+  credentials: optionalContactString(1000),
+})
+
+type ContactFormValues = z.infer<typeof contactFormSchema>
 
 export const Route = createFileRoute("/e/$slug/schedule/$token")({
   loader: async ({ params }) => {
@@ -152,7 +173,10 @@ function CrewAssignmentSchedule({
   const updateContact = useServerFn(
     updateCrewAssignmentConfirmationContactTokenFn,
   )
-  const [contactPending, setContactPending] = useState(false)
+  const contactForm = useForm<ContactFormValues>({
+    resolver: standardSchemaResolver(contactFormSchema),
+    defaultValues: getContactDefaultValues(data.volunteer),
+  })
   const schedule = useMemo(() => {
     if (data.status !== "valid" || !data.assignment) return []
     if (data.schedule.length > 0) return data.schedule
@@ -188,31 +212,23 @@ function CrewAssignmentSchedule({
     token,
   )}`
 
-  async function handleContactSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    setContactPending(true)
-
+  async function handleContactSubmit(values: ContactFormValues) {
     try {
       const result = await updateContact({
         data: {
           slug,
           token,
-          email: getFormString(formData, "email"),
-          name: getOptionalFormString(formData, "name"),
-          phone: getOptionalFormString(formData, "phone"),
-          availability: getOptionalFormString(formData, "availability") as
-            | VolunteerAvailability
-            | undefined,
-          availabilityNotes: getOptionalFormString(
-            formData,
-            "availabilityNotes",
-          ),
-          credentials: getOptionalFormString(formData, "credentials"),
+          email: values.email,
+          name: emptyToUndefined(values.name),
+          phone: emptyToUndefined(values.phone),
+          availability: values.availability || undefined,
+          availabilityNotes: emptyToUndefined(values.availabilityNotes),
+          credentials: emptyToUndefined(values.credentials),
         },
       })
       if (result.success) {
         toast.success(result.message)
+        contactForm.reset(getContactDefaultValues(result.volunteer))
       } else {
         toast.error(result.message)
       }
@@ -221,8 +237,6 @@ function CrewAssignmentSchedule({
       toast.error(
         error instanceof Error ? error.message : "Contact update failed",
       )
-    } finally {
-      setContactPending(false)
     }
   }
 
@@ -382,29 +396,40 @@ function CrewAssignmentSchedule({
 
       <section className="rounded-md border bg-card p-6 shadow-sm print:hidden">
         <h2 className="text-xl font-semibold">Contact</h2>
-        <form onSubmit={handleContactSubmit} className="mt-5 grid gap-4">
+        <form
+          onSubmit={contactForm.handleSubmit(handleContactSubmit)}
+          className="mt-5 grid gap-4"
+        >
           <label className="grid gap-2 text-sm">
             <span className="inline-flex items-center gap-2 font-medium">
               <Mail className="size-4" />
               Email
             </span>
             <input
-              name="email"
               type="email"
               required
-              defaultValue={data.volunteer?.email ?? ""}
+              {...contactForm.register("email")}
               className="h-10 rounded-md border bg-background px-3"
             />
+            {contactForm.formState.errors.email?.message ? (
+              <span className="text-xs text-destructive">
+                {contactForm.formState.errors.email.message}
+              </span>
+            ) : null}
           </label>
 
           <div className="grid gap-4 sm:grid-cols-2">
             <label className="grid gap-2 text-sm">
               <span className="font-medium">Name</span>
               <input
-                name="name"
-                defaultValue={data.volunteer?.name ?? ""}
+                {...contactForm.register("name")}
                 className="h-10 rounded-md border bg-background px-3"
               />
+              {contactForm.formState.errors.name?.message ? (
+                <span className="text-xs text-destructive">
+                  {contactForm.formState.errors.name.message}
+                </span>
+              ) : null}
             </label>
             <label className="grid gap-2 text-sm">
               <span className="inline-flex items-center gap-2 font-medium">
@@ -412,18 +437,21 @@ function CrewAssignmentSchedule({
                 Phone
               </span>
               <input
-                name="phone"
-                defaultValue={data.volunteer?.phone ?? ""}
+                {...contactForm.register("phone")}
                 className="h-10 rounded-md border bg-background px-3"
               />
+              {contactForm.formState.errors.phone?.message ? (
+                <span className="text-xs text-destructive">
+                  {contactForm.formState.errors.phone.message}
+                </span>
+              ) : null}
             </label>
           </div>
 
           <label className="grid gap-2 text-sm">
             <span className="font-medium">Availability</span>
             <select
-              name="availability"
-              defaultValue={data.volunteer?.availability ?? ""}
+              {...contactForm.register("availability")}
               className="h-10 rounded-md border bg-background px-3"
             >
               <option value="">Not provided</option>
@@ -433,34 +461,47 @@ function CrewAssignmentSchedule({
               </option>
               <option value={VOLUNTEER_AVAILABILITY.ALL_DAY}>All day</option>
             </select>
+            {contactForm.formState.errors.availability?.message ? (
+              <span className="text-xs text-destructive">
+                {contactForm.formState.errors.availability.message}
+              </span>
+            ) : null}
           </label>
 
           <label className="grid gap-2 text-sm">
             <span className="font-medium">Availability notes</span>
             <textarea
-              name="availabilityNotes"
               rows={3}
-              defaultValue={data.volunteer?.availabilityNotes ?? ""}
+              {...contactForm.register("availabilityNotes")}
               className="rounded-md border bg-background px-3 py-2"
             />
+            {contactForm.formState.errors.availabilityNotes?.message ? (
+              <span className="text-xs text-destructive">
+                {contactForm.formState.errors.availabilityNotes.message}
+              </span>
+            ) : null}
           </label>
 
           <label className="grid gap-2 text-sm">
             <span className="font-medium">Credentials</span>
             <textarea
-              name="credentials"
               rows={3}
-              defaultValue={data.volunteer?.credentials ?? ""}
+              {...contactForm.register("credentials")}
               className="rounded-md border bg-background px-3 py-2"
             />
+            {contactForm.formState.errors.credentials?.message ? (
+              <span className="text-xs text-destructive">
+                {contactForm.formState.errors.credentials.message}
+              </span>
+            ) : null}
           </label>
 
           <button
             type="submit"
-            disabled={contactPending}
+            disabled={contactForm.formState.isSubmitting}
             className="inline-flex h-10 w-fit items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {contactPending ? (
+            {contactForm.formState.isSubmitting ? (
               <Loader2 className="size-4 animate-spin" />
             ) : null}
             Save contact
@@ -517,12 +558,20 @@ function formatAvailability(availability: VolunteerAvailability | null) {
   return "Not provided"
 }
 
-function getFormString(formData: FormData, name: string) {
-  const value = formData.get(name)
-  return typeof value === "string" ? value.trim() : ""
+function getContactDefaultValues(
+  volunteer: CrewAssignmentConfirmationTokenData["volunteer"],
+): ContactFormValues {
+  return {
+    email: volunteer?.email ?? "",
+    name: volunteer?.name ?? "",
+    phone: volunteer?.phone ?? "",
+    availability: volunteer?.availability ?? "",
+    availabilityNotes: volunteer?.availabilityNotes ?? "",
+    credentials: volunteer?.credentials ?? "",
+  }
 }
 
-function getOptionalFormString(formData: FormData, name: string) {
-  const value = getFormString(formData, name)
-  return value || undefined
+function emptyToUndefined(value: string | undefined) {
+  const trimmed = value?.trim()
+  return trimmed || undefined
 }

--- a/apps/crew/src/server-fns/crew-confirmation-fns.ts
+++ b/apps/crew/src/server-fns/crew-confirmation-fns.ts
@@ -2,19 +2,24 @@
 // @lat: [[crew#Assignment Confirmations]]
 // @lat: [[crew#Server Function Runtime Boundary]]
 // @lat: [[crew#Confirmation Emails And Reminders]]
+// @lat: [[crew#Volunteer Self Service]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
+import { VOLUNTEER_AVAILABILITY } from "../db/schemas/volunteers"
 import { CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES } from "../lib/crew/assignment-confirmations"
 import type {
   QueueCrewAssignmentConfirmationEmailsInput,
   QueueCrewAssignmentConfirmationEmailsResult,
+  UpdateCrewAssignmentConfirmationContactTokenInput,
   UpdateCrewShiftAssignmentConfirmationStateInput,
 } from "../server/crew-confirmation.server"
 
 export type {
   CrewAssignmentEmailQueueMessage,
+  CrewAssignmentConfirmationContactUpdateResult,
   CrewAssignmentConfirmationResponseResult,
   CrewAssignmentConfirmationTokenData,
+  UpdateCrewAssignmentConfirmationContactTokenInput,
   CrewShiftAssignmentConfirmationStatus,
   EnsureCrewShiftAssignmentConfirmationResult,
   QueueCrewAssignmentConfirmationEmailsInput,
@@ -31,6 +36,26 @@ const publicTokenResponseInputSchema = publicTokenInputSchema.extend({
   action: z.enum(["confirm", "decline", "request_change"]),
   responseNote: z.string().trim().max(1000).optional(),
 })
+
+const publicTokenContactInputSchema = publicTokenInputSchema.extend({
+  email: z
+    .string()
+    .trim()
+    .toLowerCase()
+    .email("Enter a valid email address")
+    .max(255),
+  name: z.string().trim().max(200).optional(),
+  phone: z.string().trim().max(50).optional(),
+  availability: z
+    .enum([
+      VOLUNTEER_AVAILABILITY.MORNING,
+      VOLUNTEER_AVAILABILITY.AFTERNOON,
+      VOLUNTEER_AVAILABILITY.ALL_DAY,
+    ])
+    .optional(),
+  availabilityNotes: z.string().trim().max(5000).optional(),
+  credentials: z.string().trim().max(1000).optional(),
+}) satisfies z.ZodType<UpdateCrewAssignmentConfirmationContactTokenInput>
 
 const updateShiftAssignmentConfirmationStateInputSchema = z.object({
   eventId: z.string().min(1, "Event ID is required"),
@@ -64,6 +89,17 @@ export const respondCrewAssignmentConfirmationTokenFn = createServerFn({
       "../server/crew-confirmation.server"
     )
     return respondCrewAssignmentConfirmationToken(data)
+  })
+
+export const updateCrewAssignmentConfirmationContactTokenFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) => publicTokenContactInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { updateCrewAssignmentConfirmationContactToken } = await import(
+      "../server/crew-confirmation.server"
+    )
+    return updateCrewAssignmentConfirmationContactToken(data)
   })
 
 export const updateCrewShiftAssignmentConfirmationStateFn = createServerFn({

--- a/apps/crew/src/server-fns/crew-confirmation-fns.ts
+++ b/apps/crew/src/server-fns/crew-confirmation-fns.ts
@@ -46,13 +46,7 @@ const publicTokenContactInputSchema = publicTokenInputSchema.extend({
     .max(255),
   name: z.string().trim().max(200).optional(),
   phone: z.string().trim().max(50).optional(),
-  availability: z
-    .enum([
-      VOLUNTEER_AVAILABILITY.MORNING,
-      VOLUNTEER_AVAILABILITY.AFTERNOON,
-      VOLUNTEER_AVAILABILITY.ALL_DAY,
-    ])
-    .optional(),
+  availability: z.enum(VOLUNTEER_AVAILABILITY).optional(),
   availabilityNotes: z.string().trim().max(5000).optional(),
   credentials: z.string().trim().max(1000).optional(),
 }) satisfies z.ZodType<UpdateCrewAssignmentConfirmationContactTokenInput>

--- a/apps/crew/src/server/crew-confirmation.server.ts
+++ b/apps/crew/src/server/crew-confirmation.server.ts
@@ -2,9 +2,11 @@ import { render } from "@react-email/render"
 // @lat: [[crew#Assignment Confirmation Responses]]
 // @lat: [[crew#Assignment Confirmations]]
 // @lat: [[crew#Confirmation Emails And Reminders]]
+// @lat: [[crew#Volunteer Self Service]]
 import { env } from "cloudflare:workers"
 import {
   and,
+  asc,
   desc,
   eq,
   inArray,
@@ -27,11 +29,12 @@ import {
   CREW_EVENT_LIFECYCLE,
   crewEventSettingsTable,
 } from "../db/schemas/crew-event-settings"
-import { teamMembershipTable } from "../db/schemas/teams"
+import { SYSTEM_ROLES_ENUM, teamMembershipTable } from "../db/schemas/teams"
 import { userTable } from "../db/schemas/users"
 import {
   volunteerShiftAssignmentsTable,
   volunteerShiftsTable,
+  type VolunteerAvailability,
   type VolunteerRoleType,
 } from "../db/schemas/volunteers"
 import {
@@ -65,6 +68,11 @@ import {
   getCrewRosterRoleTypes,
   parseCrewRosterMetadata,
 } from "../lib/crew/roster-shifts"
+import {
+  buildCrewVolunteerSelfServiceSchedule,
+  resolveCrewVolunteerSelfServiceContactUpdate,
+  type CrewVolunteerSelfServiceScheduleItem,
+} from "../lib/crew/volunteer-self-service"
 import { getAppUrl } from "../lib/env"
 import { CrewAssignmentConfirmationEmail } from "../react-email/crew/assignment-confirmation"
 import { CrewAssignmentReminder24HourEmail } from "../react-email/crew/reminder-24-hour"
@@ -103,6 +111,10 @@ export interface CrewAssignmentConfirmationTokenData {
   volunteer: {
     name: string
     email: string
+    phone: string | null
+    availability: VolunteerAvailability | null
+    availabilityNotes: string | null
+    credentials: string | null
     roleTypes: VolunteerRoleType[]
   } | null
   assignment: {
@@ -117,6 +129,7 @@ export interface CrewAssignmentConfirmationTokenData {
     notes: string | null
   } | null
   confirmation: CrewAssignmentConfirmationDisplay | null
+  schedule: CrewVolunteerSelfServiceScheduleItem[]
 }
 
 export interface CrewAssignmentConfirmationResponseResult
@@ -128,6 +141,19 @@ export interface CrewAssignmentConfirmationResponseResult
     | "expired"
     | "cancelled"
     | "already_responded"
+    | "missing"
+    | "bad"
+  message: string
+}
+
+export interface CrewAssignmentConfirmationContactUpdateResult
+  extends CrewAssignmentConfirmationTokenData {
+  success: boolean
+  outcome:
+    | "updated"
+    | "idempotent"
+    | "expired"
+    | "cancelled"
     | "missing"
     | "bad"
   message: string
@@ -188,6 +214,16 @@ interface PublicTokenInput {
 interface PublicTokenResponseInput extends PublicTokenInput {
   action: CrewAssignmentResponseAction
   responseNote?: string
+}
+
+export interface UpdateCrewAssignmentConfirmationContactTokenInput
+  extends PublicTokenInput {
+  email: string
+  name?: string
+  phone?: string
+  availability?: VolunteerAvailability
+  availabilityNotes?: string
+  credentials?: string
 }
 
 interface CrewAssignmentEmailCandidate
@@ -297,6 +333,153 @@ export async function respondCrewAssignmentConfirmationToken(
         })
         .where(eq(crewAssignmentConfirmationsTable.id, row.confirmation.id))
     }
+  })
+
+  const freshData = await getCrewAssignmentConfirmationByToken(data)
+
+  return {
+    ...freshData,
+    success:
+      responseState.outcome === "updated" ||
+      responseState.outcome === "idempotent",
+    outcome: responseState.outcome,
+    message: responseState.message,
+  }
+}
+
+export async function updateCrewAssignmentConfirmationContactToken(
+  data: UpdateCrewAssignmentConfirmationContactTokenInput,
+): Promise<CrewAssignmentConfirmationContactUpdateResult> {
+  const db = getDb()
+  const tokenHash = await hashCrewAssignmentConfirmationToken(data.token)
+  const responseState: {
+    outcome: CrewAssignmentConfirmationContactUpdateResult["outcome"]
+    message: string
+  } = {
+    outcome: "missing",
+    message: "Assignment confirmation link was not found.",
+  }
+
+  await db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({
+        competitionTeamId: competitionsTable.competitionTeamId,
+        confirmation: crewAssignmentConfirmationsTable,
+        assignment: {
+          id: volunteerShiftAssignmentsTable.id,
+          membershipId: volunteerShiftAssignmentsTable.membershipId,
+        },
+        membership: {
+          id: teamMembershipTable.id,
+          metadata: teamMembershipTable.metadata,
+        },
+      })
+      .from(crewAssignmentConfirmationsTable)
+      .innerJoin(
+        competitionsTable,
+        eq(
+          crewAssignmentConfirmationsTable.competitionId,
+          competitionsTable.id,
+        ),
+      )
+      .innerJoin(
+        crewEventSettingsTable,
+        eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+      )
+      .leftJoin(
+        volunteerShiftAssignmentsTable,
+        eq(
+          crewAssignmentConfirmationsTable.assignmentId,
+          volunteerShiftAssignmentsTable.id,
+        ),
+      )
+      .leftJoin(
+        teamMembershipTable,
+        eq(volunteerShiftAssignmentsTable.membershipId, teamMembershipTable.id),
+      )
+      .where(
+        and(
+          eq(crewAssignmentConfirmationsTable.tokenHash, tokenHash),
+          eq(
+            crewAssignmentConfirmationsTable.assignmentType,
+            CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+          ),
+          eq(competitionsTable.slug, data.slug),
+          eq(crewEventSettingsTable.crewOnly, true),
+          ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
+        ),
+      )
+      .for("update")
+      .limit(1)
+
+    if (!row) {
+      responseState.outcome = "missing"
+      return
+    }
+
+    if (
+      row.confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED
+    ) {
+      responseState.outcome = "cancelled"
+      responseState.message = "This assignment confirmation has been cancelled."
+      return
+    }
+
+    const tokenState = getCrewAssignmentConfirmationTokenState(row.confirmation)
+    if (tokenState !== "valid") {
+      responseState.outcome = tokenState === "expired" ? "expired" : "bad"
+      responseState.message =
+        tokenState === "expired"
+          ? "This assignment link has expired."
+          : "This assignment link is no longer valid."
+      return
+    }
+
+    if (
+      !row.assignment?.id ||
+      !row.assignment.membershipId ||
+      !row.membership?.id
+    ) {
+      responseState.outcome = "bad"
+      responseState.message = "This assignment link is no longer valid."
+      return
+    }
+
+    const resolution = resolveCrewVolunteerSelfServiceContactUpdate(
+      row.membership.metadata,
+      data,
+    )
+
+    if (!resolution.changed) {
+      responseState.outcome = "idempotent"
+      responseState.message = "Your contact details were already up to date."
+      return
+    }
+
+    const updatedAt = new Date()
+    const updateResult = await tx
+      .update(teamMembershipTable)
+      .set({
+        metadata: JSON.stringify(resolution.metadata),
+        updatedAt,
+      })
+      .where(
+        and(
+          eq(teamMembershipTable.id, row.assignment.membershipId),
+          eq(teamMembershipTable.teamId, row.competitionTeamId),
+          eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+          eq(teamMembershipTable.isSystemRole, true),
+        ),
+      )
+
+    if (getAffectedRows(updateResult) === 0) {
+      responseState.outcome = "bad"
+      responseState.message = "This assignment link is no longer valid."
+      return
+    }
+
+    responseState.outcome = "updated"
+    responseState.message = "Contact details updated."
   })
 
   const freshData = await getCrewAssignmentConfirmationByToken(data)
@@ -903,8 +1086,8 @@ async function loadCrewAssignmentEmailCandidates(
   return rows.map((row) => {
     const metadata = parseCrewRosterMetadata(row.membership?.metadata)
     const email =
-      normalizeConfirmationEmailForSend(row.confirmation.email) ??
       normalizeConfirmationEmailForSend(metadata.signupEmail) ??
+      normalizeConfirmationEmailForSend(row.confirmation.email) ??
       normalizeConfirmationEmailForSend(row.user?.email)
     const volunteerName =
       metadata.signupName ||
@@ -1107,9 +1290,12 @@ async function getCrewAssignmentConfirmationByToken({
       },
       assignment: {
         id: volunteerShiftAssignmentsTable.id,
+        membershipId: volunteerShiftAssignmentsTable.membershipId,
+        notes: volunteerShiftAssignmentsTable.notes,
       },
       confirmationEmail: crewAssignmentConfirmationsTable.email,
       membership: {
+        id: teamMembershipTable.id,
         metadata: teamMembershipTable.metadata,
       },
       user: {
@@ -1173,6 +1359,7 @@ async function getCrewAssignmentConfirmationByToken({
       volunteer: null,
       assignment: null,
       confirmation: toConfirmationDisplay(row.confirmation),
+      schedule: [],
     }
   }
 
@@ -1185,6 +1372,7 @@ async function getCrewAssignmentConfirmationByToken({
       volunteer: null,
       assignment: null,
       confirmation: toConfirmationDisplay(row.confirmation),
+      schedule: [],
     }
   }
 
@@ -1196,7 +1384,13 @@ async function getCrewAssignmentConfirmationByToken({
     row.confirmationEmail ||
     "Volunteer"
   const email =
-    row.confirmationEmail ?? metadata.signupEmail ?? row.user?.email ?? ""
+    metadata.signupEmail ?? row.confirmationEmail ?? row.user?.email ?? ""
+  const schedule = await loadCrewVolunteerSelfServiceSchedule({
+    db,
+    competitionId: row.event.id,
+    membershipId: assignment.membershipId,
+    tokenAssignmentId: assignment.id,
+  })
 
   return {
     status,
@@ -1204,6 +1398,10 @@ async function getCrewAssignmentConfirmationByToken({
     volunteer: {
       name,
       email,
+      phone: metadata.signupPhone ?? null,
+      availability: metadata.availability ?? null,
+      availabilityNotes: metadata.availabilityNotes ?? null,
+      credentials: metadata.credentials ?? null,
       roleTypes: getCrewRosterRoleTypes(metadata.volunteerRoleTypes),
     },
     assignment: {
@@ -1215,9 +1413,10 @@ async function getCrewAssignmentConfirmationByToken({
       startTime: shift.startTime,
       endTime: shift.endTime,
       location: shift.location,
-      notes: shift.notes,
+      notes: assignment.notes ?? shift.notes,
     },
     confirmation: toConfirmationDisplay(row.confirmation),
+    schedule,
   }
 }
 
@@ -1230,7 +1429,104 @@ function emptyTokenData(
     volunteer: null,
     assignment: null,
     confirmation: null,
+    schedule: [],
   }
+}
+
+async function loadCrewVolunteerSelfServiceSchedule({
+  db,
+  competitionId,
+  membershipId,
+  tokenAssignmentId,
+}: {
+  db: DbClient
+  competitionId: string
+  membershipId: string
+  tokenAssignmentId: string
+}) {
+  const rows = await db
+    .select({
+      assignment: {
+        id: volunteerShiftAssignmentsTable.id,
+        membershipId: volunteerShiftAssignmentsTable.membershipId,
+        notes: volunteerShiftAssignmentsTable.notes,
+      },
+      shift: {
+        id: volunteerShiftsTable.id,
+        name: volunteerShiftsTable.name,
+        roleType: volunteerShiftsTable.roleType,
+        startTime: volunteerShiftsTable.startTime,
+        endTime: volunteerShiftsTable.endTime,
+        location: volunteerShiftsTable.location,
+        notes: volunteerShiftsTable.notes,
+      },
+      confirmation: {
+        id: crewAssignmentConfirmationsTable.id,
+        status: crewAssignmentConfirmationsTable.status,
+        sentAt: crewAssignmentConfirmationsTable.sentAt,
+        respondedAt: crewAssignmentConfirmationsTable.respondedAt,
+        expiresAt: crewAssignmentConfirmationsTable.expiresAt,
+        responseNote: crewAssignmentConfirmationsTable.responseNote,
+        updatedAt: crewAssignmentConfirmationsTable.updatedAt,
+      },
+    })
+    .from(volunteerShiftAssignmentsTable)
+    .innerJoin(
+      volunteerShiftsTable,
+      eq(volunteerShiftAssignmentsTable.shiftId, volunteerShiftsTable.id),
+    )
+    .leftJoin(
+      crewAssignmentConfirmationsTable,
+      and(
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        ),
+        eq(
+          crewAssignmentConfirmationsTable.assignmentId,
+          volunteerShiftAssignmentsTable.id,
+        ),
+      ),
+    )
+    .where(
+      and(
+        eq(volunteerShiftsTable.competitionId, competitionId),
+        eq(volunteerShiftAssignmentsTable.membershipId, membershipId),
+      ),
+    )
+    .orderBy(
+      asc(volunteerShiftsTable.startTime),
+      asc(volunteerShiftsTable.name),
+      desc(crewAssignmentConfirmationsTable.updatedAt),
+    )
+
+  return buildCrewVolunteerSelfServiceSchedule({
+    membershipId,
+    tokenAssignmentId,
+    assignments: rows.map((row) => ({
+      id: row.assignment.id,
+      membershipId: row.assignment.membershipId,
+      shiftId: row.shift.id,
+      name: row.shift.name,
+      roleType: row.shift.roleType,
+      roleLabel: formatVolunteerRole(row.shift.roleType),
+      startTime: row.shift.startTime,
+      endTime: row.shift.endTime,
+      location: row.shift.location,
+      notes: row.assignment.notes ?? row.shift.notes,
+      confirmation:
+        row.confirmation?.id && row.confirmation.status
+          ? {
+              id: row.confirmation.id,
+              status: row.confirmation.status,
+              sentAt: row.confirmation.sentAt,
+              respondedAt: row.confirmation.respondedAt,
+              expiresAt: row.confirmation.expiresAt,
+              responseNote: row.confirmation.responseNote,
+            }
+          : null,
+    })),
+  })
 }
 
 function toConfirmationDisplay(confirmation: {

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -242,6 +242,14 @@ Crew copy-prior-event setup lets a local operator preview structural setup from 
 
 [[apps/crew/src/components/crew-copy-event/crew-copy-prior-event-panel.tsx]] renders the setup-page preview and conservative apply action on [[apps/crew/src/routes/events/$eventId/setup.tsx]].
 
+## Volunteer Self Service
+
+Crew volunteer self-service is a no-session, no-password token surface scoped to the volunteer assignment confirmation token.
+
+[[apps/crew/src/routes/e/$slug/schedule/$token.tsx]] renders the token volunteer's own schedule, response entry point, print-friendly schedule view, calendar links, and contact metadata form. [[apps/crew/src/server-fns/crew-confirmation-fns.ts]] keeps route imports thin while [[apps/crew/src/server/crew-confirmation.server.ts]] validates the event slug, token hash, Crew-only event state, assignment row, and volunteer membership before returning or mutating data.
+
+[[apps/crew/src/lib/crew/volunteer-self-service.ts]] owns deterministic schedule shaping, metadata-only contact updates, and calendar snippet helpers. Contact updates write only volunteer roster metadata on `team_memberships`; they do not mutate user account email, assignment rows, confirmation response state, reminder counts, or sent timestamps.
+
 ## Assignment Confirmation Responses
 
 Crew assignment confirmation links are token-only volunteer surfaces. Raw tokens are generated only while creating links, stored only as hashes, and used by [[apps/crew/src/routes/e/$slug/confirm/$token.tsx]] and [[apps/crew/src/routes/e/$slug/schedule/$token.tsx]] to show safe confirm, decline, and change-request flows without requiring a session.


### PR DESCRIPTION
## Summary
- Extends the public assignment schedule token route into a volunteer self-service schedule with same-volunteer assignment hydration, response entry points, iCal/Google calendar links, and print-friendly output.
- Adds a token-scoped contact metadata update path through `crew-confirmation-fns` / `crew-confirmation.server`, writing only volunteer roster metadata on the assigned membership.
- Adds deterministic volunteer self-service helpers/tests plus the `crew#Volunteer Self Service` LAT anchor.

## Validation
- `pnpm --filter crew test -- src/lib/crew/volunteer-self-service.test.ts src/lib/crew/assignment-confirmations.test.ts` (18 tests passed)
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; reports existing warnings in untouched files)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` (passed after copying ignored local `.alchemy/local/wrangler.jsonc` from a sibling Crew worktree)
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Volunteer Self Service'`
- `git diff --check`

## Scoped Risks / Deferrals
- No schema, migration, queue binding, production deploy, live email, SMS, account, waiver, payment, assignment automation, export, import mapping, copy-prior-event, or department-lead permission changes.
- Contact updates are metadata-only and do not mutate the underlying user account email. Existing confirmation sent/reminder audit fields remain intact; future reminder recipient selection now prefers current roster metadata email before falling back to the stored confirmation email.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade the public schedule token route into a volunteer self‑service page that shows the volunteer’s schedule, adds response entry points, and provides calendar/print options. Add a secure, token‑scoped contact update flow with client and server validation that updates roster metadata only.

- **New Features**
  - Volunteer-only schedule view with response link, iCal/Google calendar links, and print-friendly output.
  - Token-scoped contact form to update email/name/phone/availability/credentials; writes roster metadata only and is idempotent, now validated with `react-hook-form` + `zod`.
  - Deterministic ICS/Google helpers and filename builder for downloads.

- **Refactors**
  - Added `updateCrewAssignmentConfirmationContactTokenFn` and backend handler with stricter token/event validation and input schema checks; token responses now include schedule and contact fields.
  - Centralized schedule shaping, calendar helpers, and contact metadata logic in `apps/crew/src/lib/crew/volunteer-self-service.ts` with tests.
  - Reminder recipient selection now prefers roster metadata email before the stored confirmation email.

<sup>Written for commit 31575c14cbfe2d165ecf6cdc34626beeeeedb51c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Volunteers can now view their crew assignments and confirm availability via secure token links
  * Added contact information updates (email, name, phone, availability, notes) for volunteers
  * Integrated calendar export functionality with iCal downloads and Google Calendar sync
  * Added visual confirmation status indicators for each assignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->