### PR TITLE
[codex] feat(crew): support manual paid and founder grants

### DIFF
--- a/apps/crew/src/lib/crew/billing-state.test.ts
+++ b/apps/crew/src/lib/crew/billing-state.test.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Crew Billing State And Audit]]
+// @lat: [[crew#Manual Paid And Founder Grants]]
 import { describe, expect, it } from "vitest"
 import { CREW_BILLING_EVENT_TYPE } from "../../db/schemas/crew-billing-events"
 import {
@@ -6,11 +7,16 @@ import {
   CREW_BILLING_STATE,
 } from "../../db/schemas/crew-event-settings"
 import {
+  MANUAL_CREW_BILLING_ACTION,
   buildCrewBillingAuditEvent,
   buildCrewBillingSettingsPatch,
+  getCrewBillingLimit,
+  hasCrewBillingFeature,
   isCrewBillingDuplicateEntryError,
   normalizeCrewBillingState,
   planCrewBillingAuditAppend,
+  planManualCrewBillingAction,
+  resolveCrewBillingEntitlements,
 } from "./billing-state"
 
 describe("Crew billing state and audit helpers", () => {
@@ -38,8 +44,85 @@ describe("Crew billing state and audit helpers", () => {
       },
       founderOverride: false,
       creditCents: 0,
+      fullPlatformCreditCents: 0,
       refundedCents: 0,
     })
+  })
+
+  it("resolves Crew event access and limits from event billing state, not team subscriptions", () => {
+    expect(
+      resolveCrewBillingEntitlements({
+        state: CREW_BILLING_STATE.PAID,
+        planId: "crew_basic",
+      }),
+    ).toMatchObject({
+      hasCrewEventAccess: true,
+      reason: "active",
+      features: [
+        "crew_events",
+        "crew_imports",
+        "crew_confirmation_reminders",
+      ],
+      limits: {
+        max_crew_events: 1,
+        max_crew_volunteers_per_event: -1,
+        max_crew_email_sends_per_event: 500,
+        max_crew_imports_per_event: 5,
+      },
+    })
+
+    expect(
+      hasCrewBillingFeature(
+        { state: CREW_BILLING_STATE.COMPED, planId: "crew_starter" },
+        "crew_events",
+      ),
+    ).toBe(true)
+    expect(
+      getCrewBillingLimit(
+        { state: CREW_BILLING_STATE.COMPED, planId: "crew_starter" },
+        "max_crew_volunteers_per_event",
+      ),
+    ).toBe(50)
+    expect(
+      hasCrewBillingFeature(
+        { state: CREW_BILLING_STATE.PAID, planId: "crew_concierge" },
+        "crew_concierge",
+      ),
+    ).toBe(true)
+    expect(
+      getCrewBillingLimit(
+        { state: CREW_BILLING_STATE.PAID, planId: "crew_founding_2026" },
+        "max_crew_email_sends_per_event",
+      ),
+    ).toBe(2000)
+    expect(
+      resolveCrewBillingEntitlements({
+        state: CREW_BILLING_STATE.CREDITED,
+        planId: "crew_pro",
+      }).hasCrewEventAccess,
+    ).toBe(true)
+    expect(
+      resolveCrewBillingEntitlements({
+        state: CREW_BILLING_STATE.REFUNDED,
+        planId: "crew_pro",
+      }),
+    ).toMatchObject({
+      hasCrewEventAccess: false,
+      reason: "refunded",
+      features: [],
+      limits: {
+        max_crew_events: 0,
+        max_crew_volunteers_per_event: 0,
+        max_crew_email_sends_per_event: 0,
+        max_crew_imports_per_event: 0,
+      },
+    })
+    expect(
+      resolveCrewBillingEntitlements({
+        state: CREW_BILLING_STATE.UNPAID,
+        planId: "crew_pro",
+      }).reason,
+    ).toBe("unpaid")
   })
 
   it("builds manual sale audit events as event-scoped paid Crew purchases", () => {
@@ -66,6 +149,43 @@ describe("Crew billing state and audit helpers", () => {
       actorLabel: "Ops",
       publicNote: "paid by invoice",
     })
+  })
+
+  it("plans manual paid Concierge unlocks without Stripe or team plan mutation", () => {
+    const plan = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID,
+      competitionId: "comp_crew",
+      teamId: "team_owner",
+      planId: "crew_concierge",
+      amountCents: 300_000,
+      actorLabel: "Ops",
+      privateMetadata: { invoiceId: "inv_manual_1" },
+    })
+
+    expect(plan.action).toBe("append")
+    expect(plan.event).toMatchObject({
+      competitionId: "comp_crew",
+      teamId: "team_owner",
+      eventType: CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED,
+      billingState: CREW_BILLING_STATE.PAID,
+      billingSource: CREW_BILLING_SOURCE.MANUAL_SALES,
+      planId: "crew_concierge",
+      amountCents: 300_000,
+      stripePaymentLinkId: null,
+      stripeCheckoutSessionId: null,
+      stripePaymentIntentId: null,
+    })
+    expect(plan.settingsPatch).not.toHaveProperty("currentPlanId")
+    expect(
+      hasCrewBillingFeature(
+        {
+          state: plan.settingsPatch.crewBillingState,
+          source: plan.settingsPatch.crewBillingSource,
+          planId: plan.settingsPatch.crewBillingPlanId,
+        },
+        "crew_concierge",
+      ),
+    ).toBe(true)
   })
 
   it("keeps Payment Link and checkout Stripe references on the event state", () => {
@@ -154,6 +274,155 @@ describe("Crew billing state and audit helpers", () => {
         creditReason: "Migrated from concierge pilot.",
       },
     })
+  })
+
+  it("keeps founder grant pricing in server-only audit metadata", () => {
+    const plan = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT,
+      competitionId: "comp_founder",
+      teamId: "team_owner",
+      privateFounderPriceCents: 9900,
+      publicNote: "Founder grant applied",
+      privateMetadata: {
+        approvalNote: "Private launch approval",
+      },
+    })
+
+    expect(plan.event).toMatchObject({
+      eventType: CREW_BILLING_EVENT_TYPE.FOUNDER_OVERRIDE_APPLIED,
+      billingState: CREW_BILLING_STATE.PAID,
+      billingSource: CREW_BILLING_SOURCE.FOUNDER_OVERRIDE,
+      planId: "crew_founding_2026",
+      amountCents: 9900,
+      publicNote: "Founder grant applied",
+      privateMetadata: {
+        approvalNote: "Private launch approval",
+        founderGrant: {
+          privatePriceCents: 9900,
+        },
+      },
+    })
+    expect(buildCrewBillingSettingsPatch({}, plan.event)).toMatchObject({
+      crewFounderOverride: true,
+      crewBillingPlanId: "crew_founding_2026",
+    })
+
+    const publicGate = resolveCrewBillingEntitlements({
+      state: plan.settingsPatch.crewBillingState,
+      source: plan.settingsPatch.crewBillingSource,
+      planId: plan.settingsPatch.crewBillingPlanId,
+    })
+    expect(publicGate).not.toHaveProperty("privateMetadata")
+    expect(publicGate).not.toHaveProperty("amountCents")
+    expect(publicGate).not.toHaveProperty("stripe")
+  })
+
+  it("sets and applies full-platform upgrade credit at most once per event", () => {
+    const creditSet = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.SET_FULL_PLATFORM_CREDIT,
+      competitionId: "comp_credit",
+      teamId: "team_owner",
+      current: {
+        state: CREW_BILLING_STATE.PAID,
+        source: CREW_BILLING_SOURCE.MANUAL_SALES,
+        planId: "crew_pro",
+        amountCents: 80_000,
+      },
+      fullPlatformCreditCents: 25_000,
+      actorLabel: "Ops",
+    })
+
+    expect(creditSet).toMatchObject({
+      action: "append",
+      event: {
+        eventType: CREW_BILLING_EVENT_TYPE.CREDIT_SET,
+        billingState: CREW_BILLING_STATE.CREDITED,
+        billingSource: CREW_BILLING_SOURCE.CREW_CREDIT,
+        planId: "crew_pro",
+        creditCents: 25_000,
+        idempotencyKey: "full-platform-credit:set",
+      },
+      settingsPatch: {
+        crewCreditCents: 25_000,
+        fullPlatformCreditCents: 25_000,
+      },
+    })
+
+    const duplicateSet = planManualCrewBillingAction([creditSet.event], {
+      action: MANUAL_CREW_BILLING_ACTION.SET_FULL_PLATFORM_CREDIT,
+      competitionId: "comp_credit",
+      teamId: "team_owner",
+      current: {
+        state: CREW_BILLING_STATE.CREDITED,
+        planId: "crew_pro",
+        creditCents: 25_000,
+        fullPlatformCreditCents: 25_000,
+      },
+      fullPlatformCreditCents: 25_000,
+    })
+    expect(duplicateSet).toMatchObject({
+      action: "skip_duplicate",
+      settingsPatch: null,
+    })
+
+    expect(() =>
+      planManualCrewBillingAction(
+        [
+          {
+            eventType: CREW_BILLING_EVENT_TYPE.CREDIT_SET,
+            idempotencyKey: null,
+            creditCents: 25_000,
+          },
+        ],
+        {
+          action: MANUAL_CREW_BILLING_ACTION.SET_FULL_PLATFORM_CREDIT,
+          competitionId: "comp_credit",
+          teamId: "team_owner",
+          fullPlatformCreditCents: 25_000,
+        },
+      ),
+    ).toThrow(/already been set or applied/)
+
+    const creditApplied = planManualCrewBillingAction([creditSet.event], {
+      action: MANUAL_CREW_BILLING_ACTION.APPLY_FULL_PLATFORM_CREDIT,
+      competitionId: "comp_credit",
+      teamId: "team_owner",
+      current: {
+        state: CREW_BILLING_STATE.CREDITED,
+        source: CREW_BILLING_SOURCE.CREW_CREDIT,
+        planId: "crew_pro",
+        amountCents: 80_000,
+        creditCents: 25_000,
+        fullPlatformCreditCents: 25_000,
+      },
+    })
+
+    expect(creditApplied).toMatchObject({
+      action: "append",
+      event: {
+        eventType: CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED,
+        billingState: CREW_BILLING_STATE.PAID,
+        billingSource: CREW_BILLING_SOURCE.CREW_CREDIT,
+        creditCents: 25_000,
+        idempotencyKey: "full-platform-credit:apply",
+      },
+    })
+
+    const duplicateApply = planManualCrewBillingAction(
+      [creditSet.event, creditApplied.event],
+      {
+        action: MANUAL_CREW_BILLING_ACTION.APPLY_FULL_PLATFORM_CREDIT,
+        competitionId: "comp_credit",
+        teamId: "team_owner",
+        current: {
+          state: CREW_BILLING_STATE.PAID,
+          planId: "crew_pro",
+          creditCents: 25_000,
+          fullPlatformCreditCents: 25_000,
+        },
+      },
+    )
+    expect(duplicateApply.action).toBe("skip_duplicate")
   })
 
   it("records comped and refunded terminal states without mutating audit history", () => {

--- a/apps/crew/src/lib/crew/billing-state.test.ts
+++ b/apps/crew/src/lib/crew/billing-state.test.ts
@@ -188,6 +188,79 @@ describe("Crew billing state and audit helpers", () => {
     ).toBe(true)
   })
 
+  it("rejects manual paid actions without a valid plan and positive amount", () => {
+    const validManualPaidInput = {
+      action: MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID,
+      competitionId: "comp_crew",
+      teamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+    } as const
+    const unsafeManualPaidInput = (overrides: Record<string, unknown>) =>
+      ({
+        ...validManualPaidInput,
+        ...overrides,
+      }) as unknown as Parameters<typeof planManualCrewBillingAction>[1]
+    const unsafeManualPaidInputWithout = (
+      key: "planId" | "amountCents",
+    ) => {
+      const input = { ...validManualPaidInput } as Record<string, unknown>
+      delete input[key]
+      return input as unknown as Parameters<typeof planManualCrewBillingAction>[1]
+    }
+
+    expect(() =>
+      planManualCrewBillingAction(
+        [],
+        unsafeManualPaidInputWithout("planId"),
+      ),
+    ).toThrow(/valid Crew plan/)
+    expect(() =>
+      planManualCrewBillingAction(
+        [],
+        unsafeManualPaidInput({ planId: "team_pro" }),
+      ),
+    ).toThrow(/valid Crew plan/)
+    expect(() =>
+      planManualCrewBillingAction(
+        [],
+        unsafeManualPaidInputWithout("amountCents"),
+      ),
+    ).toThrow(/positive amount/)
+    expect(() =>
+      planManualCrewBillingAction([], {
+        ...validManualPaidInput,
+        amountCents: 0,
+      }),
+    ).toThrow(/positive amount/)
+    expect(() =>
+      planManualCrewBillingAction([], {
+        ...validManualPaidInput,
+        amountCents: -100,
+      }),
+    ).toThrow(/positive amount/)
+  })
+
+  it("rejects direct manual sale audit appends with incomplete paid purchase data", () => {
+    expect(() =>
+      planCrewBillingAuditAppend([], {
+        competitionId: "comp_crew",
+        teamId: "team_owner",
+        eventType: CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED,
+        amountCents: 20_000,
+      }),
+    ).toThrow(/valid Crew plan/)
+    expect(() =>
+      planCrewBillingAuditAppend([], {
+        competitionId: "comp_crew",
+        teamId: "team_owner",
+        eventType: CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED,
+        planId: "crew_basic",
+        amountCents: 0,
+      }),
+    ).toThrow(/positive amount/)
+  })
+
   it("keeps Payment Link and checkout Stripe references on the event state", () => {
     const paymentLink = buildCrewBillingAuditEvent({
       competitionId: "comp_crew",
@@ -478,6 +551,8 @@ describe("Crew billing state and audit helpers", () => {
       competitionId: "comp_crew",
       teamId: "team_owner",
       eventType: CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED,
+      planId: "crew_basic",
+      amountCents: 20_000,
       publicNote: "Operator correction note.",
     })
 

--- a/apps/crew/src/lib/crew/billing-state.ts
+++ b/apps/crew/src/lib/crew/billing-state.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Crew Billing State And Audit]]
+// @lat: [[crew#Manual Paid And Founder Grants]]
 import {
   CREW_BILLING_EVENT_TYPE,
   type CrewBillingEventType,
@@ -20,6 +21,38 @@ export const crewBillingPlanIds = [
 
 export type CrewBillingPlanId = (typeof crewBillingPlanIds)[number]
 
+export const crewBillingFeatureKeys = [
+  "crew_events",
+  "crew_imports",
+  "crew_confirmation_reminders",
+  "crew_department_leads",
+  "crew_exports",
+  "crew_concierge",
+] as const
+
+export type CrewBillingFeatureKey = (typeof crewBillingFeatureKeys)[number]
+
+export const crewBillingLimitKeys = [
+  "max_crew_events",
+  "max_crew_volunteers_per_event",
+  "max_crew_email_sends_per_event",
+  "max_crew_imports_per_event",
+] as const
+
+export type CrewBillingLimitKey = (typeof crewBillingLimitKeys)[number]
+
+export const MANUAL_CREW_BILLING_ACTION = {
+  RECORD_MANUAL_PAID: "record_manual_paid",
+  APPLY_FOUNDER_GRANT: "apply_founder_grant",
+  SET_FULL_PLATFORM_CREDIT: "set_full_platform_credit",
+  APPLY_FULL_PLATFORM_CREDIT: "apply_full_platform_credit",
+  COMP_EVENT: "comp_event",
+  RECORD_REFUND: "record_refund",
+} as const
+
+export type ManualCrewBillingActionType =
+  (typeof MANUAL_CREW_BILLING_ACTION)[keyof typeof MANUAL_CREW_BILLING_ACTION]
+
 export interface CrewBillingStripeRefs {
   paymentLinkId: string | null
   checkoutSessionId: string | null
@@ -35,6 +68,7 @@ export interface CrewBillingStateSnapshot {
   stripe: CrewBillingStripeRefs
   founderOverride: boolean
   creditCents: number
+  fullPlatformCreditCents: number
   refundedCents: number
 }
 
@@ -58,6 +92,13 @@ export interface BuildCrewBillingEventInput {
   privateMetadata?: Record<string, unknown> | null
 }
 
+export interface PlanManualCrewBillingActionInput
+  extends Omit<BuildCrewBillingEventInput, "eventType" | "creditCents"> {
+  action: ManualCrewBillingActionType
+  fullPlatformCreditCents?: number | null
+  privateFounderPriceCents?: number | null
+}
+
 export interface CrewBillingAuditEvent {
   competitionId: string
   teamId: string
@@ -78,6 +119,12 @@ export interface CrewBillingAuditEvent {
   publicNote: string | null
   privateMetadata: Record<string, unknown> | null
 }
+
+export type CrewBillingExistingAuditEvent = Pick<
+  CrewBillingAuditEvent,
+  "eventType" | "idempotencyKey"
+> &
+  Partial<Pick<CrewBillingAuditEvent, "creditCents">>
 
 export type CrewBillingAppendPlan =
   | {
@@ -102,7 +149,103 @@ export interface CrewBillingSettingsPatch {
   crewStripePaymentIntentId: string | null
   crewFounderOverride: boolean
   crewCreditCents: number
+  fullPlatformCreditCents: number
   crewRefundedCents: number
+}
+
+export interface CrewBillingPlanEntitlements {
+  features: CrewBillingFeatureKey[]
+  limits: Record<CrewBillingLimitKey, number>
+}
+
+export interface CrewBillingEntitlementResolution
+  extends CrewBillingPlanEntitlements {
+  planId: CrewBillingPlanId | null
+  billingState: CrewBillingState
+  billingSource: CrewBillingSource | null
+  hasCrewEventAccess: boolean
+  reason: "active" | "no_plan" | "unpaid" | "pending" | "refunded"
+}
+
+const emptyCrewBillingLimits: Record<CrewBillingLimitKey, number> = {
+  max_crew_events: 0,
+  max_crew_volunteers_per_event: 0,
+  max_crew_email_sends_per_event: 0,
+  max_crew_imports_per_event: 0,
+}
+
+const crewBillingPlanEntitlements: Record<
+  CrewBillingPlanId,
+  CrewBillingPlanEntitlements
+> = {
+  crew_starter: {
+    features: ["crew_events"],
+    limits: {
+      max_crew_events: 1,
+      max_crew_volunteers_per_event: 50,
+      max_crew_email_sends_per_event: 0,
+      max_crew_imports_per_event: 0,
+    },
+  },
+  crew_basic: {
+    features: [
+      "crew_events",
+      "crew_imports",
+      "crew_confirmation_reminders",
+    ],
+    limits: {
+      max_crew_events: 1,
+      max_crew_volunteers_per_event: -1,
+      max_crew_email_sends_per_event: 500,
+      max_crew_imports_per_event: 5,
+    },
+  },
+  crew_pro: {
+    features: [
+      "crew_events",
+      "crew_imports",
+      "crew_confirmation_reminders",
+      "crew_department_leads",
+      "crew_exports",
+    ],
+    limits: {
+      max_crew_events: 3,
+      max_crew_volunteers_per_event: -1,
+      max_crew_email_sends_per_event: 2000,
+      max_crew_imports_per_event: -1,
+    },
+  },
+  crew_concierge: {
+    features: [
+      "crew_events",
+      "crew_imports",
+      "crew_confirmation_reminders",
+      "crew_department_leads",
+      "crew_exports",
+      "crew_concierge",
+    ],
+    limits: {
+      max_crew_events: -1,
+      max_crew_volunteers_per_event: -1,
+      max_crew_email_sends_per_event: -1,
+      max_crew_imports_per_event: -1,
+    },
+  },
+  crew_founding_2026: {
+    features: [
+      "crew_events",
+      "crew_imports",
+      "crew_confirmation_reminders",
+      "crew_department_leads",
+      "crew_exports",
+    ],
+    limits: {
+      max_crew_events: 1,
+      max_crew_volunteers_per_event: -1,
+      max_crew_email_sends_per_event: 2000,
+      max_crew_imports_per_event: -1,
+    },
+  },
 }
 
 const eventDefaults: Record<
@@ -159,8 +302,51 @@ export function normalizeCrewBillingState(
     },
     founderOverride: input.founderOverride === true,
     creditCents: normalizeCents(input.creditCents),
+    fullPlatformCreditCents: normalizeCents(input.fullPlatformCreditCents),
     refundedCents: normalizeCents(input.refundedCents),
   }
+}
+
+export function resolveCrewBillingEntitlements(
+  input: Partial<CrewBillingStateSnapshot> = {},
+): CrewBillingEntitlementResolution {
+  const current = normalizeCrewBillingState(input)
+  const planEntitlements = current.planId
+    ? crewBillingPlanEntitlements[current.planId]
+    : null
+  const reason = resolveCrewBillingAccessReason(current)
+  const hasCrewEventAccess =
+    reason === "active" &&
+    Boolean(planEntitlements?.features.includes("crew_events"))
+
+  return {
+    planId: current.planId,
+    billingState: current.state,
+    billingSource: current.source,
+    hasCrewEventAccess,
+    reason,
+    features:
+      hasCrewEventAccess && planEntitlements
+        ? [...planEntitlements.features]
+        : [],
+    limits: hasCrewEventAccess
+      ? { ...(planEntitlements?.limits ?? emptyCrewBillingLimits) }
+      : { ...emptyCrewBillingLimits },
+  }
+}
+
+export function hasCrewBillingFeature(
+  input: Partial<CrewBillingStateSnapshot>,
+  feature: CrewBillingFeatureKey,
+) {
+  return resolveCrewBillingEntitlements(input).features.includes(feature)
+}
+
+export function getCrewBillingLimit(
+  input: Partial<CrewBillingStateSnapshot>,
+  limit: CrewBillingLimitKey,
+) {
+  return resolveCrewBillingEntitlements(input).limits[limit] ?? 0
 }
 
 export function buildCrewBillingAuditEvent(
@@ -199,7 +385,7 @@ export function buildCrewBillingAuditEvent(
     currency: normalizeCurrency(input.currency ?? current.currency),
     creditCents:
       input.creditCents === undefined || input.creditCents === null
-        ? current.creditCents
+        ? current.creditCents || current.fullPlatformCreditCents
         : normalizeCents(input.creditCents),
     refundedCents:
       input.refundedCents === undefined || input.refundedCents === null
@@ -208,7 +394,7 @@ export function buildCrewBillingAuditEvent(
     stripePaymentLinkId: stripe.paymentLinkId,
     stripeCheckoutSessionId: stripe.checkoutSessionId,
     stripePaymentIntentId: stripe.paymentIntentId,
-    idempotencyKey: normalizeOptionalText(input.idempotencyKey),
+    idempotencyKey: normalizeCrewBillingIdempotencyKey(input),
     actorUserId: normalizeOptionalText(input.actorUserId),
     actorLabel: normalizeOptionalText(input.actorLabel),
     publicNote: normalizeOptionalText(input.publicNote),
@@ -236,14 +422,17 @@ export function buildCrewBillingSettingsPatch(
     crewStripePaymentIntentId: event.stripePaymentIntentId,
     crewFounderOverride: isFounderOverride,
     crewCreditCents: event.creditCents,
+    fullPlatformCreditCents:
+      event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET ||
+      event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED
+        ? event.creditCents
+        : normalized.fullPlatformCreditCents,
     crewRefundedCents: event.refundedCents,
   }
 }
 
 export function planCrewBillingAuditAppend(
-  existingEvents: Array<
-    Pick<CrewBillingAuditEvent, "eventType" | "idempotencyKey">
-  >,
+  existingEvents: CrewBillingExistingAuditEvent[],
   input: BuildCrewBillingEventInput,
 ): CrewBillingAppendPlan {
   const event = buildCrewBillingAuditEvent(input)
@@ -263,6 +452,8 @@ export function planCrewBillingAuditAppend(
     }
   }
 
+  validateCrewBillingAuditAppend(existingEvents, input.current ?? {}, event)
+
   return {
     action: "append",
     event,
@@ -270,7 +461,17 @@ export function planCrewBillingAuditAppend(
   }
 }
 
-export function isCrewBillingDuplicateEntryError(error: unknown) {
+export function planManualCrewBillingAction(
+  existingEvents: CrewBillingExistingAuditEvent[],
+  input: PlanManualCrewBillingActionInput,
+): CrewBillingAppendPlan {
+  return planCrewBillingAuditAppend(
+    existingEvents,
+    buildManualCrewBillingActionInput(input),
+  )
+}
+
+export function isCrewBillingDuplicateEntryError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false
 
   const candidate = error as {
@@ -305,6 +506,22 @@ function normalizeBillingSource(source: unknown): CrewBillingSource {
   throw new Error("Invalid Crew billing source")
 }
 
+function resolveCrewBillingAccessReason(
+  current: CrewBillingStateSnapshot,
+): CrewBillingEntitlementResolution["reason"] {
+  if (!current.planId) return "no_plan"
+  if (current.state === CREW_BILLING_STATE.REFUNDED) return "refunded"
+  if (current.state === CREW_BILLING_STATE.PENDING) return "pending"
+  if (
+    current.state === CREW_BILLING_STATE.PAID ||
+    current.state === CREW_BILLING_STATE.COMPED ||
+    current.state === CREW_BILLING_STATE.CREDITED
+  ) {
+    return "active"
+  }
+  return "unpaid"
+}
+
 function normalizeCrewBillingPlanId(planId: unknown): CrewBillingPlanId | null {
   const normalized = normalizeOptionalText(planId)
   if (!normalized) return null
@@ -317,6 +534,21 @@ function normalizeCrewBillingPlanId(planId: unknown): CrewBillingPlanId | null {
 function normalizeCents(value: unknown) {
   if (typeof value !== "number" || !Number.isFinite(value)) return 0
   return Math.max(0, Math.round(value))
+}
+
+function normalizeCrewBillingIdempotencyKey(
+  input: BuildCrewBillingEventInput,
+) {
+  if (input.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET) {
+    return "full-platform-credit:set"
+  }
+  if (input.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED) {
+    return "full-platform-credit:apply"
+  }
+  if (input.eventType === CREW_BILLING_EVENT_TYPE.FOUNDER_OVERRIDE_APPLIED) {
+    return normalizeOptionalText(input.idempotencyKey) ?? "founder-grant"
+  }
+  return normalizeOptionalText(input.idempotencyKey)
 }
 
 function normalizeCurrency(value: unknown) {
@@ -335,4 +567,155 @@ function normalizePrivateMetadata(metadata: unknown) {
     return null
   }
   return metadata as Record<string, unknown>
+}
+
+function validateCrewBillingAuditAppend(
+  existingEvents: CrewBillingExistingAuditEvent[],
+  current: Partial<CrewBillingStateSnapshot>,
+  event: CrewBillingAuditEvent,
+) {
+  const normalized = normalizeCrewBillingState(current)
+
+  if (event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET) {
+    if (
+      normalized.creditCents > 0 ||
+      normalized.fullPlatformCreditCents > 0 ||
+      existingEvents.some(isCrewCreditEvent)
+    ) {
+      throw new Error(
+        "Full platform upgrade credit has already been set or applied for this Crew event.",
+      )
+    }
+    if (event.creditCents <= 0) {
+      throw new Error("Full platform upgrade credit must be greater than zero.")
+    }
+  }
+
+  if (event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED) {
+    if (
+      existingEvents.some(
+        (existing) =>
+          existing.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED,
+      )
+    ) {
+      throw new Error(
+        "Full platform upgrade credit has already been applied for this Crew event.",
+      )
+    }
+    if (
+      event.creditCents <= 0 &&
+      normalized.creditCents <= 0 &&
+      normalized.fullPlatformCreditCents <= 0
+    ) {
+      throw new Error(
+        "Set a full platform upgrade credit before applying it.",
+      )
+    }
+  }
+}
+
+function isCrewCreditEvent(event: CrewBillingExistingAuditEvent) {
+  return (
+    event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET ||
+    event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED
+  )
+}
+
+function buildManualCrewBillingActionInput(
+  input: PlanManualCrewBillingActionInput,
+): BuildCrewBillingEventInput {
+  const current = normalizeCrewBillingState(input.current)
+  const fullPlatformCreditCents =
+    normalizeCents(input.fullPlatformCreditCents) ||
+    current.creditCents ||
+    current.fullPlatformCreditCents
+  const common = {
+    competitionId: input.competitionId,
+    teamId: input.teamId,
+    current,
+    currency: input.currency,
+    actorUserId: input.actorUserId,
+    actorLabel: input.actorLabel,
+    publicNote: input.publicNote,
+    privateMetadata: input.privateMetadata,
+  }
+
+  switch (input.action) {
+    case MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID:
+      return {
+        ...common,
+        eventType: CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED,
+        planId: input.planId,
+        amountCents: input.amountCents,
+        idempotencyKey: input.idempotencyKey,
+      }
+    case MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT:
+      return {
+        ...common,
+        eventType: CREW_BILLING_EVENT_TYPE.FOUNDER_OVERRIDE_APPLIED,
+        planId: "crew_founding_2026",
+        amountCents: input.privateFounderPriceCents ?? input.amountCents,
+        idempotencyKey: input.idempotencyKey,
+        privateMetadata: mergePrivateMetadata(input.privateMetadata, {
+          founderGrant: {
+            privatePriceCents: normalizeCents(
+              input.privateFounderPriceCents ?? input.amountCents,
+            ),
+          },
+        }),
+      }
+    case MANUAL_CREW_BILLING_ACTION.SET_FULL_PLATFORM_CREDIT:
+      return {
+        ...common,
+        eventType: CREW_BILLING_EVENT_TYPE.CREDIT_SET,
+        planId: input.planId ?? current.planId,
+        creditCents: input.fullPlatformCreditCents,
+        idempotencyKey: input.idempotencyKey,
+        privateMetadata: mergePrivateMetadata(input.privateMetadata, {
+          fullPlatformCreditCents: normalizeCents(
+            input.fullPlatformCreditCents,
+          ),
+        }),
+      }
+    case MANUAL_CREW_BILLING_ACTION.APPLY_FULL_PLATFORM_CREDIT:
+      return {
+        ...common,
+        eventType: CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED,
+        planId: input.planId ?? current.planId,
+        amountCents: input.amountCents ?? current.amountCents,
+        creditCents: fullPlatformCreditCents,
+        idempotencyKey: input.idempotencyKey,
+        privateMetadata: mergePrivateMetadata(input.privateMetadata, {
+          fullPlatformCreditCents,
+        }),
+      }
+    case MANUAL_CREW_BILLING_ACTION.COMP_EVENT:
+      return {
+        ...common,
+        eventType: CREW_BILLING_EVENT_TYPE.EVENT_COMPED,
+        planId: input.planId ?? current.planId ?? "crew_starter",
+        amountCents: 0,
+        idempotencyKey: input.idempotencyKey,
+      }
+    case MANUAL_CREW_BILLING_ACTION.RECORD_REFUND:
+      return {
+        ...common,
+        eventType: CREW_BILLING_EVENT_TYPE.REFUND_RECORDED,
+        planId: input.planId ?? current.planId,
+        amountCents: input.amountCents ?? current.amountCents,
+        refundedCents: input.refundedCents ?? current.amountCents,
+        idempotencyKey: input.idempotencyKey,
+        stripePaymentIntentId: input.stripePaymentIntentId,
+      }
+  }
+}
+
+function mergePrivateMetadata(
+  current: Record<string, unknown> | null | undefined,
+  next: Record<string, unknown>,
+) {
+  return {
+    ...(normalizePrivateMetadata(current) ?? {}),
+    ...next,
+  }
 }

--- a/apps/crew/src/lib/crew/billing-state.ts
+++ b/apps/crew/src/lib/crew/billing-state.ts
@@ -92,12 +92,25 @@ export interface BuildCrewBillingEventInput {
   privateMetadata?: Record<string, unknown> | null
 }
 
-export interface PlanManualCrewBillingActionInput
+interface BasePlanManualCrewBillingActionInput
   extends Omit<BuildCrewBillingEventInput, "eventType" | "creditCents"> {
   action: ManualCrewBillingActionType
   fullPlatformCreditCents?: number | null
   privateFounderPriceCents?: number | null
 }
+
+export type PlanManualCrewBillingActionInput =
+  | (BasePlanManualCrewBillingActionInput & {
+      action: typeof MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID
+      planId: CrewBillingPlanId
+      amountCents: number
+    })
+  | (BasePlanManualCrewBillingActionInput & {
+      action: Exclude<
+        ManualCrewBillingActionType,
+        typeof MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID
+      >
+    })
 
 export interface CrewBillingAuditEvent {
   competitionId: string
@@ -536,9 +549,23 @@ function normalizeCents(value: unknown) {
   return Math.max(0, Math.round(value))
 }
 
-function normalizeCrewBillingIdempotencyKey(
-  input: BuildCrewBillingEventInput,
-) {
+function requireManualPaidPlanId(planId: unknown) {
+  try {
+    const normalized = normalizeCrewBillingPlanId(planId)
+    if (normalized) return normalized
+  } catch {
+    // Fall through to the manual-paid boundary error below.
+  }
+  throw new Error("Manual paid Crew billing requires a valid Crew plan.")
+}
+
+function requireManualPaidAmountCents(amountCents: unknown) {
+  const normalized = normalizeCents(amountCents)
+  if (normalized > 0) return normalized
+  throw new Error("Manual paid Crew billing requires a positive amount.")
+}
+
+function normalizeCrewBillingIdempotencyKey(input: BuildCrewBillingEventInput) {
   if (input.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET) {
     return "full-platform-credit:set"
   }
@@ -575,6 +602,15 @@ function validateCrewBillingAuditAppend(
   event: CrewBillingAuditEvent,
 ) {
   const normalized = normalizeCrewBillingState(current)
+
+  if (event.eventType === CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED) {
+    if (!event.planId) {
+      throw new Error("Manual paid Crew billing requires a valid Crew plan.")
+    }
+    if (event.amountCents <= 0) {
+      throw new Error("Manual paid Crew billing requires a positive amount.")
+    }
+  }
 
   if (event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET) {
     if (
@@ -645,8 +681,8 @@ function buildManualCrewBillingActionInput(
       return {
         ...common,
         eventType: CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED,
-        planId: input.planId,
-        amountCents: input.amountCents,
+        planId: requireManualPaidPlanId(input.planId),
+        amountCents: requireManualPaidAmountCents(input.amountCents),
         idempotencyKey: input.idempotencyKey,
       }
     case MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT:

--- a/apps/crew/src/routes/events/$eventId/setup.tsx
+++ b/apps/crew/src/routes/events/$eventId/setup.tsx
@@ -91,9 +91,6 @@ function EventSetupPage() {
     event.settings.conciergeStatus,
   )
   const [crewPlan, setCrewPlan] = useState(event.settings.crewPlan)
-  const [fullPlatformCreditCents, setFullPlatformCreditCents] = useState(
-    String(event.settings.fullPlatformCreditCents),
-  )
   const [acquisitionSource, setAcquisitionSource] = useState(
     event.settings.acquisitionSource ?? "",
   )
@@ -108,7 +105,6 @@ function EventSetupPage() {
     setLifecycle(event.settings.lifecycle)
     setConciergeStatus(event.settings.conciergeStatus)
     setCrewPlan(event.settings.crewPlan)
-    setFullPlatformCreditCents(String(event.settings.fullPlatformCreditCents))
     setAcquisitionSource(event.settings.acquisitionSource ?? "")
     setSetup(nextSettings.setup)
   }, [event])
@@ -128,7 +124,6 @@ function EventSetupPage() {
           lifecycle,
           conciergeStatus,
           crewPlan,
-          fullPlatformCreditCents: Number(fullPlatformCreditCents || 0),
           acquisitionSource,
           settings: serializeCrewSettings(event.settings.settings, setup),
         },
@@ -423,21 +418,6 @@ function EventSetupPage() {
                   <option value="concierge">Concierge</option>
                   <option value="full_platform">Full platform</option>
                 </select>
-              </Field>
-              <Field
-                label="Full platform credit cents"
-                htmlFor="crew-settings-credit-cents"
-              >
-                <input
-                  id="crew-settings-credit-cents"
-                  type="number"
-                  min="0"
-                  value={fullPlatformCreditCents}
-                  onChange={(changeEvent) =>
-                    setFullPlatformCreditCents(changeEvent.target.value)
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
               </Field>
             </div>
           </section>

--- a/apps/crew/src/server-fns/crew-billing-fns.ts
+++ b/apps/crew/src/server-fns/crew-billing-fns.ts
@@ -6,6 +6,7 @@ import { CREW_BILLING_EVENT_TYPE } from "../db/schemas/crew-billing-events"
 import {
   MANUAL_CREW_BILLING_ACTION,
   crewBillingPlanIds,
+  type ManualCrewBillingActionType,
 } from "../lib/crew/billing-state"
 
 export type { CrewBillingPageData } from "../server/crew-billing.server"
@@ -23,15 +24,6 @@ const crewBillingEventTypeSchema = z.enum([
   CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED,
   CREW_BILLING_EVENT_TYPE.REFUND_RECORDED,
   CREW_BILLING_EVENT_TYPE.EVENT_COMPED,
-])
-
-const manualCrewBillingActionSchema = z.enum([
-  MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID,
-  MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT,
-  MANUAL_CREW_BILLING_ACTION.SET_FULL_PLATFORM_CREDIT,
-  MANUAL_CREW_BILLING_ACTION.APPLY_FULL_PLATFORM_CREDIT,
-  MANUAL_CREW_BILLING_ACTION.COMP_EVENT,
-  MANUAL_CREW_BILLING_ACTION.RECORD_REFUND,
 ])
 
 const crewBillingPlanIdSchema = z.enum(crewBillingPlanIds)
@@ -60,15 +52,19 @@ const recordCrewBillingEventInputSchema = getCrewBillingInputSchema.extend({
   privateMetadata: privateMetadataSchema.optional(),
 })
 
-const recordManualCrewBillingActionInputSchema =
+const optionalManualCrewBillingAmountSchema = z
+  .number()
+  .int()
+  .min(0)
+  .nullable()
+  .optional()
+
+const recordManualCrewBillingActionBaseInputSchema =
   getCrewBillingInputSchema.extend({
-    action: manualCrewBillingActionSchema,
-    planId: crewBillingPlanIdSchema.nullable().optional(),
-    amountCents: z.number().int().min(0).nullable().optional(),
     currency: nullableTextSchema,
-    fullPlatformCreditCents: z.number().int().min(0).nullable().optional(),
-    privateFounderPriceCents: z.number().int().min(0).nullable().optional(),
-    refundedCents: z.number().int().min(0).nullable().optional(),
+    fullPlatformCreditCents: optionalManualCrewBillingAmountSchema,
+    privateFounderPriceCents: optionalManualCrewBillingAmountSchema,
+    refundedCents: optionalManualCrewBillingAmountSchema,
     stripePaymentIntentId: nullableTextSchema,
     idempotencyKey: nullableTextSchema,
     actorUserId: nullableTextSchema,
@@ -76,6 +72,47 @@ const recordManualCrewBillingActionInputSchema =
     publicNote: nullableTextSchema,
     privateMetadata: privateMetadataSchema.optional(),
   })
+
+const optionalManualCrewBillingActionInputSchema = (
+  action: Exclude<
+    ManualCrewBillingActionType,
+    typeof MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID
+  >,
+) =>
+  recordManualCrewBillingActionBaseInputSchema.extend({
+    action: z.literal(action),
+    planId: crewBillingPlanIdSchema.nullable().optional(),
+    amountCents: optionalManualCrewBillingAmountSchema,
+  })
+
+const recordManualCrewBillingActionInputSchema = z.discriminatedUnion(
+  "action",
+  [
+    recordManualCrewBillingActionBaseInputSchema.extend({
+      action: z.literal(MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID),
+      planId: crewBillingPlanIdSchema,
+      amountCents: z
+        .number()
+        .int()
+        .positive("Manual paid Crew billing requires a positive amount."),
+    }),
+    optionalManualCrewBillingActionInputSchema(
+      MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT,
+    ),
+    optionalManualCrewBillingActionInputSchema(
+      MANUAL_CREW_BILLING_ACTION.SET_FULL_PLATFORM_CREDIT,
+    ),
+    optionalManualCrewBillingActionInputSchema(
+      MANUAL_CREW_BILLING_ACTION.APPLY_FULL_PLATFORM_CREDIT,
+    ),
+    optionalManualCrewBillingActionInputSchema(
+      MANUAL_CREW_BILLING_ACTION.COMP_EVENT,
+    ),
+    optionalManualCrewBillingActionInputSchema(
+      MANUAL_CREW_BILLING_ACTION.RECORD_REFUND,
+    ),
+  ],
+)
 
 export const getCrewBillingPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => getCrewBillingInputSchema.parse(data))

--- a/apps/crew/src/server-fns/crew-billing-fns.ts
+++ b/apps/crew/src/server-fns/crew-billing-fns.ts
@@ -1,0 +1,109 @@
+// @lat: [[crew#Server Function Runtime Boundary]]
+// @lat: [[crew#Manual Paid And Founder Grants]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import { CREW_BILLING_EVENT_TYPE } from "../db/schemas/crew-billing-events"
+import {
+  MANUAL_CREW_BILLING_ACTION,
+  crewBillingPlanIds,
+} from "../lib/crew/billing-state"
+
+export type { CrewBillingPageData } from "../server/crew-billing.server"
+
+const getCrewBillingInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+const crewBillingEventTypeSchema = z.enum([
+  CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED,
+  CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED,
+  CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED,
+  CREW_BILLING_EVENT_TYPE.FOUNDER_OVERRIDE_APPLIED,
+  CREW_BILLING_EVENT_TYPE.CREDIT_SET,
+  CREW_BILLING_EVENT_TYPE.CREDIT_APPLIED,
+  CREW_BILLING_EVENT_TYPE.REFUND_RECORDED,
+  CREW_BILLING_EVENT_TYPE.EVENT_COMPED,
+])
+
+const manualCrewBillingActionSchema = z.enum([
+  MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID,
+  MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT,
+  MANUAL_CREW_BILLING_ACTION.SET_FULL_PLATFORM_CREDIT,
+  MANUAL_CREW_BILLING_ACTION.APPLY_FULL_PLATFORM_CREDIT,
+  MANUAL_CREW_BILLING_ACTION.COMP_EVENT,
+  MANUAL_CREW_BILLING_ACTION.RECORD_REFUND,
+])
+
+const crewBillingPlanIdSchema = z.enum(crewBillingPlanIds)
+const nullableTextSchema = z
+  .string()
+  .trim()
+  .transform((value) => (value.length > 0 ? value : null))
+  .nullable()
+  .optional()
+const privateMetadataSchema = z.record(z.string(), z.unknown()).nullable()
+
+const recordCrewBillingEventInputSchema = getCrewBillingInputSchema.extend({
+  eventType: crewBillingEventTypeSchema,
+  planId: crewBillingPlanIdSchema.nullable().optional(),
+  amountCents: z.number().int().min(0).nullable().optional(),
+  currency: nullableTextSchema,
+  creditCents: z.number().int().min(0).nullable().optional(),
+  refundedCents: z.number().int().min(0).nullable().optional(),
+  stripePaymentLinkId: nullableTextSchema,
+  stripeCheckoutSessionId: nullableTextSchema,
+  stripePaymentIntentId: nullableTextSchema,
+  idempotencyKey: nullableTextSchema,
+  actorUserId: nullableTextSchema,
+  actorLabel: nullableTextSchema,
+  publicNote: nullableTextSchema,
+  privateMetadata: privateMetadataSchema.optional(),
+})
+
+const recordManualCrewBillingActionInputSchema =
+  getCrewBillingInputSchema.extend({
+    action: manualCrewBillingActionSchema,
+    planId: crewBillingPlanIdSchema.nullable().optional(),
+    amountCents: z.number().int().min(0).nullable().optional(),
+    currency: nullableTextSchema,
+    fullPlatformCreditCents: z.number().int().min(0).nullable().optional(),
+    privateFounderPriceCents: z.number().int().min(0).nullable().optional(),
+    refundedCents: z.number().int().min(0).nullable().optional(),
+    stripePaymentIntentId: nullableTextSchema,
+    idempotencyKey: nullableTextSchema,
+    actorUserId: nullableTextSchema,
+    actorLabel: nullableTextSchema,
+    publicNote: nullableTextSchema,
+    privateMetadata: privateMetadataSchema.optional(),
+  })
+
+export const getCrewBillingPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => getCrewBillingInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { getCrewBillingPage } = await import("../server/crew-billing.server")
+    return getCrewBillingPage(data)
+  })
+
+export const recordCrewBillingEventFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    recordCrewBillingEventInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { recordCrewBillingEvent } = await import(
+      "../server/crew-billing.server"
+    )
+    return recordCrewBillingEvent(data)
+  })
+
+export const recordManualCrewBillingActionFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) =>
+    recordManualCrewBillingActionInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { recordManualCrewBillingAction } = await import(
+      "../server/crew-billing.server"
+    )
+    return recordManualCrewBillingAction(data)
+  })

--- a/apps/crew/src/server-fns/crew-event-settings-fns.ts
+++ b/apps/crew/src/server-fns/crew-event-settings-fns.ts
@@ -67,7 +67,6 @@ const updateCrewEventSettingsInputSchema = z.object({
   lifecycle: lifecycleSchema.optional(),
   conciergeStatus: conciergeStatusSchema.optional(),
   crewPlan: crewPlanSchema.optional(),
-  fullPlatformCreditCents: z.number().int().min(0).optional(),
   acquisitionSource: nullableTextInput,
   settings: nullableTextInput,
 })

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Crew Billing State And Audit]]
+// @lat: [[crew#Manual Paid And Founder Grants]]
 import { desc, eq } from "drizzle-orm"
 import { getDb } from "../db"
 import {
@@ -15,9 +16,12 @@ import {
 import { competitionsTable } from "../db/schemas/competitions"
 import {
   type CrewBillingAuditEvent,
+  type CrewBillingAppendPlan,
   isCrewBillingDuplicateEntryError,
+  type ManualCrewBillingActionType,
   normalizeCrewBillingState,
   planCrewBillingAuditAppend,
+  planManualCrewBillingAction,
   type CrewBillingPlanId,
   type CrewBillingStateSnapshot,
 } from "../lib/crew/billing-state"
@@ -44,6 +48,34 @@ export interface RecordCrewBillingEventInput extends GetCrewBillingInput {
   privateMetadata?: Record<string, unknown> | null
 }
 
+export interface RecordManualCrewBillingActionInput extends GetCrewBillingInput {
+  action: ManualCrewBillingActionType
+  planId?: string | null
+  amountCents?: number | null
+  currency?: string | null
+  fullPlatformCreditCents?: number | null
+  privateFounderPriceCents?: number | null
+  refundedCents?: number | null
+  stripePaymentIntentId?: string | null
+  idempotencyKey?: string | null
+  actorUserId?: string | null
+  actorLabel?: string | null
+  publicNote?: string | null
+  privateMetadata?: Record<string, unknown> | null
+}
+
+type CrewBillingJsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | CrewBillingJsonValue[]
+  | { [key: string]: CrewBillingJsonValue }
+
+type CrewBillingAuditEventRow = Omit<CrewBillingEvent, "privateMetadata"> & {
+  privateMetadata: Record<string, CrewBillingJsonValue> | null
+}
+
 export interface CrewBillingPageData {
   event: {
     id: string
@@ -52,7 +84,7 @@ export interface CrewBillingPageData {
     competitionTeamId: string | null
   }
   billing: CrewBillingStateSnapshot
-  auditEvents: CrewBillingEvent[]
+  auditEvents: CrewBillingAuditEventRow[]
 }
 
 type CrewBillingScope = CrewBillingPageData["event"] & {
@@ -66,6 +98,7 @@ type CrewBillingScope = CrewBillingPageData["event"] & {
   stripePaymentIntentId: string | null
   founderOverride: boolean
   creditCents: number
+  fullPlatformCreditCents: number
   refundedCents: number
 }
 
@@ -80,7 +113,7 @@ export async function getCrewBillingPage(
   return {
     event: toCrewBillingEventSummary(scope),
     billing: toCrewBillingSnapshot(scope),
-    auditEvents,
+    auditEvents: auditEvents.map(toCrewBillingAuditEventRow),
   }
 }
 
@@ -89,16 +122,46 @@ export async function recordCrewBillingEvent(
 ): Promise<CrewBillingPageData> {
   requireLocalCrewOperatorAccess("Crew billing")
 
-  const db = getDb()
   const scope = await requireCrewBillingScope(data.eventId)
   const current = toCrewBillingSnapshot(scope)
-  const appendPlan = planCrewBillingAuditAppend([], {
+  const existingEvents = await listCrewBillingEventsForEvent(data.eventId)
+  const appendPlan = planCrewBillingAuditAppend(existingEvents, {
     ...data,
     competitionId: data.eventId,
     teamId: scope.organizingTeamId,
     current,
   })
 
+  return persistCrewBillingAppend(data, appendPlan)
+}
+
+export async function recordManualCrewBillingAction(
+  data: RecordManualCrewBillingActionInput,
+): Promise<CrewBillingPageData> {
+  requireLocalCrewOperatorAccess("Crew billing")
+
+  const scope = await requireCrewBillingScope(data.eventId)
+  const current = toCrewBillingSnapshot(scope)
+  const existingEvents = await listCrewBillingEventsForEvent(data.eventId)
+  const appendPlan = planManualCrewBillingAction(existingEvents, {
+    ...data,
+    competitionId: data.eventId,
+    teamId: scope.organizingTeamId,
+    current,
+  })
+
+  return persistCrewBillingAppend(data, appendPlan)
+}
+
+async function persistCrewBillingAppend(
+  data: GetCrewBillingInput,
+  appendPlan: CrewBillingAppendPlan,
+) {
+  if (appendPlan.action === "skip_duplicate") {
+    return getCrewBillingPage(data)
+  }
+
+  const db = getDb()
   const { event, settingsPatch } = appendPlan
 
   try {
@@ -115,7 +178,7 @@ export async function recordCrewBillingEvent(
         .where(eq(crewEventSettingsTable.competitionId, data.eventId))
     })
   } catch (error) {
-    if (data.idempotencyKey && isCrewBillingDuplicateEntryError(error)) {
+    if (isCrewBillingDuplicateEntryError(error)) {
       return getCrewBillingPage(data)
     }
     throw error
@@ -145,6 +208,7 @@ async function requireCrewBillingScope(
       stripePaymentIntentId: crewEventSettingsTable.crewStripePaymentIntentId,
       founderOverride: crewEventSettingsTable.crewFounderOverride,
       creditCents: crewEventSettingsTable.crewCreditCents,
+      fullPlatformCreditCents: crewEventSettingsTable.fullPlatformCreditCents,
       refundedCents: crewEventSettingsTable.crewRefundedCents,
     })
     .from(crewEventSettingsTable)
@@ -197,6 +261,7 @@ function toCrewBillingSnapshot(scope: CrewBillingScope) {
     },
     founderOverride: scope.founderOverride,
     creditCents: scope.creditCents,
+    fullPlatformCreditCents: scope.fullPlatformCreditCents,
     refundedCents: scope.refundedCents,
   })
 }
@@ -224,4 +289,56 @@ function toNewCrewBillingEvent(
     publicNote: event.publicNote,
     privateMetadata: event.privateMetadata,
   }
+}
+
+function toCrewBillingAuditEventRow(
+  event: CrewBillingEvent,
+): CrewBillingAuditEventRow {
+  return {
+    ...event,
+    privateMetadata: toCrewBillingJsonObject(event.privateMetadata),
+  }
+}
+
+function toCrewBillingJsonObject(
+  value: unknown,
+): Record<string, CrewBillingJsonValue> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null
+  }
+
+  const output: Record<string, CrewBillingJsonValue> = {}
+  for (const [key, child] of Object.entries(value)) {
+    const jsonValue = toCrewBillingJsonValue(child)
+    if (jsonValue !== undefined) {
+      output[key] = jsonValue
+    }
+  }
+
+  return Object.keys(output).length > 0 ? output : null
+}
+
+function toCrewBillingJsonValue(
+  value: unknown,
+): CrewBillingJsonValue | undefined {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map(toCrewBillingJsonValue)
+      .filter((child): child is CrewBillingJsonValue => child !== undefined)
+  }
+
+  if (typeof value === "object") {
+    return toCrewBillingJsonObject(value) ?? {}
+  }
+
+  return undefined
 }

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -18,10 +18,10 @@ import {
   type CrewBillingAuditEvent,
   type CrewBillingAppendPlan,
   isCrewBillingDuplicateEntryError,
-  type ManualCrewBillingActionType,
   normalizeCrewBillingState,
   planCrewBillingAuditAppend,
   planManualCrewBillingAction,
+  type PlanManualCrewBillingActionInput,
   type CrewBillingPlanId,
   type CrewBillingStateSnapshot,
 } from "../lib/crew/billing-state"
@@ -48,21 +48,19 @@ export interface RecordCrewBillingEventInput extends GetCrewBillingInput {
   privateMetadata?: Record<string, unknown> | null
 }
 
-export interface RecordManualCrewBillingActionInput extends GetCrewBillingInput {
-  action: ManualCrewBillingActionType
-  planId?: string | null
-  amountCents?: number | null
-  currency?: string | null
-  fullPlatformCreditCents?: number | null
-  privateFounderPriceCents?: number | null
-  refundedCents?: number | null
-  stripePaymentIntentId?: string | null
-  idempotencyKey?: string | null
-  actorUserId?: string | null
-  actorLabel?: string | null
-  publicNote?: string | null
-  privateMetadata?: Record<string, unknown> | null
-}
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never
+
+export type RecordManualCrewBillingActionInput = GetCrewBillingInput &
+  DistributiveOmit<
+    PlanManualCrewBillingActionInput,
+    | "competitionId"
+    | "teamId"
+    | "current"
+    | "stripePaymentLinkId"
+    | "stripeCheckoutSessionId"
+  >
 
 type CrewBillingJsonValue =
   | string
@@ -337,7 +335,7 @@ function toCrewBillingJsonValue(
   }
 
   if (typeof value === "object") {
-    return toCrewBillingJsonObject(value) ?? {}
+    return toCrewBillingJsonObject(value) ?? undefined
   }
 
   return undefined

--- a/apps/crew/src/server/crew-event-settings.server.ts
+++ b/apps/crew/src/server/crew-event-settings.server.ts
@@ -80,7 +80,6 @@ interface UpdateCrewEventSettingsInput {
   lifecycle?: CrewEventLifecycle
   conciergeStatus?: CrewConciergeStatus
   crewPlan?: CrewPlan
-  fullPlatformCreditCents?: number
   acquisitionSource?: NullableTextInput
   settings?: NullableTextInput
 }
@@ -327,9 +326,6 @@ export async function updateCrewEventSettings(
     updateData.conciergeStatus = data.conciergeStatus
   }
   if (data.crewPlan !== undefined) updateData.crewPlan = data.crewPlan
-  if (data.fullPlatformCreditCents !== undefined) {
-    updateData.fullPlatformCreditCents = data.fullPlatformCreditCents
-  }
   if (data.acquisitionSource !== undefined) {
     updateData.acquisitionSource = data.acquisitionSource
   }

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -22,6 +22,16 @@ Crew event billing is stored on the event settings row and remains separate from
 
 [[apps/crew/src/server/crew-billing.server.ts]] keeps Crew billing read/write operations server-only and local-operator guarded. It scopes audit rows by competition and organizing team, appends audit rows before updating event settings, and does not mutate team subscription billing.
 
+## Manual Paid And Founder Grants
+
+Manual Crew paid states are private operator/server actions that assign an event-level Crew catalog plan, append a billing audit row, and patch only `crew_event_settings`.
+
+[[apps/crew/src/lib/crew/billing-state.ts]] resolves event-level Crew entitlements from the paid/comped/credited/refunded billing state plus the event plan ID. It mirrors the launch catalog limits for Starter, Basic, Pro, Concierge, and Founding grants without reading or writing `teams.currentPlanId`.
+
+[[apps/crew/src/server/crew-billing.server.ts]] and [[apps/crew/src/server-fns/crew-billing-fns.ts]] expose the local-operator-only manual paid, founder grant, comp, refund, and full-platform credit actions. Founder pricing, credit notes, invoices, and Stripe references stay in server-only audit rows/private metadata; public Crew or volunteer surfaces should consume only derived access/limit signals.
+
+Full-platform upgrade credit is single-use per Crew event. Setting or applying credit uses stable idempotency keys and rejects old credit audit rows without a tested reversal path.
+
 ## Server Function Runtime Boundary
 
 Route and client code import lightweight `createServerFn` wrappers from [[apps/crew/src/server-fns]].


### PR DESCRIPTION
## Summary

- Adds deterministic Crew event billing entitlement resolution for Starter, Basic, Pro, Concierge, and Founding event plans without reading or writing `teams.currentPlanId`.
- Adds private/local-operator manual billing actions for manual paid, founder grants, full-platform credit set/apply, comps, and refunds, with append-only `crew_billing_events` audit rows.
- Keeps founder pricing, credit notes, invoices, and Stripe refs server-only, and removes the setup form's generic `fullPlatformCreditCents` write path so upgrade credit must go through billing audit actions.
- Adds `crew#Manual Paid And Founder Grants` LAT coverage.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/billing-state.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew exec tsgo --ignoreConfig --noEmit src/server-fns/crew-billing-fns.ts --module ESNext --target ES2022 --moduleResolution bundler --jsx react-jsx --skipLibCheck --strict --types node,vite/client,@cloudflare/workers-types`
- `pnpm --filter crew lint` (exits 0; reports existing unrelated baseline warnings)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `pnpm check:schema-ownership`
- `pnpm dlx lat.md locate 'crew#Manual Paid And Founder Grants'`
- `git diff --check`

## Notes

- No schema or migrations in this slice; it uses the Crew billing state/audit model from #576.
- The fresh worktree needed an ignored local `apps/crew/.alchemy/local/wrangler.jsonc` for Vite/Alchemy build validation only; it is not part of the PR diff.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-only manual billing actions and deterministic event-level Crew entitlements for Starter, Basic, Pro, Concierge, and Founding plans without touching team subscriptions. Removes the client write path for full‑platform credit; all credits now flow through audited actions.

- **New Features**
  - Resolve event entitlements from billing state and `planId` (`crew_starter`, `crew_basic`, `crew_pro`, `crew_concierge`, `crew_founding_2026`), with features and limits.
  - Local-operator actions: record manual paid (now requires a valid Crew plan and positive amount), apply founder grant, set/apply full‑platform credit (single‑use, idempotent), comp, and refund; append-only `crew_billing_events`.
  - Server-only storage for founder pricing, credit notes, invoices, and Stripe refs; public surfaces consume derived access/limits only.
  - New guarded server fns: `getCrewBillingPageFn`, `recordCrewBillingEventFn`, `recordManualCrewBillingActionFn`.
  - Added tests for entitlements, manual actions, input validation, and credit idempotency.

- **Migration**
  - No schema changes.
  - Removed setting `fullPlatformCreditCents` from the setup form; operators must use the new billing actions.

<sup>Written for commit 526de9147a1551056e9318ec86fc2a2ec563156a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for manual crew billing actions including paid plans, founder grants, comping, refunds, and full-platform credit application.
  * Full-platform credit is now single-use per event with stable idempotency keys rejecting duplicate operations.
  * Billing entitlements now derived deterministically from billing state, mirroring catalog plan limits.

* **Documentation**
  * Added guidance on manual paid states and founder grant handling for operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->