### PR TITLE
[codex] feat(db): add Crew volunteer intelligence schema

### DIFF
--- a/apps/crew/src/db/schemas/crew-volunteer-intelligence.ts
+++ b/apps/crew/src/db/schemas/crew-volunteer-intelligence.ts
@@ -1,0 +1,2 @@
+// @lat: [[crew#Strategic Moat Privacy Model]]
+export * from "@repo/wodsmith-db/schemas/crew-volunteer-intelligence"

--- a/apps/wodsmith-start/src/db/schemas/crew-volunteer-intelligence.ts
+++ b/apps/wodsmith-start/src/db/schemas/crew-volunteer-intelligence.ts
@@ -1,0 +1,2 @@
+// @lat: [[crew#Strategic Moat Privacy Model]]
+export * from "@repo/wodsmith-db/schemas/crew-volunteer-intelligence"

--- a/packages/wodsmith-db/mysql-migrations/0004_crew-volunteer-intelligence-schema.sql
+++ b/packages/wodsmith-db/mysql-migrations/0004_crew-volunteer-intelligence-schema.sql
@@ -1,0 +1,212 @@
+CREATE TABLE `crew_competition_group_settings` (
+	`created_at` datetime NOT NULL,
+	`updated_at` datetime NOT NULL,
+	`update_counter` int DEFAULT 0,
+	`id` varchar(255) NOT NULL,
+	`competition_group_id` varchar(255) NOT NULL,
+	`team_id` varchar(255) NOT NULL,
+	`memory_mode` varchar(30) NOT NULL DEFAULT 'disabled',
+	`returning_volunteer_consent_required` boolean NOT NULL DEFAULT true,
+	`history_visibility_scope` varchar(30) NOT NULL DEFAULT 'same_organizer',
+	`created_by_user_id` varchar(255),
+	`updated_by_user_id` varchar(255),
+	CONSTRAINT `crew_competition_group_settings_id` PRIMARY KEY(`id`),
+	CONSTRAINT `crew_competition_group_settings_group_unique_idx` UNIQUE(`competition_group_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `crew_event_conversions` (
+	`created_at` datetime NOT NULL,
+	`updated_at` datetime NOT NULL,
+	`update_counter` int DEFAULT 0,
+	`id` varchar(255) NOT NULL,
+	`team_id` varchar(255) NOT NULL,
+	`competition_id` varchar(255) NOT NULL,
+	`crew_event_settings_id` varchar(255),
+	`competition_group_id` varchar(255),
+	`status` varchar(30) NOT NULL DEFAULT 'requested',
+	`requested_by_user_id` varchar(255),
+	`reviewed_by_user_id` varchar(255),
+	`completed_by_user_id` varchar(255),
+	`requested_at` datetime NOT NULL,
+	`privacy_reviewed_at` datetime,
+	`completed_at` datetime,
+	`cancelled_at` datetime,
+	CONSTRAINT `crew_event_conversions_id` PRIMARY KEY(`id`),
+	CONSTRAINT `crew_event_conversions_competition_unique_idx` UNIQUE(`competition_id`)
+);
+--> statement-breakpoint
+CREATE TABLE `crew_volunteer_consents` (
+	`created_at` datetime NOT NULL,
+	`updated_at` datetime NOT NULL,
+	`update_counter` int DEFAULT 0,
+	`id` varchar(255) NOT NULL,
+	`identity_id` varchar(255) NOT NULL,
+	`team_id` varchar(255) NOT NULL,
+	`scope` varchar(50) NOT NULL,
+	`status` varchar(20) NOT NULL DEFAULT 'granted',
+	`consent_text` text NOT NULL,
+	`consent_text_version` varchar(100) NOT NULL,
+	`consent_text_hash` varchar(255) NOT NULL,
+	`source` varchar(40) NOT NULL,
+	`source_surface` varchar(100) NOT NULL,
+	`source_competition_id` varchar(255),
+	`actor_user_id` varchar(255),
+	`recorded_by_user_id` varchar(255),
+	`granted_at` datetime NOT NULL,
+	`revoked_at` datetime,
+	`revoked_by_user_id` varchar(255),
+	`revocation_source` varchar(100),
+	`superseded_by_consent_id` varchar(255),
+	CONSTRAINT `crew_volunteer_consents_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `crew_volunteer_credentials` (
+	`created_at` datetime NOT NULL,
+	`updated_at` datetime NOT NULL,
+	`update_counter` int DEFAULT 0,
+	`id` varchar(255) NOT NULL,
+	`identity_id` varchar(255) NOT NULL,
+	`team_id` varchar(255) NOT NULL,
+	`competition_id` varchar(255),
+	`credential_type` varchar(40) NOT NULL,
+	`credential_key` varchar(100),
+	`credential_label` varchar(255) NOT NULL,
+	`issuer` varchar(255),
+	`status` varchar(20) NOT NULL DEFAULT 'self_reported',
+	`visibility_scope` varchar(30) NOT NULL DEFAULT 'same_organizer',
+	`verified_at` datetime,
+	`expires_at` datetime,
+	`revoked_at` datetime,
+	`verified_by_user_id` varchar(255),
+	`source_type` varchar(50),
+	`source_id` varchar(255),
+	`consent_id` varchar(255),
+	CONSTRAINT `crew_volunteer_credentials_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `crew_volunteer_history_events` (
+	`created_at` datetime NOT NULL,
+	`updated_at` datetime NOT NULL,
+	`update_counter` int DEFAULT 0,
+	`id` varchar(255) NOT NULL,
+	`identity_id` varchar(255) NOT NULL,
+	`team_id` varchar(255) NOT NULL,
+	`competition_id` varchar(255),
+	`group_id` varchar(255),
+	`event_type` varchar(50) NOT NULL,
+	`visibility_scope` varchar(30) NOT NULL DEFAULT 'same_organizer',
+	`assignment_type` varchar(40),
+	`assignment_id` varchar(255),
+	`role_type` varchar(50),
+	`occurred_at` datetime NOT NULL,
+	`source_type` varchar(50) NOT NULL,
+	`source_id` varchar(255),
+	`source_user_id` varchar(255),
+	`consent_id` varchar(255),
+	`correction_of_event_id` varchar(255),
+	CONSTRAINT `crew_volunteer_history_events_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE TABLE `crew_volunteer_identities` (
+	`created_at` datetime NOT NULL,
+	`updated_at` datetime NOT NULL,
+	`update_counter` int DEFAULT 0,
+	`id` varchar(255) NOT NULL,
+	`team_id` varchar(255) NOT NULL,
+	`user_id` varchar(255),
+	`email_hash` varchar(255),
+	`phone_hash` varchar(255),
+	`contact_hash_version` varchar(50) NOT NULL DEFAULT 'v1',
+	`source_competition_id` varchar(255),
+	`source_membership_id` varchar(255),
+	`source_invitation_id` varchar(255),
+	`identity_source` varchar(40) NOT NULL DEFAULT 'manual',
+	`discovery_age_status` varchar(30) NOT NULL DEFAULT 'unknown',
+	`status` varchar(20) NOT NULL DEFAULT 'active',
+	CONSTRAINT `crew_volunteer_identities_id` PRIMARY KEY(`id`),
+	CONSTRAINT `crew_volunteer_identities_team_user_unique_idx` UNIQUE(`team_id`,`user_id`),
+	CONSTRAINT `crew_volunteer_identities_team_email_hash_unique_idx` UNIQUE(`team_id`,`contact_hash_version`,`email_hash`),
+	CONSTRAINT `crew_volunteer_identities_team_phone_hash_unique_idx` UNIQUE(`team_id`,`contact_hash_version`,`phone_hash`)
+);
+--> statement-breakpoint
+CREATE TABLE `crew_volunteer_intro_requests` (
+	`created_at` datetime NOT NULL,
+	`updated_at` datetime NOT NULL,
+	`update_counter` int DEFAULT 0,
+	`id` varchar(255) NOT NULL,
+	`requesting_team_id` varchar(255) NOT NULL,
+	`requesting_competition_id` varchar(255) NOT NULL,
+	`volunteer_identity_id` varchar(255) NOT NULL,
+	`discovery_consent_id` varchar(255) NOT NULL,
+	`requested_role_type` varchar(50),
+	`starts_at` datetime,
+	`ends_at` datetime,
+	`status` varchar(20) NOT NULL DEFAULT 'pending',
+	`requested_by_user_id` varchar(255),
+	`requested_at` datetime NOT NULL,
+	`responded_by_user_id` varchar(255),
+	`responded_at` datetime,
+	`expires_at` datetime,
+	`result_invitation_id` varchar(255),
+	`result_membership_id` varchar(255),
+	CONSTRAINT `crew_volunteer_intro_requests_id` PRIMARY KEY(`id`)
+);
+--> statement-breakpoint
+CREATE INDEX `crew_competition_group_settings_team_idx` ON `crew_competition_group_settings` (`team_id`);--> statement-breakpoint
+CREATE INDEX `crew_competition_group_settings_mode_idx` ON `crew_competition_group_settings` (`memory_mode`);--> statement-breakpoint
+CREATE INDEX `crew_competition_group_settings_created_by_idx` ON `crew_competition_group_settings` (`created_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_competition_group_settings_updated_by_idx` ON `crew_competition_group_settings` (`updated_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_event_conversions_team_idx` ON `crew_event_conversions` (`team_id`);--> statement-breakpoint
+CREATE INDEX `crew_event_conversions_settings_idx` ON `crew_event_conversions` (`crew_event_settings_id`);--> statement-breakpoint
+CREATE INDEX `crew_event_conversions_group_idx` ON `crew_event_conversions` (`competition_group_id`);--> statement-breakpoint
+CREATE INDEX `crew_event_conversions_status_idx` ON `crew_event_conversions` (`status`);--> statement-breakpoint
+CREATE INDEX `crew_event_conversions_requested_by_idx` ON `crew_event_conversions` (`requested_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_event_conversions_reviewed_by_idx` ON `crew_event_conversions` (`reviewed_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_event_conversions_completed_by_idx` ON `crew_event_conversions` (`completed_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_consents_identity_idx` ON `crew_volunteer_consents` (`identity_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_consents_team_idx` ON `crew_volunteer_consents` (`team_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_consents_scope_status_idx` ON `crew_volunteer_consents` (`scope`,`status`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_consents_identity_scope_status_idx` ON `crew_volunteer_consents` (`identity_id`,`scope`,`status`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_consents_source_competition_idx` ON `crew_volunteer_consents` (`source_competition_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_consents_actor_idx` ON `crew_volunteer_consents` (`actor_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_consents_recorded_by_idx` ON `crew_volunteer_consents` (`recorded_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_consents_revoked_at_idx` ON `crew_volunteer_consents` (`revoked_at`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_identity_idx` ON `crew_volunteer_credentials` (`identity_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_team_idx` ON `crew_volunteer_credentials` (`team_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_competition_idx` ON `crew_volunteer_credentials` (`competition_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_type_idx` ON `crew_volunteer_credentials` (`credential_type`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_key_idx` ON `crew_volunteer_credentials` (`credential_key`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_status_idx` ON `crew_volunteer_credentials` (`status`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_visibility_idx` ON `crew_volunteer_credentials` (`visibility_scope`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_expires_idx` ON `crew_volunteer_credentials` (`expires_at`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_verified_by_idx` ON `crew_volunteer_credentials` (`verified_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_credentials_consent_idx` ON `crew_volunteer_credentials` (`consent_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_identity_idx` ON `crew_volunteer_history_events` (`identity_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_team_idx` ON `crew_volunteer_history_events` (`team_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_competition_idx` ON `crew_volunteer_history_events` (`competition_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_group_idx` ON `crew_volunteer_history_events` (`group_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_type_idx` ON `crew_volunteer_history_events` (`event_type`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_visibility_idx` ON `crew_volunteer_history_events` (`visibility_scope`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_occurred_idx` ON `crew_volunteer_history_events` (`occurred_at`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_identity_occurred_idx` ON `crew_volunteer_history_events` (`identity_id`,`occurred_at`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_assignment_idx` ON `crew_volunteer_history_events` (`assignment_type`,`assignment_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_role_idx` ON `crew_volunteer_history_events` (`role_type`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_source_idx` ON `crew_volunteer_history_events` (`source_type`,`source_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_consent_idx` ON `crew_volunteer_history_events` (`consent_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_history_events_correction_idx` ON `crew_volunteer_history_events` (`correction_of_event_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_identities_team_idx` ON `crew_volunteer_identities` (`team_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_identities_user_idx` ON `crew_volunteer_identities` (`user_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_identities_source_competition_idx` ON `crew_volunteer_identities` (`source_competition_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_identities_status_idx` ON `crew_volunteer_identities` (`status`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_identities_age_status_idx` ON `crew_volunteer_identities` (`discovery_age_status`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_requester_idx` ON `crew_volunteer_intro_requests` (`requesting_team_id`,`requesting_competition_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_identity_idx` ON `crew_volunteer_intro_requests` (`volunteer_identity_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_consent_idx` ON `crew_volunteer_intro_requests` (`discovery_consent_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_role_idx` ON `crew_volunteer_intro_requests` (`requested_role_type`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_status_idx` ON `crew_volunteer_intro_requests` (`status`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_requested_by_idx` ON `crew_volunteer_intro_requests` (`requested_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_responded_by_idx` ON `crew_volunteer_intro_requests` (`responded_by_user_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_window_idx` ON `crew_volunteer_intro_requests` (`starts_at`,`ends_at`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_expires_idx` ON `crew_volunteer_intro_requests` (`expires_at`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_result_invitation_idx` ON `crew_volunteer_intro_requests` (`result_invitation_id`);--> statement-breakpoint
+CREATE INDEX `crew_volunteer_intro_requests_result_membership_idx` ON `crew_volunteer_intro_requests` (`result_membership_id`);

--- a/packages/wodsmith-db/mysql-migrations/0004_crew-volunteer-intelligence-schema.sql
+++ b/packages/wodsmith-db/mysql-migrations/0004_crew-volunteer-intelligence-schema.sql
@@ -126,7 +126,8 @@ CREATE TABLE `crew_volunteer_identities` (
 	CONSTRAINT `crew_volunteer_identities_id` PRIMARY KEY(`id`),
 	CONSTRAINT `crew_volunteer_identities_team_user_unique_idx` UNIQUE(`team_id`,`user_id`),
 	CONSTRAINT `crew_volunteer_identities_team_email_hash_unique_idx` UNIQUE(`team_id`,`contact_hash_version`,`email_hash`),
-	CONSTRAINT `crew_volunteer_identities_team_phone_hash_unique_idx` UNIQUE(`team_id`,`contact_hash_version`,`phone_hash`)
+	CONSTRAINT `crew_volunteer_identities_team_phone_hash_unique_idx` UNIQUE(`team_id`,`contact_hash_version`,`phone_hash`),
+	CONSTRAINT `crew_volunteer_identities_anchor_check` CHECK(`crew_volunteer_identities`.`user_id` is not null or `crew_volunteer_identities`.`email_hash` is not null or `crew_volunteer_identities`.`phone_hash` is not null)
 );
 --> statement-breakpoint
 CREATE TABLE `crew_volunteer_intro_requests` (

--- a/packages/wodsmith-db/mysql-migrations/meta/0004_snapshot.json
+++ b/packages/wodsmith-db/mysql-migrations/meta/0004_snapshot.json
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "dialect": "mysql",
-  "id": "b22d91a4-245c-4555-9dff-bc441439225b",
+  "id": "2ed73bd8-293c-4bb6-a91f-048301106349",
   "prevId": "128d38a2-1a30-484b-b159-ce7f27fc89f4",
   "tables": {
     "addresses": {
@@ -6252,7 +6252,12 @@
         }
       },
       "uniqueConstraints": {},
-      "checkConstraint": {}
+      "checkConstraint": {
+        "crew_volunteer_identities_anchor_check": {
+          "name": "crew_volunteer_identities_anchor_check",
+          "value": "`crew_volunteer_identities`.`user_id` is not null or `crew_volunteer_identities`.`email_hash` is not null or `crew_volunteer_identities`.`phone_hash` is not null"
+        }
+      }
     },
     "crew_volunteer_intro_requests": {
       "name": "crew_volunteer_intro_requests",

--- a/packages/wodsmith-db/mysql-migrations/meta/0004_snapshot.json
+++ b/packages/wodsmith-db/mysql-migrations/meta/0004_snapshot.json
@@ -1,0 +1,14629 @@
+{
+  "version": "5",
+  "dialect": "mysql",
+  "id": "b22d91a4-245c-4555-9dff-bc441439225b",
+  "prevId": "128d38a2-1a30-484b-b159-ce7f27fc89f4",
+  "tables": {
+    "addresses": {
+      "name": "addresses",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address_type": {
+          "name": "address_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "street_line1": {
+          "name": "street_line1",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "street_line2": {
+          "name": "street_line2",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "city": {
+          "name": "city",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "state_province": {
+          "name": "state_province",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "postal_code": {
+          "name": "postal_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "addresses_id": {
+          "name": "addresses_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "product_coupon_redemptions": {
+      "name": "product_coupon_redemptions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coupon_id": {
+          "name": "coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_off_cents": {
+          "name": "amount_off_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_coupon_id": {
+          "name": "stripe_coupon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "product_coupon_redemptions_coupon_idx": {
+          "name": "product_coupon_redemptions_coupon_idx",
+          "columns": [
+            "coupon_id"
+          ],
+          "isUnique": false
+        },
+        "product_coupon_redemptions_user_idx": {
+          "name": "product_coupon_redemptions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "product_coupon_redemptions_purchase_idx": {
+          "name": "product_coupon_redemptions_purchase_idx",
+          "columns": [
+            "purchase_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "product_coupon_redemptions_id": {
+          "name": "product_coupon_redemptions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "product_coupons": {
+      "name": "product_coupons",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'competition'"
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_off_cents": {
+          "name": "amount_off_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_redemptions": {
+          "name": "max_redemptions",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_redemptions": {
+          "name": "current_redemptions",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "tinyint",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "product_coupons_code_idx": {
+          "name": "product_coupons_code_idx",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        },
+        "product_coupons_team_product_idx": {
+          "name": "product_coupons_team_product_idx",
+          "columns": [
+            "team_id",
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "product_coupons_product_active_idx": {
+          "name": "product_coupons_product_active_idx",
+          "columns": [
+            "product_id",
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "product_coupons_id": {
+          "name": "product_coupons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "affiliates": {
+      "name": "affiliates",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unverified'"
+        },
+        "owner_team_id": {
+          "name": "owner_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "affiliates_name_idx": {
+          "name": "affiliates_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": false
+        },
+        "affiliates_owner_team_idx": {
+          "name": "affiliates_owner_team_idx",
+          "columns": [
+            "owner_team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "affiliates_id": {
+          "name": "affiliates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "affiliates_name_unique": {
+          "name": "affiliates_name_unique",
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "competition_broadcast_recipients": {
+      "name": "competition_broadcast_recipients",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "broadcast_id": {
+          "name": "broadcast_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_delivery_status": {
+          "name": "email_delivery_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        }
+      },
+      "indexes": {
+        "broadcast_recipients_broadcast_user_idx": {
+          "name": "broadcast_recipients_broadcast_user_idx",
+          "columns": [
+            "broadcast_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "broadcast_recipients_broadcast_invite_idx": {
+          "name": "broadcast_recipients_broadcast_invite_idx",
+          "columns": [
+            "broadcast_id",
+            "invitation_id"
+          ],
+          "isUnique": true
+        },
+        "broadcast_recipients_broadcast_idx": {
+          "name": "broadcast_recipients_broadcast_idx",
+          "columns": [
+            "broadcast_id"
+          ],
+          "isUnique": false
+        },
+        "broadcast_recipients_user_idx": {
+          "name": "broadcast_recipients_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "broadcast_recipients_invitation_idx": {
+          "name": "broadcast_recipients_invitation_idx",
+          "columns": [
+            "invitation_id"
+          ],
+          "isUnique": false
+        },
+        "broadcast_recipients_status_idx": {
+          "name": "broadcast_recipients_status_idx",
+          "columns": [
+            "email_delivery_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_broadcast_recipients_id": {
+          "name": "competition_broadcast_recipients_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_broadcasts": {
+      "name": "competition_broadcasts",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "audience_filter": {
+          "name": "audience_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recipient_count": {
+          "name": "recipient_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_broadcasts_competition_idx": {
+          "name": "competition_broadcasts_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "competition_broadcasts_team_idx": {
+          "name": "competition_broadcasts_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "competition_broadcasts_status_idx": {
+          "name": "competition_broadcasts_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_broadcasts_id": {
+          "name": "competition_broadcasts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "credit_transactions": {
+      "name": "credit_transactions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remaining_amount": {
+          "name": "remaining_amount",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiration_date": {
+          "name": "expiration_date",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expiration_date_processed_at": {
+          "name": "expiration_date_processed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_intent_id": {
+          "name": "payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "credit_transaction_user_id_idx": {
+          "name": "credit_transaction_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "credit_transaction_type_idx": {
+          "name": "credit_transaction_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "credit_transaction_created_at_idx": {
+          "name": "credit_transaction_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "credit_transaction_expiration_date_idx": {
+          "name": "credit_transaction_expiration_date_idx",
+          "columns": [
+            "expiration_date"
+          ],
+          "isUnique": false
+        },
+        "credit_transaction_payment_intent_id_idx": {
+          "name": "credit_transaction_payment_intent_id_idx",
+          "columns": [
+            "payment_intent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "credit_transactions_id": {
+          "name": "credit_transactions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "purchased_items": {
+      "name": "purchased_items",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchased_at": {
+          "name": "purchased_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "purchased_item_user_id_idx": {
+          "name": "purchased_item_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "purchased_item_type_idx": {
+          "name": "purchased_item_type_idx",
+          "columns": [
+            "item_type"
+          ],
+          "isUnique": false
+        },
+        "purchased_item_user_item_idx": {
+          "name": "purchased_item_user_item_idx",
+          "columns": [
+            "user_id",
+            "item_type",
+            "item_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "purchased_items_id": {
+          "name": "purchased_items_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "commerce_products": {
+      "name": "commerce_products",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "price_cents": {
+          "name": "price_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "commerce_product_resource_idx": {
+          "name": "commerce_product_resource_idx",
+          "columns": [
+            "type",
+            "resource_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "commerce_products_id": {
+          "name": "commerce_products_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "commerce_purchases": {
+      "name": "commerce_purchases",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division_id": {
+          "name": "division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cents": {
+          "name": "total_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_fee_cents": {
+          "name": "platform_fee_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_fee_cents": {
+          "name": "stripe_fee_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizer_net_cents": {
+          "name": "organizer_net_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "commerce_purchase_user_idx": {
+          "name": "commerce_purchase_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "commerce_purchase_product_idx": {
+          "name": "commerce_purchase_product_idx",
+          "columns": [
+            "product_id"
+          ],
+          "isUnique": false
+        },
+        "commerce_purchase_status_idx": {
+          "name": "commerce_purchase_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "commerce_purchase_stripe_session_idx": {
+          "name": "commerce_purchase_stripe_session_idx",
+          "columns": [
+            "stripe_checkout_session_id"
+          ],
+          "isUnique": false
+        },
+        "commerce_purchase_competition_idx": {
+          "name": "commerce_purchase_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "commerce_purchase_stripe_pi_idx": {
+          "name": "commerce_purchase_stripe_pi_idx",
+          "columns": [
+            "stripe_payment_intent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "commerce_purchases_id": {
+          "name": "commerce_purchases_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_divisions": {
+      "name": "competition_divisions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division_id": {
+          "name": "division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee_cents": {
+          "name": "fee_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_spots": {
+          "name": "max_spots",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_divisions_unique_idx": {
+          "name": "competition_divisions_unique_idx",
+          "columns": [
+            "competition_id",
+            "division_id"
+          ],
+          "isUnique": true
+        },
+        "competition_divisions_competition_idx": {
+          "name": "competition_divisions_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_divisions_id": {
+          "name": "competition_divisions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "purchase_transfers": {
+      "name": "purchase_transfers",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_email": {
+          "name": "target_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_email": {
+          "name": "accepted_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_user_id": {
+          "name": "target_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transfer_state": {
+          "name": "transfer_state",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'INITIATED'"
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "purchase_transfers_purchase_idx": {
+          "name": "purchase_transfers_purchase_idx",
+          "columns": [
+            "purchase_id"
+          ],
+          "isUnique": false
+        },
+        "purchase_transfers_source_idx": {
+          "name": "purchase_transfers_source_idx",
+          "columns": [
+            "source_user_id"
+          ],
+          "isUnique": false
+        },
+        "purchase_transfers_target_email_idx": {
+          "name": "purchase_transfers_target_email_idx",
+          "columns": [
+            "target_email"
+          ],
+          "isUnique": false
+        },
+        "purchase_transfers_state_idx": {
+          "name": "purchase_transfers_state_idx",
+          "columns": [
+            "transfer_state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "purchase_transfers_id": {
+          "name": "purchase_transfers_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_invite_source_division_allocations": {
+      "name": "competition_invite_source_division_allocations",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "championship_division_id": {
+          "name": "championship_division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "spots": {
+          "name": "spots",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_invite_source_division_allocations_source_div_unique": {
+          "name": "competition_invite_source_division_allocations_source_div_unique",
+          "columns": [
+            "source_id",
+            "championship_division_id"
+          ],
+          "isUnique": true
+        },
+        "competition_invite_source_division_allocations_div_idx": {
+          "name": "competition_invite_source_division_allocations_div_idx",
+          "columns": [
+            "championship_division_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_invite_source_division_allocations_id": {
+          "name": "competition_invite_source_division_allocations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_invite_sources": {
+      "name": "competition_invite_sources",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "championship_competition_id": {
+          "name": "championship_competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_competition_id": {
+          "name": "source_competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_group_id": {
+          "name": "source_group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "global_spots": {
+          "name": "global_spots",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division_mappings": {
+          "name": "division_mappings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_invite_sources_championship_sort_idx": {
+          "name": "competition_invite_sources_championship_sort_idx",
+          "columns": [
+            "championship_competition_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        },
+        "competition_invite_sources_source_competition_idx": {
+          "name": "competition_invite_sources_source_competition_idx",
+          "columns": [
+            "source_competition_id"
+          ],
+          "isUnique": false
+        },
+        "competition_invite_sources_source_group_idx": {
+          "name": "competition_invite_sources_source_group_idx",
+          "columns": [
+            "source_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_invite_sources_id": {
+          "name": "competition_invite_sources_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_invites": {
+      "name": "competition_invites",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "championship_competition_id": {
+          "name": "championship_competition_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_competition_id": {
+          "name": "source_competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_placement": {
+          "name": "source_placement",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_placement_label": {
+          "name": "source_placement_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bespoke_reason": {
+          "name": "bespoke_reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "championship_division_id": {
+          "name": "championship_division_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invitee_first_name": {
+          "name": "invitee_first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invitee_last_name": {
+          "name": "invitee_last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claim_token": {
+          "name": "claim_token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "send_attempt": {
+          "name": "send_attempt",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "declined_at": {
+          "name": "declined_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_registration_id": {
+          "name": "claimed_registration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_delivery_status": {
+          "name": "email_delivery_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "email_last_error": {
+          "name": "email_last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_marker": {
+          "name": "active_marker",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_invites_active_invite_idx": {
+          "name": "competition_invites_active_invite_idx",
+          "columns": [
+            "championship_competition_id",
+            "email",
+            "championship_division_id",
+            "active_marker"
+          ],
+          "isUnique": true
+        },
+        "competition_invites_claim_token_idx": {
+          "name": "competition_invites_claim_token_idx",
+          "columns": [
+            "claim_token"
+          ],
+          "isUnique": true
+        },
+        "competition_invites_round_idx": {
+          "name": "competition_invites_round_idx",
+          "columns": [
+            "round_id"
+          ],
+          "isUnique": false
+        },
+        "competition_invites_source_idx": {
+          "name": "competition_invites_source_idx",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "competition_invites_origin_idx": {
+          "name": "competition_invites_origin_idx",
+          "columns": [
+            "origin"
+          ],
+          "isUnique": false
+        },
+        "competition_invites_status_idx": {
+          "name": "competition_invites_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "competition_invites_email_idx": {
+          "name": "competition_invites_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "competition_invites_championship_idx": {
+          "name": "competition_invites_championship_idx",
+          "columns": [
+            "championship_competition_id"
+          ],
+          "isUnique": false
+        },
+        "competition_invites_user_idx": {
+          "name": "competition_invites_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_invites_id": {
+          "name": "competition_invites_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_events": {
+      "name": "competition_events",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "submission_opens_at": {
+          "name": "submission_opens_at",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submission_closes_at": {
+          "name": "submission_closes_at",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_events_competition_idx": {
+          "name": "competition_events_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "competition_events_workout_idx": {
+          "name": "competition_events_workout_idx",
+          "columns": [
+            "track_workout_id"
+          ],
+          "isUnique": false
+        },
+        "competition_events_comp_workout_idx": {
+          "name": "competition_events_comp_workout_idx",
+          "columns": [
+            "competition_id",
+            "track_workout_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_events_id": {
+          "name": "competition_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_groups": {
+      "name": "competition_groups",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizing_team_id": {
+          "name": "organizing_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_groups_org_slug_idx": {
+          "name": "competition_groups_org_slug_idx",
+          "columns": [
+            "organizing_team_id",
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_groups_id": {
+          "name": "competition_groups_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_heat_assignments": {
+      "name": "competition_heat_assignments",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heat_id": {
+          "name": "heat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lane_number": {
+          "name": "lane_number",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_heat_assignments_heat_idx": {
+          "name": "competition_heat_assignments_heat_idx",
+          "columns": [
+            "heat_id"
+          ],
+          "isUnique": false
+        },
+        "competition_heat_assignments_reg_idx": {
+          "name": "competition_heat_assignments_reg_idx",
+          "columns": [
+            "heat_id",
+            "registration_id"
+          ],
+          "isUnique": true
+        },
+        "competition_heat_assignments_lane_idx": {
+          "name": "competition_heat_assignments_lane_idx",
+          "columns": [
+            "heat_id",
+            "lane_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_heat_assignments_id": {
+          "name": "competition_heat_assignments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_heats": {
+      "name": "competition_heats",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heat_number": {
+          "name": "heat_number",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheduled_time": {
+          "name": "scheduled_time",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "division_id": {
+          "name": "division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_published_at": {
+          "name": "schedule_published_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_heats_competition_idx": {
+          "name": "competition_heats_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "competition_heats_workout_idx": {
+          "name": "competition_heats_workout_idx",
+          "columns": [
+            "track_workout_id"
+          ],
+          "isUnique": false
+        },
+        "competition_heats_time_idx": {
+          "name": "competition_heats_time_idx",
+          "columns": [
+            "scheduled_time"
+          ],
+          "isUnique": false
+        },
+        "competition_heats_workout_number_idx": {
+          "name": "competition_heats_workout_number_idx",
+          "columns": [
+            "track_workout_id",
+            "heat_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_heats_id": {
+          "name": "competition_heats_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_registration_answers": {
+      "name": "competition_registration_answers",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comp_reg_answers_question_idx": {
+          "name": "comp_reg_answers_question_idx",
+          "columns": [
+            "question_id"
+          ],
+          "isUnique": false
+        },
+        "comp_reg_answers_registration_idx": {
+          "name": "comp_reg_answers_registration_idx",
+          "columns": [
+            "registration_id"
+          ],
+          "isUnique": false
+        },
+        "comp_reg_answers_user_idx": {
+          "name": "comp_reg_answers_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "comp_reg_answers_unique_idx": {
+          "name": "comp_reg_answers_unique_idx",
+          "columns": [
+            "question_id",
+            "registration_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_registration_answers_id": {
+          "name": "competition_registration_answers_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_registration_questions": {
+      "name": "competition_registration_questions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "help_text": {
+          "name": "help_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "for_teammates": {
+          "name": "for_teammates",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "question_target": {
+          "name": "question_target",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'athlete'"
+        }
+      },
+      "indexes": {
+        "comp_reg_questions_competition_idx": {
+          "name": "comp_reg_questions_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "comp_reg_questions_sort_idx": {
+          "name": "comp_reg_questions_sort_idx",
+          "columns": [
+            "competition_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        },
+        "comp_reg_questions_group_idx": {
+          "name": "comp_reg_questions_group_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "comp_reg_questions_target_idx": {
+          "name": "comp_reg_questions_target_idx",
+          "columns": [
+            "question_target"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_registration_questions_id": {
+          "name": "competition_registration_questions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_registrations": {
+      "name": "competition_registrations",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_member_id": {
+          "name": "team_member_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division_id": {
+          "name": "division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "captain_user_id": {
+          "name": "captain_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "athlete_team_id": {
+          "name": "athlete_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pending_teammates": {
+          "name": "pending_teammates",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commerce_purchase_id": {
+          "name": "commerce_purchase_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_in_at": {
+          "name": "checked_in_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "checked_in_by": {
+          "name": "checked_in_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_registrations_event_user_division_idx": {
+          "name": "competition_registrations_event_user_division_idx",
+          "columns": [
+            "event_id",
+            "user_id",
+            "division_id"
+          ],
+          "isUnique": true
+        },
+        "competition_registrations_user_idx": {
+          "name": "competition_registrations_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "competition_registrations_event_idx": {
+          "name": "competition_registrations_event_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "competition_registrations_division_idx": {
+          "name": "competition_registrations_division_idx",
+          "columns": [
+            "division_id"
+          ],
+          "isUnique": false
+        },
+        "competition_registrations_captain_idx": {
+          "name": "competition_registrations_captain_idx",
+          "columns": [
+            "captain_user_id"
+          ],
+          "isUnique": false
+        },
+        "competition_registrations_athlete_team_idx": {
+          "name": "competition_registrations_athlete_team_idx",
+          "columns": [
+            "athlete_team_id"
+          ],
+          "isUnique": false
+        },
+        "competition_registrations_purchase_idx": {
+          "name": "competition_registrations_purchase_idx",
+          "columns": [
+            "commerce_purchase_id"
+          ],
+          "isUnique": false
+        },
+        "competition_registrations_status_idx": {
+          "name": "competition_registrations_status_idx",
+          "columns": [
+            "event_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "competition_registrations_checked_in_idx": {
+          "name": "competition_registrations_checked_in_idx",
+          "columns": [
+            "event_id",
+            "checked_in_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_registrations_id": {
+          "name": "competition_registrations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_venues": {
+      "name": "competition_venues",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lane_count": {
+          "name": "lane_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "transition_minutes": {
+          "name": "transition_minutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 3
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "address_id": {
+          "name": "address_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_venues_competition_idx": {
+          "name": "competition_venues_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "competition_venues_sort_idx": {
+          "name": "competition_venues_sort_idx",
+          "columns": [
+            "competition_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_venues_id": {
+          "name": "competition_venues_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competitions": {
+      "name": "competitions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organizing_team_id": {
+          "name": "organizing_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_team_id": {
+          "name": "competition_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registration_opens_at": {
+          "name": "registration_opens_at",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "registration_closes_at": {
+          "name": "registration_closes_at",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'America/Denver'"
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_registration_fee_cents": {
+          "name": "default_registration_fee_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "platform_fee_percentage": {
+          "name": "platform_fee_percentage",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform_fee_fixed": {
+          "name": "platform_fee_fixed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pass_stripe_fees_to_customer": {
+          "name": "pass_stripe_fees_to_customer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "pass_platform_fees_to_customer": {
+          "name": "pass_platform_fees_to_customer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'public'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "competition_type": {
+          "name": "competition_type",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'in-person'"
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "banner_image_url": {
+          "name": "banner_image_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_heats_per_rotation": {
+          "name": "default_heats_per_rotation",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 4
+        },
+        "default_lane_shift_pattern": {
+          "name": "default_lane_shift_pattern",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'shift_right'"
+        },
+        "default_max_spots_per_division": {
+          "name": "default_max_spots_per_division",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_total_registrations": {
+          "name": "max_total_registrations",
+          "type": "int unsigned",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "primary_address_id": {
+          "name": "primary_address_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competitions_organizing_team_idx": {
+          "name": "competitions_organizing_team_idx",
+          "columns": [
+            "organizing_team_id"
+          ],
+          "isUnique": false
+        },
+        "competitions_competition_team_idx": {
+          "name": "competitions_competition_team_idx",
+          "columns": [
+            "competition_team_id"
+          ],
+          "isUnique": false
+        },
+        "competitions_group_idx": {
+          "name": "competitions_group_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "competitions_start_date_idx": {
+          "name": "competitions_start_date_idx",
+          "columns": [
+            "start_date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competitions_id": {
+          "name": "competitions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "competitions_slug_unique": {
+          "name": "competitions_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "volunteer_registration_answers": {
+      "name": "volunteer_registration_answers",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question_id": {
+          "name": "question_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "vol_reg_answers_question_idx": {
+          "name": "vol_reg_answers_question_idx",
+          "columns": [
+            "question_id"
+          ],
+          "isUnique": false
+        },
+        "vol_reg_answers_invitation_idx": {
+          "name": "vol_reg_answers_invitation_idx",
+          "columns": [
+            "invitation_id"
+          ],
+          "isUnique": false
+        },
+        "vol_reg_answers_unique_idx": {
+          "name": "vol_reg_answers_unique_idx",
+          "columns": [
+            "question_id",
+            "invitation_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "volunteer_registration_answers_id": {
+          "name": "volunteer_registration_answers_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_billing_events": {
+      "name": "crew_billing_events",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "billing_state": {
+          "name": "billing_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "billing_source": {
+          "name": "billing_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'usd'"
+        },
+        "credit_cents": {
+          "name": "credit_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "refunded_cents": {
+          "name": "refunded_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "stripe_payment_link_id": {
+          "name": "stripe_payment_link_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_checkout_session_id": {
+          "name": "stripe_checkout_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_label": {
+          "name": "actor_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_note": {
+          "name": "public_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "private_metadata": {
+          "name": "private_metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_billing_events_competition_idx": {
+          "name": "crew_billing_events_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_team_idx": {
+          "name": "crew_billing_events_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_type_idx": {
+          "name": "crew_billing_events_type_idx",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_state_idx": {
+          "name": "crew_billing_events_state_idx",
+          "columns": [
+            "billing_state"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_source_idx": {
+          "name": "crew_billing_events_source_idx",
+          "columns": [
+            "billing_source"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_plan_idx": {
+          "name": "crew_billing_events_plan_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_payment_link_idx": {
+          "name": "crew_billing_events_payment_link_idx",
+          "columns": [
+            "stripe_payment_link_id"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_checkout_session_idx": {
+          "name": "crew_billing_events_checkout_session_idx",
+          "columns": [
+            "stripe_checkout_session_id"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_payment_intent_idx": {
+          "name": "crew_billing_events_payment_intent_idx",
+          "columns": [
+            "stripe_payment_intent_id"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_actor_idx": {
+          "name": "crew_billing_events_actor_idx",
+          "columns": [
+            "actor_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_billing_events_idempotency_unique_idx": {
+          "name": "crew_billing_events_idempotency_unique_idx",
+          "columns": [
+            "competition_id",
+            "event_type",
+            "idempotency_key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_billing_events_id": {
+          "name": "crew_billing_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_event_settings": {
+      "name": "crew_event_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "crew_only": {
+          "name": "crew_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_event_url": {
+          "name": "source_event_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "external_registration_url": {
+          "name": "external_registration_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "concierge_status": {
+          "name": "concierge_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'not_started'"
+        },
+        "crew_plan": {
+          "name": "crew_plan",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'self_serve'"
+        },
+        "crew_billing_state": {
+          "name": "crew_billing_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unpaid'"
+        },
+        "crew_billing_source": {
+          "name": "crew_billing_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crew_billing_plan_id": {
+          "name": "crew_billing_plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crew_billing_amount_cents": {
+          "name": "crew_billing_amount_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crew_billing_currency": {
+          "name": "crew_billing_currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'usd'"
+        },
+        "crew_stripe_payment_link_id": {
+          "name": "crew_stripe_payment_link_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crew_stripe_checkout_session_id": {
+          "name": "crew_stripe_checkout_session_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crew_stripe_payment_intent_id": {
+          "name": "crew_stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "crew_founder_override": {
+          "name": "crew_founder_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "crew_credit_cents": {
+          "name": "crew_credit_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "crew_refunded_cents": {
+          "name": "crew_refunded_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "full_platform_credit_cents": {
+          "name": "full_platform_credit_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "acquisition_source": {
+          "name": "acquisition_source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_event_settings_competition_unique_idx": {
+          "name": "crew_event_settings_competition_unique_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": true
+        },
+        "crew_event_settings_lifecycle_idx": {
+          "name": "crew_event_settings_lifecycle_idx",
+          "columns": [
+            "lifecycle"
+          ],
+          "isUnique": false
+        },
+        "crew_event_settings_plan_idx": {
+          "name": "crew_event_settings_plan_idx",
+          "columns": [
+            "crew_plan"
+          ],
+          "isUnique": false
+        },
+        "crew_event_settings_billing_state_idx": {
+          "name": "crew_event_settings_billing_state_idx",
+          "columns": [
+            "crew_billing_state"
+          ],
+          "isUnique": false
+        },
+        "crew_event_settings_billing_source_idx": {
+          "name": "crew_event_settings_billing_source_idx",
+          "columns": [
+            "crew_billing_source"
+          ],
+          "isUnique": false
+        },
+        "crew_event_settings_billing_plan_idx": {
+          "name": "crew_event_settings_billing_plan_idx",
+          "columns": [
+            "crew_billing_plan_id"
+          ],
+          "isUnique": false
+        },
+        "crew_event_settings_payment_link_idx": {
+          "name": "crew_event_settings_payment_link_idx",
+          "columns": [
+            "crew_stripe_payment_link_id"
+          ],
+          "isUnique": false
+        },
+        "crew_event_settings_checkout_session_idx": {
+          "name": "crew_event_settings_checkout_session_idx",
+          "columns": [
+            "crew_stripe_checkout_session_id"
+          ],
+          "isUnique": false
+        },
+        "crew_event_settings_payment_intent_idx": {
+          "name": "crew_event_settings_payment_intent_idx",
+          "columns": [
+            "crew_stripe_payment_intent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_event_settings_id": {
+          "name": "crew_event_settings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_assignment_confirmations": {
+      "name": "crew_assignment_confirmations",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignment_type": {
+          "name": "assignment_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition_invite_id": {
+          "name": "competition_invite_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "response_note": {
+          "name": "response_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reminder_at": {
+          "name": "last_reminder_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reminder_count": {
+          "name": "reminder_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "crew_assignment_confirmations_competition_idx": {
+          "name": "crew_assignment_confirmations_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_assignment_confirmations_assignment_idx": {
+          "name": "crew_assignment_confirmations_assignment_idx",
+          "columns": [
+            "assignment_type",
+            "assignment_id"
+          ],
+          "isUnique": false
+        },
+        "crew_assignment_confirmations_status_idx": {
+          "name": "crew_assignment_confirmations_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_assignment_confirmations_membership_idx": {
+          "name": "crew_assignment_confirmations_membership_idx",
+          "columns": [
+            "membership_id"
+          ],
+          "isUnique": false
+        },
+        "crew_assignment_confirmations_invitation_idx": {
+          "name": "crew_assignment_confirmations_invitation_idx",
+          "columns": [
+            "invitation_id"
+          ],
+          "isUnique": false
+        },
+        "crew_assignment_confirmations_competition_invite_idx": {
+          "name": "crew_assignment_confirmations_competition_invite_idx",
+          "columns": [
+            "competition_invite_id"
+          ],
+          "isUnique": false
+        },
+        "crew_assignment_confirmations_email_idx": {
+          "name": "crew_assignment_confirmations_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "crew_assignment_confirmations_expires_idx": {
+          "name": "crew_assignment_confirmations_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "crew_assignment_confirmations_token_hash_unique_idx": {
+          "name": "crew_assignment_confirmations_token_hash_unique_idx",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_assignment_confirmations_id": {
+          "name": "crew_assignment_confirmations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_import_rows": {
+      "name": "crew_import_rows",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "import_id": {
+          "name": "import_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_number": {
+          "name": "row_number",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_row": {
+          "name": "raw_row",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "normalized_row": {
+          "name": "normalized_row",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warnings": {
+          "name": "warnings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "errors": {
+          "name": "errors",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_import_rows_import_idx": {
+          "name": "crew_import_rows_import_idx",
+          "columns": [
+            "import_id"
+          ],
+          "isUnique": false
+        },
+        "crew_import_rows_import_row_unique_idx": {
+          "name": "crew_import_rows_import_row_unique_idx",
+          "columns": [
+            "import_id",
+            "row_number"
+          ],
+          "isUnique": true
+        },
+        "crew_import_rows_target_idx": {
+          "name": "crew_import_rows_target_idx",
+          "columns": [
+            "target_type",
+            "target_id"
+          ],
+          "isUnique": false
+        },
+        "crew_import_rows_action_idx": {
+          "name": "crew_import_rows_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_import_rows_id": {
+          "name": "crew_import_rows_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_imports": {
+      "name": "crew_imports",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_key": {
+          "name": "file_key",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'uploaded'"
+        },
+        "parser_version": {
+          "name": "parser_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "column_mapping": {
+          "name": "column_mapping",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "warning_count": {
+          "name": "warning_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_count": {
+          "name": "created_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_count": {
+          "name": "updated_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "applied_by": {
+          "name": "applied_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_imports_competition_idx": {
+          "name": "crew_imports_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_imports_status_idx": {
+          "name": "crew_imports_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_imports_kind_idx": {
+          "name": "crew_imports_kind_idx",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "crew_imports_uploaded_by_idx": {
+          "name": "crew_imports_uploaded_by_idx",
+          "columns": [
+            "uploaded_by"
+          ],
+          "isUnique": false
+        },
+        "crew_imports_applied_by_idx": {
+          "name": "crew_imports_applied_by_idx",
+          "columns": [
+            "applied_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_imports_id": {
+          "name": "crew_imports_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_department_leads": {
+      "name": "crew_department_leads",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "venue_id": {
+          "name": "venue_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'invited'"
+        },
+        "assigned_by": {
+          "name": "assigned_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_department_leads_competition_idx": {
+          "name": "crew_department_leads_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_department_leads_team_idx": {
+          "name": "crew_department_leads_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "crew_department_leads_membership_idx": {
+          "name": "crew_department_leads_membership_idx",
+          "columns": [
+            "membership_id"
+          ],
+          "isUnique": false
+        },
+        "crew_department_leads_invitation_idx": {
+          "name": "crew_department_leads_invitation_idx",
+          "columns": [
+            "invitation_id"
+          ],
+          "isUnique": false
+        },
+        "crew_department_leads_email_idx": {
+          "name": "crew_department_leads_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "crew_department_leads_role_idx": {
+          "name": "crew_department_leads_role_idx",
+          "columns": [
+            "role_type"
+          ],
+          "isUnique": false
+        },
+        "crew_department_leads_venue_idx": {
+          "name": "crew_department_leads_venue_idx",
+          "columns": [
+            "venue_id"
+          ],
+          "isUnique": false
+        },
+        "crew_department_leads_status_idx": {
+          "name": "crew_department_leads_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_department_leads_time_idx": {
+          "name": "crew_department_leads_time_idx",
+          "columns": [
+            "starts_at",
+            "ends_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_department_leads_id": {
+          "name": "crew_department_leads_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_import_mapping_presets": {
+      "name": "crew_import_mapping_presets",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'csv'"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "header_fingerprint": {
+          "name": "header_fingerprint",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "column_mapping": {
+          "name": "column_mapping",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parser_version": {
+          "name": "parser_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_import_mapping_presets_lookup_unique_idx": {
+          "name": "crew_import_mapping_presets_lookup_unique_idx",
+          "columns": [
+            "team_id",
+            "source_platform",
+            "kind",
+            "header_fingerprint"
+          ],
+          "isUnique": true
+        },
+        "crew_import_mapping_presets_team_kind_idx": {
+          "name": "crew_import_mapping_presets_team_kind_idx",
+          "columns": [
+            "team_id",
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "crew_import_mapping_presets_competition_idx": {
+          "name": "crew_import_mapping_presets_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_import_mapping_presets_last_used_idx": {
+          "name": "crew_import_mapping_presets_last_used_idx",
+          "columns": [
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_import_mapping_presets_id": {
+          "name": "crew_import_mapping_presets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_template_presets": {
+      "name": "crew_template_presets",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "preset_data": {
+          "name": "preset_data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_archived": {
+          "name": "is_archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "crew_template_presets_team_kind_idx": {
+          "name": "crew_template_presets_team_kind_idx",
+          "columns": [
+            "team_id",
+            "kind"
+          ],
+          "isUnique": false
+        },
+        "crew_template_presets_competition_idx": {
+          "name": "crew_template_presets_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_template_presets_created_by_idx": {
+          "name": "crew_template_presets_created_by_idx",
+          "columns": [
+            "created_by"
+          ],
+          "isUnique": false
+        },
+        "crew_template_presets_archived_idx": {
+          "name": "crew_template_presets_archived_idx",
+          "columns": [
+            "is_archived"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_template_presets_id": {
+          "name": "crew_template_presets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_competition_group_settings": {
+      "name": "crew_competition_group_settings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_group_id": {
+          "name": "competition_group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "memory_mode": {
+          "name": "memory_mode",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'disabled'"
+        },
+        "returning_volunteer_consent_required": {
+          "name": "returning_volunteer_consent_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "history_visibility_scope": {
+          "name": "history_visibility_scope",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'same_organizer'"
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_by_user_id": {
+          "name": "updated_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_competition_group_settings_group_unique_idx": {
+          "name": "crew_competition_group_settings_group_unique_idx",
+          "columns": [
+            "competition_group_id"
+          ],
+          "isUnique": true
+        },
+        "crew_competition_group_settings_team_idx": {
+          "name": "crew_competition_group_settings_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "crew_competition_group_settings_mode_idx": {
+          "name": "crew_competition_group_settings_mode_idx",
+          "columns": [
+            "memory_mode"
+          ],
+          "isUnique": false
+        },
+        "crew_competition_group_settings_created_by_idx": {
+          "name": "crew_competition_group_settings_created_by_idx",
+          "columns": [
+            "created_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_competition_group_settings_updated_by_idx": {
+          "name": "crew_competition_group_settings_updated_by_idx",
+          "columns": [
+            "updated_by_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_competition_group_settings_id": {
+          "name": "crew_competition_group_settings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_event_conversions": {
+      "name": "crew_event_conversions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "crew_event_settings_id": {
+          "name": "crew_event_settings_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition_group_id": {
+          "name": "competition_group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'requested'"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_by_user_id": {
+          "name": "reviewed_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_by_user_id": {
+          "name": "completed_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "privacy_reviewed_at": {
+          "name": "privacy_reviewed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_event_conversions_competition_unique_idx": {
+          "name": "crew_event_conversions_competition_unique_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": true
+        },
+        "crew_event_conversions_team_idx": {
+          "name": "crew_event_conversions_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "crew_event_conversions_settings_idx": {
+          "name": "crew_event_conversions_settings_idx",
+          "columns": [
+            "crew_event_settings_id"
+          ],
+          "isUnique": false
+        },
+        "crew_event_conversions_group_idx": {
+          "name": "crew_event_conversions_group_idx",
+          "columns": [
+            "competition_group_id"
+          ],
+          "isUnique": false
+        },
+        "crew_event_conversions_status_idx": {
+          "name": "crew_event_conversions_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_event_conversions_requested_by_idx": {
+          "name": "crew_event_conversions_requested_by_idx",
+          "columns": [
+            "requested_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_event_conversions_reviewed_by_idx": {
+          "name": "crew_event_conversions_reviewed_by_idx",
+          "columns": [
+            "reviewed_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_event_conversions_completed_by_idx": {
+          "name": "crew_event_conversions_completed_by_idx",
+          "columns": [
+            "completed_by_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_event_conversions_id": {
+          "name": "crew_event_conversions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_volunteer_consents": {
+      "name": "crew_volunteer_consents",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'granted'"
+        },
+        "consent_text": {
+          "name": "consent_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent_text_version": {
+          "name": "consent_text_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consent_text_hash": {
+          "name": "consent_text_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_surface": {
+          "name": "source_surface",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_competition_id": {
+          "name": "source_competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_user_id": {
+          "name": "actor_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recorded_by_user_id": {
+          "name": "recorded_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_by_user_id": {
+          "name": "revoked_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revocation_source": {
+          "name": "revocation_source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "superseded_by_consent_id": {
+          "name": "superseded_by_consent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_volunteer_consents_identity_idx": {
+          "name": "crew_volunteer_consents_identity_idx",
+          "columns": [
+            "identity_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_consents_team_idx": {
+          "name": "crew_volunteer_consents_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_consents_scope_status_idx": {
+          "name": "crew_volunteer_consents_scope_status_idx",
+          "columns": [
+            "scope",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_consents_identity_scope_status_idx": {
+          "name": "crew_volunteer_consents_identity_scope_status_idx",
+          "columns": [
+            "identity_id",
+            "scope",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_consents_source_competition_idx": {
+          "name": "crew_volunteer_consents_source_competition_idx",
+          "columns": [
+            "source_competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_consents_actor_idx": {
+          "name": "crew_volunteer_consents_actor_idx",
+          "columns": [
+            "actor_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_consents_recorded_by_idx": {
+          "name": "crew_volunteer_consents_recorded_by_idx",
+          "columns": [
+            "recorded_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_consents_revoked_at_idx": {
+          "name": "crew_volunteer_consents_revoked_at_idx",
+          "columns": [
+            "revoked_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_volunteer_consents_id": {
+          "name": "crew_volunteer_consents_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_volunteer_credentials": {
+      "name": "crew_volunteer_credentials",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_type": {
+          "name": "credential_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_key": {
+          "name": "credential_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credential_label": {
+          "name": "credential_label",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'self_reported'"
+        },
+        "visibility_scope": {
+          "name": "visibility_scope",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'same_organizer'"
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_by_user_id": {
+          "name": "verified_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_volunteer_credentials_identity_idx": {
+          "name": "crew_volunteer_credentials_identity_idx",
+          "columns": [
+            "identity_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_team_idx": {
+          "name": "crew_volunteer_credentials_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_competition_idx": {
+          "name": "crew_volunteer_credentials_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_type_idx": {
+          "name": "crew_volunteer_credentials_type_idx",
+          "columns": [
+            "credential_type"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_key_idx": {
+          "name": "crew_volunteer_credentials_key_idx",
+          "columns": [
+            "credential_key"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_status_idx": {
+          "name": "crew_volunteer_credentials_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_visibility_idx": {
+          "name": "crew_volunteer_credentials_visibility_idx",
+          "columns": [
+            "visibility_scope"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_expires_idx": {
+          "name": "crew_volunteer_credentials_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_verified_by_idx": {
+          "name": "crew_volunteer_credentials_verified_by_idx",
+          "columns": [
+            "verified_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_credentials_consent_idx": {
+          "name": "crew_volunteer_credentials_consent_idx",
+          "columns": [
+            "consent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_volunteer_credentials_id": {
+          "name": "crew_volunteer_credentials_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_volunteer_history_events": {
+      "name": "crew_volunteer_history_events",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identity_id": {
+          "name": "identity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility_scope": {
+          "name": "visibility_scope",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'same_organizer'"
+        },
+        "assignment_type": {
+          "name": "assignment_type",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_user_id": {
+          "name": "source_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consent_id": {
+          "name": "consent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "correction_of_event_id": {
+          "name": "correction_of_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_volunteer_history_events_identity_idx": {
+          "name": "crew_volunteer_history_events_identity_idx",
+          "columns": [
+            "identity_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_team_idx": {
+          "name": "crew_volunteer_history_events_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_competition_idx": {
+          "name": "crew_volunteer_history_events_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_group_idx": {
+          "name": "crew_volunteer_history_events_group_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_type_idx": {
+          "name": "crew_volunteer_history_events_type_idx",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_visibility_idx": {
+          "name": "crew_volunteer_history_events_visibility_idx",
+          "columns": [
+            "visibility_scope"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_occurred_idx": {
+          "name": "crew_volunteer_history_events_occurred_idx",
+          "columns": [
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_identity_occurred_idx": {
+          "name": "crew_volunteer_history_events_identity_occurred_idx",
+          "columns": [
+            "identity_id",
+            "occurred_at"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_assignment_idx": {
+          "name": "crew_volunteer_history_events_assignment_idx",
+          "columns": [
+            "assignment_type",
+            "assignment_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_role_idx": {
+          "name": "crew_volunteer_history_events_role_idx",
+          "columns": [
+            "role_type"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_source_idx": {
+          "name": "crew_volunteer_history_events_source_idx",
+          "columns": [
+            "source_type",
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_consent_idx": {
+          "name": "crew_volunteer_history_events_consent_idx",
+          "columns": [
+            "consent_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_history_events_correction_idx": {
+          "name": "crew_volunteer_history_events_correction_idx",
+          "columns": [
+            "correction_of_event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_volunteer_history_events_id": {
+          "name": "crew_volunteer_history_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_volunteer_identities": {
+      "name": "crew_volunteer_identities",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "phone_hash": {
+          "name": "phone_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_hash_version": {
+          "name": "contact_hash_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'v1'"
+        },
+        "source_competition_id": {
+          "name": "source_competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_membership_id": {
+          "name": "source_membership_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_invitation_id": {
+          "name": "source_invitation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "identity_source": {
+          "name": "identity_source",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'manual'"
+        },
+        "discovery_age_status": {
+          "name": "discovery_age_status",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'unknown'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "crew_volunteer_identities_team_user_unique_idx": {
+          "name": "crew_volunteer_identities_team_user_unique_idx",
+          "columns": [
+            "team_id",
+            "user_id"
+          ],
+          "isUnique": true
+        },
+        "crew_volunteer_identities_team_email_hash_unique_idx": {
+          "name": "crew_volunteer_identities_team_email_hash_unique_idx",
+          "columns": [
+            "team_id",
+            "contact_hash_version",
+            "email_hash"
+          ],
+          "isUnique": true
+        },
+        "crew_volunteer_identities_team_phone_hash_unique_idx": {
+          "name": "crew_volunteer_identities_team_phone_hash_unique_idx",
+          "columns": [
+            "team_id",
+            "contact_hash_version",
+            "phone_hash"
+          ],
+          "isUnique": true
+        },
+        "crew_volunteer_identities_team_idx": {
+          "name": "crew_volunteer_identities_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_identities_user_idx": {
+          "name": "crew_volunteer_identities_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_identities_source_competition_idx": {
+          "name": "crew_volunteer_identities_source_competition_idx",
+          "columns": [
+            "source_competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_identities_status_idx": {
+          "name": "crew_volunteer_identities_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_identities_age_status_idx": {
+          "name": "crew_volunteer_identities_age_status_idx",
+          "columns": [
+            "discovery_age_status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_volunteer_identities_id": {
+          "name": "crew_volunteer_identities_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "crew_volunteer_intro_requests": {
+      "name": "crew_volunteer_intro_requests",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requesting_team_id": {
+          "name": "requesting_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requesting_competition_id": {
+          "name": "requesting_competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "volunteer_identity_id": {
+          "name": "volunteer_identity_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discovery_consent_id": {
+          "name": "discovery_consent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "requested_role_type": {
+          "name": "requested_role_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_by_user_id": {
+          "name": "responded_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_invitation_id": {
+          "name": "result_invitation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "result_membership_id": {
+          "name": "result_membership_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "crew_volunteer_intro_requests_requester_idx": {
+          "name": "crew_volunteer_intro_requests_requester_idx",
+          "columns": [
+            "requesting_team_id",
+            "requesting_competition_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_identity_idx": {
+          "name": "crew_volunteer_intro_requests_identity_idx",
+          "columns": [
+            "volunteer_identity_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_consent_idx": {
+          "name": "crew_volunteer_intro_requests_consent_idx",
+          "columns": [
+            "discovery_consent_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_role_idx": {
+          "name": "crew_volunteer_intro_requests_role_idx",
+          "columns": [
+            "requested_role_type"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_status_idx": {
+          "name": "crew_volunteer_intro_requests_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_requested_by_idx": {
+          "name": "crew_volunteer_intro_requests_requested_by_idx",
+          "columns": [
+            "requested_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_responded_by_idx": {
+          "name": "crew_volunteer_intro_requests_responded_by_idx",
+          "columns": [
+            "responded_by_user_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_window_idx": {
+          "name": "crew_volunteer_intro_requests_window_idx",
+          "columns": [
+            "starts_at",
+            "ends_at"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_expires_idx": {
+          "name": "crew_volunteer_intro_requests_expires_idx",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_result_invitation_idx": {
+          "name": "crew_volunteer_intro_requests_result_invitation_idx",
+          "columns": [
+            "result_invitation_id"
+          ],
+          "isUnique": false
+        },
+        "crew_volunteer_intro_requests_result_membership_idx": {
+          "name": "crew_volunteer_intro_requests_result_membership_idx",
+          "columns": [
+            "result_membership_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "crew_volunteer_intro_requests_id": {
+          "name": "crew_volunteer_intro_requests_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "entitlements": {
+      "name": "entitlements",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entitlement_type_id": {
+          "name": "entitlement_type_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "entitlement_user_id_idx": {
+          "name": "entitlement_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "entitlement_team_id_idx": {
+          "name": "entitlement_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "entitlement_type_idx": {
+          "name": "entitlement_type_idx",
+          "columns": [
+            "entitlement_type_id"
+          ],
+          "isUnique": false
+        },
+        "entitlement_source_idx": {
+          "name": "entitlement_source_idx",
+          "columns": [
+            "source_type",
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "entitlement_deleted_at_idx": {
+          "name": "entitlement_deleted_at_idx",
+          "columns": [
+            "deleted_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entitlements_id": {
+          "name": "entitlements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "entitlement_types": {
+      "name": "entitlement_types",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "entitlement_types_id": {
+          "name": "entitlement_types_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "entitlement_types_name_unique": {
+          "name": "entitlement_types_name_unique",
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "features": {
+      "name": "features",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "features_id": {
+          "name": "features_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "features_key_unique": {
+          "name": "features_key_unique",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "limits": {
+      "name": "limits",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unit": {
+          "name": "unit",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reset_period": {
+          "name": "reset_period",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'never'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "limits_id": {
+          "name": "limits_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "limits_key_unique": {
+          "name": "limits_key_unique",
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "plan_features": {
+      "name": "plan_features",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plan_feature_plan_id_idx": {
+          "name": "plan_feature_plan_id_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "plan_feature_feature_id_idx": {
+          "name": "plan_feature_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": false
+        },
+        "plan_feature_unique_idx": {
+          "name": "plan_feature_unique_idx",
+          "columns": [
+            "plan_id",
+            "feature_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plan_features_id": {
+          "name": "plan_features_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plan_limits": {
+      "name": "plan_limits",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_id": {
+          "name": "limit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "plan_limit_plan_id_idx": {
+          "name": "plan_limit_plan_id_idx",
+          "columns": [
+            "plan_id"
+          ],
+          "isUnique": false
+        },
+        "plan_limit_limit_id_idx": {
+          "name": "plan_limit_limit_id_idx",
+          "columns": [
+            "limit_id"
+          ],
+          "isUnique": false
+        },
+        "plan_limit_unique_idx": {
+          "name": "plan_limit_unique_idx",
+          "columns": [
+            "plan_id",
+            "limit_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plan_limits_id": {
+          "name": "plan_limits_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "plans": {
+      "name": "plans",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "price": {
+          "name": "price",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval": {
+          "name": "interval",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entitlements": {
+          "name": "entitlements",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_product_id": {
+          "name": "stripe_product_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "plans_id": {
+          "name": "plans_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_addons": {
+      "name": "team_addons",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "addon_id": {
+          "name": "addon_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_subscription_item_id": {
+          "name": "stripe_subscription_item_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_addon_team_id_idx": {
+          "name": "team_addon_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_addon_status_idx": {
+          "name": "team_addon_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_addons_id": {
+          "name": "team_addons_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_entitlement_overrides": {
+      "name": "team_entitlement_overrides",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_entitlement_override_team_id_idx": {
+          "name": "team_entitlement_override_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_entitlement_override_type_idx": {
+          "name": "team_entitlement_override_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "team_entitlement_override_team_type_key_unique": {
+          "name": "team_entitlement_override_team_type_key_unique",
+          "columns": [
+            "team_id",
+            "type",
+            "key"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_entitlement_overrides_id": {
+          "name": "team_entitlement_overrides_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_feature_entitlements": {
+      "name": "team_feature_entitlements",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'plan'"
+        },
+        "source_plan_id": {
+          "name": "source_plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "team_feature_entitlement_team_id_idx": {
+          "name": "team_feature_entitlement_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_feature_entitlement_feature_id_idx": {
+          "name": "team_feature_entitlement_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": false
+        },
+        "team_feature_entitlement_team_feature_unique": {
+          "name": "team_feature_entitlement_team_feature_unique",
+          "columns": [
+            "team_id",
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_feature_entitlements_id": {
+          "name": "team_feature_entitlements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_limit_entitlements": {
+      "name": "team_limit_entitlements",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_id": {
+          "name": "limit_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'plan'"
+        },
+        "source_plan_id": {
+          "name": "source_plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "team_limit_entitlement_team_id_idx": {
+          "name": "team_limit_entitlement_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_limit_entitlement_limit_id_idx": {
+          "name": "team_limit_entitlement_limit_id_idx",
+          "columns": [
+            "limit_id"
+          ],
+          "isUnique": false
+        },
+        "team_limit_entitlement_team_limit_unique": {
+          "name": "team_limit_entitlement_team_limit_unique",
+          "columns": [
+            "team_id",
+            "limit_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_limit_entitlements_id": {
+          "name": "team_limit_entitlements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_subscriptions": {
+      "name": "team_subscriptions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_start": {
+          "name": "current_period_start",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "trial_start": {
+          "name": "trial_start",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trial_end": {
+          "name": "trial_end",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_subscription_team_id_idx": {
+          "name": "team_subscription_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_subscription_status_idx": {
+          "name": "team_subscription_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_subscriptions_id": {
+          "name": "team_subscriptions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_usages": {
+      "name": "team_usages",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "limit_key": {
+          "name": "limit_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "current_value": {
+          "name": "current_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_usage_team_id_idx": {
+          "name": "team_usage_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_usage_limit_key_idx": {
+          "name": "team_usage_limit_key_idx",
+          "columns": [
+            "limit_key"
+          ],
+          "isUnique": false
+        },
+        "team_usage_unique_idx": {
+          "name": "team_usage_unique_idx",
+          "columns": [
+            "team_id",
+            "limit_key",
+            "period_start"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_usages_id": {
+          "name": "team_usages_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "event_division_mappings": {
+      "name": "event_division_mappings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division_id": {
+          "name": "division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "edm_comp_event_div_idx": {
+          "name": "edm_comp_event_div_idx",
+          "columns": [
+            "competition_id",
+            "track_workout_id",
+            "division_id"
+          ],
+          "isUnique": true
+        },
+        "edm_competition_idx": {
+          "name": "edm_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "edm_event_idx": {
+          "name": "edm_event_idx",
+          "columns": [
+            "track_workout_id"
+          ],
+          "isUnique": false
+        },
+        "edm_division_idx": {
+          "name": "edm_division_idx",
+          "columns": [
+            "division_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "event_division_mappings_id": {
+          "name": "event_division_mappings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "event_resources": {
+      "name": "event_resources",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "event_resources_event_idx": {
+          "name": "event_resources_event_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        },
+        "event_resources_event_order_idx": {
+          "name": "event_resources_event_order_idx",
+          "columns": [
+            "event_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "event_resources_id": {
+          "name": "event_resources_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "financial_events": {
+      "name": "financial_events",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "purchase_id": {
+          "name": "purchase_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "amount_cents": {
+          "name": "amount_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'usd'"
+        },
+        "stripe_payment_intent_id": {
+          "name": "stripe_payment_intent_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_refund_id": {
+          "name": "stripe_refund_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_dispute_id": {
+          "name": "stripe_dispute_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_event_timestamp": {
+          "name": "stripe_event_timestamp",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "financial_event_purchase_idx": {
+          "name": "financial_event_purchase_idx",
+          "columns": [
+            "purchase_id"
+          ],
+          "isUnique": false
+        },
+        "financial_event_team_idx": {
+          "name": "financial_event_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "financial_event_type_idx": {
+          "name": "financial_event_type_idx",
+          "columns": [
+            "event_type"
+          ],
+          "isUnique": false
+        },
+        "financial_event_stripe_pi_idx": {
+          "name": "financial_event_stripe_pi_idx",
+          "columns": [
+            "stripe_payment_intent_id"
+          ],
+          "isUnique": false
+        },
+        "financial_event_stripe_refund_idx": {
+          "name": "financial_event_stripe_refund_idx",
+          "columns": [
+            "stripe_refund_id"
+          ],
+          "isUnique": false
+        },
+        "financial_event_stripe_dispute_idx": {
+          "name": "financial_event_stripe_dispute_idx",
+          "columns": [
+            "stripe_dispute_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "financial_events_id": {
+          "name": "financial_events_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "event_judging_sheets": {
+      "name": "event_judging_sheets",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "r2_key": {
+          "name": "r2_key",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "event_judging_sheets_competition_idx": {
+          "name": "event_judging_sheets_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "event_judging_sheets_event_idx": {
+          "name": "event_judging_sheets_event_idx",
+          "columns": [
+            "track_workout_id"
+          ],
+          "isUnique": false
+        },
+        "event_judging_sheets_uploaded_by_idx": {
+          "name": "event_judging_sheets_uploaded_by_idx",
+          "columns": [
+            "uploaded_by"
+          ],
+          "isUnique": false
+        },
+        "event_judging_sheets_sort_idx": {
+          "name": "event_judging_sheets_sort_idx",
+          "columns": [
+            "track_workout_id",
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "event_judging_sheets_id": {
+          "name": "event_judging_sheets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "submission_window_notifications": {
+      "name": "submission_window_notifications",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_event_id": {
+          "name": "competition_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sent_to_email": {
+          "name": "sent_to_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "submission_window_notif_competition_idx": {
+          "name": "submission_window_notif_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "submission_window_notif_event_idx": {
+          "name": "submission_window_notif_event_idx",
+          "columns": [
+            "competition_event_id"
+          ],
+          "isUnique": false
+        },
+        "submission_window_notif_user_idx": {
+          "name": "submission_window_notif_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "submission_window_notif_unique_idx": {
+          "name": "submission_window_notif_unique_idx",
+          "columns": [
+            "competition_event_id",
+            "registration_id",
+            "type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "submission_window_notifications_id": {
+          "name": "submission_window_notifications_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "organizer_requests": {
+      "name": "organizer_requests",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "admin_notes": {
+          "name": "admin_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organizer_request_team_idx": {
+          "name": "organizer_request_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "organizer_request_user_idx": {
+          "name": "organizer_request_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "organizer_request_status_idx": {
+          "name": "organizer_request_status_idx",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "organizer_requests_id": {
+          "name": "organizer_requests_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "programming_tracks": {
+      "name": "programming_tracks",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_team_id": {
+          "name": "owner_team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scaling_group_id": {
+          "name": "scaling_group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "programming_track_type_idx": {
+          "name": "programming_track_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "programming_track_owner_idx": {
+          "name": "programming_track_owner_idx",
+          "columns": [
+            "owner_team_id"
+          ],
+          "isUnique": false
+        },
+        "programming_track_scaling_idx": {
+          "name": "programming_track_scaling_idx",
+          "columns": [
+            "scaling_group_id"
+          ],
+          "isUnique": false
+        },
+        "programming_track_competition_idx": {
+          "name": "programming_track_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "programming_tracks_id": {
+          "name": "programming_tracks_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scheduled_workout_instances": {
+      "name": "scheduled_workout_instances",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_date": {
+          "name": "scheduled_date",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_specific_notes": {
+          "name": "team_specific_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scaling_guidance_for_day": {
+          "name": "scaling_guidance_for_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_times": {
+          "name": "class_times",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scheduled_workout_instance_team_idx": {
+          "name": "scheduled_workout_instance_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "scheduled_workout_instance_date_idx": {
+          "name": "scheduled_workout_instance_date_idx",
+          "columns": [
+            "scheduled_date"
+          ],
+          "isUnique": false
+        },
+        "scheduled_workout_instance_workout_idx": {
+          "name": "scheduled_workout_instance_workout_idx",
+          "columns": [
+            "workout_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scheduled_workout_instances_id": {
+          "name": "scheduled_workout_instances_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_programming_tracks": {
+      "name": "team_programming_tracks",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "subscribed_at": {
+          "name": "subscribed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_day_offset": {
+          "name": "start_day_offset",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "team_programming_track_active_idx": {
+          "name": "team_programming_track_active_idx",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "team_programming_track_team_idx": {
+          "name": "team_programming_track_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_programming_tracks_team_id_track_id_pk": {
+          "name": "team_programming_tracks_team_id_track_id_pk",
+          "columns": [
+            "team_id",
+            "track_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "track_workouts": {
+      "name": "track_workouts",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_id": {
+          "name": "track_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_event_id": {
+          "name": "parent_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track_order": {
+          "name": "track_order",
+          "type": "decimal(6,2)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "points_multiplier": {
+          "name": "points_multiplier",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 100
+        },
+        "heat_status": {
+          "name": "heat_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "event_status": {
+          "name": "event_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "sponsor_id": {
+          "name": "sponsor_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_heats_count": {
+          "name": "default_heats_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_lane_shift_pattern": {
+          "name": "default_lane_shift_pattern",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_heat_buffer": {
+          "name": "min_heat_buffer",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 2
+        }
+      },
+      "indexes": {
+        "track_workout_track_idx": {
+          "name": "track_workout_track_idx",
+          "columns": [
+            "track_id"
+          ],
+          "isUnique": false
+        },
+        "track_workout_order_idx": {
+          "name": "track_workout_order_idx",
+          "columns": [
+            "track_order"
+          ],
+          "isUnique": false
+        },
+        "track_workout_parent_idx": {
+          "name": "track_workout_parent_idx",
+          "columns": [
+            "parent_event_id"
+          ],
+          "isUnique": false
+        },
+        "track_workout_workoutid_idx": {
+          "name": "track_workout_workoutid_idx",
+          "columns": [
+            "workout_id"
+          ],
+          "isUnique": false
+        },
+        "track_workout_unique_idx": {
+          "name": "track_workout_unique_idx",
+          "columns": [
+            "track_id",
+            "workout_id",
+            "track_order"
+          ],
+          "isUnique": false
+        },
+        "track_workout_sponsor_idx": {
+          "name": "track_workout_sponsor_idx",
+          "columns": [
+            "sponsor_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "track_workouts_id": {
+          "name": "track_workouts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "route_doc_routes": {
+      "name": "route_doc_routes",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "route_id": {
+          "name": "route_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "route_doc_routes_route_idx": {
+          "name": "route_doc_routes_route_idx",
+          "columns": [
+            "route_id"
+          ],
+          "isUnique": false
+        },
+        "route_doc_routes_doc_route_unique": {
+          "name": "route_doc_routes_doc_route_unique",
+          "columns": [
+            "doc_id",
+            "route_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "route_doc_routes_id": {
+          "name": "route_doc_routes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "route_doc_versions": {
+      "name": "route_doc_versions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "doc_id": {
+          "name": "doc_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('markdown','video','link')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "route_doc_versions_doc_idx": {
+          "name": "route_doc_versions_doc_idx",
+          "columns": [
+            "doc_id"
+          ],
+          "isUnique": false
+        },
+        "route_doc_versions_doc_version_unique": {
+          "name": "route_doc_versions_doc_version_unique",
+          "columns": [
+            "doc_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "route_doc_versions_id": {
+          "name": "route_doc_versions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "route_docs": {
+      "name": "route_docs",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('markdown','video','link')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'markdown'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "link_url": {
+          "name": "link_url",
+          "type": "varchar(2048)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_published": {
+          "name": "is_published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "route_docs_published_idx": {
+          "name": "route_docs_published_idx",
+          "columns": [
+            "is_published"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "route_docs_id": {
+          "name": "route_docs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scaling_groups": {
+      "name": "scaling_groups",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_system": {
+          "name": "is_system",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "scaling_groups_team_idx": {
+          "name": "scaling_groups_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "scaling_groups_default_idx": {
+          "name": "scaling_groups_default_idx",
+          "columns": [
+            "is_default"
+          ],
+          "isUnique": false
+        },
+        "scaling_groups_system_idx": {
+          "name": "scaling_groups_system_idx",
+          "columns": [
+            "is_system"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scaling_groups_id": {
+          "name": "scaling_groups_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scaling_levels": {
+      "name": "scaling_levels",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scaling_group_id": {
+          "name": "scaling_group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_size": {
+          "name": "team_size",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "scaling_levels_group_idx": {
+          "name": "scaling_levels_group_idx",
+          "columns": [
+            "scaling_group_id"
+          ],
+          "isUnique": false
+        },
+        "scaling_levels_position_idx": {
+          "name": "scaling_levels_position_idx",
+          "columns": [
+            "scaling_group_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scaling_levels_id": {
+          "name": "scaling_levels_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workout_scaling_descriptions": {
+      "name": "workout_scaling_descriptions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scaling_level_id": {
+          "name": "scaling_level_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workout_scaling_desc_workout_idx": {
+          "name": "workout_scaling_desc_workout_idx",
+          "columns": [
+            "workout_id"
+          ],
+          "isUnique": false
+        },
+        "workout_scaling_desc_unique_idx": {
+          "name": "workout_scaling_desc_unique_idx",
+          "columns": [
+            "workout_id",
+            "scaling_level_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workout_scaling_descriptions_id": {
+          "name": "workout_scaling_descriptions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "series_division_mappings": {
+      "name": "series_division_mappings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_division_id": {
+          "name": "competition_division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "series_division_id": {
+          "name": "series_division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sdm_group_comp_div_idx": {
+          "name": "sdm_group_comp_div_idx",
+          "columns": [
+            "group_id",
+            "competition_id",
+            "competition_division_id"
+          ],
+          "isUnique": true
+        },
+        "sdm_group_idx": {
+          "name": "sdm_group_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "sdm_competition_idx": {
+          "name": "sdm_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "series_division_mappings_id": {
+          "name": "series_division_mappings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "series_event_mappings": {
+      "name": "series_event_mappings",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_event_id": {
+          "name": "competition_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_event_id": {
+          "name": "template_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "sem_group_comp_event_idx": {
+          "name": "sem_group_comp_event_idx",
+          "columns": [
+            "group_id",
+            "competition_id",
+            "competition_event_id"
+          ],
+          "isUnique": true
+        },
+        "sem_group_template_idx": {
+          "name": "sem_group_template_idx",
+          "columns": [
+            "group_id",
+            "template_event_id"
+          ],
+          "isUnique": false
+        },
+        "sem_competition_idx": {
+          "name": "sem_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "series_event_mappings_id": {
+          "name": "series_event_mappings_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "series_template_divisions": {
+      "name": "series_template_divisions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "division_id": {
+          "name": "division_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "fee_cents": {
+          "name": "fee_cents",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_spots": {
+          "name": "max_spots",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "std_group_division_idx": {
+          "name": "std_group_division_idx",
+          "columns": [
+            "group_id",
+            "division_id"
+          ],
+          "isUnique": true
+        },
+        "std_group_idx": {
+          "name": "std_group_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "series_template_divisions_id": {
+          "name": "series_template_divisions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "class_catalogs": {
+      "name": "class_catalogs",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "max_participants": {
+          "name": "max_participants",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "class_catalogs_id": {
+          "name": "class_catalogs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "class_catalog_to_skills": {
+      "name": "class_catalog_to_skills",
+      "columns": {
+        "class_catalog_id": {
+          "name": "class_catalog_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "class_catalog_to_skills_class_catalog_id_skill_id_pk": {
+          "name": "class_catalog_to_skills_class_catalog_id_skill_id_pk",
+          "columns": [
+            "class_catalog_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "coach_blackout_dates": {
+      "name": "coach_blackout_dates",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "coach_blackout_dates_id": {
+          "name": "coach_blackout_dates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "coach_recurring_unavailability": {
+      "name": "coach_recurring_unavailability",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "coach_recurring_unavailability_id": {
+          "name": "coach_recurring_unavailability_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "coach_to_skills": {
+      "name": "coach_to_skills",
+      "columns": {
+        "coach_id": {
+          "name": "coach_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "coach_to_skills_coach_id_skill_id_pk": {
+          "name": "coach_to_skills_coach_id_skill_id_pk",
+          "columns": [
+            "coach_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "coaches": {
+      "name": "coaches",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weekly_class_limit": {
+          "name": "weekly_class_limit",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_preference": {
+          "name": "scheduling_preference",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduling_notes": {
+          "name": "scheduling_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "coach_user_team_unique_idx": {
+          "name": "coach_user_team_unique_idx",
+          "columns": [
+            "user_id",
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "coaches_id": {
+          "name": "coaches_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "generated_schedules": {
+      "name": "generated_schedules",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "week_start_date": {
+          "name": "week_start_date",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "generated_schedules_id": {
+          "name": "generated_schedules_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "locations": {
+      "name": "locations",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 20
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "locations_id": {
+          "name": "locations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "schedule_template_class_required_skills": {
+      "name": "schedule_template_class_required_skills",
+      "columns": {
+        "template_class_id": {
+          "name": "template_class_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_id": {
+          "name": "skill_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sched_class_skills_pk": {
+          "name": "sched_class_skills_pk",
+          "columns": [
+            "template_class_id",
+            "skill_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "schedule_template_classes": {
+      "name": "schedule_template_classes",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "required_coaches": {
+          "name": "required_coaches",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "schedule_template_classes_id": {
+          "name": "schedule_template_classes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "schedule_templates": {
+      "name": "schedule_templates",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "class_catalog_id": {
+          "name": "class_catalog_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "schedule_templates_id": {
+          "name": "schedule_templates_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scheduled_classes": {
+      "name": "scheduled_classes",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "coach_id": {
+          "name": "coach_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "class_catalog_id": {
+          "name": "class_catalog_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scheduled_classes_id": {
+          "name": "scheduled_classes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "skills": {
+      "name": "skills",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "skills_id": {
+          "name": "skills_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "score_rounds": {
+      "name": "score_rounds",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score_id": {
+          "name": "score_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round_number": {
+          "name": "round_number",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scheme_override": {
+          "name": "scheme_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondary_value": {
+          "name": "secondary_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_score_rounds_score": {
+          "name": "idx_score_rounds_score",
+          "columns": [
+            "score_id",
+            "round_number"
+          ],
+          "isUnique": false
+        },
+        "idx_score_rounds_unique": {
+          "name": "idx_score_rounds_unique",
+          "columns": [
+            "score_id",
+            "round_number"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "score_rounds_id": {
+          "name": "score_rounds_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "score_verification_logs": {
+      "name": "score_verification_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score_id": {
+          "name": "score_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "athlete_user_id": {
+          "name": "athlete_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_score_value": {
+          "name": "original_score_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_status": {
+          "name": "original_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_secondary_value": {
+          "name": "original_secondary_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_tiebreak_value": {
+          "name": "original_tiebreak_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_score_value": {
+          "name": "new_score_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_status": {
+          "name": "new_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_secondary_value": {
+          "name": "new_secondary_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "new_tiebreak_value": {
+          "name": "new_tiebreak_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "penalty_type": {
+          "name": "penalty_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "penalty_percentage": {
+          "name": "penalty_percentage",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_rep_count": {
+          "name": "no_rep_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "performed_by_user_id": {
+          "name": "performed_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "performed_at": {
+          "name": "performed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_svlog_score": {
+          "name": "idx_svlog_score",
+          "columns": [
+            "score_id"
+          ],
+          "isUnique": false
+        },
+        "idx_svlog_performer": {
+          "name": "idx_svlog_performer",
+          "columns": [
+            "performed_by_user_id",
+            "performed_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "score_verification_logs_id": {
+          "name": "score_verification_logs_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "scores": {
+      "name": "scores",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_event_id": {
+          "name": "competition_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_workout_instance_id": {
+          "name": "scheduled_workout_instance_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score_type": {
+          "name": "score_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'max'"
+        },
+        "score_value": {
+          "name": "score_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tiebreak_scheme": {
+          "name": "tiebreak_scheme",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tiebreak_value": {
+          "name": "tiebreak_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_cap_ms": {
+          "name": "time_cap_ms",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondary_value": {
+          "name": "secondary_value",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'scored'"
+        },
+        "status_order": {
+          "name": "status_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sort_key": {
+          "name": "sort_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scaling_level_id": {
+          "name": "scaling_level_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "as_rx": {
+          "name": "as_rx",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verification_status": {
+          "name": "verification_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified_by_user_id": {
+          "name": "verified_by_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "penalty_type": {
+          "name": "penalty_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "penalty_percentage": {
+          "name": "penalty_percentage",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_rep_count": {
+          "name": "no_rep_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_scores_user": {
+          "name": "idx_scores_user",
+          "columns": [
+            "user_id",
+            "recorded_at"
+          ],
+          "isUnique": false
+        },
+        "idx_scores_workout": {
+          "name": "idx_scores_workout",
+          "columns": [
+            "workout_id",
+            "team_id",
+            "status_order",
+            "sort_key"
+          ],
+          "isUnique": false
+        },
+        "idx_scores_competition": {
+          "name": "idx_scores_competition",
+          "columns": [
+            "competition_event_id",
+            "status_order",
+            "sort_key"
+          ],
+          "isUnique": false
+        },
+        "idx_scores_scheduled": {
+          "name": "idx_scores_scheduled",
+          "columns": [
+            "scheduled_workout_instance_id"
+          ],
+          "isUnique": false
+        },
+        "idx_scores_competition_user_unique": {
+          "name": "idx_scores_competition_user_unique",
+          "columns": [
+            "competition_event_id",
+            "user_id",
+            "scaling_level_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scores_id": {
+          "name": "scores_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sponsor_groups": {
+      "name": "sponsor_groups",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "sponsor_groups_competition_idx": {
+          "name": "sponsor_groups_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "sponsor_groups_order_idx": {
+          "name": "sponsor_groups_order_idx",
+          "columns": [
+            "competition_id",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sponsor_groups_id": {
+          "name": "sponsor_groups_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sponsors": {
+      "name": "sponsors",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo_url": {
+          "name": "logo_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "sponsors_competition_idx": {
+          "name": "sponsors_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "sponsors_user_idx": {
+          "name": "sponsors_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "sponsors_group_idx": {
+          "name": "sponsors_group_idx",
+          "columns": [
+            "group_id"
+          ],
+          "isUnique": false
+        },
+        "sponsors_competition_order_idx": {
+          "name": "sponsors_competition_order_idx",
+          "columns": [
+            "competition_id",
+            "group_id",
+            "display_order"
+          ],
+          "isUnique": false
+        },
+        "sponsors_user_order_idx": {
+          "name": "sponsors_user_order_idx",
+          "columns": [
+            "user_id",
+            "display_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sponsors_id": {
+          "name": "sponsors_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_invitations": {
+      "name": "team_invitations",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_system_role": {
+          "name": "is_system_role",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_invitation_team_id_idx": {
+          "name": "team_invitation_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_invitation_email_idx": {
+          "name": "team_invitation_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "team_invitation_token_idx": {
+          "name": "team_invitation_token_idx",
+          "columns": [
+            "token"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_invitations_id": {
+          "name": "team_invitations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "team_invitations_token_unique": {
+          "name": "team_invitations_token_unique",
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "team_memberships": {
+      "name": "team_memberships",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_id": {
+          "name": "role_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_system_role": {
+          "name": "is_system_role",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_membership_team_id_idx": {
+          "name": "team_membership_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_membership_user_id_idx": {
+          "name": "team_membership_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "team_membership_unique_idx": {
+          "name": "team_membership_unique_idx",
+          "columns": [
+            "team_id",
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_memberships_id": {
+          "name": "team_memberships_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "team_roles": {
+      "name": "team_roles",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_editable": {
+          "name": "is_editable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "team_role_team_id_idx": {
+          "name": "team_role_team_id_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_role_name_unique_idx": {
+          "name": "team_role_name_unique_idx",
+          "columns": [
+            "team_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "team_roles_id": {
+          "name": "team_roles_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "billing_email": {
+          "name": "billing_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_expires_at": {
+          "name": "plan_expires_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "credit_balance": {
+          "name": "credit_balance",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "current_plan_id": {
+          "name": "current_plan_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_track_id": {
+          "name": "default_track_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_scaling_group_id": {
+          "name": "default_scaling_group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_personal_team": {
+          "name": "is_personal_team",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "personal_team_owner_id": {
+          "name": "personal_team_owner_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'gym'"
+        },
+        "parent_organization_id": {
+          "name": "parent_organization_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition_metadata": {
+          "name": "competition_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_connected_account_id": {
+          "name": "stripe_connected_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_account_status": {
+          "name": "stripe_account_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_account_type": {
+          "name": "stripe_account_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_onboarding_completed_at": {
+          "name": "stripe_onboarding_completed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organizer_fee_percentage": {
+          "name": "organizer_fee_percentage",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "organizer_fee_fixed": {
+          "name": "organizer_fee_fixed",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_slug_idx": {
+          "name": "team_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "team_personal_owner_idx": {
+          "name": "team_personal_owner_idx",
+          "columns": [
+            "personal_team_owner_id"
+          ],
+          "isUnique": false
+        },
+        "team_default_scaling_idx": {
+          "name": "team_default_scaling_idx",
+          "columns": [
+            "default_scaling_group_id"
+          ],
+          "isUnique": false
+        },
+        "team_type_idx": {
+          "name": "team_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "team_parent_org_idx": {
+          "name": "team_parent_org_idx",
+          "columns": [
+            "parent_organization_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "teams_id": {
+          "name": "teams_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "teams_slug_unique": {
+          "name": "teams_slug_unique",
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "passkey_credentials": {
+      "name": "passkey_credentials",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credential_public_key": {
+          "name": "credential_public_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_id_idx": {
+          "name": "user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "credential_id_idx": {
+          "name": "credential_id_idx",
+          "columns": [
+            "credential_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "passkey_credentials_id": {
+          "name": "passkey_credentials_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "passkey_credentials_credentialId_unique": {
+          "name": "passkey_credentials_credentialId_unique",
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sign_up_ip_address": {
+          "name": "sign_up_ip_address",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_account_id": {
+          "name": "google_account_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "varchar(600)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "current_credits": {
+          "name": "current_credits",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_credit_refresh_at": {
+          "name": "last_credit_refresh_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date_of_birth": {
+          "name": "date_of_birth",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "affiliate_name": {
+          "name": "affiliate_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "athlete_profile": {
+          "name": "athlete_profile",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_idx": {
+          "name": "email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        },
+        "google_account_id_idx": {
+          "name": "google_account_id_idx",
+          "columns": [
+            "google_account_id"
+          ],
+          "isUnique": false
+        },
+        "role_idx": {
+          "name": "role_idx",
+          "columns": [
+            "role"
+          ],
+          "isUnique": false
+        },
+        "user_gender_idx": {
+          "name": "user_gender_idx",
+          "columns": [
+            "gender"
+          ],
+          "isUnique": false
+        },
+        "user_dob_idx": {
+          "name": "user_dob_idx",
+          "columns": [
+            "date_of_birth"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "users_id": {
+          "name": "users_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "review_notes": {
+      "name": "review_notes",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_submission_id": {
+          "name": "video_submission_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "enum('general','no-rep')",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'general'"
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp_seconds": {
+          "name": "timestamp_seconds",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "movement_id": {
+          "name": "movement_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "review_notes_submission_idx": {
+          "name": "review_notes_submission_idx",
+          "columns": [
+            "video_submission_id"
+          ],
+          "isUnique": false
+        },
+        "review_notes_user_idx": {
+          "name": "review_notes_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "review_notes_team_idx": {
+          "name": "review_notes_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "review_notes_id": {
+          "name": "review_notes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "video_submissions": {
+      "name": "video_submissions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_index": {
+          "name": "video_index",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_url": {
+          "name": "video_url",
+          "type": "varchar(2000)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "review_status": {
+          "name": "review_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "status_updated_at": {
+          "name": "status_updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewer_notes": {
+          "name": "reviewer_notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "video_submissions_reg_event_idx": {
+          "name": "video_submissions_reg_event_idx",
+          "columns": [
+            "registration_id",
+            "track_workout_id",
+            "video_index"
+          ],
+          "isUnique": true
+        },
+        "video_submissions_user_idx": {
+          "name": "video_submissions_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "video_submissions_event_idx": {
+          "name": "video_submissions_event_idx",
+          "columns": [
+            "track_workout_id"
+          ],
+          "isUnique": false
+        },
+        "video_submissions_registration_idx": {
+          "name": "video_submissions_registration_idx",
+          "columns": [
+            "registration_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "video_submissions_id": {
+          "name": "video_submissions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "video_votes": {
+      "name": "video_votes",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "video_submission_id": {
+          "name": "video_submission_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vote_type": {
+          "name": "vote_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reason_detail": {
+          "name": "reason_detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "video_votes_user_submission_idx": {
+          "name": "video_votes_user_submission_idx",
+          "columns": [
+            "user_id",
+            "video_submission_id"
+          ],
+          "isUnique": true
+        },
+        "video_votes_submission_idx": {
+          "name": "video_votes_submission_idx",
+          "columns": [
+            "video_submission_id"
+          ],
+          "isUnique": false
+        },
+        "video_votes_user_idx": {
+          "name": "video_votes_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "video_votes_id": {
+          "name": "video_votes_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "competition_judge_rotations": {
+      "name": "competition_judge_rotations",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starting_heat": {
+          "name": "starting_heat",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "starting_lane": {
+          "name": "starting_lane",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heats_count": {
+          "name": "heats_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lane_shift_pattern": {
+          "name": "lane_shift_pattern",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'stay'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "competition_judge_rotations_competition_idx": {
+          "name": "competition_judge_rotations_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "competition_judge_rotations_workout_idx": {
+          "name": "competition_judge_rotations_workout_idx",
+          "columns": [
+            "track_workout_id"
+          ],
+          "isUnique": false
+        },
+        "competition_judge_rotations_membership_idx": {
+          "name": "competition_judge_rotations_membership_idx",
+          "columns": [
+            "membership_id"
+          ],
+          "isUnique": false
+        },
+        "competition_judge_rotations_event_heat_idx": {
+          "name": "competition_judge_rotations_event_heat_idx",
+          "columns": [
+            "track_workout_id",
+            "starting_heat"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "competition_judge_rotations_id": {
+          "name": "competition_judge_rotations_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "judge_assignment_versions": {
+      "name": "judge_assignment_versions",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "track_workout_id": {
+          "name": "track_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_by": {
+          "name": "published_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "judge_assignment_versions_workout_idx": {
+          "name": "judge_assignment_versions_workout_idx",
+          "columns": [
+            "track_workout_id"
+          ],
+          "isUnique": false
+        },
+        "judge_assignment_versions_active_idx": {
+          "name": "judge_assignment_versions_active_idx",
+          "columns": [
+            "track_workout_id",
+            "is_active"
+          ],
+          "isUnique": false
+        },
+        "judge_assignment_versions_unique_idx": {
+          "name": "judge_assignment_versions_unique_idx",
+          "columns": [
+            "track_workout_id",
+            "version"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "judge_assignment_versions_id": {
+          "name": "judge_assignment_versions_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "judge_heat_assignments": {
+      "name": "judge_heat_assignments",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "heat_id": {
+          "name": "heat_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rotation_id": {
+          "name": "rotation_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lane_number": {
+          "name": "lane_number",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "instructions": {
+          "name": "instructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_manual_override": {
+          "name": "is_manual_override",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "judge_heat_assignments_heat_idx": {
+          "name": "judge_heat_assignments_heat_idx",
+          "columns": [
+            "heat_id"
+          ],
+          "isUnique": false
+        },
+        "judge_heat_assignments_membership_idx": {
+          "name": "judge_heat_assignments_membership_idx",
+          "columns": [
+            "membership_id"
+          ],
+          "isUnique": false
+        },
+        "judge_heat_assignments_rotation_idx": {
+          "name": "judge_heat_assignments_rotation_idx",
+          "columns": [
+            "rotation_id"
+          ],
+          "isUnique": false
+        },
+        "judge_heat_assignments_version_idx": {
+          "name": "judge_heat_assignments_version_idx",
+          "columns": [
+            "version_id"
+          ],
+          "isUnique": false
+        },
+        "judge_heat_assignments_unique_idx": {
+          "name": "judge_heat_assignments_unique_idx",
+          "columns": [
+            "heat_id",
+            "membership_id",
+            "version_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "judge_heat_assignments_id": {
+          "name": "judge_heat_assignments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "volunteer_shift_assignments": {
+      "name": "volunteer_shift_assignments",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "shift_id": {
+          "name": "shift_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "membership_id": {
+          "name": "membership_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "volunteer_shift_assignments_shift_idx": {
+          "name": "volunteer_shift_assignments_shift_idx",
+          "columns": [
+            "shift_id"
+          ],
+          "isUnique": false
+        },
+        "volunteer_shift_assignments_membership_idx": {
+          "name": "volunteer_shift_assignments_membership_idx",
+          "columns": [
+            "membership_id"
+          ],
+          "isUnique": false
+        },
+        "volunteer_shift_assignments_unique_idx": {
+          "name": "volunteer_shift_assignments_unique_idx",
+          "columns": [
+            "shift_id",
+            "membership_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "volunteer_shift_assignments_id": {
+          "name": "volunteer_shift_assignments_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "volunteer_shifts": {
+      "name": "volunteer_shifts",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role_type": {
+          "name": "role_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "varchar(200)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "capacity": {
+          "name": "capacity",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "volunteer_shifts_competition_idx": {
+          "name": "volunteer_shifts_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "volunteer_shifts_start_time_idx": {
+          "name": "volunteer_shifts_start_time_idx",
+          "columns": [
+            "start_time"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "volunteer_shifts_id": {
+          "name": "volunteer_shifts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "waiver_signatures": {
+      "name": "waiver_signatures",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "waiver_id": {
+          "name": "waiver_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registration_id": {
+          "name": "registration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "signed_at": {
+          "name": "signed_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "waiver_signatures_waiver_idx": {
+          "name": "waiver_signatures_waiver_idx",
+          "columns": [
+            "waiver_id"
+          ],
+          "isUnique": false
+        },
+        "waiver_signatures_user_idx": {
+          "name": "waiver_signatures_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "waiver_signatures_registration_idx": {
+          "name": "waiver_signatures_registration_idx",
+          "columns": [
+            "registration_id"
+          ],
+          "isUnique": false
+        },
+        "waiver_signatures_waiver_user_unique": {
+          "name": "waiver_signatures_waiver_user_unique",
+          "columns": [
+            "waiver_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "waiver_signatures_id": {
+          "name": "waiver_signatures_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "waivers": {
+      "name": "waivers",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "competition_id": {
+          "name": "competition_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "required": {
+          "name": "required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "required_for_volunteers": {
+          "name": "required_for_volunteers",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "position": {
+          "name": "position",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "waivers_competition_idx": {
+          "name": "waivers_competition_idx",
+          "columns": [
+            "competition_id"
+          ],
+          "isUnique": false
+        },
+        "waivers_position_idx": {
+          "name": "waivers_position_idx",
+          "columns": [
+            "competition_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "waivers_id": {
+          "name": "waivers_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "movements": {
+      "name": "movements",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "movements_id": {
+          "name": "movements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "results": {
+      "name": "results",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "programming_track_id": {
+          "name": "programming_track_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_workout_instance_id": {
+          "name": "scheduled_workout_instance_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scale": {
+          "name": "scale",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scaling_level_id": {
+          "name": "scaling_level_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "as_rx": {
+          "name": "as_rx",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "wod_score": {
+          "name": "wod_score",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "set_count": {
+          "name": "set_count",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance": {
+          "name": "distance",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition_event_id": {
+          "name": "competition_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "competition_registration_id": {
+          "name": "competition_registration_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score_status": {
+          "name": "score_status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tie_break_score": {
+          "name": "tie_break_score",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "secondary_score": {
+          "name": "secondary_score",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entered_by": {
+          "name": "entered_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "results_scaling_level_idx": {
+          "name": "results_scaling_level_idx",
+          "columns": [
+            "scaling_level_id"
+          ],
+          "isUnique": false
+        },
+        "results_workout_scaling_idx": {
+          "name": "results_workout_scaling_idx",
+          "columns": [
+            "workout_id",
+            "scaling_level_id"
+          ],
+          "isUnique": false
+        },
+        "results_leaderboard_idx": {
+          "name": "results_leaderboard_idx",
+          "columns": [
+            "workout_id",
+            "scaling_level_id",
+            "wod_score"
+          ],
+          "isUnique": false
+        },
+        "results_user_idx": {
+          "name": "results_user_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "results_date_idx": {
+          "name": "results_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        },
+        "results_workout_idx": {
+          "name": "results_workout_idx",
+          "columns": [
+            "workout_id"
+          ],
+          "isUnique": false
+        },
+        "results_competition_event_idx": {
+          "name": "results_competition_event_idx",
+          "columns": [
+            "competition_event_id",
+            "scaling_level_id"
+          ],
+          "isUnique": false
+        },
+        "results_competition_unique_idx": {
+          "name": "results_competition_unique_idx",
+          "columns": [
+            "competition_event_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "results_id": {
+          "name": "results_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "sets": {
+      "name": "sets",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "result_id": {
+          "name": "result_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "set_number": {
+          "name": "set_number",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps": {
+          "name": "reps",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance": {
+          "name": "distance",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time": {
+          "name": "time",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sets_id": {
+          "name": "sets_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "spicy_tags": {
+      "name": "spicy_tags",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "spicy_tags_id": {
+          "name": "spicy_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "spicy_tags_name_unique": {
+          "name": "spicy_tags_name_unique",
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "checkConstraint": {}
+    },
+    "workout_movements": {
+      "name": "workout_movements",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "movement_id": {
+          "name": "movement_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workout_movements_workout_idx": {
+          "name": "workout_movements_workout_idx",
+          "columns": [
+            "workout_id"
+          ],
+          "isUnique": false
+        },
+        "workout_movements_movement_idx": {
+          "name": "workout_movements_movement_idx",
+          "columns": [
+            "movement_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workout_movements_id": {
+          "name": "workout_movements_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workout_tags": {
+      "name": "workout_tags",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workout_id": {
+          "name": "workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workout_tags_workout_idx": {
+          "name": "workout_tags_workout_idx",
+          "columns": [
+            "workout_id"
+          ],
+          "isUnique": false
+        },
+        "workout_tags_tag_idx": {
+          "name": "workout_tags_tag_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workout_tags_id": {
+          "name": "workout_tags_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    },
+    "workouts": {
+      "name": "workouts",
+      "columns": {
+        "created_at": {
+          "name": "created_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "datetime",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "update_counter": {
+          "name": "update_counter",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "id": {
+          "name": "id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "scheme": {
+          "name": "scheme",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "score_type": {
+          "name": "score_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reps_per_round": {
+          "name": "reps_per_round",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rounds_to_score": {
+          "name": "rounds_to_score",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 1
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sugar_id": {
+          "name": "sugar_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tiebreak_scheme": {
+          "name": "tiebreak_scheme",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "time_cap": {
+          "name": "time_cap",
+          "type": "int",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_track_id": {
+          "name": "source_track_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_workout_id": {
+          "name": "source_workout_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scaling_group_id": {
+          "name": "scaling_group_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workouts_scaling_group_idx": {
+          "name": "workouts_scaling_group_idx",
+          "columns": [
+            "scaling_group_id"
+          ],
+          "isUnique": false
+        },
+        "workouts_team_idx": {
+          "name": "workouts_team_idx",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "workouts_source_track_idx": {
+          "name": "workouts_source_track_idx",
+          "columns": [
+            "source_track_id"
+          ],
+          "isUnique": false
+        },
+        "workouts_source_workout_idx": {
+          "name": "workouts_source_workout_idx",
+          "columns": [
+            "source_workout_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "workouts_id": {
+          "name": "workouts_id",
+          "columns": [
+            "id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraint": {}
+    }
+  },
+  "views": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "tables": {},
+    "indexes": {}
+  }
+}

--- a/packages/wodsmith-db/mysql-migrations/meta/_journal.json
+++ b/packages/wodsmith-db/mysql-migrations/meta/_journal.json
@@ -33,7 +33,7 @@
     {
       "idx": 4,
       "version": "5",
-      "when": 1782075001578,
+      "when": 1782078074621,
       "tag": "0004_crew-volunteer-intelligence-schema",
       "breakpoints": true
     }

--- a/packages/wodsmith-db/mysql-migrations/meta/_journal.json
+++ b/packages/wodsmith-db/mysql-migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1782032559847,
       "tag": "0003_crew-billing-state-audit",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1782075001578,
+      "tag": "0004_crew-volunteer-intelligence-schema",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/wodsmith-db/src/schema.ts
+++ b/packages/wodsmith-db/src/schema.ts
@@ -16,6 +16,8 @@ export * from "./schemas/crew-event-settings"
 export * from "./schemas/crew-imports"
 // @lat: [[crew#Self Serve Preset Schema]]
 export * from "./schemas/crew-self-serve-presets"
+// @lat: [[crew#Strategic Moat Privacy Model]]
+export * from "./schemas/crew-volunteer-intelligence"
 export * from "./schemas/entitlements"
 export * from "./schemas/event-division-mappings"
 export * from "./schemas/event-resources"

--- a/packages/wodsmith-db/src/schemas/common.ts
+++ b/packages/wodsmith-db/src/schemas/common.ts
@@ -166,3 +166,13 @@ export const createCrewAssignmentConfirmationId = () => `caconf_${ulid()}`
 export const createCrewTemplatePresetId = () => `ctpres_${ulid()}`
 export const createCrewImportMappingPresetId = () => `cimap_${ulid()}`
 export const createCrewDepartmentLeadId = () => `cdlead_${ulid()}`
+
+// Crew volunteer intelligence ID generators
+// @lat: [[crew#Strategic Moat Privacy Model]]
+export const createCrewVolunteerIdentityId = () => `cvid_${ulid()}`
+export const createCrewVolunteerConsentId = () => `cvcon_${ulid()}`
+export const createCrewVolunteerHistoryEventId = () => `cvhist_${ulid()}`
+export const createCrewVolunteerCredentialId = () => `cvcred_${ulid()}`
+export const createCrewCompetitionGroupSettingsId = () => `ccgset_${ulid()}`
+export const createCrewEventConversionId = () => `cconv_${ulid()}`
+export const createCrewVolunteerIntroRequestId = () => `cvintro_${ulid()}`

--- a/packages/wodsmith-db/src/schemas/crew-volunteer-intelligence.ts
+++ b/packages/wodsmith-db/src/schemas/crew-volunteer-intelligence.ts
@@ -1,8 +1,9 @@
 // @lat: [[crew#Strategic Moat Privacy Model]]
 import type { InferSelectModel } from "drizzle-orm"
-import { relations } from "drizzle-orm"
+import { relations, sql } from "drizzle-orm"
 import {
   boolean,
+  check,
   datetime,
   index,
   mysqlTable,
@@ -230,6 +231,10 @@ export const crewVolunteerIdentitiesTable = mysqlTable(
     index("crew_volunteer_identities_status_idx").on(table.status),
     index("crew_volunteer_identities_age_status_idx").on(
       table.discoveryAgeStatus,
+    ),
+    check(
+      "crew_volunteer_identities_anchor_check",
+      sql`${table.userId} is not null or ${table.emailHash} is not null or ${table.phoneHash} is not null`,
     ),
   ],
 )

--- a/packages/wodsmith-db/src/schemas/crew-volunteer-intelligence.ts
+++ b/packages/wodsmith-db/src/schemas/crew-volunteer-intelligence.ts
@@ -1,0 +1,820 @@
+// @lat: [[crew#Strategic Moat Privacy Model]]
+import type { InferSelectModel } from "drizzle-orm"
+import { relations } from "drizzle-orm"
+import {
+  boolean,
+  datetime,
+  index,
+  mysqlTable,
+  text,
+  uniqueIndex,
+  varchar,
+} from "drizzle-orm/mysql-core"
+import {
+  commonColumns,
+  createCrewCompetitionGroupSettingsId,
+  createCrewEventConversionId,
+  createCrewVolunteerConsentId,
+  createCrewVolunteerCredentialId,
+  createCrewVolunteerHistoryEventId,
+  createCrewVolunteerIdentityId,
+  createCrewVolunteerIntroRequestId,
+} from "./common"
+import {
+  competitionGroupsTable,
+  competitionsTable,
+} from "./competitions"
+import { crewEventSettingsTable } from "./crew-event-settings"
+import { teamInvitationTable, teamMembershipTable, teamTable } from "./teams"
+import { userTable } from "./users"
+import type { VolunteerRoleType } from "./volunteers"
+
+export const CREW_VOLUNTEER_IDENTITY_SOURCE = {
+  USER: "user",
+  MEMBERSHIP: "membership",
+  INVITATION: "invitation",
+  SELF_SERVICE: "self_service",
+  IMPORT: "import",
+  MANUAL: "manual",
+} as const
+
+export type CrewVolunteerIdentitySource =
+  (typeof CREW_VOLUNTEER_IDENTITY_SOURCE)[keyof typeof CREW_VOLUNTEER_IDENTITY_SOURCE]
+
+export const CREW_VOLUNTEER_IDENTITY_STATUS = {
+  ACTIVE: "active",
+  ARCHIVED: "archived",
+} as const
+
+export type CrewVolunteerIdentityStatus =
+  (typeof CREW_VOLUNTEER_IDENTITY_STATUS)[keyof typeof CREW_VOLUNTEER_IDENTITY_STATUS]
+
+export const CREW_VOLUNTEER_DISCOVERY_AGE_STATUS = {
+  UNKNOWN: "unknown",
+  ADULT_CONFIRMED: "adult_confirmed",
+  MINOR_BLOCKED: "minor_blocked",
+} as const
+
+export type CrewVolunteerDiscoveryAgeStatus =
+  (typeof CREW_VOLUNTEER_DISCOVERY_AGE_STATUS)[keyof typeof CREW_VOLUNTEER_DISCOVERY_AGE_STATUS]
+
+export const CREW_VOLUNTEER_CONSENT_SCOPE = {
+  SAME_ORGANIZER_HISTORY: "same_organizer_history",
+  COMMUNICATION_HISTORY: "communication_history",
+  REGIONAL_DISCOVERY: "regional_discovery",
+  INTRO_REQUESTS: "intro_requests",
+} as const
+
+export type CrewVolunteerConsentScope =
+  (typeof CREW_VOLUNTEER_CONSENT_SCOPE)[keyof typeof CREW_VOLUNTEER_CONSENT_SCOPE]
+
+export const CREW_VOLUNTEER_CONSENT_STATUS = {
+  GRANTED: "granted",
+  REVOKED: "revoked",
+  SUPERSEDED: "superseded",
+} as const
+
+export type CrewVolunteerConsentStatus =
+  (typeof CREW_VOLUNTEER_CONSENT_STATUS)[keyof typeof CREW_VOLUNTEER_CONSENT_STATUS]
+
+export const CREW_VOLUNTEER_CONSENT_SOURCE = {
+  VOLUNTEER_ACCOUNT: "volunteer_account",
+  PUBLIC_TOKEN: "public_token",
+  CONSENT_CENTER: "consent_center",
+  ORGANIZER_RECORDED: "organizer_recorded",
+} as const
+
+export type CrewVolunteerConsentSource =
+  (typeof CREW_VOLUNTEER_CONSENT_SOURCE)[keyof typeof CREW_VOLUNTEER_CONSENT_SOURCE]
+
+export const CREW_VOLUNTEER_HISTORY_EVENT_TYPE = {
+  ASSIGNED: "assigned",
+  CONFIRMED: "confirmed",
+  DECLINED: "declined",
+  CHANGE_REQUESTED: "change_requested",
+  COMPLETED: "completed",
+  NO_SHOW: "no_show",
+  REPLACED: "replaced",
+  RESPONSE_RECEIVED: "response_received",
+  MESSAGE_SENT: "message_sent",
+  MESSAGE_BOUNCED: "message_bounced",
+  MESSAGE_REPLIED: "message_replied",
+  CREDENTIAL_CHECKED: "credential_checked",
+  CREDENTIAL_REVOKED: "credential_revoked",
+  CORRECTION: "correction",
+} as const
+
+export type CrewVolunteerHistoryEventType =
+  (typeof CREW_VOLUNTEER_HISTORY_EVENT_TYPE)[keyof typeof CREW_VOLUNTEER_HISTORY_EVENT_TYPE]
+
+export const CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE = {
+  VOLUNTEER_SHIFT: "volunteer_shift",
+  JUDGE_ROTATION: "judge_rotation",
+  JUDGE_HEAT: "judge_heat",
+  DEPARTMENT_LEAD: "department_lead",
+  OTHER: "other",
+} as const
+
+export type CrewVolunteerHistoryAssignmentType =
+  (typeof CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE)[keyof typeof CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE]
+
+export const CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE = {
+  SAME_ORGANIZER: "same_organizer",
+  CONSENTED_INTRO: "consented_intro",
+} as const
+
+export type CrewVolunteerHistoryVisibilityScope =
+  (typeof CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE)[keyof typeof CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE]
+
+export const CREW_VOLUNTEER_CREDENTIAL_TYPE = {
+  JUDGE_COURSE: "judge_course",
+  MEDICAL: "medical",
+  SAFETY: "safety",
+  EQUIPMENT: "equipment",
+  ORGANIZER_TRAINING: "organizer_training",
+  OTHER: "other",
+} as const
+
+export type CrewVolunteerCredentialType =
+  (typeof CREW_VOLUNTEER_CREDENTIAL_TYPE)[keyof typeof CREW_VOLUNTEER_CREDENTIAL_TYPE]
+
+export const CREW_VOLUNTEER_CREDENTIAL_STATUS = {
+  SELF_REPORTED: "self_reported",
+  VERIFIED: "verified",
+  EXPIRED: "expired",
+  REVOKED: "revoked",
+} as const
+
+export type CrewVolunteerCredentialStatus =
+  (typeof CREW_VOLUNTEER_CREDENTIAL_STATUS)[keyof typeof CREW_VOLUNTEER_CREDENTIAL_STATUS]
+
+export const CREW_SERIES_MEMORY_MODE = {
+  DISABLED: "disabled",
+  SAME_GROUP: "same_group",
+} as const
+
+export type CrewSeriesMemoryMode =
+  (typeof CREW_SERIES_MEMORY_MODE)[keyof typeof CREW_SERIES_MEMORY_MODE]
+
+export const CREW_EVENT_CONVERSION_STATUS = {
+  REQUESTED: "requested",
+  PRIVACY_REVIEWED: "privacy_reviewed",
+  IN_PROGRESS: "in_progress",
+  COMPLETED: "completed",
+  CANCELLED: "cancelled",
+} as const
+
+export type CrewEventConversionStatus =
+  (typeof CREW_EVENT_CONVERSION_STATUS)[keyof typeof CREW_EVENT_CONVERSION_STATUS]
+
+export const CREW_VOLUNTEER_INTRO_REQUEST_STATUS = {
+  PENDING: "pending",
+  ACCEPTED: "accepted",
+  DECLINED: "declined",
+  CANCELLED: "cancelled",
+  EXPIRED: "expired",
+} as const
+
+export type CrewVolunteerIntroRequestStatus =
+  (typeof CREW_VOLUNTEER_INTRO_REQUEST_STATUS)[keyof typeof CREW_VOLUNTEER_INTRO_REQUEST_STATUS]
+
+export const crewVolunteerIdentitiesTable = mysqlTable(
+  "crew_volunteer_identities",
+  {
+    ...commonColumns,
+    id: varchar({ length: 255 })
+      .primaryKey()
+      .$defaultFn(() => createCrewVolunteerIdentityId())
+      .notNull(),
+    teamId: varchar({ length: 255 }).notNull(),
+    userId: varchar({ length: 255 }),
+    emailHash: varchar({ length: 255 }),
+    phoneHash: varchar({ length: 255 }),
+    contactHashVersion: varchar({ length: 50 }).default("v1").notNull(),
+    sourceCompetitionId: varchar({ length: 255 }),
+    sourceMembershipId: varchar({ length: 255 }),
+    sourceInvitationId: varchar({ length: 255 }),
+    identitySource: varchar({ length: 40 })
+      .$type<CrewVolunteerIdentitySource>()
+      .default(CREW_VOLUNTEER_IDENTITY_SOURCE.MANUAL)
+      .notNull(),
+    discoveryAgeStatus: varchar({ length: 30 })
+      .$type<CrewVolunteerDiscoveryAgeStatus>()
+      .default(CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.UNKNOWN)
+      .notNull(),
+    status: varchar({ length: 20 })
+      .$type<CrewVolunteerIdentityStatus>()
+      .default(CREW_VOLUNTEER_IDENTITY_STATUS.ACTIVE)
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("crew_volunteer_identities_team_user_unique_idx").on(
+      table.teamId,
+      table.userId,
+    ),
+    uniqueIndex("crew_volunteer_identities_team_email_hash_unique_idx").on(
+      table.teamId,
+      table.contactHashVersion,
+      table.emailHash,
+    ),
+    uniqueIndex("crew_volunteer_identities_team_phone_hash_unique_idx").on(
+      table.teamId,
+      table.contactHashVersion,
+      table.phoneHash,
+    ),
+    index("crew_volunteer_identities_team_idx").on(table.teamId),
+    index("crew_volunteer_identities_user_idx").on(table.userId),
+    index("crew_volunteer_identities_source_competition_idx").on(
+      table.sourceCompetitionId,
+    ),
+    index("crew_volunteer_identities_status_idx").on(table.status),
+    index("crew_volunteer_identities_age_status_idx").on(
+      table.discoveryAgeStatus,
+    ),
+  ],
+)
+
+export const crewVolunteerConsentsTable = mysqlTable(
+  "crew_volunteer_consents",
+  {
+    ...commonColumns,
+    id: varchar({ length: 255 })
+      .primaryKey()
+      .$defaultFn(() => createCrewVolunteerConsentId())
+      .notNull(),
+    identityId: varchar({ length: 255 }).notNull(),
+    teamId: varchar({ length: 255 }).notNull(),
+    scope: varchar({ length: 50 }).$type<CrewVolunteerConsentScope>().notNull(),
+    status: varchar({ length: 20 })
+      .$type<CrewVolunteerConsentStatus>()
+      .default(CREW_VOLUNTEER_CONSENT_STATUS.GRANTED)
+      .notNull(),
+    consentText: text().notNull(),
+    consentTextVersion: varchar({ length: 100 }).notNull(),
+    consentTextHash: varchar({ length: 255 }).notNull(),
+    source: varchar({ length: 40 })
+      .$type<CrewVolunteerConsentSource>()
+      .notNull(),
+    sourceSurface: varchar({ length: 100 }).notNull(),
+    sourceCompetitionId: varchar({ length: 255 }),
+    actorUserId: varchar({ length: 255 }),
+    recordedByUserId: varchar({ length: 255 }),
+    grantedAt: datetime()
+      .$defaultFn(() => new Date())
+      .notNull(),
+    revokedAt: datetime(),
+    revokedByUserId: varchar({ length: 255 }),
+    revocationSource: varchar({ length: 100 }),
+    supersededByConsentId: varchar({ length: 255 }),
+  },
+  (table) => [
+    index("crew_volunteer_consents_identity_idx").on(table.identityId),
+    index("crew_volunteer_consents_team_idx").on(table.teamId),
+    index("crew_volunteer_consents_scope_status_idx").on(
+      table.scope,
+      table.status,
+    ),
+    index("crew_volunteer_consents_identity_scope_status_idx").on(
+      table.identityId,
+      table.scope,
+      table.status,
+    ),
+    index("crew_volunteer_consents_source_competition_idx").on(
+      table.sourceCompetitionId,
+    ),
+    index("crew_volunteer_consents_actor_idx").on(table.actorUserId),
+    index("crew_volunteer_consents_recorded_by_idx").on(
+      table.recordedByUserId,
+    ),
+    index("crew_volunteer_consents_revoked_at_idx").on(table.revokedAt),
+  ],
+)
+
+export const crewVolunteerHistoryEventsTable = mysqlTable(
+  "crew_volunteer_history_events",
+  {
+    ...commonColumns,
+    id: varchar({ length: 255 })
+      .primaryKey()
+      .$defaultFn(() => createCrewVolunteerHistoryEventId())
+      .notNull(),
+    identityId: varchar({ length: 255 }).notNull(),
+    teamId: varchar({ length: 255 }).notNull(),
+    competitionId: varchar({ length: 255 }),
+    groupId: varchar({ length: 255 }),
+    eventType: varchar({ length: 50 })
+      .$type<CrewVolunteerHistoryEventType>()
+      .notNull(),
+    visibilityScope: varchar({ length: 30 })
+      .$type<CrewVolunteerHistoryVisibilityScope>()
+      .default(CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER)
+      .notNull(),
+    assignmentType: varchar({ length: 40 })
+      .$type<CrewVolunteerHistoryAssignmentType>(),
+    assignmentId: varchar({ length: 255 }),
+    roleType: varchar({ length: 50 }).$type<VolunteerRoleType>(),
+    occurredAt: datetime().notNull(),
+    sourceType: varchar({ length: 50 }).notNull(),
+    sourceId: varchar({ length: 255 }),
+    sourceUserId: varchar({ length: 255 }),
+    consentId: varchar({ length: 255 }),
+    correctionOfEventId: varchar({ length: 255 }),
+  },
+  (table) => [
+    index("crew_volunteer_history_events_identity_idx").on(table.identityId),
+    index("crew_volunteer_history_events_team_idx").on(table.teamId),
+    index("crew_volunteer_history_events_competition_idx").on(
+      table.competitionId,
+    ),
+    index("crew_volunteer_history_events_group_idx").on(table.groupId),
+    index("crew_volunteer_history_events_type_idx").on(table.eventType),
+    index("crew_volunteer_history_events_visibility_idx").on(
+      table.visibilityScope,
+    ),
+    index("crew_volunteer_history_events_occurred_idx").on(table.occurredAt),
+    index("crew_volunteer_history_events_identity_occurred_idx").on(
+      table.identityId,
+      table.occurredAt,
+    ),
+    index("crew_volunteer_history_events_assignment_idx").on(
+      table.assignmentType,
+      table.assignmentId,
+    ),
+    index("crew_volunteer_history_events_role_idx").on(table.roleType),
+    index("crew_volunteer_history_events_source_idx").on(
+      table.sourceType,
+      table.sourceId,
+    ),
+    index("crew_volunteer_history_events_consent_idx").on(table.consentId),
+    index("crew_volunteer_history_events_correction_idx").on(
+      table.correctionOfEventId,
+    ),
+  ],
+)
+
+export const crewVolunteerCredentialsTable = mysqlTable(
+  "crew_volunteer_credentials",
+  {
+    ...commonColumns,
+    id: varchar({ length: 255 })
+      .primaryKey()
+      .$defaultFn(() => createCrewVolunteerCredentialId())
+      .notNull(),
+    identityId: varchar({ length: 255 }).notNull(),
+    teamId: varchar({ length: 255 }).notNull(),
+    competitionId: varchar({ length: 255 }),
+    credentialType: varchar({ length: 40 })
+      .$type<CrewVolunteerCredentialType>()
+      .notNull(),
+    credentialKey: varchar({ length: 100 }),
+    credentialLabel: varchar({ length: 255 }).notNull(),
+    issuer: varchar({ length: 255 }),
+    status: varchar({ length: 20 })
+      .$type<CrewVolunteerCredentialStatus>()
+      .default(CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED)
+      .notNull(),
+    visibilityScope: varchar({ length: 30 })
+      .$type<CrewVolunteerHistoryVisibilityScope>()
+      .default(CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER)
+      .notNull(),
+    verifiedAt: datetime(),
+    expiresAt: datetime(),
+    revokedAt: datetime(),
+    verifiedByUserId: varchar({ length: 255 }),
+    sourceType: varchar({ length: 50 }),
+    sourceId: varchar({ length: 255 }),
+    consentId: varchar({ length: 255 }),
+  },
+  (table) => [
+    index("crew_volunteer_credentials_identity_idx").on(table.identityId),
+    index("crew_volunteer_credentials_team_idx").on(table.teamId),
+    index("crew_volunteer_credentials_competition_idx").on(
+      table.competitionId,
+    ),
+    index("crew_volunteer_credentials_type_idx").on(table.credentialType),
+    index("crew_volunteer_credentials_key_idx").on(table.credentialKey),
+    index("crew_volunteer_credentials_status_idx").on(table.status),
+    index("crew_volunteer_credentials_visibility_idx").on(
+      table.visibilityScope,
+    ),
+    index("crew_volunteer_credentials_expires_idx").on(table.expiresAt),
+    index("crew_volunteer_credentials_verified_by_idx").on(
+      table.verifiedByUserId,
+    ),
+    index("crew_volunteer_credentials_consent_idx").on(table.consentId),
+  ],
+)
+
+export const crewCompetitionGroupSettingsTable = mysqlTable(
+  "crew_competition_group_settings",
+  {
+    ...commonColumns,
+    id: varchar({ length: 255 })
+      .primaryKey()
+      .$defaultFn(() => createCrewCompetitionGroupSettingsId())
+      .notNull(),
+    competitionGroupId: varchar({ length: 255 }).notNull(),
+    teamId: varchar({ length: 255 }).notNull(),
+    memoryMode: varchar({ length: 30 })
+      .$type<CrewSeriesMemoryMode>()
+      .default(CREW_SERIES_MEMORY_MODE.DISABLED)
+      .notNull(),
+    returningVolunteerConsentRequired: boolean().default(true).notNull(),
+    historyVisibilityScope: varchar({ length: 30 })
+      .$type<CrewVolunteerHistoryVisibilityScope>()
+      .default(CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER)
+      .notNull(),
+    createdByUserId: varchar({ length: 255 }),
+    updatedByUserId: varchar({ length: 255 }),
+  },
+  (table) => [
+    uniqueIndex("crew_competition_group_settings_group_unique_idx").on(
+      table.competitionGroupId,
+    ),
+    index("crew_competition_group_settings_team_idx").on(table.teamId),
+    index("crew_competition_group_settings_mode_idx").on(table.memoryMode),
+    index("crew_competition_group_settings_created_by_idx").on(
+      table.createdByUserId,
+    ),
+    index("crew_competition_group_settings_updated_by_idx").on(
+      table.updatedByUserId,
+    ),
+  ],
+)
+
+export const crewEventConversionsTable = mysqlTable(
+  "crew_event_conversions",
+  {
+    ...commonColumns,
+    id: varchar({ length: 255 })
+      .primaryKey()
+      .$defaultFn(() => createCrewEventConversionId())
+      .notNull(),
+    teamId: varchar({ length: 255 }).notNull(),
+    competitionId: varchar({ length: 255 }).notNull(),
+    crewEventSettingsId: varchar({ length: 255 }),
+    competitionGroupId: varchar({ length: 255 }),
+    status: varchar({ length: 30 })
+      .$type<CrewEventConversionStatus>()
+      .default(CREW_EVENT_CONVERSION_STATUS.REQUESTED)
+      .notNull(),
+    requestedByUserId: varchar({ length: 255 }),
+    reviewedByUserId: varchar({ length: 255 }),
+    completedByUserId: varchar({ length: 255 }),
+    requestedAt: datetime()
+      .$defaultFn(() => new Date())
+      .notNull(),
+    privacyReviewedAt: datetime(),
+    completedAt: datetime(),
+    cancelledAt: datetime(),
+  },
+  (table) => [
+    uniqueIndex("crew_event_conversions_competition_unique_idx").on(
+      table.competitionId,
+    ),
+    index("crew_event_conversions_team_idx").on(table.teamId),
+    index("crew_event_conversions_settings_idx").on(table.crewEventSettingsId),
+    index("crew_event_conversions_group_idx").on(table.competitionGroupId),
+    index("crew_event_conversions_status_idx").on(table.status),
+    index("crew_event_conversions_requested_by_idx").on(
+      table.requestedByUserId,
+    ),
+    index("crew_event_conversions_reviewed_by_idx").on(table.reviewedByUserId),
+    index("crew_event_conversions_completed_by_idx").on(
+      table.completedByUserId,
+    ),
+  ],
+)
+
+export const crewVolunteerIntroRequestsTable = mysqlTable(
+  "crew_volunteer_intro_requests",
+  {
+    ...commonColumns,
+    id: varchar({ length: 255 })
+      .primaryKey()
+      .$defaultFn(() => createCrewVolunteerIntroRequestId())
+      .notNull(),
+    requestingTeamId: varchar({ length: 255 }).notNull(),
+    requestingCompetitionId: varchar({ length: 255 }).notNull(),
+    volunteerIdentityId: varchar({ length: 255 }).notNull(),
+    discoveryConsentId: varchar({ length: 255 }).notNull(),
+    requestedRoleType: varchar({ length: 50 }).$type<VolunteerRoleType>(),
+    startsAt: datetime(),
+    endsAt: datetime(),
+    status: varchar({ length: 20 })
+      .$type<CrewVolunteerIntroRequestStatus>()
+      .default(CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING)
+      .notNull(),
+    requestedByUserId: varchar({ length: 255 }),
+    requestedAt: datetime()
+      .$defaultFn(() => new Date())
+      .notNull(),
+    respondedByUserId: varchar({ length: 255 }),
+    respondedAt: datetime(),
+    expiresAt: datetime(),
+    resultInvitationId: varchar({ length: 255 }),
+    resultMembershipId: varchar({ length: 255 }),
+  },
+  (table) => [
+    index("crew_volunteer_intro_requests_requester_idx").on(
+      table.requestingTeamId,
+      table.requestingCompetitionId,
+    ),
+    index("crew_volunteer_intro_requests_identity_idx").on(
+      table.volunteerIdentityId,
+    ),
+    index("crew_volunteer_intro_requests_consent_idx").on(
+      table.discoveryConsentId,
+    ),
+    index("crew_volunteer_intro_requests_role_idx").on(
+      table.requestedRoleType,
+    ),
+    index("crew_volunteer_intro_requests_status_idx").on(table.status),
+    index("crew_volunteer_intro_requests_requested_by_idx").on(
+      table.requestedByUserId,
+    ),
+    index("crew_volunteer_intro_requests_responded_by_idx").on(
+      table.respondedByUserId,
+    ),
+    index("crew_volunteer_intro_requests_window_idx").on(
+      table.startsAt,
+      table.endsAt,
+    ),
+    index("crew_volunteer_intro_requests_expires_idx").on(table.expiresAt),
+    index("crew_volunteer_intro_requests_result_invitation_idx").on(
+      table.resultInvitationId,
+    ),
+    index("crew_volunteer_intro_requests_result_membership_idx").on(
+      table.resultMembershipId,
+    ),
+  ],
+)
+
+export const crewVolunteerIdentitiesRelations = relations(
+  crewVolunteerIdentitiesTable,
+  ({ one, many }) => ({
+    team: one(teamTable, {
+      fields: [crewVolunteerIdentitiesTable.teamId],
+      references: [teamTable.id],
+    }),
+    user: one(userTable, {
+      fields: [crewVolunteerIdentitiesTable.userId],
+      references: [userTable.id],
+    }),
+    sourceCompetition: one(competitionsTable, {
+      fields: [crewVolunteerIdentitiesTable.sourceCompetitionId],
+      references: [competitionsTable.id],
+    }),
+    sourceMembership: one(teamMembershipTable, {
+      fields: [crewVolunteerIdentitiesTable.sourceMembershipId],
+      references: [teamMembershipTable.id],
+    }),
+    sourceInvitation: one(teamInvitationTable, {
+      fields: [crewVolunteerIdentitiesTable.sourceInvitationId],
+      references: [teamInvitationTable.id],
+    }),
+    consents: many(crewVolunteerConsentsTable),
+    historyEvents: many(crewVolunteerHistoryEventsTable),
+    credentials: many(crewVolunteerCredentialsTable),
+    introRequests: many(crewVolunteerIntroRequestsTable),
+  }),
+)
+
+export const crewVolunteerConsentsRelations = relations(
+  crewVolunteerConsentsTable,
+  ({ one, many }) => ({
+    identity: one(crewVolunteerIdentitiesTable, {
+      fields: [crewVolunteerConsentsTable.identityId],
+      references: [crewVolunteerIdentitiesTable.id],
+    }),
+    team: one(teamTable, {
+      fields: [crewVolunteerConsentsTable.teamId],
+      references: [teamTable.id],
+    }),
+    sourceCompetition: one(competitionsTable, {
+      fields: [crewVolunteerConsentsTable.sourceCompetitionId],
+      references: [competitionsTable.id],
+    }),
+    actor: one(userTable, {
+      fields: [crewVolunteerConsentsTable.actorUserId],
+      references: [userTable.id],
+      relationName: "crewVolunteerConsentActor",
+    }),
+    recordedByUser: one(userTable, {
+      fields: [crewVolunteerConsentsTable.recordedByUserId],
+      references: [userTable.id],
+      relationName: "crewVolunteerConsentRecordedBy",
+    }),
+    revokedByUser: one(userTable, {
+      fields: [crewVolunteerConsentsTable.revokedByUserId],
+      references: [userTable.id],
+      relationName: "crewVolunteerConsentRevokedBy",
+    }),
+    supersededByConsent: one(crewVolunteerConsentsTable, {
+      fields: [crewVolunteerConsentsTable.supersededByConsentId],
+      references: [crewVolunteerConsentsTable.id],
+      relationName: "crewVolunteerConsentSupersession",
+    }),
+    historyEvents: many(crewVolunteerHistoryEventsTable),
+    credentials: many(crewVolunteerCredentialsTable),
+    introRequests: many(crewVolunteerIntroRequestsTable),
+  }),
+)
+
+export const crewVolunteerHistoryEventsRelations = relations(
+  crewVolunteerHistoryEventsTable,
+  ({ one }) => ({
+    identity: one(crewVolunteerIdentitiesTable, {
+      fields: [crewVolunteerHistoryEventsTable.identityId],
+      references: [crewVolunteerIdentitiesTable.id],
+    }),
+    team: one(teamTable, {
+      fields: [crewVolunteerHistoryEventsTable.teamId],
+      references: [teamTable.id],
+    }),
+    competition: one(competitionsTable, {
+      fields: [crewVolunteerHistoryEventsTable.competitionId],
+      references: [competitionsTable.id],
+    }),
+    group: one(competitionGroupsTable, {
+      fields: [crewVolunteerHistoryEventsTable.groupId],
+      references: [competitionGroupsTable.id],
+    }),
+    sourceUser: one(userTable, {
+      fields: [crewVolunteerHistoryEventsTable.sourceUserId],
+      references: [userTable.id],
+    }),
+    consent: one(crewVolunteerConsentsTable, {
+      fields: [crewVolunteerHistoryEventsTable.consentId],
+      references: [crewVolunteerConsentsTable.id],
+    }),
+    correctionOfEvent: one(crewVolunteerHistoryEventsTable, {
+      fields: [crewVolunteerHistoryEventsTable.correctionOfEventId],
+      references: [crewVolunteerHistoryEventsTable.id],
+      relationName: "crewVolunteerHistoryEventCorrection",
+    }),
+  }),
+)
+
+export const crewVolunteerCredentialsRelations = relations(
+  crewVolunteerCredentialsTable,
+  ({ one }) => ({
+    identity: one(crewVolunteerIdentitiesTable, {
+      fields: [crewVolunteerCredentialsTable.identityId],
+      references: [crewVolunteerIdentitiesTable.id],
+    }),
+    team: one(teamTable, {
+      fields: [crewVolunteerCredentialsTable.teamId],
+      references: [teamTable.id],
+    }),
+    competition: one(competitionsTable, {
+      fields: [crewVolunteerCredentialsTable.competitionId],
+      references: [competitionsTable.id],
+    }),
+    verifiedByUser: one(userTable, {
+      fields: [crewVolunteerCredentialsTable.verifiedByUserId],
+      references: [userTable.id],
+    }),
+    consent: one(crewVolunteerConsentsTable, {
+      fields: [crewVolunteerCredentialsTable.consentId],
+      references: [crewVolunteerConsentsTable.id],
+    }),
+  }),
+)
+
+export const crewCompetitionGroupSettingsRelations = relations(
+  crewCompetitionGroupSettingsTable,
+  ({ one }) => ({
+    group: one(competitionGroupsTable, {
+      fields: [crewCompetitionGroupSettingsTable.competitionGroupId],
+      references: [competitionGroupsTable.id],
+    }),
+    team: one(teamTable, {
+      fields: [crewCompetitionGroupSettingsTable.teamId],
+      references: [teamTable.id],
+    }),
+    createdByUser: one(userTable, {
+      fields: [crewCompetitionGroupSettingsTable.createdByUserId],
+      references: [userTable.id],
+      relationName: "crewCompetitionGroupSettingsCreatedBy",
+    }),
+    updatedByUser: one(userTable, {
+      fields: [crewCompetitionGroupSettingsTable.updatedByUserId],
+      references: [userTable.id],
+      relationName: "crewCompetitionGroupSettingsUpdatedBy",
+    }),
+  }),
+)
+
+export const crewEventConversionsRelations = relations(
+  crewEventConversionsTable,
+  ({ one }) => ({
+    team: one(teamTable, {
+      fields: [crewEventConversionsTable.teamId],
+      references: [teamTable.id],
+    }),
+    competition: one(competitionsTable, {
+      fields: [crewEventConversionsTable.competitionId],
+      references: [competitionsTable.id],
+    }),
+    crewEventSettings: one(crewEventSettingsTable, {
+      fields: [crewEventConversionsTable.crewEventSettingsId],
+      references: [crewEventSettingsTable.id],
+    }),
+    competitionGroup: one(competitionGroupsTable, {
+      fields: [crewEventConversionsTable.competitionGroupId],
+      references: [competitionGroupsTable.id],
+    }),
+    requestedByUser: one(userTable, {
+      fields: [crewEventConversionsTable.requestedByUserId],
+      references: [userTable.id],
+      relationName: "crewEventConversionRequestedBy",
+    }),
+    reviewedByUser: one(userTable, {
+      fields: [crewEventConversionsTable.reviewedByUserId],
+      references: [userTable.id],
+      relationName: "crewEventConversionReviewedBy",
+    }),
+    completedByUser: one(userTable, {
+      fields: [crewEventConversionsTable.completedByUserId],
+      references: [userTable.id],
+      relationName: "crewEventConversionCompletedBy",
+    }),
+  }),
+)
+
+export const crewVolunteerIntroRequestsRelations = relations(
+  crewVolunteerIntroRequestsTable,
+  ({ one }) => ({
+    requestingTeam: one(teamTable, {
+      fields: [crewVolunteerIntroRequestsTable.requestingTeamId],
+      references: [teamTable.id],
+    }),
+    requestingCompetition: one(competitionsTable, {
+      fields: [crewVolunteerIntroRequestsTable.requestingCompetitionId],
+      references: [competitionsTable.id],
+    }),
+    volunteerIdentity: one(crewVolunteerIdentitiesTable, {
+      fields: [crewVolunteerIntroRequestsTable.volunteerIdentityId],
+      references: [crewVolunteerIdentitiesTable.id],
+    }),
+    discoveryConsent: one(crewVolunteerConsentsTable, {
+      fields: [crewVolunteerIntroRequestsTable.discoveryConsentId],
+      references: [crewVolunteerConsentsTable.id],
+    }),
+    requestedByUser: one(userTable, {
+      fields: [crewVolunteerIntroRequestsTable.requestedByUserId],
+      references: [userTable.id],
+      relationName: "crewVolunteerIntroRequestRequestedBy",
+    }),
+    respondedByUser: one(userTable, {
+      fields: [crewVolunteerIntroRequestsTable.respondedByUserId],
+      references: [userTable.id],
+      relationName: "crewVolunteerIntroRequestRespondedBy",
+    }),
+    resultInvitation: one(teamInvitationTable, {
+      fields: [crewVolunteerIntroRequestsTable.resultInvitationId],
+      references: [teamInvitationTable.id],
+    }),
+    resultMembership: one(teamMembershipTable, {
+      fields: [crewVolunteerIntroRequestsTable.resultMembershipId],
+      references: [teamMembershipTable.id],
+    }),
+  }),
+)
+
+export type CrewVolunteerIdentity = InferSelectModel<
+  typeof crewVolunteerIdentitiesTable
+>
+export type NewCrewVolunteerIdentity =
+  typeof crewVolunteerIdentitiesTable.$inferInsert
+export type CrewVolunteerConsent = InferSelectModel<
+  typeof crewVolunteerConsentsTable
+>
+export type NewCrewVolunteerConsent =
+  typeof crewVolunteerConsentsTable.$inferInsert
+export type CrewVolunteerHistoryEvent = InferSelectModel<
+  typeof crewVolunteerHistoryEventsTable
+>
+export type NewCrewVolunteerHistoryEvent =
+  typeof crewVolunteerHistoryEventsTable.$inferInsert
+export type CrewVolunteerCredential = InferSelectModel<
+  typeof crewVolunteerCredentialsTable
+>
+export type NewCrewVolunteerCredential =
+  typeof crewVolunteerCredentialsTable.$inferInsert
+export type CrewCompetitionGroupSettings = InferSelectModel<
+  typeof crewCompetitionGroupSettingsTable
+>
+export type NewCrewCompetitionGroupSettings =
+  typeof crewCompetitionGroupSettingsTable.$inferInsert
+export type CrewEventConversion = InferSelectModel<
+  typeof crewEventConversionsTable
+>
+export type NewCrewEventConversion =
+  typeof crewEventConversionsTable.$inferInsert
+export type CrewVolunteerIntroRequest = InferSelectModel<
+  typeof crewVolunteerIntroRequestsTable
+>
+export type NewCrewVolunteerIntroRequest =
+  typeof crewVolunteerIntroRequestsTable.$inferInsert


### PR DESCRIPTION
## Summary

- Add the shared `@repo/wodsmith-db` Crew volunteer intelligence schema module and Drizzle migration `0004_crew-volunteer-intelligence-schema`.
- Model organizer-scoped volunteer identities, versioned consent records, append-only factual history events, credentials, competition-group Crew settings, event conversion audit state, and blind intro requests.
- Add thin Crew and WODsmith Start app schema shims that re-export the shared package schema.

## Privacy / Scope

- Keeps `packages/wodsmith-db` as the schema owner and reuses `competitions` plus `competition_groups`.
- Uses `userId` when present and team-scoped contact hashes for no-password volunteers; no name-only identity fields or name-only matching constraints.
- Adds DB-level `crew_volunteer_identities_anchor_check` so a volunteer identity row must have at least one matching anchor: `userId`, `emailHash`, or `phoneHash`.
- Consent captures text, version, hash, source, surface, scope, actor/recorder, grant timestamp, revocation state, and supersession.
- History/reliability is append-only factual events only; no public ratings, rankings, top lists, sentiment, private notes, raw contact, emergency contact, Stripe/billing refs, or private metadata.
- Cross-organizer intro requests require an explicit discovery consent reference and remain blind until accepted.
- No routes, UI, ingestion, discovery behavior, analytics, feature flags, billing changes, production data mutation, or backfill in this slice.
- There is no write path in this schema-only PR; matching app write-time validation should live in the first ingestion/write slice that creates `crew_volunteer_identities` rows.

## Validation

- `pnpm --filter @repo/wodsmith-db type-check`
- `pnpm check:schema-ownership`
- `pnpm db:generate --dry=json`
- `pnpm db:studio --dry=json`
- `pnpm --filter crew type-check`
- `pnpm --filter wodsmith-start type-check`
- `pnpm dlx lat.md locate 'crew#Strategic Moat Privacy Model'`
- `git diff --check`

Focused schema tests: no package-local `packages/wodsmith-db` test harness found for this schema-only slice.