### PR TITLE
[codex] feat(crew): process Stripe webhooks

### DIFF
--- a/apps/crew/src/lib/crew/checkout-webhooks.test.ts
+++ b/apps/crew/src/lib/crew/checkout-webhooks.test.ts
@@ -1,0 +1,301 @@
+// @lat: [[crew#Crew Stripe Webhooks]]
+import { describe, expect, it } from "vitest"
+import { CREW_BILLING_EVENT_TYPE } from "../../db/schemas/crew-billing-events"
+import {
+  CREW_BILLING_SOURCE,
+  CREW_BILLING_STATE,
+} from "../../db/schemas/crew-event-settings"
+import type { CrewBillingStateSnapshot } from "./billing-state"
+import {
+  buildCrewCheckoutBillingEventId,
+  buildCrewCheckoutIdempotencyKey,
+} from "./checkout-sessions"
+import {
+  CrewCheckoutWebhookValidationError,
+  getCrewCheckoutSessionCompletionIdempotencyKey,
+  getCrewCheckoutStripeEventIdempotencyKey,
+  isCrewCheckoutSessionMetadata,
+  parseCrewCheckoutSessionWebhook,
+  planCrewCheckoutWebhookCompletion,
+} from "./checkout-webhooks"
+
+const checkoutIdempotencyKey = buildCrewCheckoutIdempotencyKey({
+  competitionId: "event_crew",
+  teamId: "team_owner",
+  crewPlan: "crew_basic",
+  amountCents: 20_000,
+})
+const billingEventId = buildCrewCheckoutBillingEventId(checkoutIdempotencyKey)
+
+const validMetadata = {
+  product: "crew",
+  teamId: "team_owner",
+  competitionId: "event_crew",
+  eventId: "event_crew",
+  crewPlan: "crew_basic",
+  crewEventSettingsId: "crewset_123",
+  billingEventId,
+  checkoutIdempotencyKey,
+}
+
+const pendingBilling: CrewBillingStateSnapshot = {
+  state: CREW_BILLING_STATE.PENDING,
+  source: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+  planId: "crew_basic",
+  amountCents: 20_000,
+  currency: "usd",
+  stripe: {
+    paymentLinkId: null,
+    checkoutSessionId: "cs_crew_123",
+    paymentIntentId: null,
+  },
+  founderOverride: false,
+  creditCents: 0,
+  fullPlatformCreditCents: 0,
+  refundedCents: 0,
+}
+
+describe("Crew Checkout webhook helpers", () => {
+  it("detects Crew Checkout Sessions by metadata product", () => {
+    expect(isCrewCheckoutSessionMetadata({ product: "crew" })).toBe(true)
+    expect(isCrewCheckoutSessionMetadata({ product: "registration" })).toBe(
+      false,
+    )
+    expect(isCrewCheckoutSessionMetadata({})).toBe(false)
+  })
+
+  it("validates and parses the Crew metadata contract from completed sessions", () => {
+    const completion = parseCrewCheckoutSessionWebhook({
+      stripeEventId: "evt_crew_123",
+      sessionId: "cs_crew_123",
+      metadata: validMetadata,
+      amountTotal: 20_000,
+      currency: "USD",
+      paymentIntentId: "pi_crew_123",
+    })
+
+    expect(completion).toEqual({
+      stripeEventId: "evt_crew_123",
+      sessionId: "cs_crew_123",
+      eventId: "event_crew",
+      teamId: "team_owner",
+      crewPlan: "crew_basic",
+      crewEventSettingsId: "crewset_123",
+      billingEventId,
+      checkoutIdempotencyKey,
+      amountCents: 20_000,
+      currency: "usd",
+      stripePaymentIntentId: "pi_crew_123",
+    })
+  })
+
+  it("rejects invalid Crew metadata without producing a completion input", () => {
+    expect(() =>
+      parseCrewCheckoutSessionWebhook({
+        stripeEventId: "evt_crew_123",
+        sessionId: "cs_crew_123",
+        metadata: {
+          ...validMetadata,
+          eventId: "other_event",
+        },
+        amountTotal: 20_000,
+        currency: "usd",
+      }),
+    ).toThrow(CrewCheckoutWebhookValidationError)
+
+    expect(() =>
+      parseCrewCheckoutSessionWebhook({
+        stripeEventId: "evt_crew_123",
+        sessionId: "cs_crew_123",
+        metadata: {
+          ...validMetadata,
+          crewPlan: "crew_founding_2026",
+        },
+        amountTotal: 20_000,
+        currency: "usd",
+      }),
+    ).toThrow(/invalid Crew plan/)
+
+    expect(() =>
+      parseCrewCheckoutSessionWebhook({
+        stripeEventId: "evt_crew_123",
+        sessionId: "cs_crew_123",
+        metadata: validMetadata,
+        amountTotal: 19_999,
+        currency: "usd",
+      }),
+    ).toThrow(/idempotency metadata/)
+
+    expect(() =>
+      parseCrewCheckoutSessionWebhook({
+        stripeEventId: "evt_crew_123",
+        sessionId: "cs_crew_123",
+        metadata: validMetadata,
+        amountTotal: 20_000,
+        currency: "usdollars",
+      }),
+    ).toThrow(/currency/)
+  })
+
+  it("plans Checkout completion as a paid event-level Crew audit row", () => {
+    const completion = parseCrewCheckoutSessionWebhook({
+      stripeEventId: "evt_crew_123",
+      sessionId: "cs_crew_123",
+      metadata: validMetadata,
+      amountTotal: 20_000,
+      currency: "usd",
+      paymentIntentId: "pi_crew_123",
+    })
+
+    const plan = planCrewCheckoutWebhookCompletion({
+      current: pendingBilling,
+      existingEvents: [],
+      completion,
+    })
+
+    expect(plan.action).toBe("append")
+    if (plan.action !== "append") throw new Error("Expected append plan")
+    expect(plan.appendPlan.event).toMatchObject({
+      competitionId: "event_crew",
+      teamId: "team_owner",
+      eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED,
+      billingState: CREW_BILLING_STATE.PAID,
+      billingSource: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+      planId: "crew_basic",
+      amountCents: 20_000,
+      currency: "usd",
+      stripeCheckoutSessionId: "cs_crew_123",
+      stripePaymentIntentId: "pi_crew_123",
+      idempotencyKey:
+        getCrewCheckoutSessionCompletionIdempotencyKey("cs_crew_123"),
+      privateMetadata: {
+        stripeEventId: "evt_crew_123",
+        billingEventId,
+        checkoutIdempotencyKey,
+      },
+    })
+    expect(plan.appendPlan.settingsPatch).toMatchObject({
+      crewBillingState: CREW_BILLING_STATE.PAID,
+      crewBillingSource: CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+      crewBillingPlanId: "crew_basic",
+      crewBillingAmountCents: 20_000,
+      crewBillingCurrency: "usd",
+      crewStripeCheckoutSessionId: "cs_crew_123",
+      crewStripePaymentIntentId: "pi_crew_123",
+    })
+    expect(plan.appendPlan.settingsPatch).not.toHaveProperty("currentPlanId")
+  })
+
+  it("dedupes completion by Stripe event ID and Checkout Session ID", () => {
+    const completion = parseCrewCheckoutSessionWebhook({
+      stripeEventId: "evt_crew_123",
+      sessionId: "cs_crew_123",
+      metadata: validMetadata,
+      amountTotal: 20_000,
+      currency: "usd",
+    })
+
+    expect(
+      planCrewCheckoutWebhookCompletion({
+        current: pendingBilling,
+        existingEvents: [
+          {
+            eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED,
+            idempotencyKey: null,
+            privateMetadata: { stripeEventId: "evt_crew_123" },
+          },
+        ],
+        completion,
+      }).action,
+    ).toBe("skip_duplicate")
+
+    expect(
+      planCrewCheckoutWebhookCompletion({
+        current: pendingBilling,
+        existingEvents: [
+          {
+            eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED,
+            idempotencyKey:
+              getCrewCheckoutStripeEventIdempotencyKey("evt_crew_123"),
+          },
+        ],
+        completion,
+      }).action,
+    ).toBe("skip_duplicate")
+
+    expect(
+      planCrewCheckoutWebhookCompletion({
+        current: pendingBilling,
+        existingEvents: [
+          {
+            eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED,
+            idempotencyKey:
+              getCrewCheckoutSessionCompletionIdempotencyKey("cs_crew_123"),
+          },
+        ],
+        completion,
+      }).action,
+    ).toBe("skip_duplicate")
+
+    expect(
+      planCrewCheckoutWebhookCompletion({
+        current: pendingBilling,
+        existingEvents: [
+          {
+            eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED,
+            idempotencyKey: null,
+            stripeCheckoutSessionId: "cs_crew_123",
+          },
+        ],
+        completion,
+      }).action,
+    ).toBe("skip_duplicate")
+  })
+
+  it("fails safely when completed metadata does not match pending state", () => {
+    const completion = parseCrewCheckoutSessionWebhook({
+      stripeEventId: "evt_crew_123",
+      sessionId: "cs_crew_123",
+      metadata: validMetadata,
+      amountTotal: 20_000,
+      currency: "usd",
+    })
+
+    expect(() =>
+      planCrewCheckoutWebhookCompletion({
+        current: {
+          ...pendingBilling,
+          state: CREW_BILLING_STATE.UNPAID,
+          source: null,
+        },
+        existingEvents: [],
+        completion,
+      }),
+    ).toThrow(/pending Stripe Checkout/)
+
+    expect(() =>
+      planCrewCheckoutWebhookCompletion({
+        current: {
+          ...pendingBilling,
+          planId: "crew_pro",
+        },
+        existingEvents: [],
+        completion,
+      }),
+    ).toThrow(/plan/)
+
+    expect(() =>
+      planCrewCheckoutWebhookCompletion({
+        current: {
+          ...pendingBilling,
+          stripe: {
+            ...pendingBilling.stripe,
+            checkoutSessionId: "cs_other",
+          },
+        },
+        existingEvents: [],
+        completion,
+      }),
+    ).toThrow(/session/)
+  })
+})

