### PR TITLE
feat(crew): add event-day export packet

### DIFF
--- a/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Pilot Exports]]
+// @lat: [[crew#Event Day Export Packet]]
 import { describe, expect, it } from "vitest"
 import {
   CREW_ASSIGNMENT_CONFIRMATION_STATUS,
@@ -114,6 +115,79 @@ describe("Crew pilot exports", () => {
       [2, "Lane Two"],
       [3, "OPEN"],
     ])
+  })
+
+  it("assembles an event-day packet index with day, station, and lane cards", () => {
+    const input = baseInput()
+    input.venues?.push({
+      id: "venue_annex",
+      name: "Annex floor",
+      laneCount: 2,
+      sortOrder: 2,
+    })
+    input.workouts?.push({ id: "tw_event2", name: "Event 2", sortOrder: 2 })
+    input.heats?.push({
+      id: "heat_2",
+      trackWorkoutId: "tw_event2",
+      heatNumber: 1,
+      venueId: "venue_annex",
+      scheduledTime: "2026-07-02T15:00:00.000Z",
+      durationMinutes: 10,
+    })
+    input.heatLaneAssignments?.push(
+      { heatId: "heat_2", laneNumber: 1 },
+      { heatId: "heat_2", laneNumber: 2 },
+    )
+    input.shifts?.push({
+      id: "shift_annex_briefing",
+      name: "Annex briefing",
+      roleType: VOLUNTEER_ROLE_TYPES.FLOOR_MANAGER,
+      startTime: "2026-07-02T14:30:00.000Z",
+      endTime: "2026-07-02T15:00:00.000Z",
+      capacity: 1,
+      location: "Annex floor",
+      assignments: [],
+    })
+
+    const exports = buildCrewPilotExports(input)
+
+    expect(exports.packetIndexItems.map((item) => item.id)).toEqual([
+      "master-schedule",
+      "station-cards",
+      "role-sheets",
+      "judge-cards",
+      "response-list",
+      "floor-lead-sheets",
+    ])
+    expect(exports.masterScheduleDaySections.map((section) => section.dayKey))
+      .toEqual(["2026-07-01", "2026-07-02"])
+    expect(
+      exports.masterScheduleDaySections.map((section) =>
+        section.rows.map((row) => row.label),
+      ),
+    ).toEqual([
+      ["Check-in", "Event 1 - Heat 1", "Floor reset"],
+      ["Annex briefing", "Event 2 - Heat 1"],
+    ])
+    expect(exports.stationCards.map((card) => card.stationName)).toEqual([
+      "Annex floor",
+      "Competition floor",
+      "Front desk",
+    ])
+    expect(
+      exports.stationCards.find((card) => card.stationName === "Annex floor"),
+    ).toMatchObject({
+      openBlocks: 2,
+      laneCards: [
+        { laneNumber: 1, rows: [{ workoutName: "Event 2" }] },
+        { laneNumber: 2, rows: [{ judgeName: "OPEN" }] },
+      ],
+    })
+    expect(exports.summary).toMatchObject({
+      masterScheduleDaySections: 2,
+      stationCards: 3,
+      laneCards: 5,
+    })
   })
 })
 

