### PR TITLE
feat(crew): create Crew Checkout Sessions

### DIFF
--- a/apps/crew/src/lib/crew/billing-page.test.ts
+++ b/apps/crew/src/lib/crew/billing-page.test.ts
@@ -4,11 +4,11 @@ import {
   CREW_BILLING_SOURCE,
   CREW_BILLING_STATE,
 } from "../../db/schemas/crew-event-settings"
-import type { CrewBillingStateSnapshot } from "./billing-state"
 import {
   buildCrewBillingPageViewModel,
   canViewCrewBillingPage,
 } from "./billing-page"
+import type { CrewBillingStateSnapshot } from "./billing-state"
 
 const baseBilling: CrewBillingStateSnapshot = {
   state: CREW_BILLING_STATE.UNPAID,
@@ -82,11 +82,47 @@ describe("Crew billing page view model", () => {
 
     expect(disabled.checkout.status).toBe("hidden")
     expect(enabled.checkout).toMatchObject({
-      status: "disabled",
+      status: "available",
       href: null,
-      label: "Checkout coming soon",
+      label: "Start Checkout",
     })
-    expect(enabled.checkout.helperText).toContain("session creation")
+    expect(enabled.checkout.helperText).toContain("Checkout Session")
+  })
+
+  it("disables Checkout for pending or private Crew billing states", () => {
+    const pending = buildCrewBillingPageViewModel({
+      billing: {
+        ...baseBilling,
+        state: CREW_BILLING_STATE.PENDING,
+        source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+        planId: "crew_basic",
+        amountCents: 20_000,
+        stripe: {
+          ...baseBilling.stripe,
+          checkoutSessionId: "cs_pending",
+        },
+      },
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: true,
+    })
+    const privatePlan = buildCrewBillingPageViewModel({
+      billing: {
+        ...baseBilling,
+        planId: "crew_founding_2026",
+        amountCents: 9900,
+      },
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: true,
+    })
+
+    expect(pending.checkout).toMatchObject({
+      status: "disabled",
+      label: "Checkout pending",
+    })
+    expect(privatePlan.checkout).toMatchObject({
+      status: "disabled",
+      label: "Checkout unavailable",
+    })
   })
 
   it("shows paid manual, comp, refund, and upgrade credit state without team subscription semantics", () => {

--- a/apps/crew/src/lib/crew/billing-page.ts
+++ b/apps/crew/src/lib/crew/billing-page.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Billing Page And Upgrade CTA]]
+// @lat: [[crew#Crew Checkout Sessions]]
 import {
   CREW_BILLING_SOURCE,
   CREW_BILLING_STATE,
@@ -6,10 +7,11 @@ import {
   type CrewBillingState,
 } from "../../db/schemas/crew-event-settings"
 import {
-  resolveCrewBillingEntitlements,
   type CrewBillingPlanId,
   type CrewBillingStateSnapshot,
+  resolveCrewBillingEntitlements,
 } from "./billing-state"
+import { isCrewCheckoutPlanId } from "./checkout-sessions"
 
 export interface CrewBillingPageEventAccess {
   organizingTeamId: string
@@ -157,7 +159,7 @@ export function buildCrewBillingPageViewModel({
     },
     upgradeCta: buildUpgradeCta(billing),
     paymentLink: buildPaymentLinkAction(paymentLink),
-    checkout: buildCheckoutAction(checkoutEnabled),
+    checkout: buildCheckoutAction(checkoutEnabled, billing),
   }
 }
 
@@ -210,6 +212,7 @@ function buildPaymentLinkAction(
 
 function buildCheckoutAction(
   checkoutEnabled: boolean,
+  billing: CrewBillingStateSnapshot,
 ): CrewBillingActionViewModel {
   if (!checkoutEnabled) {
     return {
@@ -220,12 +223,42 @@ function buildCheckoutAction(
     }
   }
 
+  if (billing.state === CREW_BILLING_STATE.PENDING) {
+    return {
+      label: "Checkout pending",
+      status: "disabled",
+      href: null,
+      helperText: "A Checkout Session is already pending for this event.",
+    }
+  }
+
+  if (
+    billing.state === CREW_BILLING_STATE.PAID ||
+    billing.state === CREW_BILLING_STATE.COMPED ||
+    billing.state === CREW_BILLING_STATE.CREDITED
+  ) {
+    return {
+      label: "Checkout unavailable",
+      status: "hidden",
+      href: null,
+      helperText: "Crew billing is already active for this event.",
+    }
+  }
+
+  if (billing.planId && !isCrewCheckoutPlanId(billing.planId)) {
+    return {
+      label: "Checkout unavailable",
+      status: "disabled",
+      href: null,
+      helperText: "Checkout is available for public paid Crew plans.",
+    }
+  }
+
   return {
-    label: "Checkout coming soon",
-    status: "disabled",
+    label: "Start Checkout",
+    status: "available",
     href: null,
-    helperText:
-      "Checkout is enabled, but session creation is intentionally deferred from this slice.",
+    helperText: "Create a Checkout Session for this Crew event.",
   }
 }
 

--- a/apps/crew/src/lib/crew/billing-state.test.ts
+++ b/apps/crew/src/lib/crew/billing-state.test.ts
@@ -7,12 +7,12 @@ import {
   CREW_BILLING_STATE,
 } from "../../db/schemas/crew-event-settings"
 import {
-  MANUAL_CREW_BILLING_ACTION,
   buildCrewBillingAuditEvent,
   buildCrewBillingSettingsPatch,
   getCrewBillingLimit,
   hasCrewBillingFeature,
   isCrewBillingDuplicateEntryError,
+  MANUAL_CREW_BILLING_ACTION,
   normalizeCrewBillingState,
   planCrewBillingAuditAppend,
   planManualCrewBillingAction,
@@ -58,11 +58,7 @@ describe("Crew billing state and audit helpers", () => {
     ).toMatchObject({
       hasCrewEventAccess: true,
       reason: "active",
-      features: [
-        "crew_events",
-        "crew_imports",
-        "crew_confirmation_reminders",
-      ],
+      features: ["crew_events", "crew_imports", "crew_confirmation_reminders"],
       limits: {
         max_crew_events: 1,
         max_crew_volunteers_per_event: -1,
@@ -201,19 +197,16 @@ describe("Crew billing state and audit helpers", () => {
         ...validManualPaidInput,
         ...overrides,
       }) as unknown as Parameters<typeof planManualCrewBillingAction>[1]
-    const unsafeManualPaidInputWithout = (
-      key: "planId" | "amountCents",
-    ) => {
+    const unsafeManualPaidInputWithout = (key: "planId" | "amountCents") => {
       const input = { ...validManualPaidInput } as Record<string, unknown>
       delete input[key]
-      return input as unknown as Parameters<typeof planManualCrewBillingAction>[1]
+      return input as unknown as Parameters<
+        typeof planManualCrewBillingAction
+      >[1]
     }
 
     expect(() =>
-      planManualCrewBillingAction(
-        [],
-        unsafeManualPaidInputWithout("planId"),
-      ),
+      planManualCrewBillingAction([], unsafeManualPaidInputWithout("planId")),
     ).toThrow(/valid Crew plan/)
     expect(() =>
       planManualCrewBillingAction(
@@ -302,6 +295,71 @@ describe("Crew billing state and audit helpers", () => {
     })
   })
 
+  it("plans Checkout Session creation as pending event-level billing without team plan mutation", () => {
+    const plan = planCrewBillingAuditAppend([], {
+      id: "cbill_checkout",
+      competitionId: "comp_checkout",
+      teamId: "team_owner",
+      eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED,
+      planId: "crew_basic",
+      amountCents: 20_000,
+      stripeCheckoutSessionId: "cs_checkout_123",
+      idempotencyKey: "crew-checkout:comp_checkout:team_owner:crew_basic:20000",
+    })
+
+    expect(plan).toMatchObject({
+      action: "append",
+      event: {
+        id: "cbill_checkout",
+        eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED,
+        billingState: CREW_BILLING_STATE.PENDING,
+        billingSource: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+        planId: "crew_basic",
+        amountCents: 20_000,
+        stripeCheckoutSessionId: "cs_checkout_123",
+      },
+      settingsPatch: {
+        crewBillingState: CREW_BILLING_STATE.PENDING,
+        crewBillingSource: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+        crewBillingPlanId: "crew_basic",
+        crewBillingAmountCents: 20_000,
+        crewStripeCheckoutSessionId: "cs_checkout_123",
+      },
+    })
+    expect(plan.settingsPatch).not.toHaveProperty("currentPlanId")
+    expect(
+      resolveCrewBillingEntitlements({
+        state: plan.settingsPatch.crewBillingState,
+        source: plan.settingsPatch.crewBillingSource,
+        planId: plan.settingsPatch.crewBillingPlanId,
+      }),
+    ).toMatchObject({
+      hasCrewEventAccess: false,
+      reason: "pending",
+    })
+
+    const duplicate = planCrewBillingAuditAppend([plan.event], {
+      competitionId: "comp_checkout",
+      teamId: "team_owner",
+      eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED,
+      planId: "crew_basic",
+      amountCents: 20_000,
+      stripeCheckoutSessionId: "cs_checkout_123",
+      idempotencyKey: "crew-checkout:comp_checkout:team_owner:crew_basic:20000",
+    })
+    expect(duplicate.action).toBe("skip_duplicate")
+
+    expect(() =>
+      planCrewBillingAuditAppend([], {
+        competitionId: "comp_checkout",
+        teamId: "team_owner",
+        eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED,
+        planId: "crew_basic",
+        amountCents: 20_000,
+      }),
+    ).toThrow(/Stripe session ID/)
+  })
+
   it("plans Payment Link reconciliation as an event-scoped paid Crew purchase", () => {
     const plan = planManualCrewBillingAction([], {
       action: MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
@@ -344,8 +402,9 @@ describe("Crew billing state and audit helpers", () => {
       },
     })
     expect(plan.settingsPatch).not.toHaveProperty("currentPlanId")
-    expect(JSON.stringify(resolveCrewBillingEntitlements(plan.settingsPatch)))
-      .not.toContain("plink_123")
+    expect(
+      JSON.stringify(resolveCrewBillingEntitlements(plan.settingsPatch)),
+    ).not.toContain("plink_123")
   })
 
   it("allows Payment Link reconciliation when Stripe metadata is missing", () => {

--- a/apps/crew/src/lib/crew/billing-state.ts
+++ b/apps/crew/src/lib/crew/billing-state.ts
@@ -1,6 +1,7 @@
 // @lat: [[crew#Crew Billing State And Audit]]
 // @lat: [[crew#Manual Paid And Founder Grants]]
 // @lat: [[crew#Stripe Payment Link Sales]]
+// @lat: [[crew#Crew Checkout Sessions]]
 import {
   CREW_BILLING_EVENT_TYPE,
   type CrewBillingEventType,
@@ -75,6 +76,7 @@ export interface CrewBillingStateSnapshot {
 }
 
 export interface BuildCrewBillingEventInput {
+  id?: string | null
   competitionId: string
   teamId: string
   eventType: CrewBillingEventType
@@ -121,6 +123,7 @@ export type PlanManualCrewBillingActionInput =
     })
 
 export interface CrewBillingAuditEvent {
+  id: string | null
   competitionId: string
   teamId: string
   eventType: CrewBillingEventType
@@ -209,11 +212,7 @@ const crewBillingPlanEntitlements: Record<
     },
   },
   crew_basic: {
-    features: [
-      "crew_events",
-      "crew_imports",
-      "crew_confirmation_reminders",
-    ],
+    features: ["crew_events", "crew_imports", "crew_confirmation_reminders"],
     limits: {
       max_crew_events: 1,
       max_crew_volunteers_per_event: -1,
@@ -280,6 +279,10 @@ const eventDefaults: Record<
   [CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED]: {
     state: CREW_BILLING_STATE.PAID,
     source: CREW_BILLING_SOURCE.PAYMENT_LINK,
+  },
+  [CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED]: {
+    state: CREW_BILLING_STATE.PENDING,
+    source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
   },
   [CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED]: {
     state: CREW_BILLING_STATE.PAID,
@@ -393,6 +396,7 @@ export function buildCrewBillingAuditEvent(
       : current.planId)
 
   return {
+    id: normalizeOptionalText(input.id),
     competitionId: input.competitionId,
     teamId: input.teamId,
     eventType: input.eventType,
@@ -619,6 +623,10 @@ function validateCrewBillingAuditAppend(
     validatePaidCrewBillingEvent(event, "Payment Link Crew billing")
   }
 
+  if (event.eventType === CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED) {
+    validateCheckoutSessionCreatedEvent(event)
+  }
+
   if (event.eventType === CREW_BILLING_EVENT_TYPE.CREDIT_SET) {
     if (
       normalized.creditCents > 0 ||
@@ -650,9 +658,7 @@ function validateCrewBillingAuditAppend(
       normalized.creditCents <= 0 &&
       normalized.fullPlatformCreditCents <= 0
     ) {
-      throw new Error(
-        "Set a full platform upgrade credit before applying it.",
-      )
+      throw new Error("Set a full platform upgrade credit before applying it.")
     }
   }
 }
@@ -666,6 +672,13 @@ function validatePaidCrewBillingEvent(
   }
   if (event.amountCents <= 0) {
     throw new Error(`${label} requires a positive amount.`)
+  }
+}
+
+function validateCheckoutSessionCreatedEvent(event: CrewBillingAuditEvent) {
+  validatePaidCrewBillingEvent(event, "Crew Checkout session")
+  if (!event.stripeCheckoutSessionId) {
+    throw new Error("Crew Checkout session requires a Stripe session ID.")
   }
 }
 

--- a/apps/crew/src/lib/crew/checkout-sessions.test.ts
+++ b/apps/crew/src/lib/crew/checkout-sessions.test.ts
@@ -11,9 +11,27 @@ import {
   buildCrewCheckoutMetadata,
   buildCrewCheckoutSessionCreateParams,
   isCrewStripeCheckoutEnabledValue,
+  isReusableCrewCheckoutPendingClaim,
   normalizeCrewCheckoutCatalogPlan,
   resolveCrewCheckoutPlanId,
 } from "./checkout-sessions"
+
+const unpaidBilling = {
+  state: CREW_BILLING_STATE.UNPAID,
+  source: null,
+  planId: null,
+  amountCents: 0,
+  currency: "usd",
+  stripe: {
+    paymentLinkId: null,
+    checkoutSessionId: null,
+    paymentIntentId: null,
+  },
+  founderOverride: false,
+  creditCents: 0,
+  fullPlatformCreditCents: 0,
+  refundedCents: 0,
+} as const
 
 describe("Crew Checkout Session helpers", () => {
   it("builds the Stripe metadata contract without private billing data", () => {
@@ -182,39 +200,30 @@ describe("Crew Checkout Session helpers", () => {
   })
 
   it("prevents duplicate pending sessions and active-billing checkout starts", () => {
-    const unpaid = {
-      state: CREW_BILLING_STATE.UNPAID,
-      source: null,
-      planId: null,
-      amountCents: 0,
-      currency: "usd",
-      stripe: {
-        paymentLinkId: null,
-        checkoutSessionId: null,
-        paymentIntentId: null,
-      },
-      founderOverride: false,
-      creditCents: 0,
-      fullPlatformCreditCents: 0,
-      refundedCents: 0,
-    } as const
-
-    expect(() => assertCrewCheckoutCanStart(unpaid)).not.toThrow()
+    expect(() => assertCrewCheckoutCanStart(unpaidBilling)).not.toThrow()
     expect(() =>
       assertCrewCheckoutCanStart({
-        ...unpaid,
+        ...unpaidBilling,
         state: CREW_BILLING_STATE.PENDING,
         source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
         planId: "crew_basic",
         stripe: {
-          ...unpaid.stripe,
+          ...unpaidBilling.stripe,
           checkoutSessionId: "cs_pending",
         },
       }),
     ).toThrow(/already pending/)
     expect(() =>
       assertCrewCheckoutCanStart({
-        ...unpaid,
+        ...unpaidBilling,
+        state: CREW_BILLING_STATE.PENDING,
+        source: CREW_BILLING_SOURCE.PAYMENT_LINK,
+        planId: "crew_basic",
+      }),
+    ).toThrow(/already pending/)
+    expect(() =>
+      assertCrewCheckoutCanStart({
+        ...unpaidBilling,
         state: CREW_BILLING_STATE.PAID,
         source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
         planId: "crew_basic",
@@ -222,9 +231,56 @@ describe("Crew Checkout Session helpers", () => {
     ).toThrow(/already active/)
     expect(() =>
       assertCrewCheckoutCanStart({
-        ...unpaid,
+        ...unpaidBilling,
+        planId: "crew_starter",
+      }),
+    ).toThrow(/public paid plans/)
+    expect(() =>
+      assertCrewCheckoutCanStart({
+        ...unpaidBilling,
         planId: "crew_founding_2026",
       }),
     ).toThrow(/public paid plans/)
+  })
+
+  it("identifies only same-plan pending checkout claims as retryable", () => {
+    const pendingClaim = {
+      ...unpaidBilling,
+      state: CREW_BILLING_STATE.PENDING,
+      source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+      planId: "crew_basic",
+      amountCents: 20_000,
+    } as const
+
+    expect(
+      isReusableCrewCheckoutPendingClaim({
+        billing: pendingClaim,
+        crewPlan: "crew_basic",
+        amountCents: 20_000,
+        currency: "USD",
+      }),
+    ).toBe(true)
+    expect(
+      isReusableCrewCheckoutPendingClaim({
+        billing: pendingClaim,
+        crewPlan: "crew_pro",
+        amountCents: 80_000,
+        currency: "usd",
+      }),
+    ).toBe(false)
+    expect(
+      isReusableCrewCheckoutPendingClaim({
+        billing: {
+          ...pendingClaim,
+          stripe: {
+            ...pendingClaim.stripe,
+            checkoutSessionId: "cs_pending",
+          },
+        },
+        crewPlan: "crew_basic",
+        amountCents: 20_000,
+        currency: "usd",
+      }),
+    ).toBe(false)
   })
 })

--- a/apps/crew/src/lib/crew/checkout-sessions.test.ts
+++ b/apps/crew/src/lib/crew/checkout-sessions.test.ts
@@ -1,0 +1,181 @@
+// @lat: [[crew#Crew Checkout Sessions]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_BILLING_SOURCE,
+  CREW_BILLING_STATE,
+} from "../../db/schemas/crew-event-settings"
+import {
+  assertCrewCheckoutCanStart,
+  buildCrewCheckoutIdempotencyKey,
+  buildCrewCheckoutMetadata,
+  buildCrewCheckoutSessionCreateParams,
+  isCrewStripeCheckoutEnabledValue,
+  normalizeCrewCheckoutCatalogPlan,
+  resolveCrewCheckoutPlanId,
+} from "./checkout-sessions"
+
+describe("Crew Checkout Session helpers", () => {
+  it("builds the Stripe metadata contract without private billing data", () => {
+    const idempotencyKey = buildCrewCheckoutIdempotencyKey({
+      competitionId: "comp_checkout",
+      teamId: "team_owner",
+      crewPlan: "crew_basic",
+      amountCents: 20_000,
+    })
+    const metadata = buildCrewCheckoutMetadata({
+      teamId: "team_owner",
+      competitionId: "comp_checkout",
+      crewPlan: "crew_basic",
+      crewEventSettingsId: "crewset_123",
+      billingEventId: "cbill_123",
+      checkoutIdempotencyKey: idempotencyKey,
+    })
+
+    expect(metadata).toEqual({
+      product: "crew",
+      teamId: "team_owner",
+      competitionId: "comp_checkout",
+      eventId: "comp_checkout",
+      crewPlan: "crew_basic",
+      crewEventSettingsId: "crewset_123",
+      billingEventId: "cbill_123",
+      checkoutIdempotencyKey: idempotencyKey,
+    })
+    expect(JSON.stringify(metadata)).not.toContain("founder")
+    expect(JSON.stringify(metadata)).not.toContain("invoice")
+    expect(JSON.stringify(metadata)).not.toContain("privateMetadata")
+  })
+
+  it("builds one-time Checkout Session params from the public Crew catalog plan", () => {
+    const params = buildCrewCheckoutSessionCreateParams({
+      eventName: "Boise Throwdown",
+      appUrl: "https://crew.wodsmith.com",
+      customerEmail: "organizer@example.com",
+      nowSeconds: 1_800_000_000,
+      plan: {
+        id: "crew_pro",
+        name: "Crew Pro",
+        description: "One-time Crew event plan",
+        price: 80_000,
+        currency: "usd",
+      },
+      teamId: "team_owner",
+      competitionId: "comp_checkout",
+      crewPlan: "crew_pro",
+      crewEventSettingsId: "crewset_123",
+      billingEventId: "cbill_123",
+      checkoutIdempotencyKey: "crew-checkout:comp_checkout",
+    })
+
+    expect(params.mode).toBe("payment")
+    expect(params.customer_email).toBe("organizer@example.com")
+    expect(params.expires_at).toBe(1_800_001_800)
+    expect(params.success_url).toBe(
+      "https://crew.wodsmith.com/events/comp_checkout/billing?crew_checkout=success&session_id={CHECKOUT_SESSION_ID}",
+    )
+    expect(params.cancel_url).toBe(
+      "https://crew.wodsmith.com/events/comp_checkout/billing?crew_checkout=canceled",
+    )
+    expect(params.metadata).toMatchObject({
+      product: "crew",
+      crewPlan: "crew_pro",
+      billingEventId: "cbill_123",
+    })
+    expect(params.payment_intent_data?.metadata).toMatchObject(params.metadata)
+    expect(params.line_items?.[0]).toMatchObject({
+      price_data: {
+        currency: "usd",
+        unit_amount: 80_000,
+        product_data: {
+          name: "Crew Pro - Boise Throwdown",
+          metadata: params.metadata,
+        },
+      },
+      quantity: 1,
+    })
+  })
+
+  it("parses the feature flag and rejects unsafe plan/session states", () => {
+    expect(isCrewStripeCheckoutEnabledValue("enabled")).toBe(true)
+    expect(isCrewStripeCheckoutEnabledValue("true")).toBe(true)
+    expect(isCrewStripeCheckoutEnabledValue("0")).toBe(false)
+    expect(resolveCrewCheckoutPlanId({ currentPlanId: null })).toBe(
+      "crew_basic",
+    )
+    expect(resolveCrewCheckoutPlanId({ requestedPlanId: "crew_pro" })).toBe(
+      "crew_pro",
+    )
+    expect(() =>
+      resolveCrewCheckoutPlanId({ requestedPlanId: "crew_founding_2026" }),
+    ).toThrow(/public paid plans/)
+    expect(() =>
+      normalizeCrewCheckoutCatalogPlan({
+        id: "crew_founding_2026",
+        name: "Founder",
+        description: "Private",
+        price: 9900,
+        interval: null,
+        isActive: 1,
+        isPublic: 0,
+      }),
+    ).toThrow(/public paid/)
+    expect(() =>
+      normalizeCrewCheckoutCatalogPlan({
+        id: "crew_basic",
+        name: "Crew Basic",
+        description: null,
+        price: 0,
+        interval: null,
+        isActive: 1,
+        isPublic: 1,
+      }),
+    ).toThrow(/positive/)
+  })
+
+  it("prevents duplicate pending sessions and active-billing checkout starts", () => {
+    const unpaid = {
+      state: CREW_BILLING_STATE.UNPAID,
+      source: null,
+      planId: null,
+      amountCents: 0,
+      currency: "usd",
+      stripe: {
+        paymentLinkId: null,
+        checkoutSessionId: null,
+        paymentIntentId: null,
+      },
+      founderOverride: false,
+      creditCents: 0,
+      fullPlatformCreditCents: 0,
+      refundedCents: 0,
+    } as const
+
+    expect(() => assertCrewCheckoutCanStart(unpaid)).not.toThrow()
+    expect(() =>
+      assertCrewCheckoutCanStart({
+        ...unpaid,
+        state: CREW_BILLING_STATE.PENDING,
+        source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+        planId: "crew_basic",
+        stripe: {
+          ...unpaid.stripe,
+          checkoutSessionId: "cs_pending",
+        },
+      }),
+    ).toThrow(/already pending/)
+    expect(() =>
+      assertCrewCheckoutCanStart({
+        ...unpaid,
+        state: CREW_BILLING_STATE.PAID,
+        source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+        planId: "crew_basic",
+      }),
+    ).toThrow(/already active/)
+    expect(() =>
+      assertCrewCheckoutCanStart({
+        ...unpaid,
+        planId: "crew_founding_2026",
+      }),
+    ).toThrow(/public paid plans/)
+  })
+})

--- a/apps/crew/src/lib/crew/checkout-sessions.test.ts
+++ b/apps/crew/src/lib/crew/checkout-sessions.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../db/schemas/crew-event-settings"
 import {
   assertCrewCheckoutCanStart,
+  buildCrewCheckoutBillingEventId,
   buildCrewCheckoutIdempotencyKey,
   buildCrewCheckoutMetadata,
   buildCrewCheckoutSessionCreateParams,
@@ -22,12 +23,13 @@ describe("Crew Checkout Session helpers", () => {
       crewPlan: "crew_basic",
       amountCents: 20_000,
     })
+    const billingEventId = buildCrewCheckoutBillingEventId(idempotencyKey)
     const metadata = buildCrewCheckoutMetadata({
       teamId: "team_owner",
       competitionId: "comp_checkout",
       crewPlan: "crew_basic",
       crewEventSettingsId: "crewset_123",
-      billingEventId: "cbill_123",
+      billingEventId,
       checkoutIdempotencyKey: idempotencyKey,
     })
 
@@ -38,20 +40,27 @@ describe("Crew Checkout Session helpers", () => {
       eventId: "comp_checkout",
       crewPlan: "crew_basic",
       crewEventSettingsId: "crewset_123",
-      billingEventId: "cbill_123",
+      billingEventId,
       checkoutIdempotencyKey: idempotencyKey,
     })
+    expect(billingEventId).toMatch(/^cbill_checkout_[a-z0-9]+$/)
+    expect(buildCrewCheckoutBillingEventId(idempotencyKey)).toBe(billingEventId)
     expect(JSON.stringify(metadata)).not.toContain("founder")
     expect(JSON.stringify(metadata)).not.toContain("invoice")
     expect(JSON.stringify(metadata)).not.toContain("privateMetadata")
   })
 
   it("builds one-time Checkout Session params from the public Crew catalog plan", () => {
+    const idempotencyKey = buildCrewCheckoutIdempotencyKey({
+      competitionId: "comp_checkout",
+      teamId: "team_owner",
+      crewPlan: "crew_pro",
+      amountCents: 80_000,
+    })
+    const billingEventId = buildCrewCheckoutBillingEventId(idempotencyKey)
     const params = buildCrewCheckoutSessionCreateParams({
       eventName: "Boise Throwdown",
       appUrl: "https://crew.wodsmith.com",
-      customerEmail: "organizer@example.com",
-      nowSeconds: 1_800_000_000,
       plan: {
         id: "crew_pro",
         name: "Crew Pro",
@@ -63,13 +72,13 @@ describe("Crew Checkout Session helpers", () => {
       competitionId: "comp_checkout",
       crewPlan: "crew_pro",
       crewEventSettingsId: "crewset_123",
-      billingEventId: "cbill_123",
-      checkoutIdempotencyKey: "crew-checkout:comp_checkout",
+      billingEventId,
+      checkoutIdempotencyKey: idempotencyKey,
     })
 
     expect(params.mode).toBe("payment")
-    expect(params.customer_email).toBe("organizer@example.com")
-    expect(params.expires_at).toBe(1_800_001_800)
+    expect(params.customer_email).toBeUndefined()
+    expect(params.expires_at).toBeUndefined()
     expect(params.success_url).toBe(
       "https://crew.wodsmith.com/events/comp_checkout/billing?crew_checkout=success&session_id={CHECKOUT_SESSION_ID}",
     )
@@ -79,7 +88,7 @@ describe("Crew Checkout Session helpers", () => {
     expect(params.metadata).toMatchObject({
       product: "crew",
       crewPlan: "crew_pro",
-      billingEventId: "cbill_123",
+      billingEventId,
     })
     expect(params.payment_intent_data?.metadata).toMatchObject(params.metadata)
     expect(params.line_items?.[0]).toMatchObject({
@@ -93,6 +102,46 @@ describe("Crew Checkout Session helpers", () => {
       },
       quantity: 1,
     })
+  })
+
+  it("keeps retry metadata and session params stable for the same checkout key", () => {
+    const checkoutIdempotencyKey = buildCrewCheckoutIdempotencyKey({
+      competitionId: "comp_retry",
+      teamId: "team_owner",
+      crewPlan: "crew_basic",
+      amountCents: 20_000,
+    })
+    const billingEventId = buildCrewCheckoutBillingEventId(
+      checkoutIdempotencyKey,
+    )
+    const input = {
+      eventName: "Retry Throwdown",
+      appUrl: "https://crew.wodsmith.com",
+      plan: {
+        id: "crew_basic",
+        name: "Crew Basic",
+        description: "One-time Crew event plan",
+        price: 20_000,
+        currency: "usd",
+      },
+      teamId: "team_owner",
+      competitionId: "comp_retry",
+      crewPlan: "crew_basic",
+      crewEventSettingsId: "crewset_retry",
+      billingEventId,
+      checkoutIdempotencyKey,
+    } as const
+
+    const firstAttempt = buildCrewCheckoutSessionCreateParams(input)
+    const retryAttempt = buildCrewCheckoutSessionCreateParams(input)
+
+    expect(retryAttempt).toEqual(firstAttempt)
+    expect(retryAttempt.metadata).toMatchObject({
+      billingEventId,
+      checkoutIdempotencyKey,
+    })
+    expect(retryAttempt.expires_at).toBeUndefined()
+    expect(retryAttempt.customer_email).toBeUndefined()
   })
 
   it("parses the feature flag and rejects unsafe plan/session states", () => {

--- a/apps/crew/src/lib/crew/checkout-sessions.ts
+++ b/apps/crew/src/lib/crew/checkout-sessions.ts
@@ -33,6 +33,13 @@ export interface BuildCrewCheckoutSessionParamsInput
   appUrl: string
 }
 
+export interface CrewCheckoutPendingClaimInput {
+  billing: CrewBillingStateSnapshot
+  crewPlan: CrewCheckoutPlanId
+  amountCents: number
+  currency: string
+}
+
 export function isCrewStripeCheckoutEnabledValue(value: unknown) {
   return (
     value === true ||
@@ -73,15 +80,11 @@ export function assertCrewCheckoutCanStart(billing: CrewBillingStateSnapshot) {
     throw new Error("Crew billing is already active for this event.")
   }
 
-  if (billing.state === "pending" && billing.stripe.checkoutSessionId) {
+  if (billing.state === "pending") {
     throw new Error("Crew Checkout is already pending for this event.")
   }
 
-  if (
-    billing.planId &&
-    billing.planId !== "crew_starter" &&
-    !isCrewCheckoutPlanId(billing.planId)
-  ) {
+  if (billing.planId && !isCrewCheckoutPlanId(billing.planId)) {
     throw new Error("Crew Checkout is only available for public paid plans.")
   }
 }
@@ -141,6 +144,22 @@ export function buildCrewCheckoutBillingEventId(
   }
 
   return `cbill_checkout_${buildStableCheckoutHash(normalized)}`
+}
+
+export function isReusableCrewCheckoutPendingClaim({
+  billing,
+  crewPlan,
+  amountCents,
+  currency,
+}: CrewCheckoutPendingClaimInput) {
+  return (
+    billing.state === "pending" &&
+    billing.source === "stripe_checkout" &&
+    billing.planId === crewPlan &&
+    billing.amountCents === amountCents &&
+    billing.currency === currency.toLowerCase() &&
+    !billing.stripe.checkoutSessionId
+  )
 }
 
 export function buildCrewCheckoutMetadata({

--- a/apps/crew/src/lib/crew/checkout-sessions.ts
+++ b/apps/crew/src/lib/crew/checkout-sessions.ts
@@ -31,8 +31,6 @@ export interface BuildCrewCheckoutSessionParamsInput
   eventName: string
   plan: CrewCheckoutCatalogPlan
   appUrl: string
-  customerEmail?: string | null
-  nowSeconds?: number
 }
 
 export function isCrewStripeCheckoutEnabledValue(value: unknown) {
@@ -134,6 +132,17 @@ export function buildCrewCheckoutIdempotencyKey({
     .join(":")
 }
 
+export function buildCrewCheckoutBillingEventId(
+  checkoutIdempotencyKey: string,
+) {
+  const normalized = checkoutIdempotencyKey.trim()
+  if (!normalized) {
+    throw new Error("Crew Checkout idempotency key is required.")
+  }
+
+  return `cbill_checkout_${buildStableCheckoutHash(normalized)}`
+}
+
 export function buildCrewCheckoutMetadata({
   teamId,
   competitionId,
@@ -158,8 +167,6 @@ export function buildCrewCheckoutSessionCreateParams({
   eventName,
   plan,
   appUrl,
-  customerEmail,
-  nowSeconds = Math.floor(Date.now() / 1000),
   ...metadataInput
 }: BuildCrewCheckoutSessionParamsInput): Stripe.Checkout.SessionCreateParams {
   const metadata = buildCrewCheckoutMetadata(metadataInput)
@@ -189,8 +196,6 @@ export function buildCrewCheckoutSessionCreateParams({
     },
     success_url: `${billingUrl}?crew_checkout=success&session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${billingUrl}?crew_checkout=canceled`,
-    expires_at: nowSeconds + 30 * 60,
-    customer_email: customerEmail?.trim() || undefined,
   }
 }
 
@@ -200,4 +205,19 @@ function buildCrewBillingUrl(appUrl: string, competitionId: string) {
     `/events/${encodeURIComponent(competitionId)}/billing`,
     baseUrl,
   ).toString()
+}
+
+function buildStableCheckoutHash(value: string) {
+  let first = 0x811c9dc5
+  let second = 0x811c9dc5 ^ 0x9e3779b9
+
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    first = Math.imul(first ^ code, 0x01000193)
+    second = Math.imul(second ^ code, 0x85ebca6b)
+  }
+
+  return [first, second]
+    .map((part) => (part >>> 0).toString(36).padStart(7, "0"))
+    .join("")
 }

--- a/apps/crew/src/lib/crew/checkout-sessions.ts
+++ b/apps/crew/src/lib/crew/checkout-sessions.ts
@@ -1,0 +1,203 @@
+// @lat: [[crew#Crew Checkout Sessions]]
+import type Stripe from "stripe"
+import type {
+  CrewBillingPlanId,
+  CrewBillingStateSnapshot,
+} from "./billing-state"
+
+export const crewCheckoutPlanIds = ["crew_basic", "crew_pro"] as const
+
+export type CrewCheckoutPlanId = (typeof crewCheckoutPlanIds)[number]
+
+export interface CrewCheckoutCatalogPlan {
+  id: CrewCheckoutPlanId
+  name: string
+  description: string | null
+  price: number
+  currency: string
+}
+
+export interface CrewCheckoutMetadataInput {
+  teamId: string
+  competitionId: string
+  crewPlan: CrewCheckoutPlanId
+  crewEventSettingsId: string
+  billingEventId: string
+  checkoutIdempotencyKey: string
+}
+
+export interface BuildCrewCheckoutSessionParamsInput
+  extends CrewCheckoutMetadataInput {
+  eventName: string
+  plan: CrewCheckoutCatalogPlan
+  appUrl: string
+  customerEmail?: string | null
+  nowSeconds?: number
+}
+
+export function isCrewStripeCheckoutEnabledValue(value: unknown) {
+  return (
+    value === true ||
+    ["1", "true", "yes", "enabled"].includes(String(value ?? "").toLowerCase())
+  )
+}
+
+export function isCrewCheckoutPlanId(
+  planId: string | null | undefined,
+): planId is CrewCheckoutPlanId {
+  return crewCheckoutPlanIds.includes(planId as CrewCheckoutPlanId)
+}
+
+export function resolveCrewCheckoutPlanId({
+  requestedPlanId,
+  currentPlanId,
+}: {
+  requestedPlanId?: string | null
+  currentPlanId?: CrewBillingPlanId | null
+}): CrewCheckoutPlanId {
+  if (requestedPlanId) {
+    if (isCrewCheckoutPlanId(requestedPlanId)) return requestedPlanId
+    throw new Error("Crew Checkout is only available for public paid plans.")
+  }
+
+  if (!currentPlanId) return "crew_basic"
+  if (isCrewCheckoutPlanId(currentPlanId)) return currentPlanId
+
+  throw new Error("Crew Checkout is only available for public paid plans.")
+}
+
+export function assertCrewCheckoutCanStart(billing: CrewBillingStateSnapshot) {
+  if (
+    billing.state === "paid" ||
+    billing.state === "comped" ||
+    billing.state === "credited"
+  ) {
+    throw new Error("Crew billing is already active for this event.")
+  }
+
+  if (billing.state === "pending" && billing.stripe.checkoutSessionId) {
+    throw new Error("Crew Checkout is already pending for this event.")
+  }
+
+  if (
+    billing.planId &&
+    billing.planId !== "crew_starter" &&
+    !isCrewCheckoutPlanId(billing.planId)
+  ) {
+    throw new Error("Crew Checkout is only available for public paid plans.")
+  }
+}
+
+export function normalizeCrewCheckoutCatalogPlan(
+  plan: {
+    id: string
+    name: string
+    description: string | null
+    price: number
+    interval: string | null
+    isActive: number
+    isPublic: number
+  } | null,
+): CrewCheckoutCatalogPlan {
+  if (!plan || !isCrewCheckoutPlanId(plan.id)) {
+    throw new Error("Crew Checkout requires a public paid Crew plan.")
+  }
+  if (plan.isActive !== 1 || plan.isPublic !== 1 || plan.interval !== null) {
+    throw new Error("Crew Checkout requires an active one-time public plan.")
+  }
+  if (!Number.isFinite(plan.price) || plan.price <= 0) {
+    throw new Error("Crew Checkout requires a positive event price.")
+  }
+
+  return {
+    id: plan.id,
+    name: plan.name,
+    description: plan.description,
+    price: Math.round(plan.price),
+    currency: "usd",
+  }
+}
+
+export function buildCrewCheckoutIdempotencyKey({
+  competitionId,
+  teamId,
+  crewPlan,
+  amountCents,
+}: {
+  competitionId: string
+  teamId: string
+  crewPlan: CrewCheckoutPlanId
+  amountCents: number
+}) {
+  return ["crew-checkout", competitionId, teamId, crewPlan, amountCents]
+    .map((part) => encodeURIComponent(String(part)))
+    .join(":")
+}
+
+export function buildCrewCheckoutMetadata({
+  teamId,
+  competitionId,
+  crewPlan,
+  crewEventSettingsId,
+  billingEventId,
+  checkoutIdempotencyKey,
+}: CrewCheckoutMetadataInput): Record<string, string> {
+  return {
+    product: "crew",
+    teamId,
+    competitionId,
+    eventId: competitionId,
+    crewPlan,
+    crewEventSettingsId,
+    billingEventId,
+    checkoutIdempotencyKey,
+  }
+}
+
+export function buildCrewCheckoutSessionCreateParams({
+  eventName,
+  plan,
+  appUrl,
+  customerEmail,
+  nowSeconds = Math.floor(Date.now() / 1000),
+  ...metadataInput
+}: BuildCrewCheckoutSessionParamsInput): Stripe.Checkout.SessionCreateParams {
+  const metadata = buildCrewCheckoutMetadata(metadataInput)
+  const billingUrl = buildCrewBillingUrl(appUrl, metadataInput.competitionId)
+
+  return {
+    mode: "payment",
+    payment_method_types: ["card"],
+    line_items: [
+      {
+        price_data: {
+          currency: plan.currency,
+          unit_amount: plan.price,
+          product_data: {
+            name: `${plan.name} - ${eventName}`,
+            description:
+              plan.description ?? "One-time WODsmith Crew event access",
+            metadata,
+          },
+        },
+        quantity: 1,
+      },
+    ],
+    metadata,
+    payment_intent_data: {
+      metadata,
+    },
+    success_url: `${billingUrl}?crew_checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${billingUrl}?crew_checkout=canceled`,
+    expires_at: nowSeconds + 30 * 60,
+    customer_email: customerEmail?.trim() || undefined,
+  }
+}
+
+function buildCrewBillingUrl(appUrl: string, competitionId: string) {
+  const baseUrl = appUrl.trim() || "https://wodsmith.com"
+  return new URL(
+    `/events/${encodeURIComponent(competitionId)}/billing`,
+    baseUrl,
+  ).toString()
+}

--- a/apps/crew/src/lib/stripe.ts
+++ b/apps/crew/src/lib/stripe.ts
@@ -7,6 +7,10 @@ import { env } from "cloudflare:workers"
 import { createServerOnlyFn } from "@tanstack/react-start"
 import Stripe from "stripe"
 
+type StripeEnv = typeof env & {
+  STRIPE_SECRET_KEY?: string
+}
+
 let stripeInstance: Stripe | null = null
 
 /**
@@ -18,7 +22,7 @@ export const getStripe = createServerOnlyFn(() => {
     return stripeInstance
   }
 
-  const stripeSecretKey = env.STRIPE_SECRET_KEY
+  const stripeSecretKey = (env as StripeEnv).STRIPE_SECRET_KEY
 
   if (!stripeSecretKey) {
     throw new Error("Missing STRIPE_SECRET_KEY environment variable")

--- a/apps/crew/src/routes/events/$eventId/billing.tsx
+++ b/apps/crew/src/routes/events/$eventId/billing.tsx
@@ -10,7 +10,7 @@ import {
   WalletCards,
 } from "lucide-react"
 import type { ReactNode } from "react"
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { toast } from "sonner"
 import type { CrewBillingActionViewModel } from "@/lib/crew/billing-page"
 import {
@@ -30,8 +30,11 @@ function EventBillingPage() {
   const { event, viewModel } = Route.useLoaderData()
   const createCrewCheckoutSession = useServerFn(createCrewCheckoutSessionFn)
   const [checkoutSubmitting, setCheckoutSubmitting] = useState(false)
+  const checkoutSubmittingRef = useRef(false)
 
   async function handleCheckout() {
+    if (checkoutSubmittingRef.current) return
+    checkoutSubmittingRef.current = true
     setCheckoutSubmitting(true)
     try {
       const result = await createCrewCheckoutSession({
@@ -45,6 +48,7 @@ function EventBillingPage() {
           : "Unable to start Crew Checkout",
       )
     } finally {
+      checkoutSubmittingRef.current = false
       setCheckoutSubmitting(false)
     }
   }

--- a/apps/crew/src/routes/events/$eventId/billing.tsx
+++ b/apps/crew/src/routes/events/$eventId/billing.tsx
@@ -1,14 +1,22 @@
 // @lat: [[crew#Billing Page And Upgrade CTA]]
+// @lat: [[crew#Crew Checkout Sessions]]
 import { createFileRoute } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
 import {
   CreditCard,
   ExternalLink,
+  Loader2,
   LockKeyhole,
   WalletCards,
 } from "lucide-react"
 import type { ReactNode } from "react"
+import { useState } from "react"
+import { toast } from "sonner"
 import type { CrewBillingActionViewModel } from "@/lib/crew/billing-page"
-import { getCrewBillingOrganizerPageFn } from "@/server-fns/crew-billing-fns"
+import {
+  createCrewCheckoutSessionFn,
+  getCrewBillingOrganizerPageFn,
+} from "@/server-fns/crew-billing-fns"
 
 export const Route = createFileRoute("/events/$eventId/billing")({
   loader: async ({ params }) =>
@@ -20,6 +28,26 @@ export const Route = createFileRoute("/events/$eventId/billing")({
 
 function EventBillingPage() {
   const { event, viewModel } = Route.useLoaderData()
+  const createCrewCheckoutSession = useServerFn(createCrewCheckoutSessionFn)
+  const [checkoutSubmitting, setCheckoutSubmitting] = useState(false)
+
+  async function handleCheckout() {
+    setCheckoutSubmitting(true)
+    try {
+      const result = await createCrewCheckoutSession({
+        data: { eventId: event.id },
+      })
+      window.location.assign(result.checkoutUrl)
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Unable to start Crew Checkout",
+      )
+    } finally {
+      setCheckoutSubmitting(false)
+    }
+  }
 
   return (
     <section className="space-y-6">
@@ -53,7 +81,11 @@ function EventBillingPage() {
             </div>
             <div className="flex w-full flex-col gap-2 sm:w-auto">
               <BillingAction action={viewModel.paymentLink} />
-              <BillingAction action={viewModel.checkout} />
+              <BillingAction
+                action={viewModel.checkout}
+                onAction={handleCheckout}
+                pending={checkoutSubmitting}
+              />
             </div>
           </div>
         </section>
@@ -122,7 +154,15 @@ function BillingFact({ label, value }: { label: string; value: ReactNode }) {
   )
 }
 
-function BillingAction({ action }: { action: CrewBillingActionViewModel }) {
+function BillingAction({
+  action,
+  onAction,
+  pending = false,
+}: {
+  action: CrewBillingActionViewModel
+  onAction?: () => void
+  pending?: boolean
+}) {
   if (action.status === "hidden") {
     return null
   }
@@ -140,6 +180,25 @@ function BillingAction({ action }: { action: CrewBillingActionViewModel }) {
         {action.label}
         <ExternalLink className="size-4" aria-hidden="true" />
       </a>
+    )
+  }
+
+  if (action.status === "available" && onAction) {
+    return (
+      <button
+        type="button"
+        onClick={onAction}
+        disabled={pending}
+        className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-70"
+        title={action.helperText}
+      >
+        {pending ? (
+          <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+        ) : (
+          <CreditCard className="size-4" aria-hidden="true" />
+        )}
+        {action.label}
+      </button>
     )
   }
 

--- a/apps/crew/src/server-fns/crew-billing-fns.ts
+++ b/apps/crew/src/server-fns/crew-billing-fns.ts
@@ -2,14 +2,16 @@
 // @lat: [[crew#Manual Paid And Founder Grants]]
 // @lat: [[crew#Billing Page And Upgrade CTA]]
 // @lat: [[crew#Stripe Payment Link Sales]]
+// @lat: [[crew#Crew Checkout Sessions]]
 import { createServerFn } from "@tanstack/react-start"
 import { z } from "zod"
 import { CREW_BILLING_EVENT_TYPE } from "../db/schemas/crew-billing-events"
 import {
-  MANUAL_CREW_BILLING_ACTION,
   crewBillingPlanIds,
+  MANUAL_CREW_BILLING_ACTION,
   type ManualCrewBillingActionType,
 } from "../lib/crew/billing-state"
+import { crewCheckoutPlanIds } from "../lib/crew/checkout-sessions"
 
 export type {
   CrewBillingOrganizerPageData,
@@ -23,6 +25,7 @@ const getCrewBillingInputSchema = z.object({
 const crewBillingEventTypeSchema = z.enum([
   CREW_BILLING_EVENT_TYPE.MANUAL_SALE_RECORDED,
   CREW_BILLING_EVENT_TYPE.PAYMENT_LINK_RECONCILED,
+  CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED,
   CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED,
   CREW_BILLING_EVENT_TYPE.FOUNDER_OVERRIDE_APPLIED,
   CREW_BILLING_EVENT_TYPE.CREDIT_SET,
@@ -32,6 +35,7 @@ const crewBillingEventTypeSchema = z.enum([
 ])
 
 const crewBillingPlanIdSchema = z.enum(crewBillingPlanIds)
+const crewCheckoutPlanIdSchema = z.enum(crewCheckoutPlanIds)
 const nullableTextSchema = z
   .string()
   .trim()
@@ -107,9 +111,7 @@ const recordManualCrewBillingActionInputSchema = z.discriminatedUnion(
         .positive("Manual paid Crew billing requires a positive amount."),
     }),
     recordManualCrewBillingActionBaseInputSchema.extend({
-      action: z.literal(
-        MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE,
-      ),
+      action: z.literal(MANUAL_CREW_BILLING_ACTION.RECONCILE_PAYMENT_LINK_SALE),
       planId: crewBillingPlanIdSchema,
       amountCents: z
         .number()
@@ -154,6 +156,10 @@ const reconcileCrewPaymentLinkSaleInputSchema =
     publicNote: nullableTextSchema,
     privateMetadata: privateMetadataSchema.optional(),
   })
+
+const createCrewCheckoutSessionInputSchema = getCrewBillingInputSchema.extend({
+  planId: crewCheckoutPlanIdSchema.nullable().optional(),
+})
 
 export const getCrewBillingPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) => getCrewBillingInputSchema.parse(data))
@@ -219,4 +225,15 @@ export const reconcileCrewPaymentLinkSaleFn = createServerFn({
       "../server/crew-billing.server"
     )
     return reconcileCrewPaymentLinkSale(data)
+  })
+
+export const createCrewCheckoutSessionFn = createServerFn({ method: "POST" })
+  .inputValidator((data: unknown) =>
+    createCrewCheckoutSessionInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { createCrewCheckoutSession } = await import(
+      "../server/crew-billing.server"
+    )
+    return createCrewCheckoutSession(data)
   })

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -7,7 +7,6 @@ import { env } from "cloudflare:workers"
 import { and, desc, eq } from "drizzle-orm"
 import { getDb } from "../db"
 import { ROLES_ENUM } from "../db/schema"
-import { createCrewBillingEventId } from "../db/schemas/common"
 import { competitionsTable } from "../db/schemas/competitions"
 import {
   CREW_BILLING_EVENT_TYPE,
@@ -43,6 +42,7 @@ import {
 } from "../lib/crew/billing-state"
 import {
   assertCrewCheckoutCanStart,
+  buildCrewCheckoutBillingEventId,
   buildCrewCheckoutIdempotencyKey,
   buildCrewCheckoutSessionCreateParams,
   type CrewCheckoutPlanId,
@@ -315,13 +315,13 @@ export async function createCrewCheckoutSession(
     currentPlanId: current.planId,
   })
   const plan = await requireCrewCheckoutPlan(planId)
-  const billingEventId = createCrewBillingEventId()
   const checkoutIdempotencyKey = buildCrewCheckoutIdempotencyKey({
     competitionId: scope.id,
     teamId: scope.organizingTeamId,
     crewPlan: plan.id,
     amountCents: plan.price,
   })
+  const billingEventId = buildCrewCheckoutBillingEventId(checkoutIdempotencyKey)
 
   const existingEvents = await listCrewBillingEventsForEvent(scope.id)
   if (
@@ -337,7 +337,6 @@ export async function createCrewCheckoutSession(
       eventName: scope.name,
       plan,
       appUrl: getAppUrl(),
-      customerEmail: session?.user.email,
       teamId: scope.organizingTeamId,
       competitionId: scope.id,
       crewPlan: plan.id,

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -2,39 +2,54 @@
 // @lat: [[crew#Manual Paid And Founder Grants]]
 // @lat: [[crew#Billing Page And Upgrade CTA]]
 // @lat: [[crew#Stripe Payment Link Sales]]
+// @lat: [[crew#Crew Checkout Sessions]]
 import { env } from "cloudflare:workers"
-import { desc, eq } from "drizzle-orm"
+import { and, desc, eq } from "drizzle-orm"
 import { getDb } from "../db"
+import { ROLES_ENUM } from "../db/schema"
+import { createCrewBillingEventId } from "../db/schemas/common"
+import { competitionsTable } from "../db/schemas/competitions"
 import {
+  CREW_BILLING_EVENT_TYPE,
   type CrewBillingEvent,
   type CrewBillingEventType,
-  type NewCrewBillingEvent,
   crewBillingEventsTable,
+  type NewCrewBillingEvent,
 } from "../db/schemas/crew-billing-events"
 import {
+  CREW_BILLING_SOURCE,
+  CREW_BILLING_STATE,
   type CrewBillingSource,
   type CrewBillingState,
   crewEventSettingsTable,
 } from "../db/schemas/crew-event-settings"
-import { competitionsTable } from "../db/schemas/competitions"
+import { planTable } from "../db/schemas/entitlements"
 import { TEAM_PERMISSIONS } from "../db/schemas/teams"
-import { ROLES_ENUM } from "../db/schema"
 import {
   buildCrewBillingPageViewModel,
-  canViewCrewBillingPage,
   type CrewBillingPageViewModel,
+  canViewCrewBillingPage,
 } from "../lib/crew/billing-page"
 import {
-  type CrewBillingAuditEvent,
   type CrewBillingAppendPlan,
-  isCrewBillingDuplicateEntryError,
-  normalizeCrewBillingState,
-  planCrewBillingAuditAppend,
-  planManualCrewBillingAction,
-  type PlanManualCrewBillingActionInput,
+  type CrewBillingAuditEvent,
   type CrewBillingPlanId,
   type CrewBillingStateSnapshot,
+  isCrewBillingDuplicateEntryError,
+  normalizeCrewBillingState,
+  type PlanManualCrewBillingActionInput,
+  planCrewBillingAuditAppend,
+  planManualCrewBillingAction,
 } from "../lib/crew/billing-state"
+import {
+  assertCrewCheckoutCanStart,
+  buildCrewCheckoutIdempotencyKey,
+  buildCrewCheckoutSessionCreateParams,
+  type CrewCheckoutPlanId,
+  isCrewStripeCheckoutEnabledValue,
+  normalizeCrewCheckoutCatalogPlan,
+  resolveCrewCheckoutPlanId,
+} from "../lib/crew/checkout-sessions"
 import {
   buildCrewPaymentLinkSaleActionInput,
   getCrewPaymentLinkUrlFromSettings,
@@ -42,6 +57,8 @@ import {
   normalizeCrewPaymentLinkReference,
   serializeCrewPaymentLinkSettings,
 } from "../lib/crew/payment-link-sales"
+import { getAppUrl } from "../lib/env"
+import { getStripe } from "../lib/stripe"
 import { getSessionFromCookie } from "../utils/auth"
 import {
   hasLocalCrewOperatorAccess,
@@ -85,6 +102,14 @@ export interface ReconcileCrewPaymentLinkSaleInput
   actorLabel?: string | null
   publicNote?: string | null
   privateMetadata?: Record<string, unknown> | null
+}
+
+export interface CreateCrewCheckoutSessionInput extends GetCrewBillingInput {
+  planId?: CrewCheckoutPlanId | null
+}
+
+export interface CreateCrewCheckoutSessionResult {
+  checkoutUrl: string
 }
 
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
@@ -133,6 +158,7 @@ export interface CrewBillingOrganizerPageData {
 }
 
 type CrewBillingScope = CrewBillingPageData["event"] & {
+  settingsId: string
   state: CrewBillingState
   source: CrewBillingSource | null
   planId: CrewBillingPlanId | null
@@ -272,6 +298,80 @@ export async function reconcileCrewPaymentLinkSale(
   })
 }
 
+export async function createCrewCheckoutSession(
+  data: CreateCrewCheckoutSessionInput,
+): Promise<CreateCrewCheckoutSessionResult> {
+  if (!isCrewStripeCheckoutEnabled()) {
+    throw new Error("Crew Checkout is not enabled.")
+  }
+
+  const scope = await requireCrewBillingScope(data.eventId)
+  const session = await requireCrewBillingOrganizerAccess(scope)
+  const current = toCrewBillingSnapshot(scope)
+  assertCrewCheckoutCanStart(current)
+
+  const planId = resolveCrewCheckoutPlanId({
+    requestedPlanId: data.planId,
+    currentPlanId: current.planId,
+  })
+  const plan = await requireCrewCheckoutPlan(planId)
+  const billingEventId = createCrewBillingEventId()
+  const checkoutIdempotencyKey = buildCrewCheckoutIdempotencyKey({
+    competitionId: scope.id,
+    teamId: scope.organizingTeamId,
+    crewPlan: plan.id,
+    amountCents: plan.price,
+  })
+
+  const existingEvents = await listCrewBillingEventsForEvent(scope.id)
+  if (
+    current.state === CREW_BILLING_STATE.PENDING &&
+    current.source === CREW_BILLING_SOURCE.STRIPE_CHECKOUT &&
+    current.stripe.checkoutSessionId
+  ) {
+    throw new Error("Crew Checkout is already pending for this event.")
+  }
+
+  const checkoutSession = await getStripe().checkout.sessions.create(
+    buildCrewCheckoutSessionCreateParams({
+      eventName: scope.name,
+      plan,
+      appUrl: getAppUrl(),
+      customerEmail: session?.user.email,
+      teamId: scope.organizingTeamId,
+      competitionId: scope.id,
+      crewPlan: plan.id,
+      crewEventSettingsId: scope.settingsId,
+      billingEventId,
+      checkoutIdempotencyKey,
+    }),
+    { idempotencyKey: checkoutIdempotencyKey },
+  )
+
+  if (!checkoutSession.url) {
+    throw new Error("Stripe did not return a Checkout URL.")
+  }
+
+  const appendPlan = planCrewBillingAuditAppend(existingEvents, {
+    id: billingEventId,
+    competitionId: scope.id,
+    teamId: scope.organizingTeamId,
+    eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED,
+    current,
+    planId: plan.id,
+    amountCents: plan.price,
+    currency: plan.currency,
+    stripeCheckoutSessionId: checkoutSession.id,
+    idempotencyKey: checkoutIdempotencyKey,
+    actorUserId: session?.user.id,
+    actorLabel: session?.user.email,
+  })
+
+  await persistCrewCheckoutSessionCreated(data, appendPlan)
+
+  return { checkoutUrl: checkoutSession.url }
+}
+
 async function persistCrewBillingAppend(
   data: GetCrewBillingInput,
   appendPlan: CrewBillingAppendPlan,
@@ -327,6 +427,34 @@ async function persistCrewBillingAppend(
   return getCrewBillingPage(data)
 }
 
+async function persistCrewCheckoutSessionCreated(
+  data: GetCrewBillingInput,
+  appendPlan: CrewBillingAppendPlan,
+) {
+  if (appendPlan.action === "skip_duplicate") return
+
+  const db = getDb()
+  const { event, settingsPatch } = appendPlan
+
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(crewBillingEventsTable)
+        .values(toNewCrewBillingEvent(event))
+      await tx
+        .update(crewEventSettingsTable)
+        .set({
+          ...settingsPatch,
+          updatedAt: new Date(),
+        })
+        .where(eq(crewEventSettingsTable.competitionId, data.eventId))
+    })
+  } catch (error) {
+    if (isCrewBillingDuplicateEntryError(error)) return
+    throw error
+  }
+}
+
 async function updateCrewPaymentLinkSettings({
   eventId,
   settingsText,
@@ -361,6 +489,7 @@ async function requireCrewBillingScope(
       name: competitionsTable.name,
       organizingTeamId: competitionsTable.organizingTeamId,
       competitionTeamId: competitionsTable.competitionTeamId,
+      settingsId: crewEventSettingsTable.id,
       state: crewEventSettingsTable.crewBillingState,
       source: crewEventSettingsTable.crewBillingSource,
       planId: crewEventSettingsTable.crewBillingPlanId,
@@ -414,6 +543,27 @@ async function requireCrewBillingOrganizerAccess(scope: CrewBillingScope) {
   if (!canView) {
     throw new Error("FORBIDDEN: You don't have access to Crew billing")
   }
+
+  return session
+}
+
+async function requireCrewCheckoutPlan(planId: CrewCheckoutPlanId) {
+  const db = getDb()
+  const [plan] = await db
+    .select({
+      id: planTable.id,
+      name: planTable.name,
+      description: planTable.description,
+      price: planTable.price,
+      interval: planTable.interval,
+      isActive: planTable.isActive,
+      isPublic: planTable.isPublic,
+    })
+    .from(planTable)
+    .where(and(eq(planTable.id, planId), eq(planTable.isActive, 1)))
+    .limit(1)
+
+  return normalizeCrewCheckoutCatalogPlan(plan ?? null)
 }
 
 async function listCrewBillingEventsForEvent(eventId: string) {
@@ -457,6 +607,7 @@ function toNewCrewBillingEvent(
   event: CrewBillingAuditEvent,
 ): NewCrewBillingEvent {
   return {
+    id: event.id ?? undefined,
     competitionId: event.competitionId,
     teamId: event.teamId,
     eventType: event.eventType,
@@ -534,9 +685,7 @@ function isCrewStripeCheckoutEnabled() {
   const runtimeEnv = env as typeof env & {
     CREW_STRIPE_CHECKOUT_ENABLED?: string | boolean
   }
-  const value = runtimeEnv.CREW_STRIPE_CHECKOUT_ENABLED
-  return (
-    value === true ||
-    ["1", "true", "yes", "enabled"].includes(String(value ?? "").toLowerCase())
+  return isCrewStripeCheckoutEnabledValue(
+    runtimeEnv.CREW_STRIPE_CHECKOUT_ENABLED,
   )
 }

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -45,8 +45,10 @@ import {
   buildCrewCheckoutBillingEventId,
   buildCrewCheckoutIdempotencyKey,
   buildCrewCheckoutSessionCreateParams,
+  type CrewCheckoutCatalogPlan,
   type CrewCheckoutPlanId,
   isCrewStripeCheckoutEnabledValue,
+  isReusableCrewCheckoutPendingClaim,
   normalizeCrewCheckoutCatalogPlan,
   resolveCrewCheckoutPlanId,
 } from "../lib/crew/checkout-sessions"
@@ -308,7 +310,6 @@ export async function createCrewCheckoutSession(
   const scope = await requireCrewBillingScope(data.eventId)
   const session = await requireCrewBillingOrganizerAccess(scope)
   const current = toCrewBillingSnapshot(scope)
-  assertCrewCheckoutCanStart(current)
 
   const planId = resolveCrewCheckoutPlanId({
     requestedPlanId: data.planId,
@@ -323,14 +324,12 @@ export async function createCrewCheckoutSession(
   })
   const billingEventId = buildCrewCheckoutBillingEventId(checkoutIdempotencyKey)
 
+  const claimCurrent = await claimCrewCheckoutSessionStart({
+    eventId: scope.id,
+    current,
+    plan,
+  })
   const existingEvents = await listCrewBillingEventsForEvent(scope.id)
-  if (
-    current.state === CREW_BILLING_STATE.PENDING &&
-    current.source === CREW_BILLING_SOURCE.STRIPE_CHECKOUT &&
-    current.stripe.checkoutSessionId
-  ) {
-    throw new Error("Crew Checkout is already pending for this event.")
-  }
 
   const checkoutSession = await getStripe().checkout.sessions.create(
     buildCrewCheckoutSessionCreateParams({
@@ -356,7 +355,7 @@ export async function createCrewCheckoutSession(
     competitionId: scope.id,
     teamId: scope.organizingTeamId,
     eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_SESSION_CREATED,
-    current,
+    current: claimCurrent,
     planId: plan.id,
     amountCents: plan.price,
     currency: plan.currency,
@@ -369,6 +368,96 @@ export async function createCrewCheckoutSession(
   await persistCrewCheckoutSessionCreated(data, appendPlan)
 
   return { checkoutUrl: checkoutSession.url }
+}
+
+async function claimCrewCheckoutSessionStart({
+  eventId,
+  current,
+  plan,
+}: {
+  eventId: string
+  current: CrewBillingStateSnapshot
+  plan: CrewCheckoutCatalogPlan
+}) {
+  if (
+    isReusableCrewCheckoutPendingClaim({
+      billing: current,
+      crewPlan: plan.id,
+      amountCents: plan.price,
+      currency: plan.currency,
+    })
+  ) {
+    return current
+  }
+
+  assertCrewCheckoutCanStart(current)
+
+  const claimPatch = buildCrewCheckoutClaimSnapshot(current, plan)
+  const result = await getDb()
+    .update(crewEventSettingsTable)
+    .set({
+      crewBillingState: claimPatch.state,
+      crewBillingSource: claimPatch.source,
+      crewBillingPlanId: claimPatch.planId,
+      crewBillingAmountCents: claimPatch.amountCents,
+      crewBillingCurrency: claimPatch.currency,
+      crewStripeCheckoutSessionId: null,
+      crewStripePaymentIntentId: null,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(crewEventSettingsTable.competitionId, eventId),
+        eq(crewEventSettingsTable.crewBillingState, current.state),
+      ),
+    )
+
+  if (getAffectedRows(result) > 0) return claimPatch
+
+  const latest = toCrewBillingSnapshot(await requireCrewBillingScope(eventId))
+  if (
+    isReusableCrewCheckoutPendingClaim({
+      billing: latest,
+      crewPlan: plan.id,
+      amountCents: plan.price,
+      currency: plan.currency,
+    })
+  ) {
+    return latest
+  }
+
+  assertCrewCheckoutCanStart(latest)
+  throw new Error("Crew Checkout could not start because billing changed.")
+}
+
+function buildCrewCheckoutClaimSnapshot(
+  current: CrewBillingStateSnapshot,
+  plan: CrewCheckoutCatalogPlan,
+): CrewBillingStateSnapshot {
+  return {
+    ...current,
+    state: CREW_BILLING_STATE.PENDING,
+    source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+    planId: plan.id,
+    amountCents: plan.price,
+    currency: plan.currency,
+    stripe: {
+      ...current.stripe,
+      checkoutSessionId: null,
+      paymentIntentId: null,
+    },
+  }
+}
+
+function getAffectedRows(result: unknown) {
+  return (
+    (result as { rowsAffected?: number }).rowsAffected ??
+    (result as { affectedRows?: number }).affectedRows ??
+    (Array.isArray(result)
+      ? (result[0] as { affectedRows?: number } | undefined)?.affectedRows
+      : undefined) ??
+    0
+  )
 }
 
 async function persistCrewBillingAppend(

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -52,6 +52,14 @@ Stripe Payment Link sales are recorded manually by private Crew operators withou
 
 [[apps/crew/src/server/crew-billing.server.ts]] and [[apps/crew/src/server-fns/crew-billing-fns.ts]] expose local-operator-only Payment Link reference recording and sale reconciliation. Reconciliation appends `crew_billing_events` audit rows, patches only the selected event's `crew_event_settings` billing fields, and still works when Stripe metadata is missing because the operator supplies the event, team scope, plan, amount, and currency.
 
+## Crew Checkout Sessions
+
+Crew Checkout Session creation is feature-flagged with `CREW_STRIPE_CHECKOUT_ENABLED` and uses the existing Crew event billing state instead of team subscription billing.
+
+[[apps/crew/src/lib/crew/checkout-sessions.ts]] builds Stripe Checkout Session params for public paid Crew event plans only, with metadata `product=crew`, team/event scope, Crew plan, `crewEventSettingsId`, `billingEventId`, and a stable checkout idempotency key. Private founder/concierge pricing and audit metadata are excluded from session metadata and organizer page view models.
+
+[[apps/crew/src/server/crew-billing.server.ts]] creates sessions through the shared Stripe client, appends a pending `checkout_session_created` Crew billing audit event, and patches only event-level `crew_event_settings` Checkout reference/status fields. `checkout_completed` remains reserved for the later webhook slice, and Crew one-event purchases must not update `teams.currentPlanId`.
+
 ## Server Function Runtime Boundary
 
 Route and client code import lightweight `createServerFn` wrappers from [[apps/crew/src/server-fns]].

--- a/packages/wodsmith-db/src/schemas/crew-billing-events.ts
+++ b/packages/wodsmith-db/src/schemas/crew-billing-events.ts
@@ -26,6 +26,8 @@ import { userTable } from "./users"
 export const CREW_BILLING_EVENT_TYPE = {
   MANUAL_SALE_RECORDED: "manual_sale_recorded",
   PAYMENT_LINK_RECONCILED: "payment_link_reconciled",
+  // @lat: [[crew#Crew Checkout Sessions]]
+  CHECKOUT_SESSION_CREATED: "checkout_session_created",
   CHECKOUT_COMPLETED: "checkout_completed",
   FOUNDER_OVERRIDE_APPLIED: "founder_override_applied",
   CREDIT_SET: "credit_set",


### PR DESCRIPTION
## Summary
- add feature-flagged Crew Checkout Session construction for public paid Crew event plans using the shared Stripe client
- persist pending event-level Checkout state and a checkout_session_created audit row without touching team subscription billing
- wire the private organizer billing CTA to the new server function and keep private Stripe/audit metadata out of the organizer view model
- document the LAT anchor crew#Crew Checkout Sessions

## Validation
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew exec vitest run src/lib/crew/checkout-sessions.test.ts src/lib/crew/billing-state.test.ts src/lib/crew/billing-page.test.ts
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew type-check
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew exec biome check src/lib/crew/checkout-sessions.ts src/lib/crew/checkout-sessions.test.ts src/lib/crew/billing-page.ts src/lib/crew/billing-page.test.ts src/lib/crew/billing-state.ts src/lib/crew/billing-state.test.ts src/routes/events/$eventId/billing.tsx src/server-fns/crew-billing-fns.ts src/server/crew-billing.server.ts src/lib/stripe.ts
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew lint (passes with existing unrelated warnings)
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm check:schema-ownership
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm db:generate --dry=json
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm db:studio --dry=json
- PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm dlx lat.md locate crew#Crew Checkout Sessions
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds feature-flagged Crew Checkout Session creation so organizers can start checkout from the billing page, recording a pending event-scoped billing state and audit event. Adds concurrency-safe start guards with a stable idempotency key and deterministic audit event ID to prevent duplicate sessions and retries.

- **New Features**
  - Start Checkout button on the billing page (enabled only for `crew_basic`/`crew_pro`; disabled for pending or private plans; hidden for paid/comp/credit) that creates a session and redirects.
  - `createCrewCheckoutSessionFn` creates a Stripe Checkout Session using a stable idempotency key and safe, event-scoped metadata; reuses matching pending claims and atomically claims PENDING before session creation; returns a redirect URL.
  - Persists `checkout_session_created` audit event (with deterministic ID) and patches event-level `crew_event_settings` to PENDING with the Checkout Session ID; duplicate appends are skipped.
  - Strong validation: only public one-time plans allowed; prevents duplicate pending sessions and active-billing starts; tests and docs added.

- **Migration**
  - Set `CREW_STRIPE_CHECKOUT_ENABLED` to enable Checkout.
  - Ensure `STRIPE_SECRET_KEY` is configured.
  - Ensure public, active, one-time plans `crew_basic` and `crew_pro` exist in the catalog.
  - Webhook handling for `checkout_completed` will follow in a separate slice.

<sup>Written for commit cbeac02b18da5f0d6a5adb8b0158a652961b3696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now initiate Stripe Checkout sessions directly from the event billing page to complete crew event plan upgrades
  * Checkout flow validates billing state and plan compatibility before allowing session creation

* **Documentation**
  * Added Crew Checkout Sessions documentation describing feature-flagged session creation and metadata handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->