--- a/apps/crew/src/lib/crew/checkout-webhooks.ts
+++ b/apps/crew/src/lib/crew/checkout-webhooks.ts
@@ -1,0 +1,345 @@
+// @lat: [[crew#Crew Stripe Webhooks]]
+import { CREW_BILLING_EVENT_TYPE } from "../../db/schemas/crew-billing-events"
+import {
+  CREW_BILLING_SOURCE,
+  CREW_BILLING_STATE,
+} from "../../db/schemas/crew-event-settings"
+import {
+  type CrewBillingAppendPlan,
+  type CrewBillingExistingAuditEvent,
+  type CrewBillingStateSnapshot,
+  planCrewBillingAuditAppend,
+} from "./billing-state"
+import {
+  buildCrewCheckoutBillingEventId,
+  buildCrewCheckoutIdempotencyKey,
+  type CrewCheckoutPlanId,
+  isCrewCheckoutPlanId,
+} from "./checkout-sessions"
+
+export class CrewCheckoutWebhookValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "CrewCheckoutWebhookValidationError"
+  }
+}
+
+export interface CrewCheckoutSessionWebhookInput {
+  stripeEventId: string
+  sessionId: string
+  metadata?: Record<string, string | null | undefined> | null
+  amountTotal?: number | null
+  currency?: string | null
+  paymentIntentId?: string | null
+}
+
+export interface CrewCheckoutWebhookCompletionInput {
+  stripeEventId: string
+  sessionId: string
+  eventId: string
+  teamId: string
+  crewPlan: CrewCheckoutPlanId
+  crewEventSettingsId: string
+  billingEventId: string
+  checkoutIdempotencyKey: string
+  amountCents: number
+  currency: string
+  stripePaymentIntentId: string | null
+}
+
+export type CrewCheckoutWebhookExistingEvent = CrewBillingExistingAuditEvent & {
+  stripeCheckoutSessionId?: string | null
+  privateMetadata?: Record<string, unknown> | null
+}
+
+export type CrewCheckoutWebhookCompletionPlan =
+  | {
+      action: "append"
+      appendPlan: Extract<CrewBillingAppendPlan, { action: "append" }>
+    }
+  | {
+      action: "skip_duplicate"
+    }
+
+export function getCrewCheckoutMetadataProduct(
+  metadata?: Record<string, string | null | undefined> | null,
+) {
+  return normalizeText(metadata?.product)
+}
+
+export function isCrewCheckoutSessionMetadata(
+  metadata?: Record<string, string | null | undefined> | null,
+) {
+  return getCrewCheckoutMetadataProduct(metadata) === "crew"
+}
+
+export function parseCrewCheckoutSessionWebhook(
+  input: CrewCheckoutSessionWebhookInput,
+): CrewCheckoutWebhookCompletionInput {
+  const metadata = input.metadata ?? {}
+
+  if (!isCrewCheckoutSessionMetadata(metadata)) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Checkout Session is not a Crew purchase.",
+    )
+  }
+
+  const sessionId = requireText(input.sessionId, "Stripe session ID")
+  const stripeEventId = requireText(input.stripeEventId, "Stripe event ID")
+  const teamId = requireText(metadata.teamId, "Crew team ID")
+  const competitionId = requireText(
+    metadata.competitionId,
+    "Crew competition ID",
+  )
+  const eventId = normalizeText(metadata.eventId) ?? competitionId
+
+  if (eventId !== competitionId) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew event metadata does not match competition metadata.",
+    )
+  }
+
+  const crewPlanRaw = requireText(metadata.crewPlan, "Crew plan")
+  if (!isCrewCheckoutPlanId(crewPlanRaw)) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout metadata contains an invalid Crew plan.",
+    )
+  }
+
+  const crewEventSettingsId = requireText(
+    metadata.crewEventSettingsId,
+    "Crew event settings ID",
+  )
+  const billingEventId = requireText(
+    metadata.billingEventId,
+    "Crew billing event ID",
+  )
+  const checkoutIdempotencyKey = requireText(
+    metadata.checkoutIdempotencyKey,
+    "Crew Checkout idempotency key",
+  )
+  const amountCents = requirePositiveCents(input.amountTotal)
+  const currency = normalizeCurrency(input.currency)
+  const expectedCheckoutIdempotencyKey = buildCrewCheckoutIdempotencyKey({
+    competitionId: eventId,
+    teamId,
+    crewPlan: crewPlanRaw,
+    amountCents,
+  })
+
+  if (checkoutIdempotencyKey !== expectedCheckoutIdempotencyKey) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout idempotency metadata does not match the completed session.",
+    )
+  }
+
+  if (
+    billingEventId !== buildCrewCheckoutBillingEventId(checkoutIdempotencyKey)
+  ) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout billing event metadata does not match the checkout key.",
+    )
+  }
+
+  return {
+    stripeEventId,
+    sessionId,
+    eventId,
+    teamId,
+    crewPlan: crewPlanRaw,
+    crewEventSettingsId,
+    billingEventId,
+    checkoutIdempotencyKey,
+    amountCents,
+    currency,
+    stripePaymentIntentId: normalizeText(input.paymentIntentId),
+  }
+}
+
+export function planCrewCheckoutWebhookCompletion({
+  current,
+  existingEvents,
+  completion,
+}: {
+  current: CrewBillingStateSnapshot
+  existingEvents: CrewCheckoutWebhookExistingEvent[]
+  completion: CrewCheckoutWebhookCompletionInput
+}): CrewCheckoutWebhookCompletionPlan {
+  if (
+    isDuplicateCrewCheckoutCompletion(existingEvents, completion) ||
+    isAlreadyPaidByCrewCheckoutSession(current, completion)
+  ) {
+    return { action: "skip_duplicate" }
+  }
+
+  validatePendingCrewCheckoutState(current, completion)
+
+  const appendPlan = planCrewBillingAuditAppend(existingEvents, {
+    competitionId: completion.eventId,
+    teamId: completion.teamId,
+    eventType: CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED,
+    current,
+    planId: completion.crewPlan,
+    amountCents: completion.amountCents,
+    currency: completion.currency,
+    stripeCheckoutSessionId: completion.sessionId,
+    stripePaymentIntentId: completion.stripePaymentIntentId,
+    idempotencyKey: getCrewCheckoutSessionCompletionIdempotencyKey(
+      completion.sessionId,
+    ),
+    privateMetadata: {
+      stripeEventId: completion.stripeEventId,
+      billingEventId: completion.billingEventId,
+      checkoutIdempotencyKey: completion.checkoutIdempotencyKey,
+    },
+  })
+
+  if (appendPlan.action === "skip_duplicate") {
+    return { action: "skip_duplicate" }
+  }
+
+  return { action: "append", appendPlan }
+}
+
+export function getCrewCheckoutStripeEventIdempotencyKey(
+  stripeEventId: string,
+) {
+  return `stripe-event:${stripeEventId}`
+}
+
+export function getCrewCheckoutSessionCompletionIdempotencyKey(
+  sessionId: string,
+) {
+  return `stripe-checkout-session:${sessionId}`
+}
+
+function isDuplicateCrewCheckoutCompletion(
+  existingEvents: CrewCheckoutWebhookExistingEvent[],
+  completion: CrewCheckoutWebhookCompletionInput,
+) {
+  const stripeEventKey = getCrewCheckoutStripeEventIdempotencyKey(
+    completion.stripeEventId,
+  )
+  const sessionKey = getCrewCheckoutSessionCompletionIdempotencyKey(
+    completion.sessionId,
+  )
+
+  return existingEvents.some((event) => {
+    if (event.eventType !== CREW_BILLING_EVENT_TYPE.CHECKOUT_COMPLETED) {
+      return false
+    }
+
+    return (
+      event.idempotencyKey === stripeEventKey ||
+      event.idempotencyKey === sessionKey ||
+      event.stripeCheckoutSessionId === completion.sessionId ||
+      event.privateMetadata?.stripeEventId === completion.stripeEventId
+    )
+  })
+}
+
+function isAlreadyPaidByCrewCheckoutSession(
+  current: CrewBillingStateSnapshot,
+  completion: CrewCheckoutWebhookCompletionInput,
+) {
+  return (
+    current.state === CREW_BILLING_STATE.PAID &&
+    current.source === CREW_BILLING_SOURCE.STRIPE_CHECKOUT &&
+    current.planId === completion.crewPlan &&
+    current.amountCents === completion.amountCents &&
+    current.currency === completion.currency &&
+    current.stripe.checkoutSessionId === completion.sessionId
+  )
+}
+
+function validatePendingCrewCheckoutState(
+  current: CrewBillingStateSnapshot,
+  completion: CrewCheckoutWebhookCompletionInput,
+) {
+  if (
+    current.state !== CREW_BILLING_STATE.PENDING ||
+    current.source !== CREW_BILLING_SOURCE.STRIPE_CHECKOUT
+  ) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout completion requires a pending Stripe Checkout billing state.",
+    )
+  }
+
+  if (current.planId !== completion.crewPlan) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout completion plan does not match the pending event plan.",
+    )
+  }
+
+  if (
+    current.amountCents !== completion.amountCents ||
+    current.currency !== completion.currency
+  ) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout completion amount does not match the pending event billing state.",
+    )
+  }
+
+  if (
+    current.stripe.checkoutSessionId &&
+    current.stripe.checkoutSessionId !== completion.sessionId
+  ) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout completion session does not match the pending event session.",
+    )
+  }
+
+  if (
+    current.stripe.paymentIntentId &&
+    completion.stripePaymentIntentId &&
+    current.stripe.paymentIntentId !== completion.stripePaymentIntentId
+  ) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout completion payment intent does not match the event billing state.",
+    )
+  }
+}
+
+function requireText(value: unknown, label: string) {
+  const normalized = normalizeText(value)
+  if (!normalized) {
+    throw new CrewCheckoutWebhookValidationError(`${label} is required.`)
+  }
+  return normalized
+}
+
+function requirePositiveCents(value: unknown) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value)
+  ) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout completion amount is required.",
+    )
+  }
+
+  if (value <= 0) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout completion amount must be positive.",
+    )
+  }
+
+  return value
+}
+
+function normalizeCurrency(value: unknown) {
+  const normalized = normalizeText(value)?.toLowerCase()
+  if (!normalized || !/^[a-z]{3}$/.test(normalized)) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout completion currency is required.",
+    )
+  }
+  return normalized
+}
+
+function normalizeText(value: unknown) {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as EventsEventIdExportsRouteImport } from './routes/events/$event
 import { Route as EventsEventIdDayOfRouteImport } from './routes/events/$eventId/day-of'
 import { Route as EventsEventIdBillingRouteImport } from './routes/events/$eventId/billing'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