--- a/apps/crew/src/lib/crew/exports/pilot-exports.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Pilot Exports]]
+// @lat: [[crew#Event Day Export Packet]]
 import {
   CREW_ASSIGNMENT_CONFIRMATION_STATUS,
   type CrewAssignmentConfirmationStatus,
@@ -15,6 +16,8 @@ export interface CrewPilotExportEventInput {
   name: string
   slug?: string | null
   timezone?: string | null
+  startDate?: string | null
+  endDate?: string | null
 }
 
 export interface CrewPilotExportVenueInput {
@@ -178,6 +181,46 @@ export interface CrewPilotFloorLeadSheet {
   judgeRows: CrewPilotJudgeLaneRow[]
 }
 
+export interface CrewPilotPacketIndexItem {
+  id: string
+  title: string
+  description: string
+  count: number
+}
+
+export interface CrewPilotMasterScheduleDaySection {
+  dayKey: string
+  rows: CrewPilotMasterScheduleRow[]
+}
+
+export interface CrewPilotJudgeLaneCardRow {
+  heatId: string
+  workoutName: string
+  heatNumber: number
+  startsAt: string | null
+  endsAt: string | null
+  judgeName: string
+  email: string
+  confirmationStatus: string
+}
+
+export interface CrewPilotJudgeLaneCard {
+  cardKey: string
+  venueName: string
+  laneNumber: number
+  rows: CrewPilotJudgeLaneCardRow[]
+}
+
+export interface CrewPilotStationCard {
+  stationName: string
+  startsAt: string | null
+  endsAt: string | null
+  rows: CrewPilotMasterScheduleRow[]
+  judgeRows: CrewPilotJudgeLaneRow[]
+  laneCards: CrewPilotJudgeLaneCard[]
+  openBlocks: number
+}
+
 export interface CrewPilotExports {
   generatedAt: string
   summary: {
@@ -186,11 +229,19 @@ export interface CrewPilotExports {
     judgeHeatSheets: number
     responseRows: number
     floorLeadSheets: number
+    packetIndexItems: number
+    masterScheduleDaySections: number
+    stationCards: number
+    laneCards: number
   }
+  packetIndexItems: CrewPilotPacketIndexItem[]
   masterScheduleRows: CrewPilotMasterScheduleRow[]
+  masterScheduleDaySections: CrewPilotMasterScheduleDaySection[]
   masterScheduleCsv: string
   roleSheets: CrewPilotRoleSheet[]
   judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
+  judgeLaneCards: CrewPilotJudgeLaneCard[]
+  stationCards: CrewPilotStationCard[]
   responseRows: CrewPilotResponseRow[]
   responseCsv: string
   floorLeadSheets: CrewPilotFloorLeadSheet[]
@@ -263,6 +314,26 @@ export function buildCrewPilotExports(
     masterScheduleRows,
     judgeHeatLaneSheets,
   })
+  const masterScheduleDaySections = buildMasterScheduleDaySections(
+    masterScheduleRows,
+    input.event.timezone,
+  )
+  const judgeLaneCards = buildJudgeLaneCards(judgeHeatLaneSheets)
+  const stationCards = buildStationCards({
+    masterScheduleRows,
+    judgeHeatLaneSheets,
+    judgeLaneCards,
+  })
+  const packetIndexItems = buildPacketIndexItems({
+    masterScheduleRows,
+    masterScheduleDaySections,
+    roleSheets,
+    judgeHeatLaneSheets,
+    judgeLaneCards,
+    stationCards,
+    responseRows,
+    floorLeadSheets,
+  })
 
   return {
     generatedAt,
@@ -272,8 +343,14 @@ export function buildCrewPilotExports(
       judgeHeatSheets: judgeHeatLaneSheets.length,
       responseRows: responseRows.length,
       floorLeadSheets: floorLeadSheets.length,
+      packetIndexItems: packetIndexItems.length,
+      masterScheduleDaySections: masterScheduleDaySections.length,
+      stationCards: stationCards.length,
+      laneCards: judgeLaneCards.length,
     },
+    packetIndexItems,
     masterScheduleRows,
+    masterScheduleDaySections,
     masterScheduleCsv: buildCsv(
       [
         "Type",
@@ -304,6 +381,8 @@ export function buildCrewPilotExports(
     ),
     roleSheets,
     judgeHeatLaneSheets,
+    judgeLaneCards,
+    stationCards,
     responseRows,
     responseCsv: buildCsv(
       [
@@ -592,6 +671,164 @@ function buildFloorLeadSheets(input: {
   }))
 }
 
+function buildMasterScheduleDaySections(
+  rows: CrewPilotMasterScheduleRow[],
+  timezone: string | null | undefined,
+) {
+  const rowsByDay = groupBy(rows, (row) =>
+    getDayKey(row.startsAt ?? row.endsAt, timezone),
+  )
+  return [...rowsByDay.entries()]
+    .sort(([left], [right]) => compareText(left, right))
+    .map(([dayKey, dayRows]) => ({
+      dayKey,
+      rows: dayRows.sort(compareMasterScheduleRow),
+    }))
+}
+
+function buildJudgeLaneCards(
+  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[],
+) {
+  const rowsByLane = new Map<string, CrewPilotJudgeLaneCardRow[]>()
+  const cardMeta = new Map<string, { venueName: string; laneNumber: number }>()
+
+  for (const sheet of judgeHeatLaneSheets) {
+    for (const row of sheet.rows) {
+      const cardKey = `${row.venueName}:lane:${row.laneNumber}`
+      cardMeta.set(cardKey, {
+        venueName: row.venueName,
+        laneNumber: row.laneNumber,
+      })
+      const rows = rowsByLane.get(cardKey) ?? []
+      rows.push({
+        heatId: row.heatId,
+        workoutName: row.workoutName,
+        heatNumber: row.heatNumber,
+        startsAt: row.startsAt,
+        endsAt: row.endsAt,
+        judgeName: row.judgeName,
+        email: row.email,
+        confirmationStatus: row.confirmationStatus,
+      })
+      rowsByLane.set(cardKey, rows)
+    }
+  }
+
+  return [...rowsByLane.entries()]
+    .map(([cardKey, rows]) => {
+      const meta = cardMeta.get(cardKey)
+      return {
+        cardKey,
+        venueName: meta?.venueName ?? "Unassigned",
+        laneNumber: meta?.laneNumber ?? 0,
+        rows: rows.sort(compareJudgeLaneCardRow),
+      }
+    })
+    .sort(compareJudgeLaneCard)
+}
+
+function buildStationCards(input: {
+  masterScheduleRows: CrewPilotMasterScheduleRow[]
+  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
+  judgeLaneCards: CrewPilotJudgeLaneCard[]
+}) {
+  const scheduleRowsByStation = groupBy(
+    input.masterScheduleRows,
+    (row) => row.location || "Unassigned",
+  )
+  const judgeRowsByStation = groupBy(
+    input.judgeHeatLaneSheets.flatMap((sheet) => sheet.rows),
+    (row) => row.venueName || "Unassigned",
+  )
+  const laneCardsByStation = groupBy(
+    input.judgeLaneCards,
+    (card) => card.venueName || "Unassigned",
+  )
+  const stationNames = [
+    ...new Set([
+      ...scheduleRowsByStation.keys(),
+      ...judgeRowsByStation.keys(),
+      ...laneCardsByStation.keys(),
+    ]),
+  ].sort(compareText)
+
+  return stationNames.map((stationName) => {
+    const rows = (scheduleRowsByStation.get(stationName) ?? []).sort(
+      compareMasterScheduleRow,
+    )
+    const judgeRows = (judgeRowsByStation.get(stationName) ?? []).sort(
+      compareJudgeLaneRow,
+    )
+    const laneCards = (laneCardsByStation.get(stationName) ?? []).sort(
+      compareJudgeLaneCard,
+    )
+    const allDateStrings = [
+      ...rows.flatMap((row) => [row.startsAt, row.endsAt]),
+      ...judgeRows.flatMap((row) => [row.startsAt, row.endsAt]),
+    ].filter((value): value is string => Boolean(value))
+
+    return {
+      stationName,
+      startsAt: firstDateString(allDateStrings),
+      endsAt: lastDateString(allDateStrings),
+      rows,
+      judgeRows,
+      laneCards,
+      openBlocks: rows.filter((row) => row.open > 0).length,
+    }
+  })
+}
+
+function buildPacketIndexItems(input: {
+  masterScheduleRows: CrewPilotMasterScheduleRow[]
+  masterScheduleDaySections: CrewPilotMasterScheduleDaySection[]
+  roleSheets: CrewPilotRoleSheet[]
+  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
+  judgeLaneCards: CrewPilotJudgeLaneCard[]
+  stationCards: CrewPilotStationCard[]
+  responseRows: CrewPilotResponseRow[]
+  floorLeadSheets: CrewPilotFloorLeadSheet[]
+}) {
+  return [
+    {
+      id: "master-schedule",
+      title: "Master schedule",
+      description: `${input.masterScheduleRows.length} shift and heat rows across ${input.masterScheduleDaySections.length} day sections.`,
+      count: input.masterScheduleRows.length,
+    },
+    {
+      id: "station-cards",
+      title: "Station cards",
+      description: `${input.stationCards.length} floor or station cards with local coverage and lane summaries.`,
+      count: input.stationCards.length,
+    },
+    {
+      id: "role-sheets",
+      title: "Role sheets",
+      description: `${input.roleSheets.length} department-ready role sheets with open slots included.`,
+      count: input.roleSheets.length,
+    },
+    {
+      id: "judge-cards",
+      title: "Judge cards",
+      description: `${input.judgeHeatLaneSheets.length} heat cards and ${input.judgeLaneCards.length} lane cards.`,
+      count: input.judgeHeatLaneSheets.length + input.judgeLaneCards.length,
+    },
+    {
+      id: "response-list",
+      title: "Response list",
+      description: `${input.responseRows.length} missing, pending, declined, or change-requested assignments.`,
+      count: input.responseRows.length,
+    },
+    {
+      id: "floor-lead-sheets",
+      title: "Floor lead sheets",
+      description: `${input.floorLeadSheets.length} floor lead sheets for localized day-of handoff.`,
+      count: input.floorLeadSheets.length,
+    },
+  ]
+}
+
 function normalizeHeat(
   heat: CrewPilotExportHeatInput,
   context: {
@@ -777,6 +1014,27 @@ function compareJudgeLaneRow(
   )
 }
 
+function compareJudgeLaneCardRow(
+  left: CrewPilotJudgeLaneCardRow,
+  right: CrewPilotJudgeLaneCardRow,
+) {
+  return (
+    compareDateString(left.startsAt, right.startsAt) ||
+    left.heatNumber - right.heatNumber ||
+    compareText(left.heatId, right.heatId)
+  )
+}
+
+function compareJudgeLaneCard(
+  left: CrewPilotJudgeLaneCard,
+  right: CrewPilotJudgeLaneCard,
+) {
+  return (
+    compareText(left.venueName, right.venueName) ||
+    left.laneNumber - right.laneNumber
+  )
+}
+
 function compareJudgeAssignment(
   left: CrewPilotExportJudgeAssignmentInput,
   right: CrewPilotExportJudgeAssignmentInput,
@@ -872,6 +1130,36 @@ function toDateOrNull(value: Date | string | null | undefined) {
 
 function toIsoString(value: Date | string | null | undefined) {
   return toDateOrNull(value)?.toISOString() ?? null
+}
+
+function firstDateString(values: string[]) {
+  return values.sort(compareDateString)[0] ?? null
+}
+
+function lastDateString(values: string[]) {
+  return values.sort(compareDateString).at(-1) ?? null
+}
+
+function getDayKey(value: string | null, timezone: string | null | undefined) {
+  const date = toDateOrNull(value)
+  if (!date) return "Unscheduled"
+
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone || "UTC",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).formatToParts(date)
+    const year = parts.find((part) => part.type === "year")?.value
+    const month = parts.find((part) => part.type === "month")?.value
+    const day = parts.find((part) => part.type === "day")?.value
+    if (year && month && day) return `${year}-${month}-${day}`
+  } catch {
+    return date.toISOString().slice(0, 10)
+  }
+
+  return date.toISOString().slice(0, 10)
 }
 
 function positiveIntegerOrNull(value: number | null | undefined) {

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -1,4 +1,5 @@
 // @lat: [[crew#Pilot Exports]]
+// @lat: [[crew#Event Day Export Packet]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { Download, FileSpreadsheet, Printer } from "lucide-react"
 import type { ReactNode } from "react"
@@ -6,10 +7,15 @@ import type {
   CrewPilotExports,
   CrewPilotFloorLeadSheet,
   CrewPilotJudgeHeatLaneSheet,
+  CrewPilotJudgeLaneCard,
   CrewPilotRoleSheet,
+  CrewPilotStationCard,
 } from "@/lib/crew/exports/pilot-exports"
 import { formatCrewValue } from "@/lib/crew-event-display"
-import { getCrewPilotExportsPageFn } from "@/server-fns/crew-pilot-export-fns"
+import {
+  getCrewPilotExportsPageFn,
+  type CrewPilotExportsPageData,
+} from "@/server-fns/crew-pilot-export-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
 export const Route = createFileRoute("/events/$eventId/exports")({
@@ -25,6 +31,28 @@ const parentRoute = getRouteApi("/events/$eventId")
 function EventPilotExportsPage() {
   const { eventId } = parentRoute.useParams()
   const { event, exports, sources } = Route.useLoaderData()
+
+  return (
+    <EventPilotExportsView
+      eventId={eventId}
+      event={event}
+      exports={exports}
+      sources={sources}
+    />
+  )
+}
+
+export function EventPilotExportsView({
+  eventId,
+  event,
+  exports,
+  sources,
+}: {
+  eventId: string
+  event: CrewPilotExportsPageData["event"]
+  exports: CrewPilotExports
+  sources: CrewPilotExportsPageData["sources"]
+}) {
   const timezone = event.timezone ?? "America/Denver"
 
   return (
@@ -32,7 +60,9 @@ function EventPilotExportsPage() {
       <section className="space-y-5 print:hidden">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold">Pilot exports</h2>
+            <h2 className="text-xl font-semibold">
+              Event-day export packet
+            </h2>
             <p className="text-sm text-muted-foreground">
               {formatExportDate(exports.generatedAt, timezone)} / {timezone}
             </p>
@@ -70,24 +100,59 @@ function EventPilotExportsPage() {
               onClick={() => window.print()}
             >
               <Printer className="size-4" />
-              Print sheets
+              Print packet
             </button>
           </div>
         </div>
 
-        <section className="grid gap-3 md:grid-cols-6">
+        <section className="grid gap-3 md:grid-cols-4 xl:grid-cols-8">
           <MetricPanel
             label="Rows"
             value={exports.summary.masterScheduleRows}
+          />
+          <MetricPanel
+            label="Days"
+            value={exports.summary.masterScheduleDaySections}
+          />
+          <MetricPanel
+            label="Stations"
+            value={exports.summary.stationCards}
           />
           <MetricPanel label="Role sheets" value={exports.summary.roleSheets} />
           <MetricPanel
             label="Judge sheets"
             value={exports.summary.judgeHeatSheets}
           />
+          <MetricPanel label="Lane cards" value={exports.summary.laneCards} />
           <MetricPanel label="Responses" value={exports.summary.responseRows} />
-          <MetricPanel label="Floors" value={exports.summary.floorLeadSheets} />
           <MetricPanel label="Versions" value={sources.activeJudgeVersions} />
+        </section>
+
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h3 className="font-semibold">Packet index</h3>
+              <p className="text-sm text-muted-foreground">
+                {exports.summary.masterScheduleDaySections} days /{" "}
+                {exports.summary.stationCards} stations /{" "}
+                {exports.summary.laneCards} lane cards
+              </p>
+            </div>
+            <StatusPill>{exports.summary.packetIndexItems} sections</StatusPill>
+          </div>
+          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {exports.packetIndexItems.map((item) => (
+              <div key={item.id} className="rounded-md border p-3 text-sm">
+                <div className="flex items-start justify-between gap-3">
+                  <p className="font-medium">{item.title}</p>
+                  <StatusPill>{item.count}</StatusPill>
+                </div>
+                <p className="mt-2 text-muted-foreground">
+                  {item.description}
+                </p>
+              </div>
+            ))}
+          </div>
         </section>
 
         <section className="rounded-md border bg-card p-5 shadow-sm">
@@ -137,6 +202,19 @@ function EventPilotExportsPage() {
           ) : (
             <EmptyState message="No shift or heat rows are ready to export." />
           )}
+        </section>
+
+        <section className="space-y-4">
+          <h3 className="font-semibold">Station cards</h3>
+          <div className="grid gap-4 lg:grid-cols-2">
+            {exports.stationCards.map((card) => (
+              <StationCardPreview
+                key={card.stationName}
+                card={card}
+                timezone={timezone}
+              />
+            ))}
+          </div>
         </section>
 
         <div className="grid gap-5 lg:grid-cols-2">
@@ -262,11 +340,51 @@ function PrintSheets({
       <header className="border-b pb-4">
         <h1 className="text-2xl font-semibold">{eventName}</h1>
         <p className="text-sm">
-          Pilot exports / {formatExportDate(exports.generatedAt, timezone)}
+          Event-day export packet /{" "}
+          {formatExportDate(exports.generatedAt, timezone)}
         </p>
       </header>
 
-      <PrintSection title="Master schedule">
+      <PrintSection title="Packet index">
+        <PrintTable
+          headers={["Section", "Count", "Contents"]}
+          rows={exports.packetIndexItems.map((item) => ({
+            key: item.id,
+            cells: [item.title, item.count, item.description],
+          }))}
+        />
+      </PrintSection>
+
+      {exports.masterScheduleDaySections.map((section) => (
+        <PrintSection
+          key={section.dayKey}
+          title={`Master schedule / ${formatPacketDay(section.dayKey, timezone)}`}
+        >
+          <PrintTable
+            headers={[
+              "Time",
+              "Block",
+              "Location",
+              "Role",
+              "Coverage",
+              "People",
+            ]}
+            rows={section.rows.map((row) => ({
+              key: `${row.blockType}:${row.blockId}`,
+              cells: [
+                formatRange(row.startsAt, row.endsAt, timezone),
+                row.label,
+                row.location,
+                row.role,
+                `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
+                row.people || "Unassigned",
+              ],
+            }))}
+          />
+        </PrintSection>
+      ))}
+
+      <PrintSection title="Master schedule / all days">
         <PrintTable
           headers={["Time", "Block", "Location", "Role", "Coverage", "People"]}
           rows={exports.masterScheduleRows.map((row) => ({
@@ -282,6 +400,48 @@ function PrintSheets({
           }))}
         />
       </PrintSection>
+
+      {exports.stationCards.map((card) => (
+        <PrintSection
+          key={card.stationName}
+          title={`${card.stationName} station card`}
+        >
+          <p className="mb-2 text-sm">
+            {formatRange(card.startsAt, card.endsAt, timezone)} /{" "}
+            {card.openBlocks} open blocks
+          </p>
+          <PrintTable
+            headers={["Time", "Block", "Role", "Coverage", "People"]}
+            rows={card.rows.map((row) => ({
+              key: `${row.blockType}:${row.blockId}`,
+              cells: [
+                formatRange(row.startsAt, row.endsAt, timezone),
+                row.label,
+                row.role,
+                `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
+                row.people || "Unassigned",
+              ],
+            }))}
+            empty="No schedule rows for this station."
+          />
+          <div className="mt-4">
+            <PrintTable
+              headers={["Time", "Heat", "Lane", "Judge", "Status"]}
+              rows={card.judgeRows.map((row) => ({
+                key: `${row.heatId}:lane:${row.laneNumber}`,
+                cells: [
+                  formatRange(row.startsAt, row.endsAt, timezone),
+                  `${row.workoutName} heat ${row.heatNumber}`,
+                  row.laneNumber,
+                  row.judgeName,
+                  formatCrewValue(row.confirmationStatus),
+                ],
+              }))}
+              empty="No judge lanes for this station."
+            />
+          </div>
+        </PrintSection>
+      ))}
 
       <PrintSection title="No-response and decline list">
         <PrintTable
@@ -341,6 +501,27 @@ function PrintSheets({
                 row.judgeName,
                 row.email,
                 row.position,
+                formatCrewValue(row.confirmationStatus),
+              ],
+            }))}
+          />
+        </PrintSection>
+      ))}
+
+      {exports.judgeLaneCards.map((card) => (
+        <PrintSection
+          key={card.cardKey}
+          title={`${card.venueName} lane ${card.laneNumber} card`}
+        >
+          <PrintTable
+            headers={["Time", "Heat", "Judge", "Email", "Status"]}
+            rows={card.rows.map((row) => ({
+              key: row.heatId,
+              cells: [
+                formatRange(row.startsAt, row.endsAt, timezone),
+                `${row.workoutName} heat ${row.heatNumber}`,
+                row.judgeName,
+                row.email,
                 formatCrewValue(row.confirmationStatus),
               ],
             }))}
@@ -439,6 +620,59 @@ function PrintTable({
         ))}
       </tbody>
     </table>
+  )
+}
+
+function StationCardPreview({
+  card,
+  timezone,
+}: {
+  card: CrewPilotStationCard
+  timezone: string
+}) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h4 className="font-semibold">{card.stationName}</h4>
+          <p className="text-sm text-muted-foreground">
+            {formatRange(card.startsAt, card.endsAt, timezone)}
+          </p>
+        </div>
+        <StatusPill>
+          {card.rows.length} blocks / {card.laneCards.length} lanes
+        </StatusPill>
+      </div>
+      <div className="mt-3 grid gap-3 lg:grid-cols-2">
+        <div className="space-y-2 text-sm">
+          {card.rows.slice(0, 6).map((row) => (
+            <div key={`${row.blockType}:${row.blockId}`}>
+              <p className="font-medium">{row.label}</p>
+              <p className="text-muted-foreground">
+                {formatRange(row.startsAt, row.endsAt, timezone)} / {row.role}
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-2 text-sm">
+          {card.laneCards.slice(0, 6).map((laneCard) => (
+            <LaneCardLine key={laneCard.cardKey} card={laneCard} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function LaneCardLine({ card }: { card: CrewPilotJudgeLaneCard }) {
+  return (
+    <div>
+      <p className="font-medium">Lane {card.laneNumber}</p>
+      <p className="text-muted-foreground">
+        {card.rows.length} heats /{" "}
+        {card.rows.filter((row) => row.judgeName === "OPEN").length} open
+      </p>
+    </div>
   )
 }
 
@@ -596,6 +830,22 @@ function formatExportDate(value: string | null, timezone: string) {
   return Number.isNaN(date.getTime())
     ? ""
     : formatDateTimeInTimezone(date, timezone)
+}
+
+function formatPacketDay(dayKey: string, timezone: string) {
+  if (dayKey === "Unscheduled") return dayKey
+  const date = new Date(`${dayKey}T12:00:00.000Z`)
+  if (Number.isNaN(date.getTime())) return dayKey
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(date)
+  } catch {
+    return dayKey
+  }
 }
 
 function downloadCsv(filename: string, csvText: string) {

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -47,12 +47,7 @@ export function EventPilotExportsView({
   event,
   exports,
   sources,
-}: {
-  eventId: string
-  event: CrewPilotExportsPageData["event"]
-  exports: CrewPilotExports
-  sources: CrewPilotExportsPageData["sources"]
-}) {
+}: EventPilotExportsViewProps) {
   const timezone = event.timezone ?? "America/Denver"
 
   return (
@@ -326,6 +321,13 @@ export function EventPilotExportsView({
   )
 }
 
+interface EventPilotExportsViewProps {
+  eventId: string
+  event: CrewPilotExportsPageData["event"]
+  exports: CrewPilotExports
+  sources: CrewPilotExportsPageData["sources"]
+}
+
 function PrintSheets({
   eventName,
   exports,
@@ -358,7 +360,7 @@ function PrintSheets({
       {exports.masterScheduleDaySections.map((section) => (
         <PrintSection
           key={section.dayKey}
-          title={`Master schedule / ${formatPacketDay(section.dayKey, timezone)}`}
+          title={`Master schedule / ${formatPacketDay(section.dayKey)}`}
         >
           <PrintTable
             headers={[
@@ -832,13 +834,25 @@ function formatExportDate(value: string | null, timezone: string) {
     : formatDateTimeInTimezone(date, timezone)
 }
 
-function formatPacketDay(dayKey: string, timezone: string) {
+function formatPacketDay(dayKey: string) {
   if (dayKey === "Unscheduled") return dayKey
-  const date = new Date(`${dayKey}T12:00:00.000Z`)
-  if (Number.isNaN(date.getTime())) return dayKey
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dayKey)
+  if (!match) return dayKey
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const date = new Date(Date.UTC(year, month - 1, day))
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return dayKey
+  }
+
   try {
     return new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
+      timeZone: "UTC",
       month: "short",
       day: "numeric",
       year: "numeric",

--- a/apps/crew/src/server-fns/crew-pilot-export-fns.ts
+++ b/apps/crew/src/server-fns/crew-pilot-export-fns.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Pilot Exports]]
+// @lat: [[crew#Event Day Export Packet]]
 // @lat: [[crew#Server Function Runtime Boundary]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"

--- a/apps/crew/src/server/crew-pilot-exports.server.ts
+++ b/apps/crew/src/server/crew-pilot-exports.server.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Pilot Exports]]
+// @lat: [[crew#Event Day Export Packet]]
 import {
   buildCrewPilotExports,
   type CrewPilotExports,

--- a/apps/crew/test/routes/event-day-export-packet.test.tsx
+++ b/apps/crew/test/routes/event-day-export-packet.test.tsx
@@ -1,0 +1,131 @@
+import { render, screen } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+import { VOLUNTEER_ROLE_TYPES } from "@/db/schemas/volunteers"
+import {
+  buildCrewPilotExports,
+  type CrewPilotExportInput,
+} from "@/lib/crew/exports/pilot-exports"
+import { EventPilotExportsView } from "@/routes/events/$eventId/exports"
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: Record<string, unknown>) => ({
+    ...config,
+    useLoaderData: vi.fn(),
+  }),
+  getRouteApi: () => ({
+    useParams: () => ({ eventId: "comp_packet" }),
+  }),
+  Link: ({ children, to }: { children: ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+}))
+
+vi.mock("@/server-fns/crew-pilot-export-fns", () => ({
+  getCrewPilotExportsPageFn: vi.fn(),
+}))
+
+describe("EventPilotExportsView", () => {
+  // @lat: [[crew#Event Day Export Packet]]
+  it("renders packet index, station cards, and print packet sections", () => {
+    const exports = buildCrewPilotExports(packetInput())
+
+    render(
+      <EventPilotExportsView
+        eventId="comp_packet"
+        event={{
+          id: "comp_packet",
+          name: "Packet Classic",
+          slug: "packet-classic",
+          organizingTeamId: "team_org",
+          competitionTeamId: "team_comp",
+          timezone: "America/Denver",
+          startDate: "2026-07-01",
+          endDate: "2026-07-02",
+        }}
+        exports={exports}
+        sources={{
+          shifts: 1,
+          shiftAssignments: 1,
+          heats: 1,
+          heatLaneAssignments: 2,
+          judgeAssignments: 1,
+          activeJudgeVersions: 1,
+        }}
+      />,
+    )
+
+    expect(
+      screen.getByRole("heading", { name: "Event-day export packet" }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Print packet" }),
+    ).toBeInTheDocument()
+    expect(screen.getAllByText("Packet index").length).toBeGreaterThan(0)
+    expect(screen.getAllByText("Station cards").length).toBeGreaterThan(0)
+    expect(
+      screen.getByText("Competition floor station card"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("Competition floor lane 1 card"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Master schedule / all days")).toBeInTheDocument()
+  })
+})
+
+function packetInput(): CrewPilotExportInput {
+  return {
+    event: {
+      id: "comp_packet",
+      name: "Packet Classic",
+      timezone: "America/Denver",
+    },
+    generatedAt: "2026-07-01T12:00:00.000Z",
+    venues: [{ id: "venue_floor", name: "Competition floor", laneCount: 2 }],
+    workouts: [{ id: "tw_event1", name: "Event 1", sortOrder: 1 }],
+    heats: [
+      {
+        id: "heat_1",
+        trackWorkoutId: "tw_event1",
+        heatNumber: 1,
+        venueId: "venue_floor",
+        scheduledTime: "2026-07-01T15:00:00.000Z",
+        durationMinutes: 12,
+      },
+    ],
+    heatLaneAssignments: [
+      { heatId: "heat_1", laneNumber: 1 },
+      { heatId: "heat_1", laneNumber: 2 },
+    ],
+    shifts: [
+      {
+        id: "shift_floor",
+        name: "Floor reset",
+        roleType: VOLUNTEER_ROLE_TYPES.EQUIPMENT,
+        startTime: "2026-07-01T16:00:00.000Z",
+        endTime: "2026-07-01T17:00:00.000Z",
+        capacity: 2,
+        location: "Competition floor",
+        assignments: [
+          {
+            id: "vsa_reset",
+            membershipId: "tm_reset",
+            volunteerName: "Rae Reset",
+            email: "reset@example.com",
+          },
+        ],
+      },
+    ],
+    judgeAssignments: [
+      {
+        id: "jha_lane1",
+        membershipId: "tm_judge",
+        volunteerName: "Jules Judge",
+        email: "jules@example.com",
+        heatId: "heat_1",
+        laneNumber: 1,
+        position: VOLUNTEER_ROLE_TYPES.JUDGE,
+      },
+    ],
+  }
+}

--- a/apps/crew/test/routes/event-day-export-packet.test.tsx
+++ b/apps/crew/test/routes/event-day-export-packet.test.tsx
@@ -39,7 +39,7 @@ describe("EventPilotExportsView", () => {
           slug: "packet-classic",
           organizingTeamId: "team_org",
           competitionTeamId: "team_comp",
-          timezone: "America/Denver",
+          timezone: "Pacific/Kiritimati",
           startDate: "2026-07-01",
           endDate: "2026-07-02",
         }}
@@ -69,6 +69,12 @@ describe("EventPilotExportsView", () => {
     expect(
       screen.getByText("Competition floor lane 1 card"),
     ).toBeInTheDocument()
+    expect(
+      screen.getByText("Master schedule / Jul 1, 2026"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("Master schedule / Jul 2, 2026"),
+    ).not.toBeInTheDocument()
     expect(screen.getByText("Master schedule / all days")).toBeInTheDocument()
   })
 })

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -293,3 +293,9 @@ Crew pilot exports turn the active event staffing and judge assignment data into
 [[apps/crew/src/routes/events/$eventId/exports.tsx]] renders the per-event export surface. [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]] keeps the route import light while [[apps/crew/src/server/crew-pilot-exports.server.ts]] reuses server-only staffing hydration and active judge assignment data.
 
 [[apps/crew/src/lib/crew/exports/pilot-exports.ts]] owns deterministic export derivation for master schedule CSV rows, role sheets, judge heat/lane sheets, no-response and decline lists, and printable floor lead sheets. Exports are read-only and must not send reminders, create queues, alter confirmation tokens, or mutate versioned judge assignment rows.
+
+## Event Day Export Packet
+
+The event-day packet extends [[crew#Pilot Exports]] with print-first packet assembly for multi-day, multi-floor events. The packet index, day-split master schedule, station cards, lane cards, role sheets, judge heat cards, response list, and floor lead sheets are derived from the same guarded export data in [[apps/crew/src/lib/crew/exports/pilot-exports.ts]] and rendered by [[apps/crew/src/routes/events/$eventId/exports.tsx]].
+
+The packet is still full local-operator-only through [[apps/crew/src/server/crew-pilot-exports.server.ts]] and [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]]. It does not add PDF runtime infrastructure, schema, queue/email work, public tokens, department-lead subset export access, or assignment/judge-version mutations.

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -296,6 +296,6 @@ Crew pilot exports turn the active event staffing and judge assignment data into
 
 ## Event Day Export Packet
 
-The event-day packet extends [[crew#Pilot Exports]] with print-first packet assembly for multi-day, multi-floor events. The packet index, day-split master schedule, station cards, lane cards, role sheets, judge heat cards, response list, and floor lead sheets are derived from the same guarded export data in [[apps/crew/src/lib/crew/exports/pilot-exports.ts]] and rendered by [[apps/crew/src/routes/events/$eventId/exports.tsx]].
+The event-day packet extends [[crew#Pilot Exports]] with a print-first index, day schedule, station cards, lane cards, role sheets, and judge cards from [[apps/crew/src/lib/crew/exports/pilot-exports.ts]], rendered at [[apps/crew/src/routes/events/$eventId/exports.tsx]].
 
 The packet is still full local-operator-only through [[apps/crew/src/server/crew-pilot-exports.server.ts]] and [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]]. It does not add PDF runtime infrastructure, schema, queue/email work, public tokens, department-lead subset export access, or assignment/judge-version mutations.


### PR DESCRIPTION
## Summary
- extend Crew pilot exports with event-day packet assembly: packet index, day-split master schedule sections, station cards, judge lane cards, and packet summary counts
- update `/events/$eventId/exports` with event-day packet navigation plus print-only packet sections for multi-day/multi-floor handoff
- add focused builder and route-view coverage for packet assembly/rendering, and document `crew#Event Day Export Packet`

## Validation
- `pnpm --filter crew exec vitest run src/lib/crew/exports/pilot-exports.test.ts test/routes/event-day-export-packet.test.tsx`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (passes with existing repo-wide warnings outside this slice)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` (passes after seeding ignored local `apps/crew/.alchemy/local/wrangler.jsonc` from checked-in `apps/crew/wrangler.jsonc`; existing Vite chunk-size/minify warnings only)
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Event Day Export Packet'`
- `git diff --check`

## Scoped deferrals / risks
- HTML print only; no PDF renderer/runtime infrastructure added.
- Export remains full local-operator-only. Department-lead subset packet access is deferred rather than adding new scoping semantics in this slice.
- No schema, queue/email, public-token, assignment automation, or judge-version mutation changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an event-day export packet to Crew pilot exports with a packet index, day-split master schedule, station cards, and judge lane cards, plus a print-first packet view. Day labels in the packet are now timezone-stable.

- **New Features**
  - Extended `buildCrewPilotExports` with `packetIndexItems`, `masterScheduleDaySections`, `stationCards`, `judgeLaneCards`, and summary counts.
  - Updated `/events/$eventId/exports` to show packet metrics, a packet index, station card previews, and print-only sections (packet index, per-day master schedule, station cards, lane cards).
  - Added tests for packet assembly and rendering (`pilot-exports.test.ts`, `event-day-export-packet.test.tsx`).
  - Documented `crew#Event Day Export Packet` in `lat.md/crew.md`.
  - HTML print only; no PDF infra. Local-operator-only access; no schema, queue/email, public tokens, or judge-version mutation changes.

- **Bug Fixes**
  - Stabilized per-day schedule labels using timezone-aware day keys and readable dates to avoid inconsistent day headings.

<sup>Written for commit 7b05d010bfc1940e5473e02d5f2c4cea2e271f71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the "Event-day export packet"—an operator-focused, multi-day export including a packet index, day-organized master schedule, station cards, and lane cards.
  * Added new summary metrics displaying packet items, master schedule sections, stations, and lane cards counts.
  * Renamed "Print sheets" control to "Print packet" for clearer user intent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->