### PR TITLE
[codex] feat(crew): record volunteer history events

### DIFF
--- a/apps/crew/src/lib/crew/imports/apply.ts
+++ b/apps/crew/src/lib/crew/imports/apply.ts
@@ -36,6 +36,7 @@ export interface ExistingVolunteerInvitation {
 
 export interface ExistingVolunteerMembership {
   id: string
+  userId?: string | null
   email: string
   isActive?: boolean | null
 }

--- a/apps/crew/src/server/crew-confirmation.server.ts
+++ b/apps/crew/src/server/crew-confirmation.server.ts
@@ -29,6 +29,12 @@ import {
   CREW_EVENT_LIFECYCLE,
   crewEventSettingsTable,
 } from "../db/schemas/crew-event-settings"
+import {
+  CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+  type CrewVolunteerHistoryEventType,
+} from "../db/schemas/crew-volunteer-intelligence"
 import { SYSTEM_ROLES_ENUM, teamMembershipTable } from "../db/schemas/teams"
 import { userTable } from "../db/schemas/users"
 import {
@@ -86,6 +92,7 @@ import {
   requireCrewDepartmentLeadEvent,
   resolveCrewDepartmentLeadAccess,
 } from "./crew-department-lead.server"
+import { recordCrewVolunteerHistoryEvent } from "./crew-volunteer-history.server"
 
 type DbClient = ReturnType<typeof getDb>
 
@@ -264,7 +271,26 @@ export async function respondCrewAssignmentConfirmationToken(
   await db.transaction(async (tx) => {
     const [row] = await tx
       .select({
+        event: {
+          id: competitionsTable.id,
+          organizingTeamId: competitionsTable.organizingTeamId,
+          groupId: competitionsTable.groupId,
+        },
         confirmation: crewAssignmentConfirmationsTable,
+        assignment: {
+          id: volunteerShiftAssignmentsTable.id,
+          membershipId: volunteerShiftAssignmentsTable.membershipId,
+        },
+        shift: {
+          roleType: volunteerShiftsTable.roleType,
+        },
+        membership: {
+          userId: teamMembershipTable.userId,
+          metadata: teamMembershipTable.metadata,
+        },
+        user: {
+          email: userTable.email,
+        },
       })
       .from(crewAssignmentConfirmationsTable)
       .innerJoin(
@@ -278,6 +304,22 @@ export async function respondCrewAssignmentConfirmationToken(
         crewEventSettingsTable,
         eq(crewEventSettingsTable.competitionId, competitionsTable.id),
       )
+      .leftJoin(
+        volunteerShiftAssignmentsTable,
+        eq(
+          crewAssignmentConfirmationsTable.assignmentId,
+          volunteerShiftAssignmentsTable.id,
+        ),
+      )
+      .leftJoin(
+        volunteerShiftsTable,
+        eq(volunteerShiftAssignmentsTable.shiftId, volunteerShiftsTable.id),
+      )
+      .leftJoin(
+        teamMembershipTable,
+        eq(volunteerShiftAssignmentsTable.membershipId, teamMembershipTable.id),
+      )
+      .leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
       .where(
         and(
           eq(crewAssignmentConfirmationsTable.tokenHash, tokenHash),
@@ -332,6 +374,38 @@ export async function respondCrewAssignmentConfirmationToken(
           updatedAt: resolution.respondedAt,
         })
         .where(eq(crewAssignmentConfirmationsTable.id, row.confirmation.id))
+
+      const historyEventType = historyEventTypeForConfirmationStatus(
+        resolution.status,
+      )
+      const metadata = parseCrewRosterMetadata(row.membership?.metadata)
+      if (historyEventType) {
+        await recordCrewVolunteerHistoryEvent({
+          db: tx as unknown as DbClient,
+          teamId: row.event.organizingTeamId,
+          competitionId: row.event.id,
+          groupId: row.event.groupId,
+          eventType: historyEventType,
+          identity: {
+            userId: row.membership?.userId,
+            email:
+              metadata.signupEmail ?? row.confirmation.email ?? row.user?.email,
+            phone: metadata.signupPhone,
+            sourceMembershipId:
+              row.assignment?.membershipId ??
+              row.confirmation.membershipId ??
+              null,
+            identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE,
+          },
+          assignmentType:
+            CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE.VOLUNTEER_SHIFT,
+          assignmentId: row.assignment?.id ?? row.confirmation.assignmentId,
+          roleType: row.shift?.roleType,
+          occurredAt: resolution.respondedAt,
+          sourceType: "crew_assignment_confirmation",
+          sourceId: row.confirmation.id,
+        })
+      }
     }
   })
 
@@ -661,6 +735,7 @@ export async function updateCrewShiftAssignmentConfirmationState(
         shiftEndTime: volunteerShiftsTable.endTime,
         shiftLocation: volunteerShiftsTable.location,
         membershipMetadata: teamMembershipTable.metadata,
+        membershipUserId: teamMembershipTable.userId,
         userEmail: userTable.email,
       })
       .from(volunteerShiftAssignmentsTable)
@@ -765,6 +840,35 @@ export async function updateCrewShiftAssignmentConfirmationState(
         updatedAt: now,
       })
       .where(eq(crewAssignmentConfirmationsTable.id, confirmation.id))
+
+    const historyEventType = historyEventTypeForOrganizerState(
+      data.state,
+      update.status,
+    )
+    if (historyEventType) {
+      const metadata = parseCrewRosterMetadata(assignment.membershipMetadata)
+      await recordCrewVolunteerHistoryEvent({
+        db: tx as unknown as DbClient,
+        teamId: event.organizingTeamId,
+        competitionId: event.id,
+        groupId: event.groupId,
+        eventType: historyEventType,
+        identity: {
+          userId: assignment.membershipUserId,
+          email: metadata.signupEmail ?? assignment.userEmail,
+          phone: metadata.signupPhone,
+          sourceMembershipId: assignment.membershipId,
+          identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.MEMBERSHIP,
+        },
+        assignmentType: CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE.VOLUNTEER_SHIFT,
+        assignmentId: assignment.assignmentId,
+        roleType: assignment.shiftRoleType,
+        occurredAt: update.respondedAt ?? now,
+        sourceType: "crew_assignment_confirmation",
+        sourceId: confirmation.id,
+        sourceUserId: null,
+      })
+    }
 
     return {
       success: true,
@@ -1567,6 +1671,34 @@ function getResponseSuccessMessage(action: CrewAssignmentResponseAction) {
     return "Assignment declined. The organizer will see your response."
   }
   return "Change request sent. The organizer will see your note."
+}
+
+function historyEventTypeForConfirmationStatus(
+  status: CrewAssignmentConfirmationStatus,
+): CrewVolunteerHistoryEventType | null {
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED) {
+    return CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED
+  }
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED) {
+    return CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED
+  }
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED) {
+    return CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CHANGE_REQUESTED
+  }
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.NO_SHOW) {
+    return CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW
+  }
+  return null
+}
+
+function historyEventTypeForOrganizerState(
+  state: CrewAssignmentConfirmationOrganizerState,
+  status: CrewAssignmentConfirmationStatus,
+): CrewVolunteerHistoryEventType | null {
+  if (state === "replaced") {
+    return CREW_VOLUNTEER_HISTORY_EVENT_TYPE.REPLACED
+  }
+  return historyEventTypeForConfirmationStatus(status)
 }
 
 async function withCrewAssignmentConfirmationLock<T>(

--- a/apps/crew/src/server/crew-department-lead.server.ts
+++ b/apps/crew/src/server/crew-department-lead.server.ts
@@ -30,6 +30,7 @@ export interface CrewDepartmentLeadEvent {
   id: string
   organizingTeamId: string
   competitionTeamId: string
+  groupId?: string | null
   timezone: string | null
 }
 
@@ -204,6 +205,7 @@ export async function requireCrewDepartmentLeadEvent(
       id: competitionsTable.id,
       organizingTeamId: competitionsTable.organizingTeamId,
       competitionTeamId: competitionsTable.competitionTeamId,
+      groupId: competitionsTable.groupId,
       timezone: competitionsTable.timezone,
     })
     .from(crewEventSettingsTable)