+import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
 import { Route as ESlugScheduleTokenRouteImport } from './routes/e/$slug/schedule/$token'
 import { Route as ESlugConfirmTokenRouteImport } from './routes/e/$slug/confirm/$token'
@@ -121,6 +122,11 @@ const ESlugVolunteerRoute = ESlugVolunteerRouteImport.update({
   path: '/e/$slug/volunteer',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiWebhooksStripeRoute = ApiWebhooksStripeRouteImport.update({
+  id: '/api/webhooks/stripe',
+  path: '/api/webhooks/stripe',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiCrewImportRoute = ApiCrewImportRouteImport.update({
   id: '/api/crew/import',
   path: '/api/crew/import',
@@ -144,6 +150,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
@@ -166,6 +173,7 @@ export interface FileRoutesByTo {
   '/events': typeof EventsRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
@@ -190,6 +198,7 @@ export interface FileRoutesById {
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
@@ -215,6 +224,7 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/events/new'
     | '/api/crew/import'
+    | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/billing'
     | '/events/$eventId/day-of'
@@ -237,6 +247,7 @@ export interface FileRouteTypes {
     | '/events'
     | '/events/new'
     | '/api/crew/import'
+    | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/billing'
     | '/events/$eventId/day-of'
@@ -260,6 +271,7 @@ export interface FileRouteTypes {
     | '/events/$eventId'
     | '/events/new'
     | '/api/crew/import'
+    | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/billing'
     | '/events/$eventId/day-of'
@@ -282,6 +294,7 @@ export interface RootRouteChildren {
   CalculatorRoute: typeof CalculatorRoute
   EventsRoute: typeof EventsRouteWithChildren
   ApiCrewImportRoute: typeof ApiCrewImportRoute
+  ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute
   ESlugVolunteerRoute: typeof ESlugVolunteerRoute
   ESlugConfirmTokenRoute: typeof ESlugConfirmTokenRoute
   ESlugScheduleTokenRoute: typeof ESlugScheduleTokenRoute
@@ -415,6 +428,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ESlugVolunteerRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/webhooks/stripe': {
+      id: '/api/webhooks/stripe'
+      path: '/api/webhooks/stripe'
+      fullPath: '/api/webhooks/stripe'
+      preLoaderRoute: typeof ApiWebhooksStripeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/crew/import': {
       id: '/api/crew/import'
       path: '/api/crew/import'
@@ -491,6 +511,7 @@ const rootRouteChildren: RootRouteChildren = {
   CalculatorRoute: CalculatorRoute,
   EventsRoute: EventsRouteWithChildren,
   ApiCrewImportRoute: ApiCrewImportRoute,
+  ApiWebhooksStripeRoute: ApiWebhooksStripeRoute,
   ESlugVolunteerRoute: ESlugVolunteerRoute,
   ESlugConfirmTokenRoute: ESlugConfirmTokenRoute,
   ESlugScheduleTokenRoute: ESlugScheduleTokenRoute,

--- a/apps/crew/src/routes/api/webhooks/stripe.ts
+++ b/apps/crew/src/routes/api/webhooks/stripe.ts
@@ -1,0 +1,521 @@
+// @lat: [[crew#Crew Stripe Webhooks]]
+import { createFileRoute } from "@tanstack/react-router"
+import { json } from "@tanstack/react-start"
+import { env } from "cloudflare:workers"
+import { and, eq } from "drizzle-orm"
+import type Stripe from "stripe"
+import { getDb } from "@/db"
+import {
+  COMMERCE_PURCHASE_STATUS,
+  FINANCIAL_EVENT_TYPE,
+  commercePurchaseTable,
+  competitionsTable,
+  financialEventTable,
+  teamTable,
+} from "@/db/schema"
+import { getStripeWebhookSecret } from "@/lib/env"
+import {
+  logError,
+  logInfo,
+  logWarning,
+} from "@/lib/logging/posthog-otel-logger"
+import { getStripe } from "@/lib/stripe"
+import {
+  CrewCheckoutWebhookValidationError,
+  isCrewCheckoutSessionMetadata,
+  parseCrewCheckoutSessionWebhook,
+} from "@/lib/crew/checkout-webhooks"
+import { recordRefundCompleted } from "@/server/commerce/financial-events"
+import { completeCrewCheckoutSessionFromWebhook } from "@/server/crew-billing.server"
+import { notifyPaymentExpired } from "@/server/notifications"
+import type { CheckoutCompletedParams } from "@/workflows/stripe-checkout-workflow"
+
+export const Route = createFileRoute("/api/webhooks/stripe")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        async function handleCheckoutExpired(session: Stripe.Checkout.Session) {
+          const db = getDb()
+          const purchaseIdsRaw =
+            session.metadata?.purchaseIds ?? session.metadata?.purchaseId
+
+          if (!purchaseIdsRaw) return
+
+          const purchaseIds = purchaseIdsRaw.split(",").filter(Boolean)
+
+          for (const purchaseId of purchaseIds) {
+            await db
+              .update(commercePurchaseTable)
+              .set({ status: COMMERCE_PURCHASE_STATUS.CANCELLED })
+              .where(
+                and(
+                  eq(commercePurchaseTable.id, purchaseId),
+                  eq(
+                    commercePurchaseTable.status,
+                    COMMERCE_PURCHASE_STATUS.PENDING,
+                  ),
+                ),
+              )
+
+            logInfo({
+              message: "[Stripe Webhook] Checkout expired for purchase",
+              attributes: { purchaseId },
+            })
+          }
+
+          const userId = session.metadata?.userId
+          const competitionId = session.metadata?.competitionId
+
+          if (userId && competitionId) {
+            for (const purchaseId of purchaseIds) {
+              const purchase = await db.query.commercePurchaseTable.findFirst({
+                where: eq(commercePurchaseTable.id, purchaseId),
+                columns: { divisionId: true },
+              })
+              const divisionId =
+                purchase?.divisionId ?? session.metadata?.divisionId
+
+              if (!divisionId) continue
+
+              try {
+                await notifyPaymentExpired({
+                  userId,
+                  competitionId,
+                  divisionId,
+                })
+              } catch (notifyErr) {
+                logWarning({
+                  message:
+                    "[Stripe Webhook] Failed to send payment expired notification",
+                  error: notifyErr,
+                  attributes: {
+                    userId,
+                    competitionId,
+                    divisionId,
+                    purchaseId,
+                  },
+                })
+              }
+            }
+          }
+        }
+
+        async function handleAccountUpdated(account: Stripe.Account) {
+          const db = getDb()
+
+          const team = await db.query.teamTable.findFirst({
+            where: eq(teamTable.stripeConnectedAccountId, account.id),
+          })
+
+          if (!team) {
+            logInfo({
+              message: "[Stripe Webhook] No team found for account",
+              attributes: { accountId: account.id },
+            })
+            return
+          }
+
+          const status =
+            account.charges_enabled && account.payouts_enabled
+              ? "VERIFIED"
+              : "PENDING"
+
+          const updateData: Record<string, unknown> = {
+            stripeAccountStatus: status,
+            updatedAt: new Date(),
+          }
+
+          if (status === "VERIFIED" && !team.stripeOnboardingCompletedAt) {
+            updateData.stripeOnboardingCompletedAt = new Date()
+          }
+
+          await db
+            .update(teamTable)
+            .set(updateData)
+            .where(eq(teamTable.id, team.id))
+
+          logInfo({
+            message: "[Stripe Webhook] Updated team Stripe status",
+            attributes: { teamId: team.id, status, accountId: account.id },
+          })
+        }
+
+        async function handleAccountDeauthorized(data: {
+          id: string
+          account?: string
+        }) {
+          const db = getDb()
+          const accountId = data.account || data.id
+
+          const team = await db.query.teamTable.findFirst({
+            where: eq(teamTable.stripeConnectedAccountId, accountId),
+          })
+
+          if (!team) return
+
+          await db
+            .update(teamTable)
+            .set({
+              stripeConnectedAccountId: null,
+              stripeAccountStatus: null,
+              stripeAccountType: null,
+              stripeOnboardingCompletedAt: null,
+              updatedAt: new Date(),
+            })
+            .where(eq(teamTable.id, team.id))
+
+          logWarning({
+            message: "[Stripe Webhook] Team Stripe account deauthorized",
+            attributes: { teamId: team.id, accountId },
+          })
+        }
+
+        async function findPurchaseByPaymentIntent(paymentIntentId: string) {
+          const db = getDb()
+          const purchase = await db.query.commercePurchaseTable.findFirst({
+            where: eq(
+              commercePurchaseTable.stripePaymentIntentId,
+              paymentIntentId,
+            ),
+          })
+          if (!purchase || !purchase.competitionId) return null
+
+          const competition = await db.query.competitionsTable.findFirst({
+            where: eq(competitionsTable.id, purchase.competitionId),
+            columns: { organizingTeamId: true },
+          })
+          if (!competition) return null
+
+          return { purchase, teamId: competition.organizingTeamId }
+        }
+
+        async function handleChargeRefunded(charge: Stripe.Charge) {
+          const paymentIntentId = getPaymentIntentId(charge.payment_intent)
+          if (!paymentIntentId) return
+
+          const result = await findPurchaseByPaymentIntent(paymentIntentId)
+          if (!result) return
+
+          const db = getDb()
+
+          for (const refund of charge.refunds?.data ?? []) {
+            if (refund.status !== "succeeded") continue
+
+            const existing = await db.query.financialEventTable.findFirst({
+              where: and(
+                eq(financialEventTable.stripeRefundId, refund.id),
+                eq(
+                  financialEventTable.eventType,
+                  FINANCIAL_EVENT_TYPE.REFUND_COMPLETED,
+                ),
+              ),
+              columns: { id: true },
+            })
+            if (existing) continue
+
+            await recordRefundCompleted({
+              purchaseId: result.purchase.id,
+              teamId: result.teamId,
+              amountCents: refund.amount,
+              stripePaymentIntentId: paymentIntentId,
+              stripeRefundId: refund.id,
+              reason: `Refund via Stripe: ${refund.reason ?? "no reason provided"}`,
+            })
+
+            logInfo({
+              message:
+                "[Stripe Webhook] Recorded REFUND_COMPLETED from charge.refunded",
+              attributes: {
+                purchaseId: result.purchase.id,
+                refundId: refund.id,
+                amount: refund.amount,
+              },
+            })
+          }
+        }
+
+        async function handleCrewCheckoutCompleted(
+          stripeEventId: string,
+          session: Stripe.Checkout.Session,
+        ) {
+          try {
+            const completion = parseCrewCheckoutSessionWebhook({
+              stripeEventId,
+              sessionId: session.id,
+              metadata: session.metadata,
+              amountTotal: session.amount_total,
+              currency: session.currency,
+              paymentIntentId: getPaymentIntentId(session.payment_intent),
+            })
+            const result =
+              await completeCrewCheckoutSessionFromWebhook(completion)
+
+            logInfo({
+              message: "[Stripe Webhook] Processed Crew Checkout completion",
+              attributes: {
+                stripeEventId,
+                sessionId: session.id,
+                eventId: completion.eventId,
+                teamId: completion.teamId,
+                status: result.status,
+              },
+            })
+          } catch (error) {
+            if (error instanceof CrewCheckoutWebhookValidationError) {
+              logWarning({
+                message:
+                  "[Stripe Webhook] Ignored invalid Crew Checkout completion",
+                error,
+                attributes: {
+                  stripeEventId,
+                  sessionId: session.id,
+                },
+              })
+              return
+            }
+
+            throw error
+          }
+        }
+
+        async function handleRegistrationCheckoutCompleted(
+          stripeEventId: string,
+          session: Stripe.Checkout.Session,
+        ) {
+          const competitionId = session.metadata?.competitionId
+          const userId = session.metadata?.userId
+          const purchaseIdsRaw =
+            session.metadata?.purchaseIds ?? session.metadata?.purchaseId
+
+          if (!purchaseIdsRaw || !competitionId || !userId) {
+            logError({
+              message:
+                "[Stripe Webhook] Missing required metadata in Checkout Session",
+              attributes: {
+                purchaseIds: purchaseIdsRaw,
+                competitionId,
+                userId,
+              },
+            })
+            return
+          }
+
+          const purchaseIds = purchaseIdsRaw.split(",").filter(Boolean)
+          const paymentIntent = getPaymentIntentId(session.payment_intent)
+          const workflowErrors: Array<{
+            purchaseId: string
+            error: unknown
+          }> = []
+
+          for (const purchaseId of purchaseIds) {
+            const purchase =
+              await getDb().query.commercePurchaseTable.findFirst({
+                where: eq(commercePurchaseTable.id, purchaseId),
+              })
+
+            if (!purchase) {
+              logWarning({
+                message:
+                  "[Stripe Webhook] Purchase not found, falling back to session metadata",
+                attributes: { purchaseId, eventId: stripeEventId },
+              })
+            }
+
+            const divisionId =
+              purchase?.divisionId ?? session.metadata?.divisionId ?? ""
+
+            const workflowParams: CheckoutCompletedParams = {
+              stripeEventId,
+              session: {
+                id: session.id,
+                payment_intent: paymentIntent,
+                amount_total: purchase?.totalCents ?? session.amount_total,
+                customer_email: session.customer_email,
+                metadata: {
+                  purchaseId,
+                  competitionId,
+                  divisionId,
+                  userId,
+                  couponId: session.metadata?.couponId,
+                  stripeCouponId: session.metadata?.stripeCouponId,
+                  couponCode: session.metadata?.couponCode,
+                  couponDiscountCents: session.metadata?.couponDiscountCents,
+                },
+              },
+            }
+
+            const workflowId =
+              purchaseIds.length > 1
+                ? `${stripeEventId}-${purchaseId}`
+                : stripeEventId
+            const workflow =
+              "STRIPE_CHECKOUT_WORKFLOW" in env
+                ? (env.STRIPE_CHECKOUT_WORKFLOW as
+                    | Workflow<CheckoutCompletedParams>
+                    | undefined)
+                : undefined
+
+            if (workflow && typeof workflow.create === "function") {
+              try {
+                await workflow.create({
+                  id: workflowId,
+                  params: workflowParams,
+                })
+                logInfo({
+                  message: "[Stripe Webhook] Dispatched checkout to workflow",
+                  attributes: {
+                    eventId: stripeEventId,
+                    workflowId,
+                    purchaseId,
+                    competitionId,
+                    divisionId,
+                  },
+                })
+              } catch (workflowErr) {
+                const isConflict =
+                  workflowErr instanceof Error &&
+                  workflowErr.message.includes("already exists")
+                if (isConflict) {
+                  logInfo({
+                    message:
+                      "[Stripe Webhook] Workflow already exists for event (idempotent)",
+                    attributes: { eventId: stripeEventId, workflowId },
+                  })
+                } else {
+                  logError({
+                    message: "[Stripe Webhook] Failed to dispatch workflow",
+                    error: workflowErr,
+                    attributes: {
+                      eventId: stripeEventId,
+                      workflowId,
+                      purchaseId,
+                    },
+                  })
+                  workflowErrors.push({ purchaseId, error: workflowErr })
+                }
+              }
+            } else {
+              logInfo({
+                message:
+                  "[Stripe Webhook] Workflow binding unavailable, processing inline",
+                attributes: { eventId: stripeEventId, purchaseId },
+              })
+              const { processCheckoutInline } = await import(
+                "@/workflows/stripe-checkout-workflow"
+              )
+              await processCheckoutInline(workflowParams)
+            }
+          }
+
+          if (workflowErrors.length > 0) {
+            throw new Error(
+              `Failed to dispatch ${workflowErrors.length} of ${purchaseIds.length} workflows`,
+            )
+          }
+        }
+
+        const body = await request.text()
+        const signature = request.headers.get("stripe-signature")
+
+        if (!signature) {
+          logError({
+            message: "[Stripe Webhook] Missing stripe-signature header",
+          })
+          return json({ error: "Missing signature" }, { status: 400 })
+        }
+
+        const webhookSecret = getStripeWebhookSecret()
+        if (!webhookSecret) {
+          logError({
+            message: "[Stripe Webhook] Missing STRIPE_WEBHOOK_SECRET",
+          })
+          return json({ error: "Webhook not configured" }, { status: 500 })
+        }
+
+        let event: Stripe.Event
+        try {
+          event = await getStripe().webhooks.constructEventAsync(
+            body,
+            signature,
+            webhookSecret,
+          )
+        } catch (err) {
+          logError({
+            message: "[Stripe Webhook] Signature verification failed",
+            error: err,
+          })
+          return json({ error: "Invalid signature" }, { status: 401 })
+        }
+
+        try {
+          switch (event.type) {
+            case "checkout.session.completed": {
+              const session = event.data.object as Stripe.Checkout.Session
+              if (isCrewCheckoutSessionMetadata(session.metadata)) {
+                await handleCrewCheckoutCompleted(event.id, session)
+              } else {
+                await handleRegistrationCheckoutCompleted(event.id, session)
+              }
+              break
+            }
+
+            case "checkout.session.expired":
+              await handleCheckoutExpired(
+                event.data.object as Stripe.Checkout.Session,
+              )
+              break
+
+            case "account.updated":
+              await handleAccountUpdated(event.data.object as Stripe.Account)
+              break
+
+            case "charge.refunded":
+              await handleChargeRefunded(event.data.object as Stripe.Charge)
+              break
+
+            case "account.application.authorized":
+              logInfo({
+                message: "[Stripe Webhook] Account application authorized",
+                attributes: {
+                  accountId: (event.data.object as { id: string }).id,
+                },
+              })
+              break
+
+            case "account.application.deauthorized":
+              await handleAccountDeauthorized(
+                event.data.object as {
+                  id: string
+                  account?: string
+                },
+              )
+              break
+
+            default:
+              logInfo({
+                message: "[Stripe Webhook] Unhandled event type",
+                attributes: { eventType: event.type },
+              })
+          }
+
+          return json({ received: true })
+        } catch (err) {
+          logError({
+            message: "[Stripe Webhook] Processing failed",
+            error: err,
+            attributes: { eventType: event.type },
+          })
+          return json({ error: "Processing failed" }, { status: 500 })
+        }
+      },
+    },
+  },
+})
+
+function getPaymentIntentId(
+  paymentIntent: string | Stripe.PaymentIntent | null,
+) {
+  return typeof paymentIntent === "string"
+    ? paymentIntent
+    : (paymentIntent?.id ?? null)
+}

--- a/apps/crew/src/server/crew-billing.server.ts
+++ b/apps/crew/src/server/crew-billing.server.ts
@@ -3,8 +3,9 @@
 // @lat: [[crew#Billing Page And Upgrade CTA]]
 // @lat: [[crew#Stripe Payment Link Sales]]
 // @lat: [[crew#Crew Checkout Sessions]]
+// @lat: [[crew#Crew Stripe Webhooks]]
 import { env } from "cloudflare:workers"
-import { and, desc, eq } from "drizzle-orm"
+import { and, desc, eq, isNull, or } from "drizzle-orm"
 import { getDb } from "../db"
 import { ROLES_ENUM } from "../db/schema"
 import { competitionsTable } from "../db/schemas/competitions"
@@ -52,6 +53,11 @@ import {
   normalizeCrewCheckoutCatalogPlan,
   resolveCrewCheckoutPlanId,
 } from "../lib/crew/checkout-sessions"
+import {
+  CrewCheckoutWebhookValidationError,
+  type CrewCheckoutWebhookCompletionInput,
+  planCrewCheckoutWebhookCompletion,
+} from "../lib/crew/checkout-webhooks"
 import {
   buildCrewPaymentLinkSaleActionInput,
   getCrewPaymentLinkUrlFromSettings,
@@ -112,6 +118,10 @@ export interface CreateCrewCheckoutSessionInput extends GetCrewBillingInput {
 
 export interface CreateCrewCheckoutSessionResult {
   checkoutUrl: string
+}
+
+export interface CompleteCrewCheckoutSessionFromWebhookResult {
+  status: "completed" | "duplicate"
 }
 
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
@@ -370,6 +380,38 @@ export async function createCrewCheckoutSession(
   return { checkoutUrl: checkoutSession.url }
 }
 
+export async function completeCrewCheckoutSessionFromWebhook(
+  data: CrewCheckoutWebhookCompletionInput,
+): Promise<CompleteCrewCheckoutSessionFromWebhookResult> {
+  const scope = await requireCrewBillingScope(data.eventId)
+
+  if (
+    scope.organizingTeamId !== data.teamId ||
+    scope.settingsId !== data.crewEventSettingsId
+  ) {
+    throw new CrewCheckoutWebhookValidationError(
+      "Crew Checkout metadata is outside the event billing scope.",
+    )
+  }
+
+  const current = toCrewBillingSnapshot(scope)
+  const existingEvents = await listCrewBillingEventsForEvent(data.eventId)
+  const completionPlan = planCrewCheckoutWebhookCompletion({
+    current,
+    existingEvents,
+    completion: data,
+  })
+
+  if (completionPlan.action === "skip_duplicate") {
+    return { status: "duplicate" }
+  }
+
+  return persistCrewCheckoutCompletedFromWebhook(
+    data,
+    completionPlan.appendPlan,
+  )
+}
+
 async function claimCrewCheckoutSessionStart({
   eventId,
   current,
@@ -541,6 +583,62 @@ async function persistCrewCheckoutSessionCreated(
     if (isCrewBillingDuplicateEntryError(error)) return
     throw error
   }
+}
+
+async function persistCrewCheckoutCompletedFromWebhook(
+  data: CrewCheckoutWebhookCompletionInput,
+  appendPlan: Extract<CrewBillingAppendPlan, { action: "append" }>,
+): Promise<CompleteCrewCheckoutSessionFromWebhookResult> {
+  const db = getDb()
+  const { event, settingsPatch } = appendPlan
+
+  try {
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(crewBillingEventsTable)
+        .values(toNewCrewBillingEvent(event))
+      const result = await tx
+        .update(crewEventSettingsTable)
+        .set({
+          ...settingsPatch,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(crewEventSettingsTable.competitionId, data.eventId),
+            eq(crewEventSettingsTable.id, data.crewEventSettingsId),
+            eq(
+              crewEventSettingsTable.crewBillingState,
+              CREW_BILLING_STATE.PENDING,
+            ),
+            eq(
+              crewEventSettingsTable.crewBillingSource,
+              CREW_BILLING_SOURCE.STRIPE_CHECKOUT,
+            ),
+            or(
+              isNull(crewEventSettingsTable.crewStripeCheckoutSessionId),
+              eq(
+                crewEventSettingsTable.crewStripeCheckoutSessionId,
+                data.sessionId,
+              ),
+            ),
+          ),
+        )
+
+      if (getAffectedRows(result) === 0) {
+        throw new CrewCheckoutWebhookValidationError(
+          "Crew Checkout billing state is no longer pending for this session.",
+        )
+      }
+    })
+  } catch (error) {
+    if (isCrewBillingDuplicateEntryError(error)) {
+      return { status: "duplicate" }
+    }
+    throw error
+  }
+
+  return { status: "completed" }
 }
 
 async function updateCrewPaymentLinkSettings({

--- a/apps/crew/test/routes/api/webhooks/stripe.test.ts
+++ b/apps/crew/test/routes/api/webhooks/stripe.test.ts
@@ -176,6 +176,7 @@ describe('Stripe Webhook Handler', () => {
   })
 
   describe('checkout.session.completed', () => {
+    // @lat: [[crew#Crew Stripe Webhooks]]
     it('routes Crew Checkout Sessions to Crew billing completion', async () => {
       const {buildCrewCheckoutBillingEventId, buildCrewCheckoutIdempotencyKey} =
         await import('@/lib/crew/checkout-sessions')
@@ -234,6 +235,7 @@ describe('Stripe Webhook Handler', () => {
       expect(mockWorkflowCreate).not.toHaveBeenCalled()
     })
 
+    // @lat: [[crew#Crew Stripe Webhooks]]
     it('returns 200 for invalid Crew Checkout metadata without granting access', async () => {
       const session = {
         id: 'cs_crew_invalid',
@@ -261,6 +263,7 @@ describe('Stripe Webhook Handler', () => {
       expect(mockWorkflowCreate).not.toHaveBeenCalled()
     })
 
+    // @lat: [[crew#Crew Stripe Webhooks]]
     it('treats duplicate Crew Checkout completion as webhook success', async () => {
       const {buildCrewCheckoutBillingEventId, buildCrewCheckoutIdempotencyKey} =
         await import('@/lib/crew/checkout-sessions')
@@ -304,6 +307,7 @@ describe('Stripe Webhook Handler', () => {
       expect(mockCompleteCrewCheckoutSessionFromWebhook).toHaveBeenCalledOnce()
     })
 
+    // @lat: [[crew#Crew Stripe Webhooks]]
     it('dispatches to STRIPE_CHECKOUT_WORKFLOW with correct params', async () => {
       const session = {
         id: 'cs_test_123',
@@ -359,6 +363,7 @@ describe('Stripe Webhook Handler', () => {
       })
     })
 
+    // @lat: [[crew#Crew Stripe Webhooks]]
     it('keeps non-Crew product sessions on the existing registration workflow', async () => {
       const session = {
         id: 'cs_test_registration',

--- a/apps/crew/test/routes/api/webhooks/stripe.test.ts
+++ b/apps/crew/test/routes/api/webhooks/stripe.test.ts
@@ -1,4 +1,4 @@
-import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {beforeAll, beforeEach, describe, expect, it, vi} from 'vitest'
 import {FakeDrizzleDb} from '@repo/test-utils'
 
 // Mock the database
@@ -59,6 +59,13 @@ vi.mock('@/server/commerce/financial-events', () => ({
   recordDisputeEvent: (...args: unknown[]) => mockRecordDisputeEvent(...args),
 }))
 
+// Mock Crew billing completion
+const mockCompleteCrewCheckoutSessionFromWebhook = vi.fn()
+vi.mock('@/server/crew-billing.server', () => ({
+  completeCrewCheckoutSessionFromWebhook: (...args: unknown[]) =>
+    mockCompleteCrewCheckoutSessionFromWebhook(...args),
+}))
+
 // Mock TanStack for route creation
 vi.mock('@tanstack/react-router', () => ({
   createFileRoute: () => (config: unknown) => config,
@@ -94,25 +101,39 @@ function buildStripeEvent(
 }
 
 // Helper to call the webhook handler
+let routeConfigPromise: Promise<{
+  server: {handlers: {POST: (args: {request: Request}) => Promise<Response>}}
+}> | null = null
+
+async function getRouteConfig() {
+  routeConfigPromise ??= import('@/routes/api/webhooks/stripe').then(
+    ({Route}) =>
+      Route as unknown as {
+        server: {
+          handlers: {POST: (args: {request: Request}) => Promise<Response>}
+        }
+      },
+  )
+  return routeConfigPromise
+}
+
 async function callWebhook(
   body: string,
   headers: Record<string, string> = {'stripe-signature': 'sig_test'},
 ) {
-  // Import after mocks are set up
-  const {Route} = await import('@/routes/api/webhooks/stripe')
-
   const request = new Request('https://test.wodsmith.com/api/webhooks/stripe', {
     method: 'POST',
     body,
     headers,
   })
 
-  // The route config has server.handlers.POST
-  const routeConfig = Route as unknown as {
-    server: {handlers: {POST: (args: {request: Request}) => Promise<Response>}}
-  }
+  const routeConfig = await getRouteConfig()
   return routeConfig.server.handlers.POST({request})
 }
+
+beforeAll(async () => {
+  await getRouteConfig()
+}, 30_000)
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -155,6 +176,134 @@ describe('Stripe Webhook Handler', () => {
   })
 
   describe('checkout.session.completed', () => {
+    it('routes Crew Checkout Sessions to Crew billing completion', async () => {
+      const {buildCrewCheckoutBillingEventId, buildCrewCheckoutIdempotencyKey} =
+        await import('@/lib/crew/checkout-sessions')
+      const checkoutIdempotencyKey = buildCrewCheckoutIdempotencyKey({
+        competitionId: 'event-crew-1',
+        teamId: 'team-owner-1',
+        crewPlan: 'crew_basic',
+        amountCents: 20000,
+      })
+      const billingEventId = buildCrewCheckoutBillingEventId(
+        checkoutIdempotencyKey,
+      )
+      const session = {
+        id: 'cs_crew_123',
+        payment_intent: 'pi_crew_456',
+        amount_total: 20000,
+        currency: 'usd',
+        metadata: {
+          product: 'crew',
+          teamId: 'team-owner-1',
+          competitionId: 'event-crew-1',
+          eventId: 'event-crew-1',
+          crewPlan: 'crew_basic',
+          crewEventSettingsId: 'crewset_123',
+          billingEventId,
+          checkoutIdempotencyKey,
+        },
+      }
+
+      const event = buildStripeEvent(
+        'checkout.session.completed',
+        session,
+        'evt_crew_123',
+      )
+      mockConstructEventAsync.mockResolvedValue(event)
+      mockCompleteCrewCheckoutSessionFromWebhook.mockResolvedValue({
+        status: 'completed',
+      })
+
+      const response = await callWebhook(JSON.stringify(event))
+      expect(response.status).toBe(200)
+
+      expect(mockCompleteCrewCheckoutSessionFromWebhook).toHaveBeenCalledWith({
+        stripeEventId: 'evt_crew_123',
+        sessionId: 'cs_crew_123',
+        eventId: 'event-crew-1',
+        teamId: 'team-owner-1',
+        crewPlan: 'crew_basic',
+        crewEventSettingsId: 'crewset_123',
+        billingEventId,
+        checkoutIdempotencyKey,
+        amountCents: 20000,
+        currency: 'usd',
+        stripePaymentIntentId: 'pi_crew_456',
+      })
+      expect(mockWorkflowCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns 200 for invalid Crew Checkout metadata without granting access', async () => {
+      const session = {
+        id: 'cs_crew_invalid',
+        payment_intent: 'pi_crew_invalid',
+        amount_total: 20000,
+        currency: 'usd',
+        metadata: {
+          product: 'crew',
+          teamId: 'team-owner-1',
+          competitionId: 'event-crew-1',
+          crewPlan: 'crew_basic',
+        },
+      }
+
+      const event = buildStripeEvent(
+        'checkout.session.completed',
+        session,
+        'evt_crew_invalid',
+      )
+      mockConstructEventAsync.mockResolvedValue(event)
+
+      const response = await callWebhook(JSON.stringify(event))
+      expect(response.status).toBe(200)
+      expect(mockCompleteCrewCheckoutSessionFromWebhook).not.toHaveBeenCalled()
+      expect(mockWorkflowCreate).not.toHaveBeenCalled()
+    })
+
+    it('treats duplicate Crew Checkout completion as webhook success', async () => {
+      const {buildCrewCheckoutBillingEventId, buildCrewCheckoutIdempotencyKey} =
+        await import('@/lib/crew/checkout-sessions')
+      const checkoutIdempotencyKey = buildCrewCheckoutIdempotencyKey({
+        competitionId: 'event-crew-1',
+        teamId: 'team-owner-1',
+        crewPlan: 'crew_basic',
+        amountCents: 20000,
+      })
+      const session = {
+        id: 'cs_crew_duplicate',
+        payment_intent: 'pi_crew_duplicate',
+        amount_total: 20000,
+        currency: 'usd',
+        metadata: {
+          product: 'crew',
+          teamId: 'team-owner-1',
+          competitionId: 'event-crew-1',
+          eventId: 'event-crew-1',
+          crewPlan: 'crew_basic',
+          crewEventSettingsId: 'crewset_123',
+          billingEventId: buildCrewCheckoutBillingEventId(
+            checkoutIdempotencyKey,
+          ),
+          checkoutIdempotencyKey,
+        },
+      }
+
+      const event = buildStripeEvent(
+        'checkout.session.completed',
+        session,
+        'evt_crew_duplicate',
+      )
+      mockConstructEventAsync.mockResolvedValue(event)
+      mockCompleteCrewCheckoutSessionFromWebhook.mockResolvedValue({
+        status: 'duplicate',
+      })
+
+      const response = await callWebhook(JSON.stringify(event))
+      expect(response.status).toBe(200)
+      expect(mockCompleteCrewCheckoutSessionFromWebhook).toHaveBeenCalledOnce()
+    })
+
     it('dispatches to STRIPE_CHECKOUT_WORKFLOW with correct params', async () => {
       const session = {
         id: 'cs_test_123',
@@ -208,6 +357,47 @@ describe('Stripe Webhook Handler', () => {
           },
         },
       })
+    })
+
+    it('keeps non-Crew product sessions on the existing registration workflow', async () => {
+      const session = {
+        id: 'cs_test_registration',
+        payment_intent: 'pi_test_registration',
+        amount_total: 5000,
+        customer_email: 'athlete@test.com',
+        metadata: {
+          product: 'registration',
+          purchaseId: 'purchase-1',
+          competitionId: 'comp-1',
+          divisionId: 'div-1',
+          userId: 'user-1',
+        },
+      }
+
+      const event = buildStripeEvent(
+        'checkout.session.completed',
+        session,
+        'evt_registration_product',
+      )
+      mockConstructEventAsync.mockResolvedValue(event)
+      mockWorkflowCreate.mockResolvedValue(undefined)
+      mockDb.query.commercePurchaseTable = {
+        findFirst: vi.fn().mockResolvedValue({
+          id: 'purchase-1',
+          divisionId: 'div-1',
+          totalCents: 5000,
+        }),
+        findMany: vi.fn().mockResolvedValue([]),
+      }
+
+      const response = await callWebhook(JSON.stringify(event))
+      expect(response.status).toBe(200)
+      expect(mockCompleteCrewCheckoutSessionFromWebhook).not.toHaveBeenCalled()
+      expect(mockWorkflowCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'evt_registration_product',
+        }),
+      )
     })
 
     it('returns 200 when metadata is missing (logs error, no workflow)', async () => {

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -58,7 +58,17 @@ Crew Checkout Session creation is feature-flagged with `CREW_STRIPE_CHECKOUT_ENA
 
 [[apps/crew/src/lib/crew/checkout-sessions.ts]] builds Stripe Checkout Session params for public paid Crew event plans only, with metadata `product=crew`, team/event scope, Crew plan, `crewEventSettingsId`, `billingEventId`, and a stable checkout idempotency key. Private founder/concierge pricing and audit metadata are excluded from session metadata and organizer page view models.
 
-[[apps/crew/src/server/crew-billing.server.ts]] creates sessions through the shared Stripe client, appends a pending `checkout_session_created` Crew billing audit event, and patches only event-level `crew_event_settings` Checkout reference/status fields. `checkout_completed` remains reserved for the later webhook slice, and Crew one-event purchases must not update `teams.currentPlanId`.
+[[apps/crew/src/server/crew-billing.server.ts]] creates sessions through the shared Stripe client, appends a pending `checkout_session_created` Crew billing audit event, and patches only event-level `crew_event_settings` Checkout reference/status fields. The webhook completion path owns the later `checkout_completed` transition, and Crew one-event purchases must not update `teams.currentPlanId`.
+
+## Crew Stripe Webhooks
+
+Crew Stripe webhooks complete the event-level Checkout flow after Stripe verifies payment.
+
+[[apps/crew/src/routes/api/webhooks/stripe.ts]] routes completed Checkout Sessions by `session.metadata.product`. Sessions with `product=crew` are handled by Crew billing completion, while non-Crew registration sessions continue through the existing athlete registration checkout workflow.
+
+[[apps/crew/src/lib/crew/checkout-webhooks.ts]] validates the Crew metadata contract, including team/event scope, public Crew plan, event settings row ID, billing event ID, checkout idempotency key, amount, currency, Checkout Session ID, and Stripe event ID. Duplicate delivery is treated as idempotent by both Stripe event ID and Checkout Session ID.
+
+[[apps/crew/src/server/crew-billing.server.ts]] completes only a matching pending Stripe Checkout event settings row, appends one `checkout_completed` billing audit row, and patches only `crew_event_settings` billing fields. Crew Checkout completion must not mutate WODsmith team subscription state or assign Crew one-event plan IDs to `teams.currentPlanId`.
 
 ## Server Function Runtime Boundary
 


### PR DESCRIPTION
## Summary
- Add Crew Checkout webhook parsing/planning with fail-closed metadata validation and duplicate detection by Stripe event ID plus Checkout Session ID.
- Add the Crew Stripe webhook route that branches completed Checkout Sessions by `metadata.product`, sending `product=crew` to Crew billing and preserving non-Crew registration checkout behavior.
- Complete only matching pending event-level Crew billing settings, append one `checkout_completed` audit row, and keep team subscription state untouched.
- Add LAT coverage for `crew#Crew Stripe Webhooks`.

## Validation
- Focused Vitest: `node ../../node_modules/.pnpm/node_modules/vitest/vitest.mjs run src/lib/crew/checkout-webhooks.test.ts test/routes/api/webhooks/stripe.test.ts` — 27 tests passed.
- Crew type-check equivalent: `node node_modules/@typescript/native-preview/bin/tsgo.js --noEmit` — passed.
- Crew lint equivalent: `node node_modules/@biomejs/biome/bin/biome lint .` — passed with existing unrelated warnings.
- Crew build: `CLOUDFLARE_VITE_REMOTE_BINDINGS=false ... ./node_modules/.bin/vite build` — passed with existing large-chunk warning.
- LAT locate: `pnpm dlx lat.md locate "crew#Crew Stripe Webhooks"` — found `lat.md/crew.md:63-72`.
- `git diff --check` — passed.

## Notes
- No schema or migration changes.
- No live Stripe calls or production data mutations.
- No deploy or webhook endpoint provisioning in this slice; it reuses the existing Stripe client and webhook secret helpers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Processes Stripe webhooks for Crew Checkout and registration with strict validation and idempotent event-level billing updates. Adds a single `/api/webhooks/stripe` endpoint with signature verification and routes non-Crew sessions to the existing registration workflow.

- **New Features**
  - Added `POST /api/webhooks/stripe` with signature verification and branch by `session.metadata.product`.
  - Crew: strict metadata contract validation; dedupe by Stripe event ID and Checkout Session ID; append one `checkout_completed` audit event; patch only event-level `crew_event_settings` (no team subscription changes).
  - Registration: dispatches to the existing checkout workflow (or inline fallback) and supports multi-purchase.
  - Also handles `checkout.session.expired` (cancel pending + notify), `charge.refunded` (record `REFUND_COMPLETED`), and connected account `account.updated`/`account.application.deauthorized` sync.
  - Tests: expanded coverage for webhook routing, Crew completion idempotency, and invalid Crew metadata handling.

<sup>Written for commit 2532738a4c9b9963a02e46657196416ff8578759. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stripe webhook endpoint now handles Crew checkout completions, expired sessions, account updates, refunds, and authorization events.
  * Added validation and deduplication for Crew checkout sessions to ensure idempotent processing.

* **Tests**
  * Added comprehensive test coverage for webhook routing and Crew checkout handling.

* **Documentation**
  * Documented Crew Stripe webhook processing behavior and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->