### PR TITLE
[codex] feat(crew): add billing page and upgrade CTA

### DIFF
--- a/apps/crew/src/lib/crew/billing-page.test.ts
+++ b/apps/crew/src/lib/crew/billing-page.test.ts
@@ -127,6 +127,27 @@ describe("Crew billing page view model", () => {
     expect(comped.plan.hasCrewEventAccess).toBe(true)
   })
 
+  it("falls back to USD labels instead of throwing for malformed persisted currency", () => {
+    const viewModel = buildCrewBillingPageViewModel({
+      billing: {
+        ...baseBilling,
+        state: CREW_BILLING_STATE.PAID,
+        source: CREW_BILLING_SOURCE.MANUAL_SALES,
+        planId: "crew_pro",
+        amountCents: 49900,
+        currency: "not a currency",
+        fullPlatformCreditCents: 25000,
+        refundedCents: 5000,
+      },
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: false,
+    })
+
+    expect(viewModel.billing.amountLabel).toBe("$499.00")
+    expect(viewModel.billing.upgradeCreditLabel).toBe("$250.00")
+    expect(viewModel.billing.refundedLabel).toBe("$50.00")
+  })
+
   it("does not leak founder pricing, Stripe references, audit metadata, or invoices", () => {
     const viewModel = buildCrewBillingPageViewModel({
       billing: {

--- a/apps/crew/src/lib/crew/billing-page.test.ts
+++ b/apps/crew/src/lib/crew/billing-page.test.ts
@@ -1,0 +1,222 @@
+// @lat: [[crew#Billing Page And Upgrade CTA]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_BILLING_SOURCE,
+  CREW_BILLING_STATE,
+} from "../../db/schemas/crew-event-settings"
+import type { CrewBillingStateSnapshot } from "./billing-state"
+import {
+  buildCrewBillingPageViewModel,
+  canViewCrewBillingPage,
+} from "./billing-page"
+
+const baseBilling: CrewBillingStateSnapshot = {
+  state: CREW_BILLING_STATE.UNPAID,
+  source: null,
+  planId: null,
+  amountCents: 0,
+  currency: "usd",
+  stripe: {
+    paymentLinkId: null,
+    checkoutSessionId: null,
+    paymentIntentId: null,
+  },
+  founderOverride: false,
+  creditCents: 0,
+  fullPlatformCreditCents: 0,
+  refundedCents: 0,
+}
+
+describe("Crew billing page view model", () => {
+  it("shows an upgrade CTA and deferred Payment Link state when no URL exists", () => {
+    const viewModel = buildCrewBillingPageViewModel({
+      billing: baseBilling,
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: false,
+    })
+
+    expect(viewModel.upgradeCta.visible).toBe(true)
+    expect(viewModel.plan.hasCrewEventAccess).toBe(false)
+    expect(viewModel.paymentLink).toMatchObject({
+      status: "disabled",
+      href: null,
+      label: "Payment Link unavailable",
+    })
+    expect(viewModel.paymentLink.helperText).toContain("deferred")
+  })
+
+  it("enables a Payment Link button only when an organizer-safe URL exists", () => {
+    const viewModel = buildCrewBillingPageViewModel({
+      billing: {
+        ...baseBilling,
+        stripe: {
+          ...baseBilling.stripe,
+          paymentLinkId: "plink_123",
+        },
+      },
+      paymentLink: {
+        id: "plink_123",
+        url: "https://buy.stripe.com/test_123",
+      },
+      checkoutEnabled: false,
+    })
+
+    expect(viewModel.paymentLink).toMatchObject({
+      status: "available",
+      href: "https://buy.stripe.com/test_123",
+      label: "Open Payment Link",
+    })
+  })
+
+  it("keeps Checkout hidden until the Crew checkout flag is enabled", () => {
+    const disabled = buildCrewBillingPageViewModel({
+      billing: baseBilling,
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: false,
+    })
+    const enabled = buildCrewBillingPageViewModel({
+      billing: baseBilling,
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: true,
+    })
+
+    expect(disabled.checkout.status).toBe("hidden")
+    expect(enabled.checkout).toMatchObject({
+      status: "disabled",
+      href: null,
+      label: "Checkout coming soon",
+    })
+    expect(enabled.checkout.helperText).toContain("session creation")
+  })
+
+  it("shows paid manual, comp, refund, and upgrade credit state without team subscription semantics", () => {
+    const viewModel = buildCrewBillingPageViewModel({
+      billing: {
+        ...baseBilling,
+        state: CREW_BILLING_STATE.PAID,
+        source: CREW_BILLING_SOURCE.MANUAL_SALES,
+        planId: "crew_pro",
+        amountCents: 49900,
+        fullPlatformCreditCents: 25000,
+        refundedCents: 5000,
+      },
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: false,
+    })
+
+    expect(viewModel.plan.label).toBe("Crew Pro")
+    expect(viewModel.plan.hasCrewEventAccess).toBe(true)
+    expect(viewModel.billing.sourceLabel).toBe("Manual sale")
+    expect(viewModel.billing.amountLabel).toBe("$499.00")
+    expect(viewModel.billing.upgradeCreditLabel).toBe("$250.00")
+    expect(viewModel.billing.refundedLabel).toBe("$50.00")
+    expect(viewModel.upgradeCta.visible).toBe(true)
+
+    const comped = buildCrewBillingPageViewModel({
+      billing: {
+        ...baseBilling,
+        state: CREW_BILLING_STATE.COMPED,
+        source: CREW_BILLING_SOURCE.COMP,
+        planId: "crew_basic",
+      },
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: false,
+    })
+
+    expect(comped.billing.fulfillmentLabel).toBe("Comped event")
+    expect(comped.plan.hasCrewEventAccess).toBe(true)
+  })
+
+  it("does not leak founder pricing, Stripe references, audit metadata, or invoices", () => {
+    const viewModel = buildCrewBillingPageViewModel({
+      billing: {
+        ...baseBilling,
+        state: CREW_BILLING_STATE.PAID,
+        source: CREW_BILLING_SOURCE.FOUNDER_OVERRIDE,
+        planId: "crew_founding_2026",
+        amountCents: 12345,
+        founderOverride: true,
+        stripe: {
+          paymentLinkId: "plink_private",
+          checkoutSessionId: "cs_private",
+          paymentIntentId: "pi_private",
+        },
+      },
+      paymentLink: { id: "plink_private", url: null },
+      checkoutEnabled: true,
+    })
+
+    const serialized = JSON.stringify(viewModel)
+
+    expect(viewModel.billing.amountLabel).toBe("Private founder grant amount")
+    expect(serialized).not.toContain("12345")
+    expect(serialized).not.toContain("plink_private")
+    expect(serialized).not.toContain("cs_private")
+    expect(serialized).not.toContain("pi_private")
+    expect(serialized).not.toContain("privateMetadata")
+    expect(serialized).not.toContain("invoice")
+  })
+})
+
+describe("Crew billing page access", () => {
+  it("allows local operators, site admins, and organizer billing members", () => {
+    const event = {
+      organizingTeamId: "team_org",
+      competitionTeamId: "team_event",
+    }
+
+    expect(
+      canViewCrewBillingPage({
+        isLocalCrewOperator: true,
+        isSiteAdmin: false,
+        teams: [],
+        event,
+        billingPermission: "access_billing",
+      }),
+    ).toBe(true)
+    expect(
+      canViewCrewBillingPage({
+        isLocalCrewOperator: false,
+        isSiteAdmin: true,
+        teams: [],
+        event,
+        billingPermission: "access_billing",
+      }),
+    ).toBe(true)
+    expect(
+      canViewCrewBillingPage({
+        isLocalCrewOperator: false,
+        isSiteAdmin: false,
+        teams: [{ id: "team_org", permissions: ["access_billing"] }],
+        event,
+        billingPermission: "access_billing",
+      }),
+    ).toBe(true)
+  })
+
+  it("rejects unrelated teams and competition-event-only members", () => {
+    const event = {
+      organizingTeamId: "team_org",
+      competitionTeamId: "team_event",
+    }
+
+    expect(
+      canViewCrewBillingPage({
+        isLocalCrewOperator: false,
+        isSiteAdmin: false,
+        teams: [{ id: "team_other", permissions: ["access_billing"] }],
+        event,
+        billingPermission: "access_billing",
+      }),
+    ).toBe(false)
+    expect(
+      canViewCrewBillingPage({
+        isLocalCrewOperator: false,
+        isSiteAdmin: false,
+        teams: [{ id: "team_event", permissions: ["access_billing"] }],
+        event,
+        billingPermission: "access_billing",
+      }),
+    ).toBe(false)
+  })
+})

--- a/apps/crew/src/lib/crew/billing-page.ts
+++ b/apps/crew/src/lib/crew/billing-page.ts
@@ -1,0 +1,258 @@
+// @lat: [[crew#Billing Page And Upgrade CTA]]
+import {
+  CREW_BILLING_SOURCE,
+  CREW_BILLING_STATE,
+  type CrewBillingSource,
+  type CrewBillingState,
+} from "../../db/schemas/crew-event-settings"
+import {
+  resolveCrewBillingEntitlements,
+  type CrewBillingPlanId,
+  type CrewBillingStateSnapshot,
+} from "./billing-state"
+
+export interface CrewBillingPageEventAccess {
+  organizingTeamId: string
+  competitionTeamId: string | null
+}
+
+export interface CrewBillingPageTeamAccess {
+  id: string
+  permissions: string[]
+}
+
+export interface CanViewCrewBillingPageInput {
+  isLocalCrewOperator: boolean
+  isSiteAdmin: boolean
+  teams: CrewBillingPageTeamAccess[]
+  event: CrewBillingPageEventAccess
+  billingPermission: string
+}
+
+export interface CrewBillingPaymentLinkInput {
+  id: string | null
+  url: string | null
+}
+
+export interface CrewBillingPageViewModelInput {
+  billing: CrewBillingStateSnapshot
+  paymentLink: CrewBillingPaymentLinkInput
+  checkoutEnabled: boolean
+}
+
+export interface CrewBillingActionViewModel {
+  label: string
+  status: "available" | "disabled" | "hidden"
+  href: string | null
+  helperText: string
+}
+
+export interface CrewBillingPageViewModel {
+  plan: {
+    id: CrewBillingPlanId | null
+    label: string
+    hasCrewEventAccess: boolean
+    accessReason: ReturnType<typeof resolveCrewBillingEntitlements>["reason"]
+  }
+  billing: {
+    state: CrewBillingState
+    stateLabel: string
+    source: CrewBillingSource | null
+    sourceLabel: string
+    amountLabel: string
+    upgradeCreditLabel: string
+    refundedLabel: string
+    fulfillmentLabel: string
+  }
+  upgradeCta: {
+    visible: boolean
+    title: string
+    description: string
+  }
+  paymentLink: CrewBillingActionViewModel
+  checkout: CrewBillingActionViewModel
+}
+
+const planLabels: Record<CrewBillingPlanId, string> = {
+  crew_starter: "Crew Starter",
+  crew_basic: "Crew Basic",
+  crew_pro: "Crew Pro",
+  crew_concierge: "Crew Concierge",
+  crew_founding_2026: "Founding Crew grant",
+}
+
+const billingStateLabels: Record<CrewBillingState, string> = {
+  [CREW_BILLING_STATE.UNPAID]: "Unpaid",
+  [CREW_BILLING_STATE.PENDING]: "Pending",
+  [CREW_BILLING_STATE.PAID]: "Paid",
+  [CREW_BILLING_STATE.COMPED]: "Comped",
+  [CREW_BILLING_STATE.CREDITED]: "Credit available",
+  [CREW_BILLING_STATE.REFUNDED]: "Refunded",
+}
+
+const billingSourceLabels: Record<CrewBillingSource, string> = {
+  [CREW_BILLING_SOURCE.MANUAL_SALES]: "Manual sale",
+  [CREW_BILLING_SOURCE.PAYMENT_LINK]: "Payment Link",
+  [CREW_BILLING_SOURCE.STRIPE_CHECKOUT]: "Checkout",
+  [CREW_BILLING_SOURCE.FOUNDER_OVERRIDE]: "Founder grant",
+  [CREW_BILLING_SOURCE.CREW_CREDIT]: "Crew credit",
+  [CREW_BILLING_SOURCE.COMP]: "Comp",
+}
+
+export function canViewCrewBillingPage({
+  isLocalCrewOperator,
+  isSiteAdmin,
+  teams,
+  event,
+  billingPermission,
+}: CanViewCrewBillingPageInput) {
+  if (isLocalCrewOperator || isSiteAdmin) return true
+
+  return teams.some(
+    (team) =>
+      team.id === event.organizingTeamId &&
+      team.permissions.includes(billingPermission),
+  )
+}
+
+export function buildCrewBillingPageViewModel({
+  billing,
+  paymentLink,
+  checkoutEnabled,
+}: CrewBillingPageViewModelInput): CrewBillingPageViewModel {
+  const entitlements = resolveCrewBillingEntitlements(billing)
+  const planLabel = billing.planId ? planLabels[billing.planId] : "No plan"
+  const amountLabel = isPrivateFounderBilling(billing)
+    ? "Private founder grant amount"
+    : billing.amountCents > 0
+      ? formatMoney(billing.amountCents, billing.currency)
+      : "No event charge recorded"
+  const upgradeCreditLabel =
+    billing.fullPlatformCreditCents > 0
+      ? formatMoney(billing.fullPlatformCreditCents, billing.currency)
+      : "No upgrade credit recorded"
+  const refundedLabel =
+    billing.refundedCents > 0
+      ? formatMoney(billing.refundedCents, billing.currency)
+      : "No refund recorded"
+
+  return {
+    plan: {
+      id: billing.planId,
+      label: planLabel,
+      hasCrewEventAccess: entitlements.hasCrewEventAccess,
+      accessReason: entitlements.reason,
+    },
+    billing: {
+      state: billing.state,
+      stateLabel: billingStateLabels[billing.state],
+      source: billing.source,
+      sourceLabel: billing.source
+        ? billingSourceLabels[billing.source]
+        : "Not recorded",
+      amountLabel,
+      upgradeCreditLabel,
+      refundedLabel,
+      fulfillmentLabel: getFulfillmentLabel(billing),
+    },
+    upgradeCta: buildUpgradeCta(billing),
+    paymentLink: buildPaymentLinkAction(paymentLink),
+    checkout: buildCheckoutAction(checkoutEnabled),
+  }
+}
+
+function buildUpgradeCta(billing: CrewBillingStateSnapshot) {
+  const paidOrComped =
+    billing.state === CREW_BILLING_STATE.PAID ||
+    billing.state === CREW_BILLING_STATE.COMPED
+  const visible = !paidOrComped || billing.fullPlatformCreditCents > 0
+
+  return {
+    visible,
+    title: visible ? "Upgrade this event" : "Crew access is active",
+    description:
+      billing.fullPlatformCreditCents > 0
+        ? "Use the recorded full-platform credit when this organizer is ready to move beyond one-event Crew."
+        : "Upgrade unlocks the paid Crew event plan for this competition without changing the team's subscription plan.",
+  }
+}
+
+function isPrivateFounderBilling(billing: CrewBillingStateSnapshot) {
+  return (
+    billing.founderOverride ||
+    billing.source === CREW_BILLING_SOURCE.FOUNDER_OVERRIDE ||
+    billing.planId === "crew_founding_2026"
+  )
+}
+
+function buildPaymentLinkAction(
+  paymentLink: CrewBillingPaymentLinkInput,
+): CrewBillingActionViewModel {
+  if (paymentLink.url) {
+    return {
+      label: "Open Payment Link",
+      status: "available",
+      href: paymentLink.url,
+      helperText:
+        "This uses an already configured Payment Link URL for the event.",
+    }
+  }
+
+  return {
+    label: "Payment Link unavailable",
+    status: "disabled",
+    href: null,
+    helperText: paymentLink.id
+      ? "A Payment Link reference exists, but no organizer-safe URL is configured yet."
+      : "Payment Link recording is deferred to the next billing source-plan slice.",
+  }
+}
+
+function buildCheckoutAction(
+  checkoutEnabled: boolean,
+): CrewBillingActionViewModel {
+  if (!checkoutEnabled) {
+    return {
+      label: "Checkout unavailable",
+      status: "hidden",
+      href: null,
+      helperText: "Checkout is not enabled for Crew billing yet.",
+    }
+  }
+
+  return {
+    label: "Checkout coming soon",
+    status: "disabled",
+    href: null,
+    helperText:
+      "Checkout is enabled, but session creation is intentionally deferred from this slice.",
+  }
+}
+
+function getFulfillmentLabel(billing: CrewBillingStateSnapshot) {
+  if (billing.state === CREW_BILLING_STATE.COMPED) return "Comped event"
+  if (billing.state === CREW_BILLING_STATE.REFUNDED) return "Refund recorded"
+  if (billing.source === CREW_BILLING_SOURCE.FOUNDER_OVERRIDE) {
+    return "Founder grant"
+  }
+  if (billing.source === CREW_BILLING_SOURCE.MANUAL_SALES) {
+    return "Manual sale"
+  }
+  if (billing.source === CREW_BILLING_SOURCE.PAYMENT_LINK) {
+    return "Payment Link"
+  }
+  if (billing.source === CREW_BILLING_SOURCE.STRIPE_CHECKOUT) {
+    return "Checkout"
+  }
+  if (billing.source === CREW_BILLING_SOURCE.CREW_CREDIT) {
+    return "Crew credit"
+  }
+  return "Awaiting payment"
+}
+
+function formatMoney(cents: number, currency: string) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: currency.toUpperCase(),
+  }).format(cents / 100)
+}

--- a/apps/crew/src/lib/crew/billing-page.ts
+++ b/apps/crew/src/lib/crew/billing-page.ts
@@ -251,8 +251,23 @@ function getFulfillmentLabel(billing: CrewBillingStateSnapshot) {
 }
 
 function formatMoney(cents: number, currency: string) {
+  const amount = cents / 100
+  const normalizedCurrency = currency.trim().toUpperCase() || "USD"
+
+  try {
+    return formatCurrencyWithIntl(amount, normalizedCurrency)
+  } catch {
+    try {
+      return formatCurrencyWithIntl(amount, "USD")
+    } catch {
+      return `$${amount.toFixed(2)}`
+    }
+  }
+}
+
+function formatCurrencyWithIntl(amount: number, currency: string) {
   return new Intl.NumberFormat("en-US", {
     style: "currency",
-    currency: currency.toUpperCase(),
-  }).format(cents / 100)
+    currency,
+  }).format(amount)
 }

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as EventsEventIdJudgesRouteImport } from './routes/events/$eventI
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
 import { Route as EventsEventIdExportsRouteImport } from './routes/events/$eventId/exports'
 import { Route as EventsEventIdDayOfRouteImport } from './routes/events/$eventId/day-of'
