### PR TITLE
feat(crew): show returning volunteers

### DIFF
--- a/apps/crew/src/lib/crew/returning-volunteers.test.ts
+++ b/apps/crew/src/lib/crew/returning-volunteers.test.ts
@@ -1,0 +1,244 @@
+// @lat: [[crew#Strategic Moat Privacy Model]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_CREDENTIAL_TYPE,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+} from "../../db/schemas/crew-volunteer-intelligence"
+import { buildReturningVolunteerSuggestions } from "./returning-volunteers"
+
+describe("returning volunteer suggestions", () => {
+  it("summarizes same-organizer factual history without leaking raw contact fields", () => {
+    const suggestions = buildReturningVolunteerSuggestions({
+      organizerTeamId: "team_organizer",
+      currentCompetitionId: "comp_current",
+      roster: [
+        {
+          id: "membership:tmem_current",
+          name: "Ada Lovelace",
+          status: "active",
+          availability: "morning",
+          roleTypes: ["judge"],
+        },
+      ],
+      identities: [
+        {
+          id: "cvid_ada",
+          teamId: "team_organizer",
+          rosterVolunteerId: "membership:tmem_current",
+        },
+      ],
+      historyEvents: [
+        {
+          identityId: "cvid_ada",
+          teamId: "team_organizer",
+          competitionId: "comp_prior",
+          competitionName: "Boise Throwdown",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+          visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          roleType: "judge",
+          occurredAt: "2026-05-01T12:00:00.000Z",
+        },
+        {
+          identityId: "cvid_ada",
+          teamId: "team_organizer",
+          competitionId: "comp_prior",
+          competitionName: "Boise Throwdown",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+          visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          roleType: "medical",
+          occurredAt: "2026-05-02T12:00:00.000Z",
+        },
+      ],
+      credentials: [
+        {
+          identityId: "cvid_ada",
+          teamId: "team_organizer",
+          credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.JUDGE_COURSE,
+          credentialLabel: "L1 Judge",
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED,
+          visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        },
+      ],
+    })
+
+    expect(suggestions).toEqual([
+      {
+        rosterVolunteerId: "membership:tmem_current",
+        volunteerName: "Ada Lovelace",
+        rosterStatus: "active",
+        currentAvailability: "morning",
+        currentRoleTypes: ["judge"],
+        priorEventCount: 1,
+        lastEvent: {
+          competitionId: "comp_prior",
+          label: "Boise Throwdown",
+          occurredAt: "2026-05-02T12:00:00.000Z",
+        },
+        priorRoleTypes: ["medical", "judge"],
+        reliability: {
+          signedUp: 0,
+          imported: 0,
+          assigned: 0,
+          confirmed: 1,
+          declined: 0,
+          changeRequested: 0,
+          noShow: 0,
+          completed: 1,
+        },
+        credentials: [
+          {
+            credentialType: "judge_course",
+            credentialLabel: "L1 Judge",
+            status: "self_reported",
+          },
+        ],
+      },
+    ])
+    expect(JSON.stringify(suggestions)).not.toContain("ada@example.com")
+    expect(JSON.stringify(suggestions)).not.toContain("555")
+    expect(JSON.stringify(suggestions)).not.toContain("privateNote")
+    expect(JSON.stringify(suggestions)).not.toContain("stripe")
+  })
+
+  it("excludes current-event and cross-organizer history", () => {
+    const suggestions = buildReturningVolunteerSuggestions({
+      organizerTeamId: "team_organizer",
+      currentCompetitionId: "comp_current",
+      roster: [
+        {
+          id: "invitation:tinv_current",
+          name: "Grace Hopper",
+          status: "pending",
+          availability: null,
+          roleTypes: ["general"],
+        },
+      ],
+      identities: [
+        {
+          id: "cvid_grace",
+          teamId: "team_organizer",
+          rosterVolunteerId: "invitation:tinv_current",
+        },
+        {
+          id: "cvid_other",
+          teamId: "team_other",
+          rosterVolunteerId: "invitation:tinv_current",
+        },
+      ],
+      historyEvents: [
+        {
+          identityId: "cvid_grace",
+          teamId: "team_organizer",
+          competitionId: "comp_current",
+          competitionName: "Current Event",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+          visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          roleType: "general",
+          occurredAt: "2026-06-21T12:00:00.000Z",
+        },
+        {
+          identityId: "cvid_other",
+          teamId: "team_other",
+          competitionId: "comp_other",
+          competitionName: "Other Organizer Event",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+          visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          roleType: "judge",
+          occurredAt: "2026-05-01T12:00:00.000Z",
+        },
+      ],
+      credentials: [],
+    })
+
+    expect(suggestions).toEqual([])
+  })
+
+  it("counts factual reliability states and omits unsafe credential states", () => {
+    const suggestions = buildReturningVolunteerSuggestions({
+      organizerTeamId: "team_organizer",
+      currentCompetitionId: "comp_current",
+      roster: [
+        {
+          id: "membership:tmem_1",
+          name: "Katherine Johnson",
+          status: "active",
+          availability: "all_day",
+          roleTypes: ["staff"],
+        },
+      ],
+      identities: [
+        {
+          id: "cvid_katherine",
+          teamId: "team_organizer",
+          rosterVolunteerId: "membership:tmem_1",
+        },
+      ],
+      historyEvents: [
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.SIGNED_UP,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CHANGE_REQUESTED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+      ].map((eventType, index) => ({
+        identityId: "cvid_katherine",
+        teamId: "team_organizer",
+        competitionId: index < 4 ? "comp_a" : "comp_b",
+        competitionName: index < 4 ? "Spring Classic" : "Fall Classic",
+        eventType,
+        visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        roleType: "staff" as const,
+        occurredAt: `2026-04-0${index + 1}T12:00:00.000Z`,
+      })),
+      credentials: [
+        {
+          identityId: "cvid_katherine",
+          teamId: "team_organizer",
+          credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.MEDICAL,
+          credentialLabel: "EMT",
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+          visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        },
+        {
+          identityId: "cvid_katherine",
+          teamId: "team_organizer",
+          credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.SAFETY,
+          credentialLabel: "Expired safety",
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.EXPIRED,
+          visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        },
+        {
+          identityId: "cvid_katherine",
+          teamId: "team_organizer",
+          credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.EQUIPMENT,
+          credentialLabel: "Revoked rigging",
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.REVOKED,
+          visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        },
+      ],
+    })
+
+    expect(suggestions[0]?.priorEventCount).toBe(2)
+    expect(suggestions[0]?.reliability).toEqual({
+      signedUp: 1,
+      imported: 1,
+      assigned: 1,
+      confirmed: 1,
+      declined: 1,
+      changeRequested: 1,
+      noShow: 1,
+      completed: 1,
+    })
+    expect(suggestions[0]?.credentials).toEqual([
+      {
+        credentialType: "medical",
+        credentialLabel: "EMT",
+        status: "verified",
+      },
+    ])
+  })
+})

