### PR TITLE
[codex] chore(crew): paid launch ops hardening

### DIFF
--- a/apps/crew/docs/guides/paid-launch-ops-runbook.md
+++ b/apps/crew/docs/guides/paid-launch-ops-runbook.md
@@ -1,0 +1,78 @@
+# Crew Paid Launch Ops Runbook
+
+This runbook keeps the first paid Crew launches operator-led while preserving the event-level billing model.
+
+## Launch Posture
+
+- Default sales path: manual paid grant or manually reconciled Stripe Payment Link sale.
+- Self-serve Checkout path: disabled unless `CREW_STRIPE_CHECKOUT_ENABLED` is explicitly enabled.
+- Billing scope: Crew paid state belongs to the selected event's `crew_event_settings` row and append-only `crew_billing_events` audit rows.
+- Team subscription scope: do not set, clear, or reinterpret `teams.currentPlanId` for a one-event Crew purchase.
+- Private data scope: founder pricing, invoices, internal notes, raw Stripe references, and reconciliation metadata stay server-only or local-operator-only.
+
+## Preflight Checklist
+
+- Confirm the organizer team and Crew event are the intended production records.
+- Confirm the desired Crew catalog plan is event-level: `crew_starter`, `crew_basic`, `crew_pro`, `crew_concierge`, or `crew_founding_2026`.
+- Confirm the sale path is manual, Payment Link reconciliation, founder/private grant, comp, refund, or Checkout.
+- Confirm no route or script in the planned operation updates team subscription billing.
+- Confirm the operator can read back event billing status on the private Crew billing page.
+- Confirm `CREW_STRIPE_CHECKOUT_ENABLED` is unset or false unless the explicit Checkout launch decision has been made.
+
+## Manual Paid And Founder Grants
+
+Use the private operator action for paid launch grants that do not depend on Stripe automation.
+
+1. Select the Crew event and organizing team from server-side event context.
+2. Record the Crew plan, amount, currency, actor label, and public note.
+3. Put invoice IDs, founder approvals, private prices, and internal reconciliation notes in private metadata only.
+4. Verify the resulting audit event is appended before the event settings patch is applied.
+5. Verify the event settings patch contains Crew billing fields only and does not include `currentPlanId`.
+
+Founder grants should use `crew_founding_2026`. Concierge sales should use `crew_concierge`. Neither should be exposed as public Checkout choices.
+
+## Payment Link Reconciliation
+
+Payment Links are a manual fallback, not a live Stripe API dependency.
+
+1. Store only organizer-safe Payment Link URLs in event settings.
+2. Reconcile from operator-provided event ID, organizing team ID, Crew plan, amount, and currency.
+3. Use Stripe Payment Link or Payment Intent references when available.
+4. If Stripe metadata is missing, reconcile with the stable manual idempotency key for the event, team, plan, amount, and currency.
+5. Verify duplicate reconciliation attempts skip by idempotency key and do not patch billing state again.
+
+## Refund And Credit Policy
+
+Refunds record the refunded amount and move the Crew event to a refunded fulfillment state. They do not delete prior audit history.
+
+Full-platform upgrade credit is single-use per Crew event. Set it once, apply it once, and keep the credit reason in private metadata when it references founder, invoice, or concierge terms.
+
+After a refund or credit operation:
+
+- Verify the private billing page shows refund or credit labels.
+- Verify Crew access gates reflect the terminal state.
+- Verify no team subscription plan was changed as a side effect.
+
+## Checkout Flag Readiness
+
+Before enabling `CREW_STRIPE_CHECKOUT_ENABLED`:
+
+- Confirm the billing page still hides Checkout when the flag is false.
+- Confirm Checkout plan choices are public paid plans only.
+- Confirm Checkout metadata excludes founder/private pricing, invoices, and audit notes.
+- Confirm webhook completion requires matching pending event billing state, Checkout Session ID, plan, amount, currency, and idempotency metadata.
+- Confirm non-Crew registration Checkout Sessions still route through the existing athlete registration workflow.
+
+## No-Live-Stripe Validation
+
+Use focused helper tests before any production operation:
+
+```bash
+pnpm --filter crew test -- src/lib/crew/billing-state.test.ts src/lib/crew/billing-page.test.ts src/lib/crew/payment-link-sales.test.ts src/lib/crew/checkout-sessions.test.ts src/lib/crew/checkout-webhooks.test.ts
+pnpm --filter crew type-check
+pnpm --filter crew lint
+pnpm dlx lat.md locate 'crew#Paid Launch Ops Hardening'
+git diff --check
+```
+
+Only run live Stripe checks after the Checkout flag decision is made and the target environment is explicitly approved.