+import { Route as EventsEventIdBillingRouteImport } from './routes/events/$eventId/billing'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
 import { Route as ESlugScheduleTokenRouteImport } from './routes/e/$slug/schedule/$token'
@@ -110,6 +111,11 @@ const EventsEventIdDayOfRoute = EventsEventIdDayOfRouteImport.update({
   path: '/day-of',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdBillingRoute = EventsEventIdBillingRouteImport.update({
+  id: '/billing',
+  path: '/billing',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const ESlugVolunteerRoute = ESlugVolunteerRouteImport.update({
   id: '/e/$slug/volunteer',
   path: '/e/$slug/volunteer',
@@ -139,6 +145,7 @@ export interface FileRoutesByFullPath {
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
@@ -160,6 +167,7 @@ export interface FileRoutesByTo {
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
@@ -183,6 +191,7 @@ export interface FileRoutesById {
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
@@ -207,6 +216,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/api/crew/import'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/billing'
     | '/events/$eventId/day-of'
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
@@ -228,6 +238,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/api/crew/import'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/billing'
     | '/events/$eventId/day-of'
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
@@ -250,6 +261,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/api/crew/import'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/billing'
     | '/events/$eventId/day-of'
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
@@ -389,6 +401,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdDayOfRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/billing': {
+      id: '/events/$eventId/billing'
+      path: '/billing'
+      fullPath: '/events/$eventId/billing'
+      preLoaderRoute: typeof EventsEventIdBillingRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/e/$slug/volunteer': {
       id: '/e/$slug/volunteer'
       path: '/e/$slug/volunteer'
@@ -421,6 +440,7 @@ declare module '@tanstack/react-router' {
 }
 
 interface EventsEventIdRouteChildren {
+  EventsEventIdBillingRoute: typeof EventsEventIdBillingRoute
   EventsEventIdDayOfRoute: typeof EventsEventIdDayOfRoute
   EventsEventIdExportsRoute: typeof EventsEventIdExportsRoute
   EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
@@ -435,6 +455,7 @@ interface EventsEventIdRouteChildren {
 }
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
+  EventsEventIdBillingRoute: EventsEventIdBillingRoute,
   EventsEventIdDayOfRoute: EventsEventIdDayOfRoute,
   EventsEventIdExportsRoute: EventsEventIdExportsRoute,
   EventsEventIdImportsRoute: EventsEventIdImportsRoute,

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -2,6 +2,7 @@
 // @lat: [[crew#Staffing Page Gap Report]]
 // @lat: [[crew#Day Of Operations Board]]
 // @lat: [[crew#Pilot Exports]]
+// @lat: [[crew#Billing Page And Upgrade CTA]]
 import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
 import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
 
@@ -63,6 +64,14 @@ function EventShell() {
             className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             Setup
+          </Link>
+          <Link
+            to="/events/$eventId/billing"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Billing
           </Link>
           <Link
             to="/events/$eventId/imports"

--- a/apps/crew/src/routes/events/$eventId/billing.tsx
+++ b/apps/crew/src/routes/events/$eventId/billing.tsx
@@ -1,0 +1,157 @@
+// @lat: [[crew#Billing Page And Upgrade CTA]]
+import { createFileRoute } from "@tanstack/react-router"
+import {
+  CreditCard,
+  ExternalLink,
+  LockKeyhole,
+  WalletCards,
+} from "lucide-react"
+import type { ReactNode } from "react"
+import type { CrewBillingActionViewModel } from "@/lib/crew/billing-page"
+import { getCrewBillingOrganizerPageFn } from "@/server-fns/crew-billing-fns"
+
+export const Route = createFileRoute("/events/$eventId/billing")({
+  loader: async ({ params }) =>
+    await getCrewBillingOrganizerPageFn({
+      data: { eventId: params.eventId },
+    }),
+  component: EventBillingPage,
+})
+
+function EventBillingPage() {
+  const { event, viewModel } = Route.useLoaderData()
+
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <BillingMetric label="Plan" value={viewModel.plan.label} />
+        <BillingMetric
+          label="Billing status"
+          value={viewModel.billing.stateLabel}
+        />
+        <BillingMetric label="Source" value={viewModel.billing.sourceLabel} />
+        <BillingMetric
+          label="Upgrade credit"
+          value={viewModel.billing.upgradeCreditLabel}
+        />
+      </div>
+
+      {viewModel.upgradeCta.visible ? (
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2 text-sm font-medium text-primary">
+                <WalletCards className="size-4" aria-hidden="true" />
+                Crew upgrade
+              </div>
+              <h2 className="text-xl font-semibold">
+                {viewModel.upgradeCta.title}
+              </h2>
+              <p className="max-w-3xl text-sm text-muted-foreground">
+                {viewModel.upgradeCta.description}
+              </p>
+            </div>
+            <div className="flex w-full flex-col gap-2 sm:w-auto">
+              <BillingAction action={viewModel.paymentLink} />
+              <BillingAction action={viewModel.checkout} />
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+        <div className="rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-xl font-semibold">Event billing</h2>
+          <dl className="mt-4 grid gap-4 text-sm sm:grid-cols-2">
+            <BillingFact label="Event" value={event.name} />
+            <BillingFact
+              label="Event access"
+              value={
+                viewModel.plan.hasCrewEventAccess ? "Active" : "Not active yet"
+              }
+            />
+            <BillingFact
+              label="Fulfillment"
+              value={viewModel.billing.fulfillmentLabel}
+            />
+            <BillingFact label="Amount" value={viewModel.billing.amountLabel} />
+            <BillingFact
+              label="Refund state"
+              value={viewModel.billing.refundedLabel}
+            />
+            <BillingFact
+              label="Access reason"
+              value={viewModel.plan.accessReason}
+            />
+          </dl>
+        </div>
+
+        <aside className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex items-center gap-2">
+            <LockKeyhole className="size-4 text-muted-foreground" />
+            <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+              Private page
+            </h2>
+          </div>
+          <p className="mt-4 text-sm text-muted-foreground">
+            Billing reads are scoped to the event organizer team. Stripe
+            references, invoices, audit rows, and internal notes stay off this
+            page.
+          </p>
+        </aside>
+      </section>
+    </section>
+  )
+}
+
+function BillingMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function BillingFact({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="break-words font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function BillingAction({ action }: { action: CrewBillingActionViewModel }) {
+  if (action.status === "hidden") {
+    return null
+  }
+
+  if (action.status === "available" && action.href) {
+    return (
+      <a
+        href={action.href}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        title={action.helperText}
+      >
+        <CreditCard className="size-4" aria-hidden="true" />
+        {action.label}
+        <ExternalLink className="size-4" aria-hidden="true" />
+      </a>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      disabled
+      className="inline-flex items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium text-muted-foreground"
+      title={action.helperText}
+    >
+      <CreditCard className="size-4" aria-hidden="true" />
+      {action.label}
+    </button>
+  )
+}

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -1,6 +1,7 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
 // @lat: [[crew#Staffing Page Gap Report]]
 // @lat: [[crew#Day Of Operations Board]]
+// @lat: [[crew#Billing Page And Upgrade CTA]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { formatCrewValue, getSafeHttpUrl } from "@/lib/crew-event-display"
 import {
@@ -72,6 +73,25 @@ function EventOverviewPage() {
             className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             Open checklist
+          </Link>
+        </div>
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Billing</h2>
+            <p className="text-sm text-muted-foreground">
+              Review event plan status, upgrade credit, and available upgrade
+              actions.
+            </p>
+          </div>
+          <Link
+            to="/events/$eventId/billing"
+            params={{ eventId }}
+            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Open billing
           </Link>
         </div>
       </section>

--- a/apps/crew/src/server-fns/crew-billing-fns.ts
+++ b/apps/crew/src/server-fns/crew-billing-fns.ts
@@ -1,5 +1,6 @@
 // @lat: [[crew#Server Function Runtime Boundary]]
 // @lat: [[crew#Manual Paid And Founder Grants]]
+// @lat: [[crew#Billing Page And Upgrade CTA]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
 import { CREW_BILLING_EVENT_TYPE } from "../db/schemas/crew-billing-events"
@@ -9,7 +10,10 @@ import {
   type ManualCrewBillingActionType,
 } from "../lib/crew/billing-state"
 
-export type { CrewBillingPageData } from "../server/crew-billing.server"
+export type {
+  CrewBillingOrganizerPageData,
+  CrewBillingPageData,
+} from "../server/crew-billing.server"
 
 const getCrewBillingInputSchema = z.object({
   eventId: z.string().min(1, "Event ID is required"),
@@ -119,6 +123,15 @@ export const getCrewBillingPageFn = createServerFn({ method: "GET" })
   .handler(async ({ data }) => {
     const { getCrewBillingPage } = await import("../server/crew-billing.server")
     return getCrewBillingPage(data)
+  })
+
+export const getCrewBillingOrganizerPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => getCrewBillingInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { getCrewBillingOrganizerPage } = await import(
+      "../server/crew-billing.server"
+    )
+    return getCrewBillingOrganizerPage(data)
   })
 
 export const recordCrewBillingEventFn = createServerFn({ method: "POST" })

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -1,5 +1,7 @@
 // @lat: [[crew#Crew Billing State And Audit]]
 // @lat: [[crew#Manual Paid And Founder Grants]]
+// @lat: [[crew#Billing Page And Upgrade CTA]]
+import { env } from "cloudflare:workers"
 import { desc, eq } from "drizzle-orm"
 import { getDb } from "../db"
 import {
@@ -14,6 +16,13 @@ import {
   crewEventSettingsTable,
 } from "../db/schemas/crew-event-settings"
 import { competitionsTable } from "../db/schemas/competitions"
+import { TEAM_PERMISSIONS } from "../db/schemas/teams"
+import { ROLES_ENUM } from "../db/schema"
+import {
+  buildCrewBillingPageViewModel,
+  canViewCrewBillingPage,
+  type CrewBillingPageViewModel,
+} from "../lib/crew/billing-page"
 import {
   type CrewBillingAuditEvent,
   type CrewBillingAppendPlan,
@@ -25,7 +34,11 @@ import {
   type CrewBillingPlanId,
   type CrewBillingStateSnapshot,
 } from "../lib/crew/billing-state"
-import { requireLocalCrewOperatorAccess } from "./crew-local-access"
+import { getSessionFromCookie } from "../utils/auth"
+import {
+  hasLocalCrewOperatorAccess,
+  requireLocalCrewOperatorAccess,
+} from "./crew-local-access"
 
 export interface GetCrewBillingInput {
   eventId: string
@@ -85,6 +98,14 @@ export interface CrewBillingPageData {
   auditEvents: CrewBillingAuditEventRow[]
 }
 
+export interface CrewBillingOrganizerPageData {
+  event: {
+    id: string
+    name: string
+  }
+  viewModel: CrewBillingPageViewModel
+}
+
 type CrewBillingScope = CrewBillingPageData["event"] & {
   state: CrewBillingState
   source: CrewBillingSource | null
@@ -98,6 +119,7 @@ type CrewBillingScope = CrewBillingPageData["event"] & {
   creditCents: number
   fullPlatformCreditCents: number
   refundedCents: number
+  settingsText: string | null
 }
 
 export async function getCrewBillingPage(
@@ -112,6 +134,31 @@ export async function getCrewBillingPage(
     event: toCrewBillingEventSummary(scope),
     billing: toCrewBillingSnapshot(scope),
     auditEvents: auditEvents.map(toCrewBillingAuditEventRow),
+  }
+}
+
+export async function getCrewBillingOrganizerPage(
+  data: GetCrewBillingInput,
+): Promise<CrewBillingOrganizerPageData> {
+  const scope = await requireCrewBillingScope(data.eventId)
+  await requireCrewBillingOrganizerAccess(scope)
+
+  const billing = toCrewBillingSnapshot(scope)
+  const paymentLinkUrl = getCrewPaymentLinkUrlFromSettings(scope.settingsText)
+
+  return {
+    event: {
+      id: scope.id,
+      name: scope.name,
+    },
+    viewModel: buildCrewBillingPageViewModel({
+      billing,
+      paymentLink: {
+        id: billing.stripe.paymentLinkId,
+        url: paymentLinkUrl,
+      },
+      checkoutEnabled: isCrewStripeCheckoutEnabled(),
+    }),
   }
 }
 
@@ -208,6 +255,7 @@ async function requireCrewBillingScope(
       creditCents: crewEventSettingsTable.crewCreditCents,
       fullPlatformCreditCents: crewEventSettingsTable.fullPlatformCreditCents,
       refundedCents: crewEventSettingsTable.crewRefundedCents,
+      settingsText: crewEventSettingsTable.settings,
     })
     .from(crewEventSettingsTable)
     .innerJoin(
@@ -224,6 +272,28 @@ async function requireCrewBillingScope(
   return {
     ...event,
     planId: event.planId as CrewBillingPlanId | null,
+  }
+}
+
+async function requireCrewBillingOrganizerAccess(scope: CrewBillingScope) {
+  const session = await getSessionFromCookie().catch(() => null)
+  const canView = canViewCrewBillingPage({
+    isLocalCrewOperator: hasLocalCrewOperatorAccess(),
+    isSiteAdmin: session?.user.role === ROLES_ENUM.ADMIN,
+    teams:
+      session?.teams?.map((team) => ({
+        id: team.id,
+        permissions: team.permissions,
+      })) ?? [],
+    event: {
+      organizingTeamId: scope.organizingTeamId,
+      competitionTeamId: scope.competitionTeamId,
+    },
+    billingPermission: TEAM_PERMISSIONS.ACCESS_BILLING,
+  })
+
+  if (!canView) {
+    throw new Error("FORBIDDEN: You don't have access to Crew billing")
   }
 }
 
@@ -339,4 +409,77 @@ function toCrewBillingJsonValue(
   }
 
   return undefined
+}
+
+function getCrewPaymentLinkUrlFromSettings(settingsText: string | null) {
+  const settings = parseSettingsObject(settingsText)
+  if (!settings) return null
+
+  const candidates = [
+    getNestedString(settings, ["billing", "paymentLinkUrl"]),
+    getNestedString(settings, ["billing", "crewPaymentLinkUrl"]),
+    getNestedString(settings, ["crewBilling", "paymentLinkUrl"]),
+    getNestedString(settings, ["crewBilling", "crewPaymentLinkUrl"]),
+    getNestedString(settings, ["paymentLinkUrl"]),
+    getNestedString(settings, ["crewPaymentLinkUrl"]),
+  ]
+
+  for (const candidate of candidates) {
+    const safeUrl = getSafeHttpUrl(candidate)
+    if (safeUrl) return safeUrl
+  }
+
+  return null
+}
+
+function parseSettingsObject(settingsText: string | null) {
+  if (!settingsText) return null
+
+  try {
+    const parsed: unknown = JSON.parse(settingsText)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+function getNestedString(
+  object: Record<string, unknown>,
+  path: string[],
+): string | null {
+  let current: unknown = object
+  for (const key of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return null
+    }
+    current = (current as Record<string, unknown>)[key]
+  }
+
+  return typeof current === "string" ? current : null
+}
+
+function getSafeHttpUrl(value: string | null) {
+  if (!value) return null
+
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : null
+  } catch {
+    return null
+  }
+}
+
+function isCrewStripeCheckoutEnabled() {
+  const runtimeEnv = env as typeof env & {
+    CREW_STRIPE_CHECKOUT_ENABLED?: string | boolean
+  }
+  const value = runtimeEnv.CREW_STRIPE_CHECKOUT_ENABLED
+  return (
+    value === true ||
+    ["1", "true", "yes", "enabled"].includes(String(value ?? "").toLowerCase())
+  )
 }

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -23,6 +23,7 @@ import {
   canViewCrewBillingPage,
   type CrewBillingPageViewModel,
 } from "../lib/crew/billing-page"
+import { safeHttpUrl } from "../lib/safe-url"
 import {
   type CrewBillingAuditEvent,
   type CrewBillingAppendPlan,
@@ -425,7 +426,7 @@ function getCrewPaymentLinkUrlFromSettings(settingsText: string | null) {
   ]
 
   for (const candidate of candidates) {
-    const safeUrl = getSafeHttpUrl(candidate)
+    const safeUrl = safeHttpUrl(candidate)
     if (safeUrl) return safeUrl
   }
 
@@ -458,19 +459,6 @@ function getNestedString(
   }
 
   return typeof current === "string" ? current : null
-}
-
-function getSafeHttpUrl(value: string | null) {
-  if (!value) return null
-
-  try {
-    const url = new URL(value)
-    return url.protocol === "http:" || url.protocol === "https:"
-      ? url.toString()
-      : null
-  } catch {
-    return null
-  }
 }
 
 function isCrewStripeCheckoutEnabled() {

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -32,6 +32,16 @@ Manual Crew paid states are private operator/server actions that assign an event
 
 Full-platform upgrade credit is single-use per Crew event. Setting or applying credit uses stable idempotency keys and rejects old credit audit rows without a tested reversal path.
 
+## Billing Page And Upgrade CTA
+
+The private Crew billing page shows organizer-safe event billing state without exposing operator-only audit metadata.
+
+[[apps/crew/src/routes/events/$eventId/billing.tsx]] renders event plan, billing status/source, fulfillment state, upgrade credit, refund state, and the narrow upgrade CTA for the selected Crew event.
+
+[[apps/crew/src/lib/crew/billing-page.ts]] derives public page labels and CTA state from normalized event-level Crew billing state. It does not read team subscription state, expose founder pricing, or pass Stripe IDs through to the route view model.
+
+[[apps/crew/src/server/crew-billing.server.ts]] and [[apps/crew/src/server-fns/crew-billing-fns.ts]] keep the organizer billing loader server-only, scoped to the event organizing team's billing permission with local operator fallback. Payment Link buttons only use an already configured safe URL from event settings, and Checkout remains a disabled flag-gated slot until a later slice creates sessions.
+
 ## Server Function Runtime Boundary
 
 Route and client code import lightweight `createServerFn` wrappers from [[apps/crew/src/server-fns]].


### PR DESCRIPTION
## Summary

Adds the private Crew event billing page at `/events/$eventId/billing` with a small nav and overview entry point. The page shows organizer-safe plan/status/source, manual/comp/refund fulfillment state, upgrade credit, and upgrade CTA behavior derived from event-level Crew billing state.

The server loader reuses the post-runtime-boundary `crew-billing-fns` wrapper and `crew-billing.server.ts` implementation pattern. It keeps audit rows, Stripe references, invoices, internal notes, and private founder pricing out of the organizer route view model. Payment Link is only clickable when an existing safe URL is present in event settings, and Checkout remains a disabled flag-gated slot behind `CREW_STRIPE_CHECKOUT_ENABLED` without creating sessions.

LAT anchor: `crew#Billing Page And Upgrade CTA`.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/billing-page.test.ts` passed: 7 tests
- `pnpm --filter crew type-check` passed
- `pnpm --filter crew lint` exited 0; reported existing unrelated warnings in legacy files
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` passed after restoring ignored local `.alchemy/local/wrangler.jsonc` tooling config
- `pnpm dlx lat.md locate 'crew#Billing Page And Upgrade CTA'` passed
- `pnpm dlx lat.md refs 'crew#Billing Page And Upgrade CTA'` passed
- `git diff --check` passed

## Deferred

- No Payment Link reconciliation or recording logic
- No Checkout Session creation or Stripe calls
- No webhooks, schema changes, production data mutation, or team subscription plan changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a private Crew billing page at `/events/$eventId/billing` with a nav and overview entry point. It shows organizer-safe plan/status, upgrade credit, and an upgrade CTA; actions are gated by a safe Payment Link URL and the `CREW_STRIPE_CHECKOUT_ENABLED` flag.

- **New Features**
  - New page and nav entry: `/events/$eventId/billing`, plus overview link.
  - Server-only loader `getCrewBillingOrganizerPageFn` builds a safe view model; no Stripe IDs, invoices, founder pricing, or audit rows leak.
  - Payment Link button only enabled when a safe URL exists in event settings; otherwise disabled.
  - Checkout action hidden/disabled behind `CREW_STRIPE_CHECKOUT_ENABLED`; no session creation here.
  - Access: local operator, site admin, or organizing team with `ACCESS_BILLING`.
  - Tests cover view model and access logic. No Stripe calls, webhooks, or schema changes.

- **Bug Fixes**
  - Hardened currency formatting: falls back to USD when the stored currency is invalid, preventing rendering errors.

<sup>Written for commit 1297a712bc543b69b638a524090a9b445232a105. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Billing page accessible from event details, displaying plan information, billing status, and fulfillment details.
  * Event organizers can now view upgrade options and manage payment settings through an integrated Payment Link.
  * Added a Billing status card to the event overview page for quick access to billing information.

* **Documentation**
  * Updated documentation describing the new Billing page and upgrade CTA features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->