--- a/apps/crew/src/lib/crew/returning-volunteers.ts
+++ b/apps/crew/src/lib/crew/returning-volunteers.ts
@@ -1,0 +1,298 @@
+// @lat: [[crew#Strategic Moat Privacy Model]]
+import {
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  type CrewVolunteerCredentialStatus,
+  type CrewVolunteerCredentialType,
+  type CrewVolunteerHistoryEventType,
+  type CrewVolunteerHistoryVisibilityScope,
+} from "../../db/schemas/crew-volunteer-intelligence"
+import type {
+  VolunteerAvailability,
+  VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+
+export interface ReturningVolunteerRosterEntry {
+  id: string
+  name: string
+  status: string
+  availability: VolunteerAvailability | null
+  roleTypes: VolunteerRoleType[]
+}
+
+export interface ReturningVolunteerIdentityRecord {
+  id: string
+  teamId: string
+  rosterVolunteerId: string
+}
+
+export interface ReturningVolunteerHistoryRecord {
+  identityId: string
+  teamId: string
+  competitionId: string | null
+  competitionName: string | null
+  eventType: CrewVolunteerHistoryEventType
+  visibilityScope: CrewVolunteerHistoryVisibilityScope
+  roleType: VolunteerRoleType | null
+  occurredAt: Date | string
+}
+
+export interface ReturningVolunteerCredentialRecord {
+  identityId: string
+  teamId: string
+  credentialType: CrewVolunteerCredentialType
+  credentialLabel: string
+  status: CrewVolunteerCredentialStatus
+  visibilityScope: CrewVolunteerHistoryVisibilityScope
+  expiresAt?: Date | string | null
+  revokedAt?: Date | string | null
+}
+
+export interface ReturningVolunteerSummaryInput {
+  organizerTeamId: string
+  currentCompetitionId: string
+  roster: ReturningVolunteerRosterEntry[]
+  identities: ReturningVolunteerIdentityRecord[]
+  historyEvents: ReturningVolunteerHistoryRecord[]
+  credentials: ReturningVolunteerCredentialRecord[]
+  maxSuggestions?: number
+}
+
+export interface CrewReturningVolunteerSuggestion {
+  rosterVolunteerId: string
+  volunteerName: string
+  rosterStatus: string
+  currentAvailability: VolunteerAvailability | null
+  currentRoleTypes: VolunteerRoleType[]
+  priorEventCount: number
+  lastEvent: {
+    competitionId: string | null
+    label: string
+    occurredAt: string
+  } | null
+  priorRoleTypes: VolunteerRoleType[]
+  reliability: {
+    signedUp: number
+    imported: number
+    assigned: number
+    confirmed: number
+    declined: number
+    changeRequested: number
+    noShow: number
+    completed: number
+  }
+  credentials: Array<{
+    credentialType: CrewVolunteerCredentialType
+    credentialLabel: string
+    status: Extract<
+      CrewVolunteerCredentialStatus,
+      "self_reported" | "verified"
+    >
+  }>
+}
+
+const countedEventTypes = new Set<CrewVolunteerHistoryEventType>([
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.SIGNED_UP,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CHANGE_REQUESTED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+])
+
+const safeCredentialStatuses = new Set<CrewVolunteerCredentialStatus>([
+  CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED,
+  CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+])
+
+export function buildReturningVolunteerSuggestions({
+  organizerTeamId,
+  currentCompetitionId,
+  roster,
+  identities,
+  historyEvents,
+  credentials,
+  maxSuggestions = 8,
+}: ReturningVolunteerSummaryInput): CrewReturningVolunteerSuggestion[] {
+  const rosterById = new Map(roster.map((volunteer) => [volunteer.id, volunteer]))
+  const identityIdsByRosterId = new Map<string, Set<string>>()
+
+  for (const identity of identities) {
+    if (identity.teamId !== organizerTeamId) continue
+    if (!rosterById.has(identity.rosterVolunteerId)) continue
+    const identityIds =
+      identityIdsByRosterId.get(identity.rosterVolunteerId) ?? new Set<string>()
+    identityIds.add(identity.id)
+    identityIdsByRosterId.set(identity.rosterVolunteerId, identityIds)
+  }
+
+  return [...identityIdsByRosterId.entries()]
+    .flatMap(([rosterVolunteerId, identityIds]) => {
+      const volunteer = rosterById.get(rosterVolunteerId)
+      if (!volunteer) return []
+
+      const priorHistory = historyEvents
+        .filter((event) => {
+          if (!identityIds.has(event.identityId)) return false
+          if (event.teamId !== organizerTeamId) return false
+          if (
+            event.visibilityScope !==
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER
+          ) {
+            return false
+          }
+          if (event.competitionId === currentCompetitionId) return false
+          return countedEventTypes.has(event.eventType)
+        })
+        .sort(
+          (left, right) =>
+            toTime(right.occurredAt) - toTime(left.occurredAt),
+        )
+
+      if (priorHistory.length === 0) return []
+
+      const safeCredentials = credentials
+        .filter((credential) => {
+          if (!identityIds.has(credential.identityId)) return false
+          if (credential.teamId !== organizerTeamId) return false
+          if (
+            credential.visibilityScope !==
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER
+          ) {
+            return false
+          }
+          if (!safeCredentialStatuses.has(credential.status)) return false
+          if (credential.revokedAt) return false
+          if (credential.expiresAt && toTime(credential.expiresAt) < Date.now()) {
+            return false
+          }
+          return true
+        })
+        .map((credential) => ({
+          credentialType: credential.credentialType,
+          credentialLabel: credential.credentialLabel,
+          status: credential.status as Extract<
+            CrewVolunteerCredentialStatus,
+            "self_reported" | "verified"
+          >,
+        }))
+
+      return [
+        {
+          rosterVolunteerId,
+          volunteerName: volunteer.name,
+          rosterStatus: volunteer.status,
+          currentAvailability: volunteer.availability,
+          currentRoleTypes: volunteer.roleTypes,
+          priorEventCount: countPriorEvents(priorHistory),
+          lastEvent: toLastEvent(priorHistory[0] ?? null),
+          priorRoleTypes: uniqueRoleTypes(priorHistory),
+          reliability: countReliabilityFacts(priorHistory),
+          credentials: dedupeCredentials(safeCredentials),
+        },
+      ]
+    })
+    .sort(compareReturningVolunteerSuggestions)
+    .slice(0, maxSuggestions)
+}
+
+function countPriorEvents(events: ReturningVolunteerHistoryRecord[]) {
+  return new Set(
+    events.map((event) => event.competitionId).filter(Boolean),
+  ).size
+}
+
+function toLastEvent(event: ReturningVolunteerHistoryRecord | null) {
+  if (!event) return null
+  return {
+    competitionId: event.competitionId,
+    label: event.competitionName ?? "Prior event",
+    occurredAt: toIsoString(event.occurredAt),
+  }
+}
+
+function uniqueRoleTypes(events: ReturningVolunteerHistoryRecord[]) {
+  return [
+    ...new Set(events.map((event) => event.roleType).filter(Boolean)),
+  ] as VolunteerRoleType[]
+}
+
+function countReliabilityFacts(events: ReturningVolunteerHistoryRecord[]) {
+  const reliability = {
+    signedUp: 0,
+    imported: 0,
+    assigned: 0,
+    confirmed: 0,
+    declined: 0,
+    changeRequested: 0,
+    noShow: 0,
+    completed: 0,
+  }
+
+  for (const event of events) {
+    if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.SIGNED_UP) {
+      reliability.signedUp += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED) {
+      reliability.imported += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED) {
+      reliability.assigned += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED) {
+      reliability.confirmed += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED) {
+      reliability.declined += 1
+    } else if (
+      event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CHANGE_REQUESTED
+    ) {
+      reliability.changeRequested += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW) {
+      reliability.noShow += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED) {
+      reliability.completed += 1
+    }
+  }
+
+  return reliability
+}
+
+function dedupeCredentials(
+  credentials: CrewReturningVolunteerSuggestion["credentials"],
+) {
+  const seen = new Set<string>()
+  return credentials.filter((credential) => {
+    const key = [
+      credential.credentialType,
+      credential.credentialLabel.toLowerCase(),
+      credential.status,
+    ].join("|")
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function compareReturningVolunteerSuggestions(
+  left: CrewReturningVolunteerSuggestion,
+  right: CrewReturningVolunteerSuggestion,
+) {
+  const eventCountDelta = right.priorEventCount - left.priorEventCount
+  if (eventCountDelta !== 0) return eventCountDelta
+
+  const leftLast = left.lastEvent ? toTime(left.lastEvent.occurredAt) : 0
+  const rightLast = right.lastEvent ? toTime(right.lastEvent.occurredAt) : 0
+  if (rightLast !== leftLast) return rightLast - leftLast
+
+  return left.volunteerName.localeCompare(right.volunteerName)
+}
+
+function toIsoString(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? new Date(0).toISOString() : date.toISOString()
+}
+
+function toTime(value: Date | string) {
+  const time = new Date(value).getTime()
+  return Number.isNaN(time) ? 0 : time
+}

--- a/apps/crew/src/routes/events/$eventId/volunteers.tsx
+++ b/apps/crew/src/routes/events/$eventId/volunteers.tsx
@@ -7,7 +7,7 @@ import {
   useRouter,
 } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
-import { ClipboardPaste, Loader2, Pencil, UserPlus } from "lucide-react"
+import { ClipboardPaste, History, Loader2, Pencil, UserPlus } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
@@ -36,6 +36,7 @@ import {
   VOLUNTEER_ROLE_OPTIONS,
 } from "@/db/schemas/volunteers"
 import { formatCrewValue } from "@/lib/crew-event-display"
+import type { CrewReturningVolunteerSuggestion } from "@/lib/crew/returning-volunteers"
 import type {
   CrewRosterStatus,
   CrewRosterVolunteer,
@@ -62,7 +63,8 @@ const parentRoute = getRouteApi("/events/$eventId")
 
 function VolunteersPage() {
   const { eventId } = parentRoute.useParams()
-  const { roster, summary, shiftSummary } = Route.useLoaderData()
+  const { roster, summary, shiftSummary, returningVolunteerSuggestions } =
+    Route.useLoaderData()
   const router = useRouter()
   const [addOpen, setAddOpen] = useState(false)
   const [pasteOpen, setPasteOpen] = useState(false)
@@ -111,6 +113,8 @@ function VolunteersPage() {
           value={shiftSummary.confirmationSummary.confirmed}
         />
       </div>
+
+      <ReturningVolunteersPanel suggestions={returningVolunteerSuggestions} />
 
       <section className="overflow-hidden rounded-md border bg-card shadow-sm">
         {roster.length > 0 ? (
@@ -169,6 +173,142 @@ function VolunteersPage() {
         onSaved={reloadRoster}
       />
     </section>
+  )
+}
+
+function ReturningVolunteersPanel({
+  suggestions,
+}: {
+  suggestions: CrewReturningVolunteerSuggestion[]
+}) {
+  if (suggestions.length === 0) return null
+
+  return (
+    <section className="rounded-md border bg-card shadow-sm">
+      <div className="flex items-center gap-2 border-b px-4 py-3">
+        <History className="h-4 w-4 text-muted-foreground" />
+        <div>
+          <h3 className="font-semibold">Returning volunteers</h3>
+          <p className="text-sm text-muted-foreground">
+            {suggestions.length} matched on organizer history
+          </p>
+        </div>
+      </div>
+      <div className="divide-y">
+        {suggestions.map((suggestion) => (
+          <ReturningVolunteerRow
+            key={suggestion.rosterVolunteerId}
+            suggestion={suggestion}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ReturningVolunteerRow({
+  suggestion,
+}: {
+  suggestion: CrewReturningVolunteerSuggestion
+}) {
+  const facts = buildReturningVolunteerFacts(suggestion)
+
+  return (
+    <div className="grid gap-3 px-4 py-3 md:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+      <div>
+        <div className="font-medium">{suggestion.volunteerName}</div>
+        <div className="mt-1 text-sm text-muted-foreground">
+          {suggestion.priorEventCount} prior event
+          {suggestion.priorEventCount === 1 ? "" : "s"}
+          {suggestion.lastEvent ? (
+            <>
+              {" "}
+              · Last: {suggestion.lastEvent.label},{" "}
+              {formatReturningVolunteerDate(suggestion.lastEvent.occurredAt)}
+            </>
+          ) : null}
+        </div>
+        <div className="mt-2 flex flex-wrap gap-1">
+          {suggestion.currentRoleTypes.map((roleType) => (
+            <span
+              key={roleType}
+              className="rounded-md border bg-background px-2 py-1 text-xs"
+            >
+              {formatVolunteerRole(roleType)}
+            </span>
+          ))}
+          <span className="rounded-md border bg-background px-2 py-1 text-xs">
+            {formatVolunteerAvailability(suggestion.currentAvailability)}
+          </span>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <FactList facts={facts} />
+        {suggestion.priorRoleTypes.length > 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Prior roles:{" "}
+            {suggestion.priorRoleTypes.map(formatVolunteerRole).join(", ")}
+          </p>
+        ) : null}
+        {suggestion.credentials.length > 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Credentials:{" "}
+            {suggestion.credentials
+              .map(
+                (credential) =>
+                  `${credential.credentialLabel} (${formatCrewValue(
+                    credential.status,
+                  )})`,
+              )
+              .join(", ")}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function FactList({ facts }: { facts: string[] }) {
+  if (facts.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-1">
+      {facts.map((fact) => (
+        <span
+          key={fact}
+          className="rounded-md border bg-background px-2 py-1 text-xs"
+        >
+          {fact}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function buildReturningVolunteerFacts(
+  suggestion: CrewReturningVolunteerSuggestion,
+) {
+  const { reliability } = suggestion
+  return [
+    formatReturningFact("Confirmed", reliability.confirmed),
+    formatReturningFact("Completed", reliability.completed),
+    formatReturningFact("Assigned", reliability.assigned),
+    formatReturningFact("Signed up", reliability.signedUp),
+    formatReturningFact("Imported", reliability.imported),
+    formatReturningFact("Declined", reliability.declined),
+    formatReturningFact("Change requested", reliability.changeRequested),
+    formatReturningFact("No-show", reliability.noShow),
+  ].filter((fact): fact is string => Boolean(fact))
+}
+
+function formatReturningFact(label: string, count: number) {
+  return count > 0 ? `${label} ${count}` : null
+}
+
+function formatReturningVolunteerDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "unknown date"
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+    date,
   )
 }
 

--- a/apps/crew/src/server/crew-roster-shift.server.ts
+++ b/apps/crew/src/server/crew-roster-shift.server.ts
@@ -3,7 +3,7 @@
 // @lat: [[crew#Shift Board Pilot Ops]]
 // @lat: [[crew#Roster Volunteer Editing]]
 import { createId } from "@paralleldrive/cuid2"
-import { and, asc, eq, inArray, sql } from "drizzle-orm"
+import { and, asc, eq, gt, inArray, isNull, or, sql } from "drizzle-orm"
 import { getDb } from "../db"
 import {
   createTeamInvitationId,
@@ -13,6 +13,13 @@ import type { Competition } from "../db/schemas/competitions"
 import { competitionsTable } from "../db/schemas/competitions"
 import { CREW_ASSIGNMENT_CONFIRMATION_TYPE } from "../db/schemas/crew-imports"
 import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import {
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  crewVolunteerCredentialsTable,
+  crewVolunteerHistoryEventsTable,
+  crewVolunteerIdentitiesTable,
+} from "../db/schemas/crew-volunteer-intelligence"
 import {
   INVITATION_STATUS,
   SYSTEM_ROLES_ENUM,
@@ -39,6 +46,11 @@ import {
   parseManualVolunteerEmailPaste,
   planManualVolunteerIntake,
 } from "../lib/crew/manual-volunteer-intake"
+import {
+  buildReturningVolunteerSuggestions,
+  type CrewReturningVolunteerSuggestion,
+  type ReturningVolunteerIdentityRecord,
+} from "../lib/crew/returning-volunteers"
 import type {
   CrewRosterSummary,
   CrewRosterVolunteer,
@@ -86,6 +98,7 @@ import {
   formatDateTimeInTimezone,
 } from "../utils/timezone-utils"
 import { getFirstExecuteValue } from "../server-fns/db-execute"
+import { hashCrewVolunteerContactAnchor } from "./crew-volunteer-history.server"
 
 type DbClient = ReturnType<typeof getDb>
 
@@ -141,6 +154,7 @@ export interface CrewRosterPageData {
   roster: CrewRosterVolunteer[]
   summary: CrewRosterSummary
   shiftSummary: CrewShiftSummary
+  returningVolunteerSuggestions: CrewReturningVolunteerSuggestion[]
 }
 
 export interface CrewShiftBoardData {
@@ -285,12 +299,15 @@ export async function getCrewRosterPage(
     access,
     scopedShifts,
   )
+  const returningVolunteerSuggestions =
+    await loadReturningVolunteerSuggestions(event, scopedRoster)
 
   return {
     event,
     roster: scopedRoster,
     summary: summarizeCrewRoster(scopedRoster),
     shiftSummary: summarizeCrewShifts(scopedShifts),
+    returningVolunteerSuggestions,
   }
 }
 
@@ -917,6 +934,198 @@ export async function loadCrewRoster(competitionTeamId: string) {
   return buildCrewRoster(invitations, memberships)
 }
 
+async function loadReturningVolunteerSuggestions(
+  event: CrewRosterCompetition,
+  roster: CrewRosterVolunteer[],
+) {
+  if (roster.length === 0) return []
+
+  const db = getDb()
+  const emailHashesByRosterId = new Map<string, string>()
+  const membershipIds = uniqueText(
+    roster.map((volunteer) => volunteer.membershipId),
+  )
+  const invitationIds = uniqueText(
+    roster.map((volunteer) => volunteer.invitationId),
+  )
+
+  for (const volunteer of roster) {
+    const emailHash = await hashCrewVolunteerContactAnchor(
+      "email",
+      volunteer.email,
+    )
+    if (emailHash) {
+      emailHashesByRosterId.set(volunteer.id, emailHash)
+    }
+  }
+
+  const emailHashes = uniqueText([...emailHashesByRosterId.values()])
+  const identityConditions = [
+    emailHashes.length > 0
+      ? inArray(crewVolunteerIdentitiesTable.emailHash, emailHashes)
+      : null,
+    membershipIds.length > 0
+      ? inArray(crewVolunteerIdentitiesTable.sourceMembershipId, membershipIds)
+      : null,
+    invitationIds.length > 0
+      ? inArray(crewVolunteerIdentitiesTable.sourceInvitationId, invitationIds)
+      : null,
+  ].filter((condition): condition is NonNullable<typeof condition> =>
+    Boolean(condition),
+  )
+
+  if (identityConditions.length === 0) return []
+
+  const identityRows = await db
+    .select({
+      id: crewVolunteerIdentitiesTable.id,
+      teamId: crewVolunteerIdentitiesTable.teamId,
+      emailHash: crewVolunteerIdentitiesTable.emailHash,
+      sourceMembershipId: crewVolunteerIdentitiesTable.sourceMembershipId,
+      sourceInvitationId: crewVolunteerIdentitiesTable.sourceInvitationId,
+    })
+    .from(crewVolunteerIdentitiesTable)
+    .where(
+      and(
+        eq(crewVolunteerIdentitiesTable.teamId, event.organizingTeamId),
+        identityConditions.length === 1
+          ? identityConditions[0]
+          : or(...identityConditions),
+      ),
+    )
+
+  const identities = buildReturningVolunteerIdentityMatches({
+    roster,
+    identityRows,
+    emailHashesByRosterId,
+  })
+  const identityIds = uniqueText(identities.map((identity) => identity.id))
+  if (identityIds.length === 0) return []
+
+  const [historyEvents, credentials] = await Promise.all([
+    db
+      .select({
+        identityId: crewVolunteerHistoryEventsTable.identityId,
+        teamId: crewVolunteerHistoryEventsTable.teamId,
+        competitionId: crewVolunteerHistoryEventsTable.competitionId,
+        competitionName: competitionsTable.name,
+        eventType: crewVolunteerHistoryEventsTable.eventType,
+        visibilityScope: crewVolunteerHistoryEventsTable.visibilityScope,
+        roleType: crewVolunteerHistoryEventsTable.roleType,
+        occurredAt: crewVolunteerHistoryEventsTable.occurredAt,
+      })
+      .from(crewVolunteerHistoryEventsTable)
+      .leftJoin(
+        competitionsTable,
+        eq(crewVolunteerHistoryEventsTable.competitionId, competitionsTable.id),
+      )
+      .where(
+        and(
+          eq(crewVolunteerHistoryEventsTable.teamId, event.organizingTeamId),
+          inArray(crewVolunteerHistoryEventsTable.identityId, identityIds),
+          eq(
+            crewVolunteerHistoryEventsTable.visibilityScope,
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          ),
+        ),
+      ),
+    db
+      .select({
+        identityId: crewVolunteerCredentialsTable.identityId,
+        teamId: crewVolunteerCredentialsTable.teamId,
+        credentialType: crewVolunteerCredentialsTable.credentialType,
+        credentialLabel: crewVolunteerCredentialsTable.credentialLabel,
+        status: crewVolunteerCredentialsTable.status,
+        visibilityScope: crewVolunteerCredentialsTable.visibilityScope,
+        expiresAt: crewVolunteerCredentialsTable.expiresAt,
+        revokedAt: crewVolunteerCredentialsTable.revokedAt,
+      })
+      .from(crewVolunteerCredentialsTable)
+      .where(
+        and(
+          eq(crewVolunteerCredentialsTable.teamId, event.organizingTeamId),
+          inArray(crewVolunteerCredentialsTable.identityId, identityIds),
+          eq(
+            crewVolunteerCredentialsTable.visibilityScope,
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          ),
+          inArray(crewVolunteerCredentialsTable.status, [
+            CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED,
+            CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+          ]),
+          isNull(crewVolunteerCredentialsTable.revokedAt),
+          or(
+            isNull(crewVolunteerCredentialsTable.expiresAt),
+            gt(crewVolunteerCredentialsTable.expiresAt, new Date()),
+          ),
+        ),
+      ),
+  ])
+
+  return buildReturningVolunteerSuggestions({
+    organizerTeamId: event.organizingTeamId,
+    currentCompetitionId: event.id,
+    roster: roster.map((volunteer) => ({
+      id: volunteer.id,
+      name: volunteer.name,
+      status: volunteer.status,
+      availability: volunteer.availability,
+      roleTypes: volunteer.roleTypes,
+    })),
+    identities,
+    historyEvents,
+    credentials,
+  })
+}
+
+function buildReturningVolunteerIdentityMatches({
+  roster,
+  identityRows,
+  emailHashesByRosterId,
+}: {
+  roster: CrewRosterVolunteer[]
+  identityRows: Array<{
+    id: string
+    teamId: string
+    emailHash: string | null
+    sourceMembershipId: string | null
+    sourceInvitationId: string | null
+  }>
+  emailHashesByRosterId: Map<string, string>
+}): ReturningVolunteerIdentityRecord[] {
+  const matches: ReturningVolunteerIdentityRecord[] = []
+  const seen = new Set<string>()
+
+  for (const volunteer of roster) {
+    const emailHash = emailHashesByRosterId.get(volunteer.id)
+    for (const identity of identityRows) {
+      const matchedByEmail =
+        emailHash !== undefined && identity.emailHash === emailHash
+      const matchedByMembership =
+        volunteer.membershipId !== null &&
+        identity.sourceMembershipId === volunteer.membershipId
+      const matchedByInvitation =
+        volunteer.invitationId !== null &&
+        identity.sourceInvitationId === volunteer.invitationId
+
+      if (!matchedByEmail && !matchedByMembership && !matchedByInvitation) {
+        continue
+      }
+
+      const key = `${volunteer.id}:${identity.id}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      matches.push({
+        id: identity.id,
+        teamId: identity.teamId,
+        rosterVolunteerId: volunteer.id,
+      })
+    }
+  }
+
+  return matches
+}
+
 async function createManualCrewVolunteerRows(
   event: CrewRosterCompetition,
   rows: ManualCrewVolunteerCreateRow[],
@@ -1286,6 +1495,10 @@ async function requireCrewShift(competitionId: string, shiftId: string) {
 function emptyToNull(value: string | null | undefined) {
   const trimmed = value?.trim()
   return trimmed ? trimmed : null
+}
+
+function uniqueText(values: Array<string | null | undefined>) {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))]
 }
 
 function getAssignmentConfirmationExpiry(now: Date) {


### PR DESCRIPTION
## Summary
- add a same-organizer returning-volunteer summary helper with focused coverage for current-event exclusion, organizer scoping, factual counts, and safe fields
- load returning-volunteer suggestions from merged Crew volunteer identity/history/credential tables on the existing organizer roster page
- render a read-only returning volunteers panel with prior event count, last event, prior roles, factual response counts, and safe credential claims

## Privacy and scope
- same-organizer only via organizingTeamId and SAME_ORGANIZER visibility
- no cross-organizer discovery, consent mutation, invite sending, queue/email/SMS behavior, raw contact details, internal notes, billing refs, rankings, ratings, or negative badges
- no schema or migration changes

## Validation
- pnpm --filter crew test -- src/lib/crew/returning-volunteers.test.ts
- pnpm --filter crew type-check
- pnpm --filter crew lint (exits 0; existing unrelated warnings remain)
- CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build
- pnpm dlx lat.md locate 'crew#Strategic Moat Privacy Model'
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show returning volunteers on the event roster page to help organizers spot prior contributors without exposing contact info. Suggestions are scoped to the same organizer and exclude the current event.

- New Features
  - Added `buildReturningVolunteerSuggestions` to summarize history and safe credentials with `SAME_ORGANIZER` visibility; counts prior events and reliability facts.
  - Loaded identity matches by email hash/membership/invitation and fetched history/credentials in `crew-roster-shift.server.ts`, filtering expired/revoked credentials; no schema changes.
  - Rendered a read-only “Returning volunteers” panel in `/events/$eventId/volunteers` with prior event count, last event, prior roles, reliability chips, and safe credential claims.
  - Added unit tests in `returning-volunteers.test.ts` for current-event exclusion, organizer scoping, factual counts, and safe field output.

<sup>Written for commit 92bc776caefe4291ba2ac0e6f98169c30903a46b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Returning Volunteers" section to the event volunteers page, displaying suggestions for experienced volunteers from the same organizer with their prior event counts, last event details, prior roles worked, and verified credentials.
  * Suggestions include reliability metrics and only display safe, non-expired credential information while filtering out sensitive data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->