### PR TITLE
fix(crew): preserve department lead refined update schema

### DIFF
--- a/apps/crew/src/server-fns/crew-department-lead-fns.test.ts
+++ b/apps/crew/src/server-fns/crew-department-lead-fns.test.ts
@@ -1,0 +1,100 @@
+// @lat: [[crew#Department Leads]]
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+type ServerFnCall = {
+  method?: string
+  inputValidator?: (data: unknown) => unknown
+  handler?: (options: unknown) => unknown
+}
+
+const { serverFnCalls } = vi.hoisted(() => ({
+  serverFnCalls: [] as ServerFnCall[],
+}))
+
+vi.mock("@tanstack/react-start", () => ({
+  createServerFn: (options: { method?: string } = {}) => {
+    const call: ServerFnCall = { method: options.method }
+    serverFnCalls.push(call)
+
+    const builder = {
+      inputValidator(inputValidator: ServerFnCall["inputValidator"]) {
+        call.inputValidator = inputValidator
+        return builder
+      },
+      handler(handler: ServerFnCall["handler"]) {
+        call.handler = handler
+        return async () => undefined
+      },
+    }
+
+    return builder
+  },
+}))
+
+const validUpdateInput = {
+  eventId: "tw_event",
+  leadId: "cdlead_123",
+  email: "lead@example.com",
+  name: null,
+  membershipId: null,
+  roleType: "judge",
+  floor: null,
+  startsAt: null,
+  endsAt: null,
+  notes: null,
+}
+
+async function importDepartmentLeadServerFns() {
+  serverFnCalls.length = 0
+  return import("./crew-department-lead-fns")
+}
+
+function findUpdateInputValidator() {
+  const updateInputWithoutLeadId = {
+    ...validUpdateInput,
+    leadId: undefined,
+  }
+
+  for (const call of serverFnCalls) {
+    if (!call.inputValidator) {
+      continue
+    }
+
+    try {
+      call.inputValidator(updateInputWithoutLeadId)
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("leadId")) {
+        return call.inputValidator
+      }
+    }
+  }
+
+  throw new Error("Update department lead input validator was not registered")
+}
+
+describe("Crew department lead server functions", () => {
+  afterEach(() => {
+    vi.resetModules()
+    serverFnCalls.length = 0
+  })
+
+  it("evaluates the server-fn module without throwing", async () => {
+    await expect(importDepartmentLeadServerFns()).resolves.toMatchObject({
+      updateCrewDepartmentLeadFn: expect.any(Function),
+    })
+  })
+
+  it("keeps the update input email or membershipId refinement", async () => {
+    await importDepartmentLeadServerFns()
+
+    const updateInputValidator = findUpdateInputValidator()
+
+    expect(() =>
+      updateInputValidator({
+        ...validUpdateInput,
+        email: null,
+        membershipId: null,
+      }),
+    ).toThrow("Add an email or choose a volunteer.")
+  })
+})

--- a/apps/crew/src/server-fns/crew-department-lead-fns.test.ts
+++ b/apps/crew/src/server-fns/crew-department-lead-fns.test.ts
@@ -1,7 +1,7 @@
 // @lat: [[crew#Department Leads]]
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-type ServerFnCall = {
+interface ServerFnCall {
   method?: string
   inputValidator?: (data: unknown) => unknown
   handler?: (options: unknown) => unknown
@@ -50,9 +50,14 @@ async function importDepartmentLeadServerFns() {
 }
 
 function findUpdateInputValidator() {
-  const updateInputWithoutLeadId = {
+  const invalidLeadIdProbe = {
     ...validUpdateInput,
-    leadId: undefined,
+    leadId: "lead_123",
+  }
+  const updateProbe = {
+    ...validUpdateInput,
+    email: null,
+    membershipId: null,
   }
 
   for (const call of serverFnCalls) {
@@ -61,9 +66,20 @@ function findUpdateInputValidator() {
     }
 
     try {
-      call.inputValidator(updateInputWithoutLeadId)
+      call.inputValidator(invalidLeadIdProbe)
+      continue
+    } catch {
+      // The update validator is the only department-lead input validator that
+      // both requires a valid leadId and preserves the base contact refinement.
+    }
+
+    try {
+      call.inputValidator(updateProbe)
     } catch (error) {
-      if (error instanceof Error && error.message.includes("leadId")) {
+      if (
+        error instanceof Error &&
+        error.message.includes("Add an email or choose a volunteer.")
+      ) {
         return call.inputValidator
       }
     }

--- a/apps/crew/src/server-fns/crew-department-lead-fns.ts
+++ b/apps/crew/src/server-fns/crew-department-lead-fns.ts
@@ -54,7 +54,7 @@ const departmentLeadInputSchema = z
     }
   })
 
-const updateDepartmentLeadInputSchema = departmentLeadInputSchema.extend({
+const updateDepartmentLeadInputSchema = departmentLeadInputSchema.safeExtend({
   leadId: leadIdSchema,
 })
 


### PR DESCRIPTION
## Summary

- Change the Crew department lead update schema from `.extend(...)` to `.safeExtend(...)` so Zod 4 can compose the refined base object at module evaluation time.
- Add a focused server-fn module regression test that imports `crew-department-lead-fns.ts` and asserts the update validator still enforces the email-or-membership refinement.

## Root cause

`departmentLeadInputSchema` has a `.superRefine(...)` rule requiring either `email` or `membershipId`. Zod 4.2.1 rejects `.extend(...)` on refined object schemas during module evaluation, which made SSR startup fail when the setup route imported the department lead server functions.

## Validation

- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew exec vitest run src/server-fns/crew-department-lead-fns.test.ts` passed: 1 file, 2 tests.
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew type-check` passed.
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew lint` exited 0 with the existing warning baseline.
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` passed after copying the ignored local `.alchemy/local/wrangler.jsonc` from a sibling Crew worktree for validation.
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew dev` was attempted but blocked by an existing local TanStack devtools event-bus listener on port 42069.
- Fallback smoke: `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH CLOUDFLARE_VITE_REMOTE_BINDINGS=false CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_HYPERDRIVE=postgres://user:pass@127.0.0.1:5432/db pnpm --filter crew exec vite dev --port 3002 --mode production` reached Vite ready on `http://localhost:3003/`, and `curl -I --max-time 10 http://localhost:3003/` returned `HTTP/1.1 200 OK`; server stopped afterward.
- `git diff --check` passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the department lead update schema to `.safeExtend` so the base refinement works with `zod` v4 and SSR no longer fails to start.

- **Bug Fixes**
  - Use `.safeExtend` for `updateDepartmentLeadInputSchema` to compose the refined base at module load and preserve the email-or-membership rule.
  - Add `crew-department-lead-fns.test.ts` with a deterministic validator lookup (via a hoisted `@tanstack/react-start` mock) to confirm the module evaluates and the refinement error is enforced.

<sup>Written for commit 9b51cfd51d357e3f83e94a31668530aacb7b79e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite for crew department lead functions with comprehensive validation coverage, ensuring proper error handling for invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->