### PR TITLE
[codex] feat(crew): record Payment Link sales

### DIFF
--- a/apps/crew/src/lib/crew/billing-state.test.ts
+++ b/apps/crew/src/lib/crew/billing-state.test.ts
@@ -374,6 +374,37 @@ describe("Crew billing state and audit helpers", () => {
     })
   })
 
+  it("preserves an existing Payment Link reference during missing metadata reconciliation", () => {
+    const plan = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
+      competitionId: "comp_existing_reference",
+      teamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      current: {
+        stripe: {
+          paymentLinkId: "plink_existing",
+          checkoutSessionId: null,
+          paymentIntentId: null,
+        },
+      },
+      idempotencyKey: "payment-link:plink_existing:missing-payment-intent",
+    })
+
+    expect(plan).toMatchObject({
+      action: "append",
+      event: {
+        eventType: CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED,
+        stripePaymentLinkId: "plink_existing",
+        stripePaymentIntentId: null,
+      },
+      settingsPatch: {
+        crewStripePaymentLinkId: "plink_existing",
+        crewStripePaymentIntentId: null,
+      },
+    })
+  })
+
   it("dedupes Payment Link reconciliation by idempotency key", () => {
     const first = planManualCrewBillingAction([], {
       action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,

--- a/apps/crew/src/lib/crew/billing-state.test.ts
+++ b/apps/crew/src/lib/crew/billing-state.test.ts
@@ -302,6 +302,135 @@ describe("Crew billing state and audit helpers", () => {
     })
   })
 
+  it("plans Payment Link reconciliation as an event-scoped paid Crew purchase", () => {
+    const plan = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
+      competitionId: "comp_payment_link",
+      teamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      currency: "USD",
+      stripePaymentLinkId: "plink_123",
+      stripePaymentIntentId: "pi_123",
+      idempotencyKey: "payment-link:plink_123:pi_123",
+      privateMetadata: {
+        adminNote: "Matched from Stripe dashboard without webhook metadata.",
+      },
+    })
+
+    expect(plan).toMatchObject({
+      action: "append",
+      event: {
+        competitionId: "comp_payment_link",
+        teamId: "team_owner",
+        eventType: CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED,
+        billingState: CREW_BILLING_STATE.PAID,
+        billingSource: CREW_BILLING_SOURCE.PAYMENT_LINK,
+        planId: "crew_basic",
+        amountCents: 20_000,
+        currency: "usd",
+        stripePaymentLinkId: "plink_123",
+        stripePaymentIntentId: "pi_123",
+        idempotencyKey: "payment-link:plink_123:pi_123",
+      },
+      settingsPatch: {
+        crewBillingState: CREW_BILLING_STATE.PAID,
+        crewBillingSource: CREW_BILLING_SOURCE.PAYMENT_LINK,
+        crewBillingPlanId: "crew_basic",
+        crewBillingAmountCents: 20_000,
+        crewBillingCurrency: "usd",
+        crewStripePaymentLinkId: "plink_123",
+        crewStripePaymentIntentId: "pi_123",
+      },
+    })
+    expect(plan.settingsPatch).not.toHaveProperty("currentPlanId")
+    expect(JSON.stringify(resolveCrewBillingEntitlements(plan.settingsPatch)))
+      .not.toContain("plink_123")
+  })
+
+  it("allows Payment Link reconciliation when Stripe metadata is missing", () => {
+    const plan = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
+      competitionId: "comp_missing_metadata",
+      teamId: "team_owner",
+      planId: "crew_pro",
+      amountCents: 49_900,
+      currency: "usd",
+      idempotencyKey:
+        "payment-link:manual:comp_missing_metadata:team_owner:crew_pro:49900:usd",
+      actorLabel: "Ops",
+    })
+
+    expect(plan).toMatchObject({
+      action: "append",
+      event: {
+        eventType: CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED,
+        billingSource: CREW_BILLING_SOURCE.PAYMENT_LINK,
+        planId: "crew_pro",
+        amountCents: 49_900,
+        stripePaymentLinkId: null,
+        stripePaymentIntentId: null,
+      },
+    })
+  })
+
+  it("dedupes Payment Link reconciliation by idempotency key", () => {
+    const first = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
+      competitionId: "comp_payment_link",
+      teamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      idempotencyKey: "payment-link:plink_123:pi_123",
+      stripePaymentLinkId: "plink_123",
+      stripePaymentIntentId: "pi_123",
+    })
+    const duplicate = planManualCrewBillingAction([first.event], {
+      action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
+      competitionId: "comp_payment_link",
+      teamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      idempotencyKey: "payment-link:plink_123:pi_123",
+      stripePaymentLinkId: "plink_123",
+      stripePaymentIntentId: "pi_123",
+    })
+
+    expect(first.action).toBe("append")
+    expect(duplicate).toMatchObject({
+      action: "skip_duplicate",
+      settingsPatch: null,
+    })
+  })
+
+  it("rejects Payment Link reconciliation without a valid event plan and amount", () => {
+    const validPaymentLinkInput = {
+      action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
+      competitionId: "comp_payment_link",
+      teamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+    } as const
+    const unsafePaymentLinkInput = (overrides: Record<string, unknown>) =>
+      ({
+        ...validPaymentLinkInput,
+        ...overrides,
+      }) as unknown as Parameters<typeof planManualCrewBillingAction>[1]
+
+    expect(() =>
+      planManualCrewBillingAction(
+        [],
+        unsafePaymentLinkInput({ planId: "team_pro" }),
+      ),
+    ).toThrow(/valid Crew plan/)
+    expect(() =>
+      planManualCrewBillingAction(
+        [],
+        unsafePaymentLinkInput({ amountCents: 0 }),
+      ),
+    ).toThrow(/positive amount/)
+  })
+
   it("stores founder and credit details in private audit metadata", () => {
     const founder = buildCrewBillingAuditEvent({
       competitionId: "comp_crew",
@@ -532,6 +661,8 @@ describe("Crew billing state and audit helpers", () => {
       competitionId: "comp_crew",
       teamId: "team_owner",
       eventType: CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED,
+      planId: "crew_basic",
+      amountCents: 20_000,
       idempotencyKey: "plink_123:pi_123",
       stripePaymentLinkId: "plink_123",
       stripePaymentIntentId: "pi_123",
@@ -543,6 +674,8 @@ describe("Crew billing state and audit helpers", () => {
       competitionId: "comp_crew",
       teamId: "team_owner",
       eventType: CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED,
+      planId: "crew_basic",
+      amountCents: 20_000,
       idempotencyKey: "plink_123:pi_123",
       stripePaymentLinkId: "plink_123",
       stripePaymentIntentId: "pi_123",

--- a/apps/crew/src/lib/crew/billing-state.ts
+++ b/apps/crew/src/lib/crew/billing-state.ts
@@ -1,5 +1,6 @@
 // @lat: [[crew#Crew Billing State And Audit]]
 // @lat: [[crew#Manual Paid And Founder Grants]]
+// @lat: [[crew#Stripe Payment Link Sales]]
 import {
   CREW_BILLING_EVENT_TYPE,
   type CrewBillingEventType,
@@ -43,6 +44,7 @@ export type CrewBillingLimitKey = (typeof crewBillingLimitKeys)[number]
 
 export const MANUAL_CREW_BILLING_ACTION = {
   RECORD_MANUAL_PAID: "record_manual_paid",
+  RECONCILE_PAYMENT_LINK_SALE: "reconcile_payment_link_sale",
   APPLY_FOUNDER_GRANT: "apply_founder_grant",
   SET_FULL_PLATFORM_CREDIT: "set_full_platform_credit",
   APPLY_FULL_PLATFORM_CREDIT: "apply_full_platform_credit",
@@ -106,9 +108,15 @@ export type PlanManualCrewBillingActionInput =
       amountCents: number
     })
   | (BasePlanManualCrewBillingActionInput & {
+      action: typeof MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE
+      planId: CrewBillingPlanId
+      amountCents: number
+    })
+  | (BasePlanManualCrewBillingActionInput & {
       action: Exclude<
         ManualCrewBillingActionType,
-        typeof MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID
+        | typeof MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID
+        | typeof MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE
       >
     })
 
@@ -604,12 +612,11 @@ function validateCrewBillingAuditAppend(
   const normalized = normalizeCrewBillingState(current)
 
   if (event.eventType === CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED) {
-    if (!event.planId) {
-      throw new Error("Manual paid Crew billing requires a valid Crew plan.")
-    }
-    if (event.amountCents <= 0) {
-      throw new Error("Manual paid Crew billing requires a positive amount.")
-    }
+    validatePaidCrewBillingEvent(event, "Manual paid Crew billing")
+  }
+
+  if (event.eventType === CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED) {
+    validatePaidCrewBillingEvent(event, "Payment Link Crew billing")
   }
 
   if (event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET) {
@@ -650,6 +657,18 @@ function validateCrewBillingAuditAppend(
   }
 }
 
+function validatePaidCrewBillingEvent(
+  event: CrewBillingAuditEvent,
+  label: string,
+) {
+  if (!event.planId) {
+    throw new Error(`${label} requires a valid Crew plan.`)
+  }
+  if (event.amountCents <= 0) {
+    throw new Error(`${label} requires a positive amount.`)
+  }
+}
+
 function isCrewCreditEvent(event: CrewBillingExistingAuditEvent) {
   return (
     event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET ||
@@ -684,6 +703,16 @@ function buildManualCrewBillingActionInput(
         planId: requireManualPaidPlanId(input.planId),
         amountCents: requireManualPaidAmountCents(input.amountCents),
         idempotencyKey: input.idempotencyKey,
+      }
+    case MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE:
+      return {
+        ...common,
+        eventType: CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED,
+        planId: requireManualPaidPlanId(input.planId),
+        amountCents: requireManualPaidAmountCents(input.amountCents),
+        idempotencyKey: input.idempotencyKey,
+        stripePaymentLinkId: input.stripePaymentLinkId,
+        stripePaymentIntentId: input.stripePaymentIntentId,
       }
     case MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT:
       return {

--- a/apps/crew/src/lib/crew/payment-link-sales.test.ts
+++ b/apps/crew/src/lib/crew/payment-link-sales.test.ts
@@ -173,4 +173,29 @@ describe("Crew Payment Link sales helpers", () => {
       }),
     ).toBe("manual-key")
   })
+
+  it("does not collide when Payment Link idempotency parts contain colons", () => {
+    const first = buildCrewPaymentLinkSaleIdempotencyKey({
+      eventId: "comp_crew",
+      organizingTeamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      currency: "usd",
+      paymentLinkReference: "a:b",
+      stripePaymentIntentId: "c",
+    })
+    const second = buildCrewPaymentLinkSaleIdempotencyKey({
+      eventId: "comp_crew",
+      organizingTeamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      currency: "usd",
+      paymentLinkReference: "a",
+      stripePaymentIntentId: "b:c",
+    })
+
+    expect(first).toBe("payment-link:a%3Ab:c")
+    expect(second).toBe("payment-link:a:b%3Ac")
+    expect(first).not.toBe(second)
+  })
 })

--- a/apps/crew/src/lib/crew/payment-link-sales.test.ts
+++ b/apps/crew/src/lib/crew/payment-link-sales.test.ts
@@ -1,0 +1,146 @@
+// @lat: [[crew#Stripe Payment Link Sales]]
+import { describe, expect, it } from "vitest"
+import {
+  buildCrewPaymentLinkSaleActionInput,
+  buildCrewPaymentLinkSaleIdempotencyKey,
+  getCrewPaymentLinkUrlFromSettings,
+  normalizeCrewPaymentLinkReference,
+  serializeCrewPaymentLinkSettings,
+} from "./payment-link-sales"
+
+describe("Crew Payment Link sales helpers", () => {
+  it("normalizes Payment Link references and safe organizer URLs", () => {
+    expect(
+      normalizeCrewPaymentLinkReference({
+        paymentLinkReference: "  plink_123  ",
+        paymentLinkUrl: " https://buy.stripe.com/test_123 ",
+      }),
+    ).toEqual({
+      reference: "plink_123",
+      url: "https://buy.stripe.com/test_123",
+    })
+
+    expect(
+      normalizeCrewPaymentLinkReference({
+        paymentLinkReference: "https://buy.stripe.com/test_from_reference",
+      }),
+    ).toEqual({
+      reference: null,
+      url: "https://buy.stripe.com/test_from_reference",
+    })
+
+    expect(
+      normalizeCrewPaymentLinkReference({
+        paymentLinkReference: "plink_123",
+        paymentLinkUrl: "javascript:alert(1)",
+      }),
+    ).toEqual({
+      reference: "plink_123",
+      url: null,
+    })
+  })
+
+  it("records safe Payment Link URL state in settings without replacing existing Crew settings", () => {
+    const settingsText = serializeCrewPaymentLinkSettings(
+      JSON.stringify({
+        setup: { assumptions: "Keep this" },
+        crewBilling: { existing: true },
+      }),
+      {
+        paymentLinkReference: "plink_abc",
+        paymentLinkUrl: "https://buy.stripe.com/live_abc",
+      },
+    )
+    const parsed = JSON.parse(settingsText ?? "{}")
+
+    expect(parsed).toMatchObject({
+      setup: { assumptions: "Keep this" },
+      crewBilling: {
+        existing: true,
+        paymentLinkReference: "plink_abc",
+        paymentLinkUrl: "https://buy.stripe.com/live_abc",
+      },
+    })
+    expect(getCrewPaymentLinkUrlFromSettings(settingsText)).toBe(
+      "https://buy.stripe.com/live_abc",
+    )
+  })
+
+  it("preserves invalid legacy settings text while adding Payment Link URL state", () => {
+    const settingsText = serializeCrewPaymentLinkSettings("{not json", {
+      paymentLinkUrl: "https://buy.stripe.com/live_legacy",
+    })
+    const parsed = JSON.parse(settingsText ?? "{}")
+
+    expect(parsed).toMatchObject({
+      legacySettingsText: "{not json",
+      crewBilling: {
+        paymentLinkUrl: "https://buy.stripe.com/live_legacy",
+      },
+    })
+  })
+
+  it("builds scoped reconciliation action input from the server event/team scope", () => {
+    const action = buildCrewPaymentLinkSaleActionInput({
+      eventId: "comp_scope",
+      organizingTeamId: "team_scope",
+      planId: "crew_pro",
+      amountCents: 49_900,
+      currency: "USD",
+      paymentLinkReference: "plink_scope",
+      paymentLinkUrl: "https://buy.stripe.com/scope",
+      stripePaymentIntentId: "pi_scope",
+      actorLabel: "Ops",
+      privateMetadata: { adminNote: "matched from Stripe dashboard" },
+    })
+
+    expect(action).toMatchObject({
+      action: "reconcile_payment_link_sale",
+      competitionId: "comp_scope",
+      teamId: "team_scope",
+      planId: "crew_pro",
+      amountCents: 49_900,
+      currency: "USD",
+      stripePaymentLinkId: "plink_scope",
+      stripePaymentIntentId: "pi_scope",
+      idempotencyKey: "payment-link:plink_scope:pi_scope",
+      actorLabel: "Ops",
+      privateMetadata: { adminNote: "matched from Stripe dashboard" },
+    })
+    expect(action).not.toHaveProperty("currentPlanId")
+  })
+
+  it("supports missing Stripe metadata with a stable manual idempotency key", () => {
+    const action = buildCrewPaymentLinkSaleActionInput({
+      eventId: "comp_missing_metadata",
+      organizingTeamId: "team_scope",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      currency: "USD",
+    })
+
+    expect(action).toMatchObject({
+      action: "reconcile_payment_link_sale",
+      competitionId: "comp_missing_metadata",
+      teamId: "team_scope",
+      stripePaymentLinkId: null,
+      stripePaymentIntentId: undefined,
+      idempotencyKey:
+        "payment-link:manual:comp_missing_metadata:team_scope:crew_basic:20000:usd",
+    })
+  })
+
+  it("prefers an admin-provided idempotency key when reconciling manually", () => {
+    expect(
+      buildCrewPaymentLinkSaleIdempotencyKey({
+        eventId: "comp_crew",
+        organizingTeamId: "team_owner",
+        planId: "crew_basic",
+        amountCents: 20_000,
+        currency: "usd",
+        paymentLinkReference: "plink_123",
+        idempotencyKey: " manual-key ",
+      }),
+    ).toBe("manual-key")
+  })
+})

--- a/apps/crew/src/lib/crew/payment-link-sales.test.ts
+++ b/apps/crew/src/lib/crew/payment-link-sales.test.ts
@@ -130,6 +130,36 @@ describe("Crew Payment Link sales helpers", () => {
     })
   })
 
+  it("preserves an existing Payment Link reference when reconciling missing metadata", () => {
+    const action = buildCrewPaymentLinkSaleActionInput({
+      eventId: "comp_existing_reference",
+      organizingTeamId: "team_scope",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      currency: "USD",
+      current: {
+        stripe: {
+          paymentLinkId: "plink_existing",
+          checkoutSessionId: null,
+          paymentIntentId: null,
+        },
+      },
+    })
+
+    expect(action).toMatchObject({
+      action: "reconcile_payment_link_sale",
+      competitionId: "comp_existing_reference",
+      teamId: "team_scope",
+      stripePaymentLinkId: "plink_existing",
+      idempotencyKey: "payment-link:plink_existing:missing-payment-intent",
+      current: {
+        stripe: {
+          paymentLinkId: "plink_existing",
+        },
+      },
+    })
+  })
+
   it("prefers an admin-provided idempotency key when reconciling manually", () => {
     expect(
       buildCrewPaymentLinkSaleIdempotencyKey({

--- a/apps/crew/src/lib/crew/payment-link-sales.ts
+++ b/apps/crew/src/lib/crew/payment-link-sales.ts
@@ -1,0 +1,209 @@
+// @lat: [[crew#Stripe Payment Link Sales]]
+import { safeHttpUrl } from "../safe-url"
+import {
+  MANUAL_CREW_BILLING_ACTION,
+  type CrewBillingPlanId,
+  type PlanManualCrewBillingActionInput,
+} from "./billing-state"
+
+export interface CrewPaymentLinkReferenceInput {
+  paymentLinkReference?: string | null
+  paymentLinkUrl?: string | null
+}
+
+export interface NormalizedCrewPaymentLinkReference {
+  reference: string | null
+  url: string | null
+}
+
+export interface CrewPaymentLinkSaleInput
+  extends CrewPaymentLinkReferenceInput {
+  eventId: string
+  organizingTeamId: string
+  planId: CrewBillingPlanId
+  amountCents: number
+  currency?: string | null
+  stripePaymentIntentId?: string | null
+  idempotencyKey?: string | null
+  actorUserId?: string | null
+  actorLabel?: string | null
+  publicNote?: string | null
+  privateMetadata?: Record<string, unknown> | null
+}
+
+export function normalizeCrewPaymentLinkReference({
+  paymentLinkReference,
+  paymentLinkUrl,
+}: CrewPaymentLinkReferenceInput): NormalizedCrewPaymentLinkReference {
+  const referenceText = normalizeOptionalText(paymentLinkReference)
+  const urlFromUrlField = normalizeCrewPaymentLinkUrl(paymentLinkUrl)
+  const urlFromReference = normalizeCrewPaymentLinkUrl(referenceText)
+  const reference = urlFromReference ? null : normalizePaymentLinkId(referenceText)
+
+  return {
+    reference,
+    url: urlFromUrlField ?? urlFromReference,
+  }
+}
+
+export function normalizeCrewPaymentLinkUrl(input: string | null | undefined) {
+  return safeHttpUrl(normalizeOptionalText(input))
+}
+
+export function hasCrewPaymentLinkReference(
+  paymentLink: NormalizedCrewPaymentLinkReference,
+) {
+  return paymentLink.reference !== null || paymentLink.url !== null
+}
+
+export function serializeCrewPaymentLinkSettings(
+  settingsText: string | null,
+  input: CrewPaymentLinkReferenceInput,
+) {
+  const paymentLink = normalizeCrewPaymentLinkReference(input)
+  if (!hasCrewPaymentLinkReference(paymentLink)) return settingsText
+
+  const baseSettings = parseSettingsObject(settingsText)
+  const crewBilling = getPlainObject(baseSettings.crewBilling)
+
+  return JSON.stringify(
+    {
+      ...baseSettings,
+      crewBilling: {
+        ...crewBilling,
+        ...(paymentLink.reference
+          ? { paymentLinkReference: paymentLink.reference }
+          : {}),
+        ...(paymentLink.url ? { paymentLinkUrl: paymentLink.url } : {}),
+      },
+    },
+    null,
+    2,
+  )
+}
+
+export function getCrewPaymentLinkUrlFromSettings(settingsText: string | null) {
+  const settings = parseSettingsObject(settingsText)
+
+  const candidates = [
+    getNestedString(settings, ["crewBilling", "paymentLinkUrl"]),
+    getNestedString(settings, ["billing", "paymentLinkUrl"]),
+    getNestedString(settings, ["billing", "crewPaymentLinkUrl"]),
+    getNestedString(settings, ["crewBilling", "crewPaymentLinkUrl"]),
+    getNestedString(settings, ["paymentLinkUrl"]),
+    getNestedString(settings, ["crewPaymentLinkUrl"]),
+  ]
+
+  for (const candidate of candidates) {
+    const safeUrl = normalizeCrewPaymentLinkUrl(candidate)
+    if (safeUrl) return safeUrl
+  }
+
+  return null
+}
+
+export function buildCrewPaymentLinkSaleActionInput(
+  input: CrewPaymentLinkSaleInput,
+): PlanManualCrewBillingActionInput {
+  const paymentLink = normalizeCrewPaymentLinkReference(input)
+
+  return {
+    action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
+    competitionId: input.eventId,
+    teamId: input.organizingTeamId,
+    planId: input.planId,
+    amountCents: input.amountCents,
+    currency: input.currency,
+    stripePaymentLinkId: paymentLink.reference,
+    stripePaymentIntentId: input.stripePaymentIntentId,
+    idempotencyKey: buildCrewPaymentLinkSaleIdempotencyKey({
+      ...input,
+      paymentLinkReference: paymentLink.reference,
+    }),
+    actorUserId: input.actorUserId,
+    actorLabel: input.actorLabel,
+    publicNote: input.publicNote,
+    privateMetadata: input.privateMetadata,
+  }
+}
+
+export function buildCrewPaymentLinkSaleIdempotencyKey(
+  input: Pick<
+    CrewPaymentLinkSaleInput,
+    | "eventId"
+    | "organizingTeamId"
+    | "planId"
+    | "amountCents"
+    | "currency"
+    | "stripePaymentIntentId"
+    | "idempotencyKey"
+  > & { paymentLinkReference?: string | null },
+) {
+  const provided = normalizeOptionalText(input.idempotencyKey)
+  if (provided) return provided
+
+  const paymentLinkReference = normalizeOptionalText(input.paymentLinkReference)
+  const paymentIntentId = normalizeOptionalText(input.stripePaymentIntentId)
+  if (paymentLinkReference || paymentIntentId) {
+    return [
+      "payment-link",
+      paymentLinkReference ?? "missing-link",
+      paymentIntentId ?? "missing-payment-intent",
+    ].join(":")
+  }
+
+  return [
+    "payment-link",
+    "manual",
+    input.eventId,
+    input.organizingTeamId,
+    input.planId,
+    Math.max(0, Math.round(input.amountCents)),
+    normalizeCurrency(input.currency),
+  ].join(":")
+}
+
+function normalizePaymentLinkId(input: string | null) {
+  if (!input) return null
+  return input.length <= 255 ? input : null
+}
+
+function parseSettingsObject(settingsText: string | null) {
+  if (!settingsText?.trim()) return {}
+
+  try {
+    const parsed: unknown = JSON.parse(settingsText)
+    return getPlainObject(parsed)
+  } catch {
+    return { legacySettingsText: settingsText }
+  }
+}
+
+function getPlainObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function getNestedString(object: Record<string, unknown>, path: string[]) {
+  let current: unknown = object
+  for (const key of path) {
+    if (!current || typeof current !== "object" || Array.isArray(current)) {
+      return null
+    }
+    current = (current as Record<string, unknown>)[key]
+  }
+
+  return typeof current === "string" ? current : null
+}
+
+function normalizeOptionalText(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}
+
+function normalizeCurrency(value: unknown) {
+  const normalized = normalizeOptionalText(value)?.toLowerCase() ?? "usd"
+  return /^[a-z]{3}$/.test(normalized) ? normalized : "usd"
+}

--- a/apps/crew/src/lib/crew/payment-link-sales.ts
+++ b/apps/crew/src/lib/crew/payment-link-sales.ts
@@ -3,6 +3,7 @@ import { safeHttpUrl } from "../safe-url"
 import {
   MANUAL_CREW_BILLING_ACTION,
   type CrewBillingPlanId,
+  type CrewBillingStateSnapshot,
   type PlanManualCrewBillingActionInput,
 } from "./billing-state"
 
@@ -23,6 +24,7 @@ export interface CrewPaymentLinkSaleInput
   planId: CrewBillingPlanId
   amountCents: number
   currency?: string | null
+  current?: Partial<CrewBillingStateSnapshot>
   stripePaymentIntentId?: string | null
   idempotencyKey?: string | null
   actorUserId?: string | null
@@ -106,19 +108,22 @@ export function buildCrewPaymentLinkSaleActionInput(
   input: CrewPaymentLinkSaleInput,
 ): PlanManualCrewBillingActionInput {
   const paymentLink = normalizeCrewPaymentLinkReference(input)
+  const paymentLinkReference =
+    paymentLink.reference ?? input.current?.stripe?.paymentLinkId ?? null
 
   return {
     action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
     competitionId: input.eventId,
     teamId: input.organizingTeamId,
+    current: input.current,
     planId: input.planId,
     amountCents: input.amountCents,
     currency: input.currency,
-    stripePaymentLinkId: paymentLink.reference,
+    stripePaymentLinkId: paymentLinkReference,
     stripePaymentIntentId: input.stripePaymentIntentId,
     idempotencyKey: buildCrewPaymentLinkSaleIdempotencyKey({
       ...input,
-      paymentLinkReference: paymentLink.reference,
+      paymentLinkReference,
     }),
     actorUserId: input.actorUserId,
     actorLabel: input.actorLabel,

--- a/apps/crew/src/lib/crew/payment-link-sales.ts
+++ b/apps/crew/src/lib/crew/payment-link-sales.ts
@@ -33,6 +33,8 @@ export interface CrewPaymentLinkSaleInput
   privateMetadata?: Record<string, unknown> | null
 }
 
+const MAX_PAYMENT_LINK_ID_LENGTH = 255
+
 export function normalizeCrewPaymentLinkReference({
   paymentLinkReference,
   paymentLinkUrl,
@@ -150,14 +152,14 @@ export function buildCrewPaymentLinkSaleIdempotencyKey(
   const paymentLinkReference = normalizeOptionalText(input.paymentLinkReference)
   const paymentIntentId = normalizeOptionalText(input.stripePaymentIntentId)
   if (paymentLinkReference || paymentIntentId) {
-    return [
+    return joinCrewPaymentLinkIdempotencyParts(
       "payment-link",
       paymentLinkReference ?? "missing-link",
       paymentIntentId ?? "missing-payment-intent",
-    ].join(":")
+    )
   }
 
-  return [
+  return joinCrewPaymentLinkIdempotencyParts(
     "payment-link",
     "manual",
     input.eventId,
@@ -165,12 +167,18 @@ export function buildCrewPaymentLinkSaleIdempotencyKey(
     input.planId,
     Math.max(0, Math.round(input.amountCents)),
     normalizeCurrency(input.currency),
-  ].join(":")
+  )
 }
 
 function normalizePaymentLinkId(input: string | null) {
   if (!input) return null
-  return input.length <= 255 ? input : null
+  return input.length <= MAX_PAYMENT_LINK_ID_LENGTH ? input : null
+}
+
+function joinCrewPaymentLinkIdempotencyParts(
+  ...parts: Array<string | number>
+) {
+  return parts.map((part) => encodeURIComponent(String(part))).join(":")
 }
 
 function parseSettingsObject(settingsText: string | null) {

--- a/apps/crew/src/server-fns/crew-billing-fns.ts
+++ b/apps/crew/src/server-fns/crew-billing-fns.ts
@@ -1,6 +1,7 @@
 // @lat: [[crew#Server Function Runtime Boundary]]
 // @lat: [[crew#Manual Paid And Founder Grants]]
 // @lat: [[crew#Billing Page And Upgrade CTA]]
+// @lat: [[crew#Stripe Payment Link Sales]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
 import { CREW_BILLING_EVENT_TYPE } from "../db/schemas/crew-billing-events"
@@ -38,6 +39,10 @@ const nullableTextSchema = z
   .nullable()
   .optional()
 const privateMetadataSchema = z.record(z.string(), z.unknown()).nullable()
+const paymentLinkReferenceInputSchema = z.object({
+  paymentLinkReference: nullableTextSchema,
+  paymentLinkUrl: nullableTextSchema,
+})
 
 const recordCrewBillingEventInputSchema = getCrewBillingInputSchema.extend({
   eventType: crewBillingEventTypeSchema,
@@ -80,7 +85,8 @@ const recordManualCrewBillingActionBaseInputSchema =
 const optionalManualCrewBillingActionInputSchema = (
   action: Exclude<
     ManualCrewBillingActionType,
-    typeof MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID
+    | typeof MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID
+    | typeof MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE
   >,
 ) =>
   recordManualCrewBillingActionBaseInputSchema.extend({
@@ -100,6 +106,17 @@ const recordManualCrewBillingActionInputSchema = z.discriminatedUnion(
         .int()
         .positive("Manual paid Crew billing requires a positive amount."),
     }),
+    recordManualCrewBillingActionBaseInputSchema.extend({
+      action: z.literal(
+        MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
+      ),
+      planId: crewBillingPlanIdSchema,
+      amountCents: z
+        .number()
+        .int()
+        .positive("Payment Link Crew billing requires a positive amount."),
+      stripePaymentLinkId: nullableTextSchema,
+    }),
     optionalManualCrewBillingActionInputSchema(
       MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT,
     ),
@@ -117,6 +134,26 @@ const recordManualCrewBillingActionInputSchema = z.discriminatedUnion(
     ),
   ],
 )
+
+const recordCrewPaymentLinkInputSchema = getCrewBillingInputSchema.merge(
+  paymentLinkReferenceInputSchema,
+)
+
+const reconcileCrewPaymentLinkSaleInputSchema =
+  recordCrewPaymentLinkInputSchema.extend({
+    planId: crewBillingPlanIdSchema,
+    amountCents: z
+      .number()
+      .int()
+      .positive("Payment Link Crew billing requires a positive amount."),
+    currency: nullableTextSchema,
+    stripePaymentIntentId: nullableTextSchema,
+    idempotencyKey: nullableTextSchema,
+    actorUserId: nullableTextSchema,
+    actorLabel: nullableTextSchema,
+    publicNote: nullableTextSchema,
+    privateMetadata: privateMetadataSchema.optional(),
+  })
 
 export const getCrewBillingPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => getCrewBillingInputSchema.parse(data))
@@ -156,4 +193,30 @@ export const recordManualCrewBillingActionFn = createServerFn({
       "../server/crew-billing.server"
     )
     return recordManualCrewBillingAction(data)
+  })
+
+export const recordCrewPaymentLinkReferenceFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) =>
+    recordCrewPaymentLinkInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { recordCrewPaymentLinkReference } = await import(
+      "../server/crew-billing.server"
+    )
+    return recordCrewPaymentLinkReference(data)
+  })
+
+export const reconcileCrewPaymentLinkSaleFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) =>
+    reconcileCrewPaymentLinkSaleInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { reconcileCrewPaymentLinkSale } = await import(
+      "../server/crew-billing.server"
+    )
+    return reconcileCrewPaymentLinkSale(data)
   })

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -259,6 +259,7 @@ export async function reconcileCrewPaymentLinkSale(
       ...data,
       eventId: scope.id,
       organizingTeamId: scope.organizingTeamId,
+      current,
     }),
   )
 

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -1,6 +1,7 @@
 // @lat: [[crew#Crew Billing State And Audit]]
 // @lat: [[crew#Manual Paid And Founder Grants]]
 // @lat: [[crew#Billing Page And Upgrade CTA]]
+// @lat: [[crew#Stripe Payment Link Sales]]
 import { env } from "cloudflare:workers"
 import { desc, eq } from "drizzle-orm"
 import { getDb } from "../db"
@@ -23,7 +24,6 @@ import {
   canViewCrewBillingPage,
   type CrewBillingPageViewModel,
 } from "../lib/crew/billing-page"
-import { safeHttpUrl } from "../lib/safe-url"
 import {
   type CrewBillingAuditEvent,
   type CrewBillingAppendPlan,
@@ -35,6 +35,13 @@ import {
   type CrewBillingPlanId,
   type CrewBillingStateSnapshot,
 } from "../lib/crew/billing-state"
+import {
+  buildCrewPaymentLinkSaleActionInput,
+  getCrewPaymentLinkUrlFromSettings,
+  hasCrewPaymentLinkReference,
+  normalizeCrewPaymentLinkReference,
+  serializeCrewPaymentLinkSettings,
+} from "../lib/crew/payment-link-sales"
 import { getSessionFromCookie } from "../utils/auth"
 import {
   hasLocalCrewOperatorAccess,
@@ -54,6 +61,24 @@ export interface RecordCrewBillingEventInput extends GetCrewBillingInput {
   refundedCents?: number | null
   stripePaymentLinkId?: string | null
   stripeCheckoutSessionId?: string | null
+  stripePaymentIntentId?: string | null
+  idempotencyKey?: string | null
+  actorUserId?: string | null
+  actorLabel?: string | null
+  publicNote?: string | null
+  privateMetadata?: Record<string, unknown> | null
+}
+
+export interface RecordCrewPaymentLinkInput extends GetCrewBillingInput {
+  paymentLinkReference?: string | null
+  paymentLinkUrl?: string | null
+}
+
+export interface ReconcileCrewPaymentLinkSaleInput
+  extends RecordCrewPaymentLinkInput {
+  planId: CrewBillingPlanId
+  amountCents: number
+  currency?: string | null
   stripePaymentIntentId?: string | null
   idempotencyKey?: string | null
   actorUserId?: string | null
@@ -199,11 +224,76 @@ export async function recordManualCrewBillingAction(
   return persistCrewBillingAppend(data, appendPlan)
 }
 
+export async function recordCrewPaymentLinkReference(
+  data: RecordCrewPaymentLinkInput,
+): Promise<CrewBillingPageData> {
+  requireLocalCrewOperatorAccess("Crew billing")
+
+  const scope = await requireCrewBillingScope(data.eventId)
+  const paymentLink = normalizeCrewPaymentLinkReference(data)
+  if (!hasCrewPaymentLinkReference(paymentLink)) {
+    throw new Error("Crew Payment Link recording requires a reference or URL.")
+  }
+
+  await updateCrewPaymentLinkSettings({
+    eventId: data.eventId,
+    settingsText: serializeCrewPaymentLinkSettings(scope.settingsText, data),
+    paymentLinkReference: paymentLink.reference ?? undefined,
+  })
+
+  return getCrewBillingPage(data)
+}
+
+export async function reconcileCrewPaymentLinkSale(
+  data: ReconcileCrewPaymentLinkSaleInput,
+): Promise<CrewBillingPageData> {
+  requireLocalCrewOperatorAccess("Crew billing")
+
+  const scope = await requireCrewBillingScope(data.eventId)
+  const current = toCrewBillingSnapshot(scope)
+  const existingEvents = await listCrewBillingEventsForEvent(data.eventId)
+  const paymentLink = normalizeCrewPaymentLinkReference(data)
+  const appendPlan = planManualCrewBillingAction(
+    existingEvents,
+    buildCrewPaymentLinkSaleActionInput({
+      ...data,
+      eventId: scope.id,
+      organizingTeamId: scope.organizingTeamId,
+    }),
+  )
+
+  return persistCrewBillingAppend(data, appendPlan, {
+    settingsText: hasCrewPaymentLinkReference(paymentLink)
+      ? serializeCrewPaymentLinkSettings(scope.settingsText, data)
+      : undefined,
+    paymentLinkReference: paymentLink.reference ?? undefined,
+    current,
+  })
+}
+
 async function persistCrewBillingAppend(
   data: GetCrewBillingInput,
   appendPlan: CrewBillingAppendPlan,
+  options: {
+    settingsText?: string | null
+    paymentLinkReference?: string | null
+    current?: CrewBillingStateSnapshot
+  } = {},
 ) {
   if (appendPlan.action === "skip_duplicate") {
+    if (
+      options.settingsText !== undefined ||
+      options.paymentLinkReference !== undefined
+    ) {
+      await updateCrewPaymentLinkSettings({
+        eventId: data.eventId,
+        settingsText: options.settingsText,
+        paymentLinkReference:
+          options.paymentLinkReference ??
+          options.current?.stripe.paymentLinkId ??
+          null,
+      })
+    }
     return getCrewBillingPage(data)
   }
 
@@ -219,6 +309,9 @@ async function persistCrewBillingAppend(
         .update(crewEventSettingsTable)
         .set({
           ...settingsPatch,
+          ...(options.settingsText !== undefined
+            ? { settings: options.settingsText }
+            : {}),
           updatedAt: new Date(),
         })
         .where(eq(crewEventSettingsTable.competitionId, data.eventId))
@@ -231,6 +324,30 @@ async function persistCrewBillingAppend(
   }
 
   return getCrewBillingPage(data)
+}
+
+async function updateCrewPaymentLinkSettings({
+  eventId,
+  settingsText,
+  paymentLinkReference,
+}: {
+  eventId: string
+  settingsText?: string | null
+  paymentLinkReference?: string | null
+}) {
+  if (settingsText === undefined && paymentLinkReference === undefined) return
+
+  const db = getDb()
+  await db
+    .update(crewEventSettingsTable)
+    .set({
+      ...(settingsText !== undefined ? { settings: settingsText } : {}),
+      ...(paymentLinkReference !== undefined
+        ? { crewStripePaymentLinkId: paymentLinkReference }
+        : {}),
+      updatedAt: new Date(),
+    })
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
 }
 
 async function requireCrewBillingScope(
@@ -410,55 +527,6 @@ function toCrewBillingJsonValue(
   }
 
   return undefined
-}
-
-function getCrewPaymentLinkUrlFromSettings(settingsText: string | null) {
-  const settings = parseSettingsObject(settingsText)
-  if (!settings) return null
-
-  const candidates = [
-    getNestedString(settings, ["billing", "paymentLinkUrl"]),
-    getNestedString(settings, ["billing", "crewPaymentLinkUrl"]),
-    getNestedString(settings, ["crewBilling", "paymentLinkUrl"]),
-    getNestedString(settings, ["crewBilling", "crewPaymentLinkUrl"]),
-    getNestedString(settings, ["paymentLinkUrl"]),
-    getNestedString(settings, ["crewPaymentLinkUrl"]),
-  ]
-
-  for (const candidate of candidates) {
-    const safeUrl = safeHttpUrl(candidate)
-    if (safeUrl) return safeUrl
-  }
-
-  return null
-}
-
-function parseSettingsObject(settingsText: string | null) {
-  if (!settingsText) return null
-
-  try {
-    const parsed: unknown = JSON.parse(settingsText)
-    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : null
-  } catch {
-    return null
-  }
-}
-
-function getNestedString(
-  object: Record<string, unknown>,
-  path: string[],
-): string | null {
-  let current: unknown = object
-  for (const key of path) {
-    if (!current || typeof current !== "object" || Array.isArray(current)) {
-      return null
-    }
-    current = (current as Record<string, unknown>)[key]
-  }
-
-  return typeof current === "string" ? current : null
 }
 
 function isCrewStripeCheckoutEnabled() {

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -42,6 +42,16 @@ The private Crew billing page shows organizer-safe event billing state without e
 
 [[apps/crew/src/server/crew-billing.server.ts]] and [[apps/crew/src/server-fns/crew-billing-fns.ts]] keep the organizer billing loader server-only, scoped to the event organizing team's billing permission with local operator fallback. Payment Link buttons only use an already configured safe URL from event settings, and Checkout remains a disabled flag-gated slot until a later slice creates sessions.
 
+## Stripe Payment Link Sales
+
+Stripe Payment Link sales are recorded manually by private Crew operators without calling Stripe APIs, creating Checkout Sessions, or wiring webhooks.
+
+[[apps/crew/src/lib/crew/payment-link-sales.ts]] normalizes operator-provided Payment Link references and organizer-safe URLs, stores safe URLs under `crew_event_settings.settings`, derives stable reconciliation idempotency keys, and builds server-scoped manual reconciliation inputs from the event ID plus organizing team ID resolved on the server.
+
+[[apps/crew/src/lib/crew/billing-state.ts]] maps Payment Link reconciliation to an event-level paid Crew purchase with source `PAYMENT_LINK`, requiring a Crew event plan and positive amount while keeping the plan separate from `teams.currentPlanId`.
+
+[[apps/crew/src/server/crew-billing.server.ts]] and [[apps/crew/src/server-fns/crew-billing-fns.ts]] expose local-operator-only Payment Link reference recording and sale reconciliation. Reconciliation appends `crew_billing_events` audit rows, patches only the selected event's `crew_event_settings` billing fields, and still works when Stripe metadata is missing because the operator supplies the event, team scope, plan, amount, and currency.
+
 ## Server Function Runtime Boundary
 
 Route and client code import lightweight `createServerFn` wrappers from [[apps/crew/src/server-fns]].


### PR DESCRIPTION
## Summary

- Add pure Crew Payment Link helpers for safe URL/reference normalization, settings JSON persistence, and stable manual reconciliation idempotency keys.
- Add local-operator-only server actions to record a Payment Link reference/URL and reconcile a Payment Link sale into event-level Crew billing state/audit rows.
- Extend billing planning/tests and LAT docs for `crew#Stripe Payment Link Sales` while keeping Crew event purchases separate from team subscription plans.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/billing-state.test.ts src/lib/crew/billing-page.test.ts src/lib/crew/payment-link-sales.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exit 0; existing unrelated Biome warnings remain)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `pnpm dlx lat.md locate 'crew#Stripe Payment Link Sales'`
- `git diff --check`

## Notes

- No schema or migrations.
- No live Stripe API calls, Checkout Sessions, webhooks, public checkout flow, or team subscription mutation.
- Build required the ignored local Alchemy Wrangler config at `apps/crew/.alchemy/local/wrangler.jsonc`, copied from the sibling local Crew worktree for this isolated worktree only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds manual Stripe Payment Link sales for Crew events. Operators can record links and reconcile a sale into event billing with safe URLs, idempotent deduping (URL-encoded keys), and audit trails—no Stripe APIs or schema changes.

- **New Features**
  - Payment Link helpers normalize references/URLs, store a safe URL in `crew_event_settings.settings`, read existing URLs, and build stable idempotency keys (prefers admin-provided); serializer preserves legacy invalid JSON.
  - Billing state adds `RECONCILE_PAYMENT_LINK_SALE` as `PAYMENT_LINK`, requires a valid Crew plan and positive amount, dedupes by idempotency key, and preserves an existing `stripePaymentLinkId` when metadata is missing.
  - Local-operator server actions `recordCrewPaymentLinkReferenceFn` and `reconcileCrewPaymentLinkSaleFn` persist safe URLs/IDs and append audit events.

- **Bug Fixes**
  - Idempotency key parts are URL-encoded to avoid collisions when values contain colons.
  - Preserve existing Payment Link reference even when reconciliation is deduped.

<sup>Written for commit 984c863b59fdaf4af2db45a9923b71ec9eedd5ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for manual Stripe payment link sales recording and reconciliation in crew billing workflows.
  * Introduced payment link reference normalization, validation, and persistent storage.
  * Implemented idempotent reconciliation to prevent duplicate billing entries.

* **Tests**
  * Added comprehensive test coverage for payment link sales and billing reconciliation.

* **Documentation**
  * Added Stripe payment link sales workflow documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->