--- a/apps/crew/src/lib/crew/billing-page.test.ts
+++ b/apps/crew/src/lib/crew/billing-page.test.ts
@@ -1,4 +1,5 @@
 // @lat: [[crew#Billing Page And Upgrade CTA]]
+// @lat: [[crew#Paid Launch Ops Hardening]]
 import { describe, expect, it } from "vitest"
 import {
   CREW_BILLING_SOURCE,
@@ -87,6 +88,25 @@ describe("Crew billing page view model", () => {
       label: "Start Checkout",
     })
     expect(enabled.checkout.helperText).toContain("Checkout Session")
+  })
+
+  it("keeps the disabled Checkout state stable for paid launch when the flag is off", () => {
+    const viewModel = buildCrewBillingPageViewModel({
+      billing: {
+        ...baseBilling,
+        planId: "crew_basic",
+      },
+      paymentLink: { id: null, url: null },
+      checkoutEnabled: false,
+    })
+
+    expect(viewModel.checkout).toEqual({
+      label: "Checkout unavailable",
+      status: "hidden",
+      href: null,
+      helperText: "Checkout is not enabled for Crew billing yet.",
+    })
+    expect(JSON.stringify(viewModel.checkout)).not.toContain("crew_basic")
   })
 
   it("disables Checkout for pending or private Crew billing states", () => {

--- a/apps/crew/src/lib/crew/billing-state.test.ts
+++ b/apps/crew/src/lib/crew/billing-state.test.ts
@@ -1,5 +1,6 @@
 // @lat: [[crew#Crew Billing State And Audit]]
 // @lat: [[crew#Manual Paid And Founder Grants]]
+// @lat: [[crew#Paid Launch Ops Hardening]]
 import { describe, expect, it } from "vitest"
 import { CREW_BILLING_EVENT_TYPE } from "../../db/schemas/crew-billing-events"
 import {
@@ -182,6 +183,80 @@ describe("Crew billing state and audit helpers", () => {
         "crew_concierge",
       ),
     ).toBe(true)
+  })
+
+  it("keeps every paid-launch manual operation scoped away from team subscription plans", () => {
+    const manualSale = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.RECORD_MANUAL_PAID,
+      competitionId: "comp_manual",
+      teamId: "team_owner",
+      planId: "crew_basic",
+      amountCents: 20_000,
+      privateMetadata: { invoiceId: "inv_manual" },
+    })
+    const founderGrant = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.APPLY_FOUNDER_GRANT,
+      competitionId: "comp_founder",
+      teamId: "team_owner",
+      privateFounderPriceCents: 9900,
+      privateMetadata: { approvalNote: "private approval" },
+    })
+    const creditSet = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.SET_FULL_PLATFORM_CREDIT,
+      competitionId: "comp_credit",
+      teamId: "team_owner",
+      current: {
+        state: CREW_BILLING_STATE.PAID,
+        source: CREW_BILLING_SOURCE.MANUAL_SALES,
+        planId: "crew_pro",
+        amountCents: 80_000,
+      },
+      fullPlatformCreditCents: 25_000,
+    })
+    const creditApplied = planManualCrewBillingAction([creditSet.event], {
+      action: MANUAL_CREW_BILLING_ACTION.APPLY_FULL_PLATFORM_CREDIT,
+      competitionId: "comp_credit",
+      teamId: "team_owner",
+      current: {
+        state: CREW_BILLING_STATE.CREDITED,
+        source: CREW_BILLING_SOURCE.CREW_CREDIT,
+        planId: "crew_pro",
+        amountCents: 80_000,
+        fullPlatformCreditCents: 25_000,
+      },
+    })
+    const comped = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.COMP_EVENT,
+      competitionId: "comp_comped",
+      teamId: "team_owner",
+      planId: "crew_starter",
+    })
+    const refunded = planManualCrewBillingAction([], {
+      action: MANUAL_CREW_BILLING_ACTION.RECORD_REFUND,
+      competitionId: "comp_refund",
+      teamId: "team_owner",
+      current: {
+        state: CREW_BILLING_STATE.PAID,
+        source: CREW_BILLING_SOURCE.MANUAL_SALES,
+        planId: "crew_basic",
+        amountCents: 20_000,
+      },
+      refundedCents: 20_000,
+      privateMetadata: { refundReason: "operator reversal" },
+    })
+
+    for (const plan of [
+      manualSale,
+      founderGrant,
+      creditSet,
+      creditApplied,
+      comped,
+      refunded,
+    ]) {
+      expect(plan.action).toBe("append")
+      expect(plan.settingsPatch).not.toHaveProperty("currentPlanId")
+      expect(JSON.stringify(plan.settingsPatch)).not.toContain("currentPlanId")
+    }
   })
 
   it("rejects manual paid actions without a valid plan and positive amount", () => {

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -70,6 +70,16 @@ Crew Stripe webhooks complete the event-level Checkout flow after Stripe verifie
 
 [[apps/crew/src/server/crew-billing.server.ts]] completes only a matching pending Stripe Checkout event settings row, appends one `checkout_completed` billing audit row, and patches only `crew_event_settings` billing fields. Crew Checkout completion must not mutate WODsmith team subscription state or assign Crew one-event plan IDs to `teams.currentPlanId`.
 
+## Paid Launch Ops Hardening
+
+Crew paid launch remains operator-led unless the Checkout flag is explicitly enabled.
+
+[[apps/crew/docs/guides/paid-launch-ops-runbook.md]] is the day-one runbook for manual paid grants, founder/private pricing, Stripe Payment Link reconciliation, refund and full-platform credit policy, and no-live-Stripe validation before turning on self-serve Checkout.
+
+[[apps/crew/src/lib/crew/billing-state.test.ts]] locks the manual, founder, credit, refund, Payment Link, Checkout creation, and webhook completion plans to event-level `crew_event_settings` patches without `teams.currentPlanId` mutation.
+
+[[apps/crew/src/lib/crew/billing-page.test.ts]] keeps organizer-safe billing view models free of founder pricing, invoices, private audit metadata, and raw Stripe references while preserving the disabled Checkout expectation when `CREW_STRIPE_CHECKOUT_ENABLED` is off.
+
 ## Server Function Runtime Boundary
 
 Route and client code import lightweight `createServerFn` wrappers from [[apps/crew/src/server-fns]].


### PR DESCRIPTION
## Summary

Adds a narrow Crew paid-launch operations hardening slice after the billing/webhook merge:

- adds a day-one paid launch runbook for manual grants, founder/private pricing, Payment Link reconciliation, refunds, credits, Checkout flag readiness, and no-live-Stripe validation
- adds the `crew#Paid Launch Ops Hardening` LAT anchor with refs to the runbook and focused guard tests
- tightens helper tests around event-scoped manual paid/founder/credit/refund patches and disabled Checkout view-model output

## Scope Notes

No schema, migration, entitlement rewrite, public pricing page, Checkout behavior change, webhook behavior change, live Stripe call, or team subscription billing change. The new guards keep Crew one-event purchase state separate from `teams.currentPlanId`.

## Validation

- `pnpm --filter crew test -- src/lib/crew/billing-state.test.ts src/lib/crew/billing-page.test.ts src/lib/crew/payment-link-sales.test.ts src/lib/crew/checkout-sessions.test.ts src/lib/crew/checkout-webhooks.test.ts` — 50 tests passed
- `pnpm --filter crew type-check` — passed
- `pnpm --filter crew lint` — completed with existing unrelated warnings, no errors
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` — passed after seeding local-only `apps/crew/.alchemy/local/wrangler.jsonc` from checked-in `apps/crew/wrangler.jsonc`
- `pnpm dlx lat.md locate 'crew#Paid Launch Ops Hardening'` — passed
- `git diff --check` — passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Crew’s paid launch ops by adding an operator runbook and guard tests that keep billing event-scoped, hide Checkout by default, and prevent team subscription mutations. This makes day-one paid launches safer without relying on live Stripe.

- New Features
  - Added paid-launch ops runbook covering manual grants, founder/private pricing, Payment Link reconciliation, refunds/credits, Checkout flag readiness, and no-live-Stripe validation.
  - Introduced LAT anchor `crew#Paid Launch Ops Hardening` with links to the runbook and targeted tests.
  - Tightened tests to ensure manual/founder/credit/refund actions never touch `teams.currentPlanId` and that Checkout stays hidden when the flag is off.

<sup>Written for commit 4782481f89e79b1fa35139619f46e64b4fc6873a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational runbook for early paid Crew launches, documenting billing procedures, sales posture, and preflight checklist.
  * Added documentation clarifying paid launch operations scope and testing coverage.

* **Tests**
  * Added test verification ensuring billing operations maintain proper event-level scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->