@@ -222,6 +224,7 @@ export async function requireCrewDepartmentLeadEvent(
     id: event.id,
     organizingTeamId: event.organizingTeamId,
     competitionTeamId: event.competitionTeamId,
+    groupId: event.groupId,
     timezone: event.timezone,
   }
 }

--- a/apps/crew/src/server/crew-imports.server.ts
+++ b/apps/crew/src/server/crew-imports.server.ts
@@ -29,6 +29,10 @@ import {
 } from "../db/schemas/competitions"
 import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
 import {
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+} from "../db/schemas/crew-volunteer-intelligence"
+import {
   crewImportMappingPresetsTable,
   type CrewImportMappingPreset,
 } from "../db/schemas/crew-self-serve-presets"
@@ -95,6 +99,7 @@ import {
 import { parseCompetitionSettings } from "../utils/competition-settings"
 import { DEFAULT_TIMEZONE } from "../utils/timezone-utils"
 import { requireLocalCrewOperatorAccess } from "./crew-local-access"
+import { recordCrewVolunteerHistoryEvent } from "./crew-volunteer-history.server"
 
 export const MAX_CREW_IMPORT_BYTES = 1_000_000
 
@@ -580,6 +585,12 @@ async function applyVolunteerImport({
     existingInvitations,
     existingMemberships,
   })
+  const volunteerRowsByRowNumber = new Map(
+    previewRows.map((row) => [
+      row.rowNumber,
+      row.normalizedRow as VolunteerImportRow,
+    ]),
+  )
   const timestamp = new Date()
 
   await db.transaction(async (tx) => {
@@ -618,6 +629,40 @@ async function applyVolunteerImport({
       }
 
       await updateImportRowAudit(client, importRecord.id, row, timestamp)
+      if (
+        row.action !== "error" &&
+        row.action !== "skip" &&
+        row.targetId &&
+        row.targetType
+      ) {
+        const volunteer = volunteerRowsByRowNumber.get(row.rowNumber)
+        const membership =
+          row.targetType === "team_membership"
+            ? existingMemberships.find(
+                (candidate) => candidate.id === row.targetId,
+              )
+            : null
+        await recordCrewVolunteerHistoryEvent({
+          db: client,
+          teamId: event.organizingTeamId,
+          competitionId: event.id,
+          groupId: event.groupId,
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED,
+          identity: {
+            userId: membership?.userId,
+            email: row.email,
+            phone: volunteer?.phone,
+            sourceMembershipId:
+              row.targetType === "team_membership" ? row.targetId : null,
+            sourceInvitationId:
+              row.targetType === "team_invitation" ? row.targetId : null,
+            identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.IMPORT,
+          },
+          occurredAt: timestamp,
+          sourceType: "crew_import_row",
+          sourceId: `${importRecord.id}:${row.rowNumber}`,
+        })
+      }
     }
 
     await updateImportApplySummary(
@@ -832,6 +877,7 @@ async function listVolunteerMemberships(
   const rows = await db
     .select({
       id: teamMembershipTable.id,
+      userId: teamMembershipTable.userId,
       email: userTable.email,
       isActive: teamMembershipTable.isActive,
       metadata: teamMembershipTable.metadata,
@@ -1758,6 +1804,7 @@ async function requireCrewEvent(eventId: string) {
       name: competitionsTable.name,
       organizingTeamId: competitionsTable.organizingTeamId,
       competitionTeamId: competitionsTable.competitionTeamId,
+      groupId: competitionsTable.groupId,
       startDate: competitionsTable.startDate,
       timezone: competitionsTable.timezone,
       settings: competitionsTable.settings,

--- a/apps/crew/src/server/crew-volunteer-history.server.test.ts
+++ b/apps/crew/src/server/crew-volunteer-history.server.test.ts
@@ -1,0 +1,163 @@
+// @lat: [[crew#Strategic Moat Privacy Model]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+} from "../db/schemas/crew-volunteer-intelligence"
+import {
+  assertCrewVolunteerIdentityHasAnchor,
+  buildCrewVolunteerHistoryDedupeKey,
+  buildCrewVolunteerHistoryEventInsert,
+  buildCrewVolunteerIdentityAnchors,
+  buildCrewVolunteerIdentityInsert,
+  hashCrewVolunteerContactAnchor,
+  normalizeCrewVolunteerHistoryEmail,
+  normalizeCrewVolunteerHistoryPhone,
+} from "./crew-volunteer-history.server"
+
+describe("Crew volunteer history helpers", () => {
+  it("normalizes and hashes contact anchors without storing raw contact values", async () => {
+    expect(normalizeCrewVolunteerHistoryEmail("  PERSON@Example.COM ")).toBe(
+      "person@example.com",
+    )
+    expect(normalizeCrewVolunteerHistoryPhone(" +1 (555) 123-4567 ")).toBe(
+      "+15551234567",
+    )
+
+    const emailHash = await hashCrewVolunteerContactAnchor(
+      "email",
+      "Person@example.com",
+    )
+    const sameEmailHash = await hashCrewVolunteerContactAnchor(
+      "email",
+      " person@EXAMPLE.com ",
+    )
+    const phoneHash = await hashCrewVolunteerContactAnchor(
+      "phone",
+      "+1 (555) 123-4567",
+    )
+
+    expect(emailHash).toBe(sameEmailHash)
+    expect(emailHash).toMatch(/^sha256:[0-9a-f]{64}$/)
+    expect(phoneHash).toMatch(/^sha256:[0-9a-f]{64}$/)
+    expect(emailHash).not.toContain("person@example.com")
+    expect(phoneHash).not.toContain("555")
+  })
+
+  it("requires at least one identity anchor before creating an identity row", async () => {
+    const anchors = await buildCrewVolunteerIdentityAnchors({
+      email: " volunteer@example.com ",
+    })
+    expect(() => assertCrewVolunteerIdentityHasAnchor(anchors)).not.toThrow()
+
+    const identity = buildCrewVolunteerIdentityInsert({
+      teamId: "team_organizer",
+      anchors,
+      sourceCompetitionId: "comp_1",
+      sourceMembershipId: null,
+      sourceInvitationId: "tinv_1",
+      identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE,
+      now: new Date("2026-06-21T12:00:00.000Z"),
+    })
+
+    expect(identity).toMatchObject({
+      teamId: "team_organizer",
+      userId: null,
+      phoneHash: null,
+      contactHashVersion: "v1",
+      sourceCompetitionId: "comp_1",
+      sourceInvitationId: "tinv_1",
+      identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE,
+    })
+    expect(identity.emailHash).toMatch(/^sha256:[0-9a-f]{64}$/)
+
+    await expect(buildCrewVolunteerIdentityAnchors({})).resolves.toMatchObject({
+      userId: null,
+      emailHash: null,
+      phoneHash: null,
+    })
+    expect(() =>
+      buildCrewVolunteerIdentityInsert({
+        teamId: "team_organizer",
+        anchors: {
+          userId: null,
+          emailHash: null,
+          phoneHash: null,
+          contactHashVersion: "v1",
+        },
+        sourceCompetitionId: "comp_1",
+        sourceMembershipId: null,
+        sourceInvitationId: null,
+        identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.MANUAL,
+        now: new Date("2026-06-21T12:00:00.000Z"),
+      }),
+    ).toThrow(/requires a user, email hash, or phone hash anchor/)
+  })
+
+  it("scopes history to the organizer team and safe factual fields only", () => {
+    const occurredAt = new Date("2026-06-21T12:00:00.000Z")
+    const event = buildCrewVolunteerHistoryEventInsert({
+      teamId: "team_organizer",
+      competitionId: "comp_crew",
+      groupId: "cgrp_series",
+      identityId: "cvid_1",
+      eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED,
+      assignmentType: CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE.VOLUNTEER_SHIFT,
+      assignmentId: "vsa_1",
+      roleType: "judge",
+      occurredAt,
+      sourceType: "crew_import_row",
+      sourceId: "cimp_1:2",
+      sourceUserId: "user_ops",
+    })
+
+    expect(event).toMatchObject({
+      teamId: "team_organizer",
+      competitionId: "comp_crew",
+      groupId: "cgrp_series",
+      visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+      eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED,
+      sourceType: "crew_import_row",
+      sourceId: "cimp_1:2",
+      sourceUserId: "user_ops",
+      roleType: "judge",
+    })
+    expect(JSON.stringify(event)).not.toContain("volunteer@example.com")
+    expect(event).not.toHaveProperty("metadata")
+    expect(event).not.toHaveProperty("email")
+    expect(event).not.toHaveProperty("phone")
+    expect(event).not.toHaveProperty("privateNote")
+    expect(event).not.toHaveProperty("stripePaymentIntentId")
+  })
+
+  it("uses stable dedupe keys for replayed source actions", () => {
+    const replay = {
+      teamId: "team_organizer",
+      competitionId: "comp_crew",
+      identityId: "cvid_1",
+      eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+      sourceType: "crew_assignment_confirmation",
+      sourceId: "caconf_1",
+      assignmentType: CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE.VOLUNTEER_SHIFT,
+      assignmentId: "vsa_1",
+    }
+
+    expect(buildCrewVolunteerHistoryDedupeKey(replay)).toBe(
+      buildCrewVolunteerHistoryDedupeKey({ ...replay }),
+    )
+    expect(
+      buildCrewVolunteerHistoryDedupeKey({
+        ...replay,
+        eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED,
+      }),
+    ).not.toBe(buildCrewVolunteerHistoryDedupeKey(replay))
+    expect(
+      buildCrewVolunteerHistoryDedupeKey({
+        ...replay,
+        teamId: "team_other",
+      }),
+    ).not.toBe(buildCrewVolunteerHistoryDedupeKey(replay))
+  })
+})

--- a/apps/crew/src/server/crew-volunteer-history.server.ts
+++ b/apps/crew/src/server/crew-volunteer-history.server.ts
@@ -1,0 +1,396 @@
+// @lat: [[crew#Strategic Moat Privacy Model]]
+import { and, eq, isNull, or } from "drizzle-orm"
+import type { getDb } from "../db"
+import {
+  createCrewVolunteerHistoryEventId,
+  createCrewVolunteerIdentityId,
+} from "../db/schemas/common"
+import {
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+  crewVolunteerHistoryEventsTable,
+  crewVolunteerIdentitiesTable,
+  type CrewVolunteerHistoryAssignmentType,
+  type CrewVolunteerHistoryEventType,
+  type CrewVolunteerIdentitySource,
+} from "../db/schemas/crew-volunteer-intelligence"
+import type { VolunteerRoleType } from "../db/schemas/volunteers"
+
+type DbClient = ReturnType<typeof getDb>
+
+export const CREW_VOLUNTEER_CONTACT_HASH_VERSION = "v1"
+const CONTACT_HASH_PREFIX = "sha256:"
+
+export interface CrewVolunteerIdentityAnchorInput {
+  userId?: string | null
+  email?: string | null
+  phone?: string | null
+}
+
+export interface CrewVolunteerIdentityAnchors {
+  userId: string | null
+  emailHash: string | null
+  phoneHash: string | null
+  contactHashVersion: typeof CREW_VOLUNTEER_CONTACT_HASH_VERSION
+}
+
+interface ResolveCrewVolunteerIdentityInput
+  extends CrewVolunteerIdentityAnchorInput {
+  db: DbClient
+  teamId: string
+  sourceCompetitionId?: string | null
+  sourceMembershipId?: string | null
+  sourceInvitationId?: string | null
+  identitySource: CrewVolunteerIdentitySource
+  now?: Date
+}
+
+export interface RecordCrewVolunteerHistoryEventInput {
+  db: DbClient
+  teamId: string
+  competitionId: string
+  groupId?: string | null
+  eventType: CrewVolunteerHistoryEventType
+  identity: CrewVolunteerIdentityAnchorInput & {
+    sourceMembershipId?: string | null
+    sourceInvitationId?: string | null
+    identitySource: CrewVolunteerIdentitySource
+  }
+  assignmentType?: CrewVolunteerHistoryAssignmentType | null
+  assignmentId?: string | null
+  roleType?: VolunteerRoleType | null
+  occurredAt?: Date
+  sourceType: string
+  sourceId: string
+  sourceUserId?: string | null
+  consentId?: string | null
+  correctionOfEventId?: string | null
+}
+
+export interface CrewVolunteerHistoryEventInsert {
+  id: string
+  identityId: string
+  teamId: string
+  competitionId: string
+  groupId: string | null
+  eventType: CrewVolunteerHistoryEventType
+  visibilityScope: typeof CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER
+  assignmentType: CrewVolunteerHistoryAssignmentType | null
+  assignmentId: string | null
+  roleType: VolunteerRoleType | null
+  occurredAt: Date
+  sourceType: string
+  sourceId: string
+  sourceUserId: string | null
+  consentId: string | null
+  correctionOfEventId: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export async function recordCrewVolunteerHistoryEvent(
+  input: RecordCrewVolunteerHistoryEventInput,
+): Promise<{ id: string; action: "created" | "existing" }> {
+  const occurredAt = input.occurredAt ?? new Date()
+  const identityId = await resolveCrewVolunteerIdentity({
+    db: input.db,
+    teamId: input.teamId,
+    userId: input.identity.userId,
+    email: input.identity.email,
+    phone: input.identity.phone,
+    sourceCompetitionId: input.competitionId,
+    sourceMembershipId: input.identity.sourceMembershipId,
+    sourceInvitationId: input.identity.sourceInvitationId,
+    identitySource: input.identity.identitySource,
+    now: occurredAt,
+  })
+
+  const [existing] = await input.db
+    .select({ id: crewVolunteerHistoryEventsTable.id })
+    .from(crewVolunteerHistoryEventsTable)
+    .where(
+      and(
+        eq(crewVolunteerHistoryEventsTable.identityId, identityId),
+        eq(crewVolunteerHistoryEventsTable.teamId, input.teamId),
+        eq(crewVolunteerHistoryEventsTable.competitionId, input.competitionId),
+        eq(crewVolunteerHistoryEventsTable.eventType, input.eventType),
+        eq(crewVolunteerHistoryEventsTable.sourceType, input.sourceType),
+        eq(crewVolunteerHistoryEventsTable.sourceId, input.sourceId),
+        input.assignmentType
+          ? eq(
+              crewVolunteerHistoryEventsTable.assignmentType,
+              input.assignmentType,
+            )
+          : isNull(crewVolunteerHistoryEventsTable.assignmentType),
+        input.assignmentId
+          ? eq(crewVolunteerHistoryEventsTable.assignmentId, input.assignmentId)
+          : isNull(crewVolunteerHistoryEventsTable.assignmentId),
+      ),
+    )
+    .limit(1)
+
+  if (existing) {
+    return { id: existing.id, action: "existing" }
+  }
+
+  const event = buildCrewVolunteerHistoryEventInsert({
+    ...input,
+    identityId,
+    occurredAt,
+  })
+
+  await input.db.insert(crewVolunteerHistoryEventsTable).values(event)
+  return { id: event.id, action: "created" }
+}
+
+export async function resolveCrewVolunteerIdentity(
+  input: ResolveCrewVolunteerIdentityInput,
+): Promise<string> {
+  const anchors = await buildCrewVolunteerIdentityAnchors(input)
+  assertCrewVolunteerIdentityHasAnchor(anchors)
+
+  const existing = await findCrewVolunteerIdentity(
+    input.db,
+    input.teamId,
+    anchors,
+  )
+  if (existing) {
+    return existing.id
+  }
+
+  const identity = buildCrewVolunteerIdentityInsert({
+    teamId: input.teamId,
+    anchors,
+    sourceCompetitionId: input.sourceCompetitionId ?? null,
+    sourceMembershipId: input.sourceMembershipId ?? null,
+    sourceInvitationId: input.sourceInvitationId ?? null,
+    identitySource: input.identitySource,
+    now: input.now ?? new Date(),
+  })
+
+  try {
+    await input.db.insert(crewVolunteerIdentitiesTable).values(identity)
+    return identity.id
+  } catch (error) {
+    if (!isDuplicateEntryError(error)) {
+      throw error
+    }
+    const racedExisting = await findCrewVolunteerIdentity(
+      input.db,
+      input.teamId,
+      anchors,
+    )
+    if (racedExisting) return racedExisting.id
+    throw error
+  }
+}
+
+export async function buildCrewVolunteerIdentityAnchors(
+  input: CrewVolunteerIdentityAnchorInput,
+): Promise<CrewVolunteerIdentityAnchors> {
+  return {
+    userId: normalizeNullableText(input.userId),
+    emailHash: await hashCrewVolunteerContactAnchor("email", input.email),
+    phoneHash: await hashCrewVolunteerContactAnchor("phone", input.phone),
+    contactHashVersion: CREW_VOLUNTEER_CONTACT_HASH_VERSION,
+  }
+}
+
+export function assertCrewVolunteerIdentityHasAnchor(
+  anchors: Pick<
+    CrewVolunteerIdentityAnchors,
+    "userId" | "emailHash" | "phoneHash"
+  >,
+) {
+  if (anchors.userId || anchors.emailHash || anchors.phoneHash) return
+  throw new Error(
+    "Crew volunteer identity requires a user, email hash, or phone hash anchor.",
+  )
+}
+
+export async function hashCrewVolunteerContactAnchor(
+  type: "email" | "phone",
+  value: string | null | undefined,
+) {
+  const normalized =
+    type === "email"
+      ? normalizeCrewVolunteerHistoryEmail(value)
+      : normalizeCrewVolunteerHistoryPhone(value)
+  if (!normalized) return null
+
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(
+      `${CREW_VOLUNTEER_CONTACT_HASH_VERSION}:${type}:${normalized}`,
+    ),
+  )
+  return `${CONTACT_HASH_PREFIX}${bytesToHex(new Uint8Array(digest))}`
+}
+
+export function normalizeCrewVolunteerHistoryEmail(
+  value: string | null | undefined,
+) {
+  const trimmed = value?.trim().toLowerCase()
+  return trimmed || null
+}
+
+export function normalizeCrewVolunteerHistoryPhone(
+  value: string | null | undefined,
+) {
+  const trimmed = value?.trim()
+  if (!trimmed) return null
+
+  const hasPlus = trimmed.startsWith("+")
+  const digits = trimmed.replace(/\D/g, "")
+  if (!digits) return null
+  return hasPlus ? `+${digits}` : digits
+}
+
+export function buildCrewVolunteerHistoryDedupeKey(input: {
+  teamId: string
+  competitionId: string
+  identityId: string
+  eventType: CrewVolunteerHistoryEventType
+  sourceType: string
+  sourceId: string
+  assignmentType?: CrewVolunteerHistoryAssignmentType | null
+  assignmentId?: string | null
+}) {
+  return [
+    input.teamId,
+    input.competitionId,
+    input.identityId,
+    input.eventType,
+    input.sourceType,
+    input.sourceId,
+    input.assignmentType ?? "",
+    input.assignmentId ?? "",
+  ].join("|")
+}
+
+export function buildCrewVolunteerHistoryEventInsert(
+  input: Omit<RecordCrewVolunteerHistoryEventInput, "db" | "identity"> & {
+    identityId: string
+    occurredAt: Date
+  },
+): CrewVolunteerHistoryEventInsert {
+  const now = input.occurredAt
+  return {
+    id: createCrewVolunteerHistoryEventId(),
+    identityId: input.identityId,
+    teamId: input.teamId,
+    competitionId: input.competitionId,
+    groupId: input.groupId ?? null,
+    eventType: input.eventType,
+    visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+    assignmentType: input.assignmentType ?? null,
+    assignmentId: input.assignmentId ?? null,
+    roleType: input.roleType ?? null,
+    occurredAt: input.occurredAt,
+    sourceType: input.sourceType,
+    sourceId: input.sourceId,
+    sourceUserId: input.sourceUserId ?? null,
+    consentId: input.consentId ?? null,
+    correctionOfEventId: input.correctionOfEventId ?? null,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+export function buildCrewVolunteerIdentityInsert(input: {
+  teamId: string
+  anchors: CrewVolunteerIdentityAnchors
+  sourceCompetitionId: string | null
+  sourceMembershipId: string | null
+  sourceInvitationId: string | null
+  identitySource: CrewVolunteerIdentitySource
+  now: Date
+}) {
+  assertCrewVolunteerIdentityHasAnchor(input.anchors)
+  return {
+    id: createCrewVolunteerIdentityId(),
+    teamId: input.teamId,
+    userId: input.anchors.userId,
+    emailHash: input.anchors.emailHash,
+    phoneHash: input.anchors.phoneHash,
+    contactHashVersion: input.anchors.contactHashVersion,
+    sourceCompetitionId: input.sourceCompetitionId,
+    sourceMembershipId: input.sourceMembershipId,
+    sourceInvitationId: input.sourceInvitationId,
+    identitySource: input.identitySource,
+    createdAt: input.now,
+    updatedAt: input.now,
+  }
+}
+
+async function findCrewVolunteerIdentity(
+  db: DbClient,
+  teamId: string,
+  anchors: CrewVolunteerIdentityAnchors,
+) {
+  const anchorConditions = [
+    anchors.userId
+      ? eq(crewVolunteerIdentitiesTable.userId, anchors.userId)
+      : null,
+    anchors.emailHash
+      ? and(
+          eq(crewVolunteerIdentitiesTable.emailHash, anchors.emailHash),
+          eq(
+            crewVolunteerIdentitiesTable.contactHashVersion,
+            anchors.contactHashVersion,
+          ),
+        )
+      : null,
+    anchors.phoneHash
+      ? and(
+          eq(crewVolunteerIdentitiesTable.phoneHash, anchors.phoneHash),
+          eq(
+            crewVolunteerIdentitiesTable.contactHashVersion,
+            anchors.contactHashVersion,
+          ),
+        )
+      : null,
+  ].filter((condition): condition is NonNullable<typeof condition> =>
+    Boolean(condition),
+  )
+
+  assertCrewVolunteerIdentityHasAnchor(anchors)
+
+  const [existing] = await db
+    .select({ id: crewVolunteerIdentitiesTable.id })
+    .from(crewVolunteerIdentitiesTable)
+    .where(
+      and(
+        eq(crewVolunteerIdentitiesTable.teamId, teamId),
+        anchorConditions.length === 1
+          ? anchorConditions[0]
+          : or(...anchorConditions),
+      ),
+    )
+    .limit(1)
+
+  return existing ?? null
+}
+
+function normalizeNullableText(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed || null
+}
+
+function bytesToHex(bytes: Uint8Array) {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  )
+}
+
+function isDuplicateEntryError(error: unknown) {
+  const maybe = error as { code?: unknown; errno?: unknown; message?: unknown }
+  return (
+    maybe.code === "ER_DUP_ENTRY" ||
+    maybe.errno === 1062 ||
+    (typeof maybe.message === "string" &&
+      maybe.message.toLowerCase().includes("duplicate"))
+  )
+}
+
+export { CREW_VOLUNTEER_IDENTITY_SOURCE }

--- a/apps/crew/src/server/crew-volunteer.server.ts
+++ b/apps/crew/src/server/crew-volunteer.server.ts
@@ -14,6 +14,10 @@ import {
   crewEventSettingsTable,
 } from "../db/schemas/crew-event-settings"
 import {
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+} from "../db/schemas/crew-volunteer-intelligence"
+import {
   INVITATION_STATUS,
   SYSTEM_ROLES_ENUM,
   teamInvitationTable,
@@ -35,6 +39,7 @@ import {
 } from "../lib/crew/volunteer-signup"
 import { getFirstExecuteValue } from "../server-fns/db-execute"
 import type { QuestionType } from "../server-fns/registration-questions-fns"
+import { recordCrewVolunteerHistoryEvent } from "./crew-volunteer-history.server"
 
 type DbClient = ReturnType<typeof getDb>
 const PUBLIC_DUPLICATE_VOLUNTEER_SIGNUP_ERROR =
@@ -232,6 +237,22 @@ export async function submitCrewVolunteerSignup(
           data.answers ?? [],
           timestamp,
         )
+        await recordCrewVolunteerHistoryEvent({
+          db: client,
+          teamId: event.organizingTeamId,
+          competitionId: event.id,
+          groupId: event.groupId,
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.SIGNED_UP,
+          identity: {
+            email,
+            phone: data.signupPhone,
+            sourceInvitationId: invitationId,
+            identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE,
+          },
+          occurredAt: timestamp,
+          sourceType: "crew_volunteer_signup",
+          sourceId: invitationId,
+        })
       },
     )
   })
@@ -312,6 +333,7 @@ const publicCrewEventSelect = {
   slug: competitionsTable.slug,
   name: competitionsTable.name,
   description: competitionsTable.description,
+  organizingTeamId: competitionsTable.organizingTeamId,
   startDate: competitionsTable.startDate,
   endDate: competitionsTable.endDate,
   timezone: competitionsTable.timezone,
@@ -320,6 +342,7 @@ const publicCrewEventSelect = {
 }
 
 type InternalPublicCrewEvent = PublicCrewVolunteerEvent & {
+  organizingTeamId: string
   groupId: string | null
 }
 

--- a/packages/wodsmith-db/src/schemas/crew-volunteer-intelligence.ts
+++ b/packages/wodsmith-db/src/schemas/crew-volunteer-intelligence.ts
@@ -89,6 +89,8 @@ export type CrewVolunteerConsentSource =
   (typeof CREW_VOLUNTEER_CONSENT_SOURCE)[keyof typeof CREW_VOLUNTEER_CONSENT_SOURCE]
 
 export const CREW_VOLUNTEER_HISTORY_EVENT_TYPE = {
+  SIGNED_UP: "signed_up",
+  IMPORTED: "imported",
   ASSIGNED: "assigned",
   CONFIRMED: "confirmed",
   DECLINED: "declined",


### PR DESCRIPTION
## Summary

Adds the first Crew volunteer history ingestion layer on top of the merged volunteer intelligence schema.

- Adds a server-only volunteer history helper that resolves organizer-scoped identities from `userId` or normalized contact hashes and rejects name-only identity creation.
- Records append-only factual history rows for public volunteer signup, volunteer import apply rows, public assignment confirmation responses, and organizer/day-of confirmation state updates.
- Keeps history scoped to the organizing team plus the relevant competition/group context, and stores only factual source/assignment references with same-organizer visibility.
- Extends the shared typed history event labels with `signed_up` and `imported` without changing the database schema or migrations.

## Privacy / Scope Notes

- No returning-volunteer UI, regional discovery, consent-center UI, analytics, queue/email/SMS behavior, billing behavior, production mutation, or backfill is included.
- Raw email/phone values are only accepted by the helper as inputs for normalized SHA-256 identity anchors; history-event rows do not include raw contact details, notes, emergency contact data, billing/Stripe refs, rankings, or private metadata.
- Idempotency is keyed from replayable source facts such as invitation IDs, import row IDs, and assignment confirmation IDs.

## Validation

- `pnpm --filter crew exec vitest run src/server/crew-volunteer-history.server.test.ts src/lib/crew/imports/apply.test.ts src/lib/crew/assignment-confirmations.test.ts src/lib/crew/volunteer-signup.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; existing unrelated warnings remain outside touched files)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` (passed after creating local `.alchemy/local/wrangler.jsonc` from checked-in `apps/crew/wrangler.jsonc`)
- `pnpm --filter @repo/wodsmith-db type-check`
- `pnpm check:schema-ownership`
- `pnpm db:generate --dry=json`
- `pnpm db:studio --dry=json`
- `pnpm dlx lat.md locate 'crew#Strategic Moat Privacy Model'`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the first volunteer history ingestion layer for Crew. We now record append-only events for signups, imports, and assignment confirmations with organizer-scoped visibility and hashed identity anchors.

- New Features
  - Identity resolution via userId or SHA‑256 hashed email/phone anchors (v1); rejects name-only identities.
  - Records events from public signup, import apply, and confirmation flows (confirmed/declined/change_requested/no_show/replaced); links assignment and role when available.
  - Idempotent writes using a stable dedupe key (team, competition, identity, event, source, assignment).
  - Scoped to the same organizer; events include team/competition/group and store only references (no raw email/phone).
  - Extends `CREW_VOLUNTEER_HISTORY_EVENT_TYPE` in `@repo/wodsmith-db` with `signed_up` and `imported`; no migrations required.

<sup>Written for commit 1cce2a73c5d8b23d6df835a4cb80fafa02fa9457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added volunteer history tracking that automatically records when volunteers sign up, are imported via file, or confirm crew assignments to maintain an audit trail
  * Volunteer activity deduplication prevents duplicate recording of the same actions

* **Tests**
  * Added test suite validating volunteer history tracking functionality, identity management, and data integrity safeguards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->