### PR TITLE
[codex] feat(crew): add volunteer consent center

### DIFF
--- a/apps/crew/src/lib/crew/volunteer-consent-center.test.ts
+++ b/apps/crew/src/lib/crew/volunteer-consent-center.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest"
+import {
+  CREW_VOLUNTEER_CONSENT_SCOPE,
+  CREW_VOLUNTEER_CONSENT_SOURCE,
+  CREW_VOLUNTEER_CONSENT_STATUS,
+  CREW_VOLUNTEER_DISCOVERY_AGE_STATUS,
+} from "../../db/schemas/crew-volunteer-intelligence"
+import {
+  buildCrewVolunteerConsentCenterView,
+  getCrewVolunteerConsentText,
+  hashCrewVolunteerConsentText,
+  resolveCrewVolunteerConsentMutation,
+} from "./volunteer-consent-center"
+
+describe("Crew volunteer consent center view model", () => {
+  it("summarizes consent state without leaking raw contact or private metadata", () => {
+    const view = buildCrewVolunteerConsentCenterView({
+      eventName: "Boise Throwdown",
+      volunteerLabel: "Your crew profile",
+      identityAgeStatus: CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.ADULT_CONFIRMED,
+      consentRecords: [
+        {
+          id: "cvcon_communication",
+          scope: CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY,
+          status: CREW_VOLUNTEER_CONSENT_STATUS.GRANTED,
+          consentTextVersion: "2026-06-21.v1",
+          source: CREW_VOLUNTEER_CONSENT_SOURCE.CONSENT_CENTER,
+          sourceSurface: "public_consent_center",
+          grantedAt: "2026-06-21T12:00:00.000Z",
+          revokedAt: null,
+          supersededByConsentId: null,
+        },
+      ],
+    })
+
+    expect(view.scopes).toEqual([
+      expect.objectContaining({
+        scope: CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY,
+        granted: true,
+        canRevoke: true,
+        statusLabel: "Granted",
+      }),
+      expect.objectContaining({
+        scope: CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+        granted: false,
+        canGrant: true,
+        statusLabel: "Not granted",
+      }),
+    ])
+    const serialized = JSON.stringify(view)
+    expect(serialized).not.toContain("ada@example.com")
+    expect(serialized).not.toContain("555")
+    expect(serialized).not.toContain("emergency")
+    expect(serialized).not.toContain("internalNotes")
+    expect(serialized).not.toContain("stripe")
+  })
+
+  it("keeps imported or unknown-age volunteers out of regional discovery by default", () => {
+    const view = buildCrewVolunteerConsentCenterView({
+      eventName: "Boise Throwdown",
+      volunteerLabel: "Your crew profile",
+      identityAgeStatus: CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.UNKNOWN,
+      consentRecords: [],
+    })
+
+    expect(
+      view.scopes.find(
+        (scope) =>
+          scope.scope === CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+      ),
+    ).toMatchObject({
+      granted: false,
+      canGrant: false,
+      disabledReason:
+        "Regional discovery requires adult eligibility before opt-in.",
+    })
+  })
+
+  it("treats revocation as the current state while retaining audit metadata", () => {
+    const view = buildCrewVolunteerConsentCenterView({
+      eventName: "Boise Throwdown",
+      volunteerLabel: "Your crew profile",
+      identityAgeStatus: CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.ADULT_CONFIRMED,
+      consentRecords: [
+        {
+          id: "cvcon_old",
+          scope: CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+          status: CREW_VOLUNTEER_CONSENT_STATUS.REVOKED,
+          consentTextVersion: "2026-06-21.v1",
+          source: CREW_VOLUNTEER_CONSENT_SOURCE.CONSENT_CENTER,
+          sourceSurface: "public_consent_center",
+          grantedAt: "2026-06-20T12:00:00.000Z",
+          revokedAt: "2026-06-21T12:00:00.000Z",
+          supersededByConsentId: "cvcon_revoke",
+        },
+        {
+          id: "cvcon_revoke",
+          scope: CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+          status: CREW_VOLUNTEER_CONSENT_STATUS.REVOKED,
+          consentTextVersion: "2026-06-21.v1",
+          source: CREW_VOLUNTEER_CONSENT_SOURCE.CONSENT_CENTER,
+          sourceSurface: "public_consent_center",
+          grantedAt: "2026-06-21T12:00:00.000Z",
+          revokedAt: "2026-06-21T12:00:00.000Z",
+          supersededByConsentId: null,
+        },
+      ],
+    })
+
+    expect(
+      view.scopes.find(
+        (scope) =>
+          scope.scope === CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+      ),
+    ).toMatchObject({
+      currentConsentId: "cvcon_revoke",
+      granted: false,
+      canGrant: true,
+      statusLabel: "Revoked",
+      lastUpdatedAt: "2026-06-21T12:00:00.000Z",
+    })
+  })
+})
+
+describe("Crew volunteer consent mutation policy", () => {
+  it("blocks regional discovery grants without adult eligibility", () => {
+    expect(
+      resolveCrewVolunteerConsentMutation({
+        action: "grant",
+        scope: CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+        identityAgeStatus: CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.MINOR_BLOCKED,
+        activeConsentId: null,
+      }),
+    ).toEqual({ ok: false, reason: "regional_age_blocked" })
+  })
+
+  it("makes repeated grant and revoke actions idempotent", () => {
+    expect(
+      resolveCrewVolunteerConsentMutation({
+        action: "grant",
+        scope: CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY,
+        identityAgeStatus: CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.UNKNOWN,
+        activeConsentId: "cvcon_active",
+      }),
+    ).toEqual({ ok: true, outcome: "idempotent" })
+
+    expect(
+      resolveCrewVolunteerConsentMutation({
+        action: "revoke",
+        scope: CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY,
+        identityAgeStatus: CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.UNKNOWN,
+        activeConsentId: null,
+      }),
+    ).toEqual({ ok: true, outcome: "idempotent" })
+  })
+
+  it("hashes versioned consent text without raw contact fields", async () => {
+    const text = getCrewVolunteerConsentText({
+      scope: CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY,
+      action: "grant",
+    })
+    const hash = await hashCrewVolunteerConsentText(text)
+
+    expect(text).toContain("does not enable SMS messaging")
+    expect(text).not.toContain("555")
+    expect(hash).toMatch(/^sha256:[0-9a-f]{64}$/)
+    await expect(hashCrewVolunteerConsentText(text)).resolves.toBe(hash)
+  })
+})

--- a/apps/crew/src/lib/crew/volunteer-consent-center.ts
+++ b/apps/crew/src/lib/crew/volunteer-consent-center.ts
@@ -1,0 +1,237 @@
+import {
+  CREW_VOLUNTEER_CONSENT_SCOPE,
+  CREW_VOLUNTEER_CONSENT_STATUS,
+  CREW_VOLUNTEER_DISCOVERY_AGE_STATUS,
+  type CrewVolunteerConsentScope,
+  type CrewVolunteerConsentSource,
+  type CrewVolunteerConsentStatus,
+  type CrewVolunteerDiscoveryAgeStatus,
+} from "../../db/schemas/crew-volunteer-intelligence"
+
+export const CREW_VOLUNTEER_CONSENT_CENTER_VERSION = "2026-06-21.v1"
+export const CREW_VOLUNTEER_CONSENT_CENTER_SURFACE = "public_consent_center"
+
+export const CREW_VOLUNTEER_CONSENT_CENTER_SCOPES = [
+  CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY,
+  CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+] as const
+
+export type CrewVolunteerConsentCenterScope =
+  (typeof CREW_VOLUNTEER_CONSENT_CENTER_SCOPES)[number]
+
+export type CrewVolunteerConsentCenterAction = "grant" | "revoke"
+
+export interface CrewVolunteerConsentCenterRecord {
+  id: string
+  scope: CrewVolunteerConsentScope
+  status: CrewVolunteerConsentStatus
+  consentTextVersion: string
+  source: CrewVolunteerConsentSource
+  sourceSurface: string
+  grantedAt: Date | string
+  revokedAt: Date | string | null
+  supersededByConsentId: string | null
+  updatedAt?: Date | string | null
+}
+
+export interface CrewVolunteerConsentCenterViewInput {
+  eventName: string
+  volunteerLabel: string
+  identityAgeStatus: CrewVolunteerDiscoveryAgeStatus | null
+  consentRecords: CrewVolunteerConsentCenterRecord[]
+}
+
+export interface CrewVolunteerConsentCenterScopeView {
+  scope: CrewVolunteerConsentCenterScope
+  label: string
+  description: string
+  granted: boolean
+  canGrant: boolean
+  canRevoke: boolean
+  disabledReason: string | null
+  currentConsentId: string | null
+  statusLabel: string
+  lastUpdatedAt: string | null
+  consentTextVersion: string | null
+}
+
+export interface CrewVolunteerConsentCenterView {
+  eventName: string
+  volunteerLabel: string
+  scopes: CrewVolunteerConsentCenterScopeView[]
+  notices: string[]
+}
+
+export interface CrewVolunteerConsentMutationInput {
+  action: CrewVolunteerConsentCenterAction
+  scope: CrewVolunteerConsentCenterScope
+  identityAgeStatus: CrewVolunteerDiscoveryAgeStatus | null
+  activeConsentId?: string | null
+}
+
+export type CrewVolunteerConsentMutationResolution =
+  | { ok: true; outcome: "grant" | "revoke" | "idempotent" }
+  | { ok: false; reason: "scope_not_supported" | "regional_age_blocked" }
+
+export function buildCrewVolunteerConsentCenterView({
+  eventName,
+  volunteerLabel,
+  identityAgeStatus,
+  consentRecords,
+}: CrewVolunteerConsentCenterViewInput): CrewVolunteerConsentCenterView {
+  const currentByScope = new Map<
+    CrewVolunteerConsentCenterScope,
+    CrewVolunteerConsentCenterRecord
+  >()
+  const sortedRecords = [...consentRecords].sort(compareConsentRecordsDesc)
+
+  for (const record of sortedRecords) {
+    if (!isCrewVolunteerConsentCenterScope(record.scope)) continue
+    if (currentByScope.has(record.scope)) continue
+    currentByScope.set(record.scope, record)
+  }
+
+  return {
+    eventName,
+    volunteerLabel,
+    scopes: CREW_VOLUNTEER_CONSENT_CENTER_SCOPES.map((scope) =>
+      buildScopeView(
+        scope,
+        currentByScope.get(scope) ?? null,
+        identityAgeStatus,
+      ),
+    ),
+    notices: [
+      "SMS messaging is not enabled from this consent center.",
+      "Regional discovery stays off unless you explicitly opt in and the account is eligible.",
+    ],
+  }
+}
+
+export function resolveCrewVolunteerConsentMutation({
+  action,
+  scope,
+  identityAgeStatus,
+  activeConsentId,
+}: CrewVolunteerConsentMutationInput): CrewVolunteerConsentMutationResolution {
+  if (!isCrewVolunteerConsentCenterScope(scope)) {
+    return { ok: false, reason: "scope_not_supported" }
+  }
+  if (
+    action === "grant" &&
+    scope === CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY &&
+    identityAgeStatus !== CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.ADULT_CONFIRMED
+  ) {
+    return { ok: false, reason: "regional_age_blocked" }
+  }
+  if (action === "grant" && activeConsentId) {
+    return { ok: true, outcome: "idempotent" }
+  }
+  if (action === "revoke" && !activeConsentId) {
+    return { ok: true, outcome: "idempotent" }
+  }
+  return { ok: true, outcome: action }
+}
+
+export function isCrewVolunteerConsentCenterScope(
+  scope: string,
+): scope is CrewVolunteerConsentCenterScope {
+  return CREW_VOLUNTEER_CONSENT_CENTER_SCOPES.includes(
+    scope as CrewVolunteerConsentCenterScope,
+  )
+}
+
+export function getCrewVolunteerConsentText(params: {
+  scope: CrewVolunteerConsentCenterScope
+  action: CrewVolunteerConsentCenterAction
+}) {
+  if (params.scope === CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY) {
+    return params.action === "grant"
+      ? "I agree that WODsmith Crew may keep my crew communication history for this organizing team so future event crew workflows can use factual prior email and assignment response context. This does not enable SMS messaging."
+      : "I revoke permission for WODsmith Crew to use my crew communication history for future event crew workflows. This does not delete prior audit records."
+  }
+
+  return params.action === "grant"
+    ? "I agree that WODsmith Crew may mark me as eligible for regional volunteer discovery after eligibility checks. Discovery must not expose my raw email, phone, private notes, billing data, or emergency contact details."
+    : "I revoke permission for WODsmith Crew to include me in future regional volunteer discovery. This does not delete prior audit records."
+}
+
+export async function hashCrewVolunteerConsentText(text: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(
+      `${CREW_VOLUNTEER_CONSENT_CENTER_VERSION}:${text}`,
+    ),
+  )
+  return `sha256:${bytesToHex(new Uint8Array(digest))}`
+}
+
+function buildScopeView(
+  scope: CrewVolunteerConsentCenterScope,
+  record: CrewVolunteerConsentCenterRecord | null,
+  identityAgeStatus: CrewVolunteerDiscoveryAgeStatus | null,
+): CrewVolunteerConsentCenterScopeView {
+  const granted = record?.status === CREW_VOLUNTEER_CONSENT_STATUS.GRANTED
+  const regionalAgeBlocked =
+    scope === CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY &&
+    identityAgeStatus !== CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.ADULT_CONFIRMED
+
+  return {
+    scope,
+    label:
+      scope === CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY
+        ? "Communication history"
+        : "Regional discovery",
+    description:
+      scope === CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY
+        ? "Let this organizing team use factual crew communication and assignment response history for future Crew workflows."
+        : "Allow future regional volunteer discovery only after eligibility checks. Raw contact and private metadata stay hidden.",
+    granted,
+    canGrant: !granted && !regionalAgeBlocked,
+    canRevoke: granted,
+    disabledReason: regionalAgeBlocked
+      ? "Regional discovery requires adult eligibility before opt-in."
+      : null,
+    currentConsentId: record?.id ?? null,
+    statusLabel: granted
+      ? "Granted"
+      : record?.status === CREW_VOLUNTEER_CONSENT_STATUS.REVOKED
+        ? "Revoked"
+        : "Not granted",
+    lastUpdatedAt: record
+      ? toIsoString(record.revokedAt ?? record.updatedAt ?? record.grantedAt)
+      : null,
+    consentTextVersion: record?.consentTextVersion ?? null,
+  }
+}
+
+function compareConsentRecordsDesc(
+  left: CrewVolunteerConsentCenterRecord,
+  right: CrewVolunteerConsentCenterRecord,
+) {
+  const effectiveDiff = getConsentSortTime(right) - getConsentSortTime(left)
+  if (effectiveDiff !== 0) return effectiveDiff
+  return toTime(right.grantedAt) - toTime(left.grantedAt)
+}
+
+function getConsentSortTime(record: CrewVolunteerConsentCenterRecord) {
+  return toTime(record.revokedAt ?? record.updatedAt ?? record.grantedAt)
+}
+
+function toTime(value: Date | string | null | undefined) {
+  if (!value) return 0
+  const date = value instanceof Date ? value : new Date(value)
+  const time = date.getTime()
+  return Number.isNaN(time) ? 0 : time
+}
+
+function toIsoString(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function bytesToHex(bytes: Uint8Array) {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+    "",
+  )
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
 import { Route as ESlugScheduleTokenRouteImport } from './routes/e/$slug/schedule/$token'
+import { Route as ESlugConsentTokenRouteImport } from './routes/e/$slug/consent/$token'
 import { Route as ESlugConfirmTokenRouteImport } from './routes/e/$slug/confirm/$token'
 
 const EventsRoute = EventsRouteImport.update({
@@ -137,6 +138,11 @@ const ESlugScheduleTokenRoute = ESlugScheduleTokenRouteImport.update({
   path: '/e/$slug/schedule/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ESlugConsentTokenRoute = ESlugConsentTokenRouteImport.update({
+  id: '/e/$slug/consent/$token',
+  path: '/e/$slug/consent/$token',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ESlugConfirmTokenRoute = ESlugConfirmTokenRouteImport.update({
   id: '/e/$slug/confirm/$token',
   path: '/e/$slug/confirm/$token',
@@ -165,6 +171,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
+  '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRoutesByTo {
@@ -188,6 +195,7 @@ export interface FileRoutesByTo {
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
+  '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRoutesById {
@@ -213,6 +221,7 @@ export interface FileRoutesById {
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
+  '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
 }
 export interface FileRouteTypes {
@@ -239,6 +248,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
     | '/e/$slug/confirm/$token'
+    | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -262,6 +272,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/volunteers'
     | '/events/$eventId'
     | '/e/$slug/confirm/$token'
+    | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
   id:
     | '__root__'
@@ -286,6 +297,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/volunteers'
     | '/events/$eventId/'
     | '/e/$slug/confirm/$token'
+    | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
   fileRoutesById: FileRoutesById
 }
@@ -297,6 +309,7 @@ export interface RootRouteChildren {
   ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute
   ESlugVolunteerRoute: typeof ESlugVolunteerRoute
   ESlugConfirmTokenRoute: typeof ESlugConfirmTokenRoute
+  ESlugConsentTokenRoute: typeof ESlugConsentTokenRoute
   ESlugScheduleTokenRoute: typeof ESlugScheduleTokenRoute
 }
 
@@ -449,6 +462,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ESlugScheduleTokenRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/e/$slug/consent/$token': {
+      id: '/e/$slug/consent/$token'
+      path: '/e/$slug/consent/$token'
+      fullPath: '/e/$slug/consent/$token'
+      preLoaderRoute: typeof ESlugConsentTokenRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/e/$slug/confirm/$token': {
       id: '/e/$slug/confirm/$token'
       path: '/e/$slug/confirm/$token'
@@ -514,6 +534,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiWebhooksStripeRoute: ApiWebhooksStripeRoute,
   ESlugVolunteerRoute: ESlugVolunteerRoute,
   ESlugConfirmTokenRoute: ESlugConfirmTokenRoute,
+  ESlugConsentTokenRoute: ESlugConsentTokenRoute,
   ESlugScheduleTokenRoute: ESlugScheduleTokenRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/crew/src/routes/e/$slug/consent/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/consent/$token.tsx
@@ -1,0 +1,201 @@
+import { createFileRoute, notFound, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { Loader2, ShieldCheck, ShieldOff } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+import type {
+  CrewVolunteerConsentCenterAction,
+  CrewVolunteerConsentCenterScope,
+  CrewVolunteerConsentCenterScopeView,
+} from "@/lib/crew/volunteer-consent-center"
+import {
+  getCrewVolunteerConsentCenterTokenFn,
+  updateCrewVolunteerConsentCenterTokenFn,
+} from "@/server-fns/crew-volunteer-consent-fns"
+
+export const Route = createFileRoute("/e/$slug/consent/$token")({
+  loader: async ({ params }) => {
+    const result = await getCrewVolunteerConsentCenterTokenFn({
+      data: { slug: params.slug, token: params.token },
+    })
+    if (result.status !== "valid") {
+      throw notFound()
+    }
+    return result
+  },
+  component: CrewVolunteerConsentCenterPage,
+  head: ({ loaderData }) => ({
+    meta: [
+      {
+        title: loaderData?.view
+          ? `${loaderData.view.eventName} Consent Center | WODsmith Crew`
+          : "Volunteer Consent Center | WODsmith Crew",
+      },
+    ],
+  }),
+})
+
+function CrewVolunteerConsentCenterPage() {
+  const { slug, token } = Route.useParams()
+  const { view } = Route.useLoaderData()
+  const router = useRouter()
+  const updateConsent = useServerFn(updateCrewVolunteerConsentCenterTokenFn)
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+
+  async function handleConsentAction(
+    scope: CrewVolunteerConsentCenterScope,
+    action: CrewVolunteerConsentCenterAction,
+  ) {
+    const pendingKey = `${scope}:${action}`
+    setPendingAction(pendingKey)
+    try {
+      const result = await updateConsent({
+        data: { slug, token, scope, action },
+      })
+      if (result.success) {
+        toast.success(result.message)
+      } else {
+        toast.error(result.message)
+      }
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Consent update failed",
+      )
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <p className="text-sm font-medium text-muted-foreground">
+          Volunteer consent center
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold">{view.eventName}</h1>
+        <p className="mt-2 text-muted-foreground">{view.volunteerLabel}</p>
+      </section>
+
+      <section className="grid gap-4">
+        {view.scopes.map((scope) => (
+          <ConsentScopeCard
+            key={scope.scope}
+            scope={scope}
+            pendingAction={pendingAction}
+            onAction={handleConsentAction}
+          />
+        ))}
+      </section>
+
+      <section className="rounded-md border bg-card p-5 text-sm text-muted-foreground shadow-sm">
+        <ul className="grid gap-2">
+          {view.notices.map((notice) => (
+            <li key={notice}>{notice}</li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  )
+}
+
+function ConsentScopeCard({
+  scope,
+  pendingAction,
+  onAction,
+}: {
+  scope: CrewVolunteerConsentCenterScopeView
+  pendingAction: string | null
+  onAction: (
+    scope: CrewVolunteerConsentCenterScope,
+    action: CrewVolunteerConsentCenterAction,
+  ) => Promise<void>
+}) {
+  const grantPending = pendingAction === `${scope.scope}:grant`
+  const revokePending = pendingAction === `${scope.scope}:revoke`
+
+  return (
+    <article className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div className="flex items-center gap-2">
+            {scope.granted ? (
+              <ShieldCheck className="size-5 text-emerald-600" />
+            ) : (
+              <ShieldOff className="size-5 text-muted-foreground" />
+            )}
+            <h2 className="text-lg font-semibold">{scope.label}</h2>
+          </div>
+          <p className="text-sm text-muted-foreground">{scope.description}</p>
+        </div>
+        <span
+          className={`inline-flex w-fit rounded-md border px-2 py-1 text-xs font-medium ${
+            scope.granted
+              ? "border-emerald-200 bg-emerald-50 text-emerald-700"
+              : "border-muted bg-muted/40 text-muted-foreground"
+          }`}
+        >
+          {scope.statusLabel}
+        </span>
+      </div>
+
+      <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
+        <InfoRow
+          label="Last updated"
+          value={formatConsentDate(scope.lastUpdatedAt)}
+        />
+        <InfoRow
+          label="Consent text"
+          value={scope.consentTextVersion ?? "Not recorded"}
+        />
+      </dl>
+
+      {scope.disabledReason ? (
+        <p className="mt-4 rounded-md border bg-muted/30 px-3 py-2 text-sm text-muted-foreground">
+          {scope.disabledReason}
+        </p>
+      ) : null}
+
+      <div className="mt-5 flex flex-wrap gap-2">
+        <button
+          type="button"
+          disabled={!scope.canGrant || !!pendingAction}
+          onClick={() => onAction(scope.scope, "grant")}
+          className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {grantPending ? <Loader2 className="size-4 animate-spin" /> : null}
+          Grant
+        </button>
+        <button
+          type="button"
+          disabled={!scope.canRevoke || !!pendingAction}
+          onClick={() => onAction(scope.scope, "revoke")}
+          className="inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {revokePending ? <Loader2 className="size-4 animate-spin" /> : null}
+          Revoke
+        </button>
+      </div>
+    </article>
+  )
+}
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-sm text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function formatConsentDate(value: string | null) {
+  if (!value) return "Not recorded"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "Not recorded"
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -10,6 +10,7 @@ import {
   Mail,
   Phone,
   Printer,
+  ShieldCheck,
 } from "lucide-react"
 import { useMemo } from "react"
 import { useForm } from "react-hook-form"
@@ -100,6 +101,8 @@ export const Route = createFileRoute("/e/$slug/schedule/$token")({
 
 function CrewVolunteerScheduleTokenPage() {
   const loaderData = Route.useLoaderData()
+  const { slug, token } = Route.useParams()
+  const consentHref = buildConsentCenterHref(slug, token)
 
   if (loaderData.mode === "assignment") {
     return <CrewAssignmentSchedule data={loaderData.assignmentResult} />
@@ -114,13 +117,24 @@ function CrewVolunteerScheduleTokenPage() {
   return (
     <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
       <section className="rounded-md border bg-card p-6 shadow-sm">
-        <p className="text-sm font-medium text-muted-foreground">
-          Volunteer schedule
-        </p>
-        <h1 className="mt-2 text-3xl font-semibold">{event.name}</h1>
-        <p className="mt-2 text-muted-foreground">
-          {event.startDate} to {event.endDate}
-        </p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="text-sm font-medium text-muted-foreground">
+              Volunteer schedule
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold">{event.name}</h1>
+            <p className="mt-2 text-muted-foreground">
+              {event.startDate} to {event.endDate}
+            </p>
+          </div>
+          <a
+            href={consentHref}
+            className="inline-flex h-10 w-fit items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+          >
+            <ShieldCheck className="size-4" />
+            Consent
+          </a>
+        </div>
       </section>
 
       <section className="grid gap-4 sm:grid-cols-2">
@@ -211,6 +225,7 @@ function CrewAssignmentSchedule({
   const confirmHref = `/e/${encodeURIComponent(slug)}/confirm/${encodeURIComponent(
     token,
   )}`
+  const consentHref = buildConsentCenterHref(slug, token)
 
   async function handleContactSubmit(values: ContactFormValues) {
     try {
@@ -307,6 +322,13 @@ function CrewAssignmentSchedule({
               <Printer className="size-4" />
               Print
             </button>
+            <a
+              href={consentHref}
+              className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+            >
+              <ShieldCheck className="size-4" />
+              Consent
+            </a>
           </div>
         </div>
       </section>
@@ -574,4 +596,8 @@ function getContactDefaultValues(
 function emptyToUndefined(value: string | undefined) {
   const trimmed = value?.trim()
   return trimmed || undefined
+}
+
+function buildConsentCenterHref(slug: string, token: string) {
+  return `/e/${encodeURIComponent(slug)}/consent/${encodeURIComponent(token)}`
 }

--- a/apps/crew/src/server-fns/crew-volunteer-consent-fns.ts
+++ b/apps/crew/src/server-fns/crew-volunteer-consent-fns.ts
@@ -1,0 +1,54 @@
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+import { CREW_VOLUNTEER_CONSENT_SCOPE } from "../db/schemas/crew-volunteer-intelligence"
+import {
+  CREW_VOLUNTEER_CONSENT_CENTER_SCOPES,
+  type CrewVolunteerConsentCenterAction,
+} from "../lib/crew/volunteer-consent-center"
+
+export type {
+  CrewVolunteerConsentCenterTokenData,
+  CrewVolunteerConsentCenterTokenInput,
+  UpdateCrewVolunteerConsentCenterTokenInput,
+  UpdateCrewVolunteerConsentCenterTokenResult,
+} from "../server/crew-volunteer-consent.server"
+
+const publicTokenInputSchema = z.object({
+  slug: z.string().trim().min(1, "Event slug is required").max(255),
+  token: z.string().trim().min(1, "Token is required").max(255),
+})
+
+const updateConsentInputSchema = publicTokenInputSchema.extend({
+  scope: z.enum(CREW_VOLUNTEER_CONSENT_CENTER_SCOPES),
+  action: z.enum(["grant", "revoke"] satisfies [
+    CrewVolunteerConsentCenterAction,
+    CrewVolunteerConsentCenterAction,
+  ]),
+})
+
+export const getCrewVolunteerConsentCenterTokenFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) => publicTokenInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { getCrewVolunteerConsentCenterToken } = await import(
+      "../server/crew-volunteer-consent.server"
+    )
+    return getCrewVolunteerConsentCenterToken(data)
+  })
+
+export const updateCrewVolunteerConsentCenterTokenFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) => updateConsentInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { updateCrewVolunteerConsentCenterToken } = await import(
+      "../server/crew-volunteer-consent.server"
+    )
+    return updateCrewVolunteerConsentCenterToken(data)
+  })
+
+export const CREW_VOLUNTEER_CONSENT_CENTER_SCOPE_OPTIONS = {
+  COMMUNICATION_HISTORY: CREW_VOLUNTEER_CONSENT_SCOPE.COMMUNICATION_HISTORY,
+  REGIONAL_DISCOVERY: CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+} as const

--- a/apps/crew/src/server/crew-volunteer-consent.server.ts
+++ b/apps/crew/src/server/crew-volunteer-consent.server.ts
@@ -1,0 +1,648 @@
+import { and, desc, eq, ne, or } from "drizzle-orm"
+import { getDb } from "../db"
+import { competitionsTable } from "../db/schemas/competitions"
+import { createCrewVolunteerConsentId } from "../db/schemas/common"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+  crewAssignmentConfirmationsTable,
+} from "../db/schemas/crew-imports"
+import {
+  CREW_EVENT_LIFECYCLE,
+  crewEventSettingsTable,
+} from "../db/schemas/crew-event-settings"
+import {
+  CREW_VOLUNTEER_CONSENT_SOURCE,
+  CREW_VOLUNTEER_CONSENT_STATUS,
+  CREW_VOLUNTEER_DISCOVERY_AGE_STATUS,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+  crewVolunteerConsentsTable,
+  crewVolunteerIdentitiesTable,
+  type CrewVolunteerConsentScope,
+} from "../db/schemas/crew-volunteer-intelligence"
+import {
+  SYSTEM_ROLES_ENUM,
+  teamInvitationTable,
+  teamMembershipTable,
+} from "../db/schemas/teams"
+import { userTable } from "../db/schemas/users"
+import { volunteerShiftAssignmentsTable } from "../db/schemas/volunteers"
+import {
+  getCrewAssignmentConfirmationTokenState,
+  hashCrewAssignmentConfirmationToken,
+} from "../lib/crew/assignment-confirmations"
+import { parseCrewRosterMetadata } from "../lib/crew/roster-shifts"
+import {
+  CREW_VOLUNTEER_CONSENT_CENTER_SURFACE,
+  CREW_VOLUNTEER_CONSENT_CENTER_VERSION,
+  buildCrewVolunteerConsentCenterView,
+  getCrewVolunteerConsentText,
+  hashCrewVolunteerConsentText,
+  resolveCrewVolunteerConsentMutation,
+  type CrewVolunteerConsentCenterAction,
+  type CrewVolunteerConsentCenterScope,
+  type CrewVolunteerConsentCenterView,
+} from "../lib/crew/volunteer-consent-center"
+import {
+  getCrewVolunteerTokenState,
+  type CrewVolunteerSignupMetadata,
+} from "../lib/crew/volunteer-signup"
+import {
+  buildCrewVolunteerIdentityAnchors,
+  resolveCrewVolunteerIdentity,
+  type CrewVolunteerIdentityAnchorInput,
+  type CrewVolunteerIdentityAnchors,
+} from "./crew-volunteer-history.server"
+
+type DbClient = ReturnType<typeof getDb>
+
+export interface CrewVolunteerConsentCenterTokenInput {
+  slug: string
+  token: string
+}
+
+export interface UpdateCrewVolunteerConsentCenterTokenInput
+  extends CrewVolunteerConsentCenterTokenInput {
+  scope: CrewVolunteerConsentCenterScope
+  action: CrewVolunteerConsentCenterAction
+}
+
+export type CrewVolunteerConsentCenterTokenData =
+  | {
+      status: "valid"
+      view: CrewVolunteerConsentCenterView
+    }
+  | {
+      status: "missing" | "expired" | "bad"
+      view: null
+    }
+
+export type UpdateCrewVolunteerConsentCenterTokenResult =
+  CrewVolunteerConsentCenterTokenData & {
+    success: boolean
+    outcome:
+      | "granted"
+      | "revoked"
+      | "idempotent"
+      | "missing"
+      | "expired"
+      | "bad"
+      | "blocked"
+    message: string
+  }
+
+interface CrewVolunteerConsentTokenContext {
+  event: {
+    id: string
+    name: string
+    organizingTeamId: string
+    groupId: string | null
+  }
+  identitySource: typeof CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE
+  anchors: CrewVolunteerIdentityAnchorInput
+  sourceCompetitionId: string
+  sourceMembershipId: string | null
+  sourceInvitationId: string | null
+}
+
+export async function getCrewVolunteerConsentCenterToken(
+  data: CrewVolunteerConsentCenterTokenInput,
+): Promise<CrewVolunteerConsentCenterTokenData> {
+  const db = getDb()
+  const resolved = await resolveCrewVolunteerConsentToken(db, data)
+  if (resolved.status !== "valid") {
+    return { status: resolved.status, view: null }
+  }
+
+  const anchors = await buildCrewVolunteerIdentityAnchors(
+    resolved.context.anchors,
+  )
+  const identity = await findCrewVolunteerIdentityByAnchors(
+    db,
+    resolved.context.event.organizingTeamId,
+    anchors,
+  )
+  const consentRecords = identity
+    ? await listCrewVolunteerConsentCenterRecords(db, identity.id)
+    : []
+
+  return {
+    status: "valid",
+    view: buildCrewVolunteerConsentCenterView({
+      eventName: resolved.context.event.name,
+      volunteerLabel: "Your crew profile",
+      identityAgeStatus:
+        identity?.discoveryAgeStatus ??
+        CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.UNKNOWN,
+      consentRecords,
+    }),
+  }
+}
+
+export async function updateCrewVolunteerConsentCenterToken(
+  data: UpdateCrewVolunteerConsentCenterTokenInput,
+): Promise<UpdateCrewVolunteerConsentCenterTokenResult> {
+  const db = getDb()
+  const now = new Date()
+  const resolved = await resolveCrewVolunteerConsentToken(db, data)
+  if (resolved.status !== "valid") {
+    return {
+      status: resolved.status,
+      view: null,
+      success: false,
+      outcome: resolved.status,
+      message: messageForInvalidTokenStatus(resolved.status),
+    }
+  }
+
+  let mutationOutcome: UpdateCrewVolunteerConsentCenterTokenResult["outcome"] =
+    "idempotent"
+  let mutationMessage = "Your consent settings were already up to date."
+  let mutationSucceeded = true
+
+  await db.transaction(async (tx) => {
+    const client = tx as unknown as DbClient
+    const context = resolved.context
+    const anchors = await buildCrewVolunteerIdentityAnchors(context.anchors)
+    const existingIdentity = await findCrewVolunteerIdentityByAnchors(
+      client,
+      context.event.organizingTeamId,
+      anchors,
+    )
+    const identityAgeStatus =
+      existingIdentity?.discoveryAgeStatus ??
+      CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.UNKNOWN
+    const activeConsent = existingIdentity
+      ? await getActiveCrewVolunteerConsent(
+          client,
+          existingIdentity.id,
+          data.scope,
+        )
+      : null
+    const resolution = resolveCrewVolunteerConsentMutation({
+      action: data.action,
+      scope: data.scope,
+      identityAgeStatus,
+      activeConsentId: activeConsent?.id ?? null,
+    })
+
+    if (!resolution.ok) {
+      mutationOutcome = "blocked"
+      mutationSucceeded = false
+      mutationMessage =
+        resolution.reason === "regional_age_blocked"
+          ? "Regional discovery requires adult eligibility before opt-in."
+          : "That consent scope is not available here."
+      return
+    }
+
+    if (resolution.outcome === "idempotent") {
+      mutationOutcome = "idempotent"
+      mutationMessage =
+        data.action === "grant"
+          ? "That consent is already granted."
+          : "That consent is already revoked."
+      return
+    }
+
+    const identityId = await resolveCrewVolunteerIdentity({
+      db: client,
+      teamId: context.event.organizingTeamId,
+      userId: context.anchors.userId,
+      email: context.anchors.email,
+      phone: context.anchors.phone,
+      sourceCompetitionId: context.sourceCompetitionId,
+      sourceMembershipId: context.sourceMembershipId,
+      sourceInvitationId: context.sourceInvitationId,
+      identitySource: context.identitySource,
+      now,
+    })
+
+    const consentId = createCrewVolunteerConsentId()
+    const consentText = getCrewVolunteerConsentText({
+      scope: data.scope,
+      action: data.action,
+    })
+    const consentTextHash = await hashCrewVolunteerConsentText(consentText)
+
+    await client.insert(crewVolunteerConsentsTable).values({
+      id: consentId,
+      identityId,
+      teamId: context.event.organizingTeamId,
+      scope: data.scope,
+      status:
+        data.action === "grant"
+          ? CREW_VOLUNTEER_CONSENT_STATUS.GRANTED
+          : CREW_VOLUNTEER_CONSENT_STATUS.REVOKED,
+      consentText,
+      consentTextVersion: CREW_VOLUNTEER_CONSENT_CENTER_VERSION,
+      consentTextHash,
+      source: CREW_VOLUNTEER_CONSENT_SOURCE.CONSENT_CENTER,
+      sourceSurface: CREW_VOLUNTEER_CONSENT_CENTER_SURFACE,
+      sourceCompetitionId: context.event.id,
+      actorUserId: context.anchors.userId ?? null,
+      recordedByUserId: null,
+      grantedAt: now,
+      revokedAt: data.action === "revoke" ? now : null,
+      revokedByUserId:
+        data.action === "revoke" ? (context.anchors.userId ?? null) : null,
+      revocationSource:
+        data.action === "revoke" ? CREW_VOLUNTEER_CONSENT_CENTER_SURFACE : null,
+      supersededByConsentId: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+
+    if (data.action === "grant") {
+      await supersedePriorGrantedConsents(client, {
+        identityId,
+        scope: data.scope,
+        supersededByConsentId: consentId,
+        now,
+      })
+      mutationOutcome = "granted"
+      mutationMessage = "Consent granted."
+      return
+    }
+
+    await revokePriorGrantedConsents(client, {
+      identityId,
+      scope: data.scope,
+      supersededByConsentId: consentId,
+      revokedByUserId: context.anchors.userId ?? null,
+      now,
+    })
+    mutationOutcome = "revoked"
+    mutationMessage = "Consent revoked."
+  })
+
+  const freshData = await getCrewVolunteerConsentCenterToken(data)
+  return {
+    ...freshData,
+    success: mutationSucceeded,
+    outcome: mutationOutcome,
+    message: mutationMessage,
+  }
+}
+
+async function resolveCrewVolunteerConsentToken(
+  db: DbClient,
+  data: CrewVolunteerConsentCenterTokenInput,
+): Promise<
+  | { status: "valid"; context: CrewVolunteerConsentTokenContext }
+  | { status: "missing" | "expired" | "bad" }
+> {
+  const assignment = await resolveAssignmentConfirmationConsentToken(db, data)
+  if (assignment.status !== "missing") return assignment
+  return await resolveVolunteerInvitationConsentToken(db, data)
+}
+
+async function resolveAssignmentConfirmationConsentToken(
+  db: DbClient,
+  data: CrewVolunteerConsentCenterTokenInput,
+) {
+  const tokenHash = await hashCrewAssignmentConfirmationToken(data.token)
+  const [row] = await db
+    .select({
+      event: {
+        id: competitionsTable.id,
+        name: competitionsTable.name,
+        organizingTeamId: competitionsTable.organizingTeamId,
+        groupId: competitionsTable.groupId,
+      },
+      confirmation: {
+        id: crewAssignmentConfirmationsTable.id,
+        tokenHash: crewAssignmentConfirmationsTable.tokenHash,
+        status: crewAssignmentConfirmationsTable.status,
+        expiresAt: crewAssignmentConfirmationsTable.expiresAt,
+        email: crewAssignmentConfirmationsTable.email,
+        membershipId: crewAssignmentConfirmationsTable.membershipId,
+      },
+      assignment: {
+        membershipId: volunteerShiftAssignmentsTable.membershipId,
+      },
+      membership: {
+        id: teamMembershipTable.id,
+        userId: teamMembershipTable.userId,
+        metadata: teamMembershipTable.metadata,
+      },
+      user: {
+        email: userTable.email,
+      },
+    })
+    .from(crewAssignmentConfirmationsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewAssignmentConfirmationsTable.competitionId, competitionsTable.id),
+    )
+    .innerJoin(
+      crewEventSettingsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .leftJoin(
+      volunteerShiftAssignmentsTable,
+      eq(
+        crewAssignmentConfirmationsTable.assignmentId,
+        volunteerShiftAssignmentsTable.id,
+      ),
+    )
+    .leftJoin(
+      teamMembershipTable,
+      eq(volunteerShiftAssignmentsTable.membershipId, teamMembershipTable.id),
+    )
+    .leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(
+      and(
+        eq(crewAssignmentConfirmationsTable.tokenHash, tokenHash),
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        ),
+        eq(competitionsTable.slug, data.slug),
+        eq(crewEventSettingsTable.crewOnly, true),
+        ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
+      ),
+    )
+    .limit(1)
+
+  if (!row) return { status: "missing" as const }
+  if (
+    row.confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED
+  ) {
+    return { status: "bad" as const }
+  }
+
+  const tokenState = getCrewAssignmentConfirmationTokenState(row.confirmation)
+  if (tokenState !== "valid") return { status: tokenState }
+
+  const metadata = parseCrewRosterMetadata(row.membership?.metadata)
+  const anchors = {
+    userId: row.membership?.userId ?? null,
+    email: metadata.signupEmail ?? row.confirmation.email ?? row.user?.email,
+    phone: metadata.signupPhone,
+  }
+
+  if (!hasIdentityAnchor(anchors)) return { status: "bad" as const }
+
+  return {
+    status: "valid" as const,
+    context: {
+      event: row.event,
+      identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE,
+      anchors,
+      sourceCompetitionId: row.event.id,
+      sourceMembershipId:
+        row.assignment?.membershipId ?? row.confirmation.membershipId ?? null,
+      sourceInvitationId: null,
+    },
+  }
+}
+
+async function resolveVolunteerInvitationConsentToken(
+  db: DbClient,
+  data: CrewVolunteerConsentCenterTokenInput,
+) {
+  const [row] = await db
+    .select({
+      event: {
+        id: competitionsTable.id,
+        name: competitionsTable.name,
+        organizingTeamId: competitionsTable.organizingTeamId,
+        groupId: competitionsTable.groupId,
+      },
+      invitation: {
+        id: teamInvitationTable.id,
+        email: teamInvitationTable.email,
+        token: teamInvitationTable.token,
+        status: teamInvitationTable.status,
+        expiresAt: teamInvitationTable.expiresAt,
+        metadata: teamInvitationTable.metadata,
+      },
+    })
+    .from(teamInvitationTable)
+    .innerJoin(
+      competitionsTable,
+      eq(teamInvitationTable.teamId, competitionsTable.competitionTeamId),
+    )
+    .innerJoin(
+      crewEventSettingsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(
+      and(
+        eq(competitionsTable.slug, data.slug),
+        eq(teamInvitationTable.token, data.token),
+        eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamInvitationTable.isSystemRole, true),
+        eq(crewEventSettingsTable.crewOnly, true),
+        ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
+      ),
+    )
+    .limit(1)
+
+  if (!row) return { status: "missing" as const }
+
+  const tokenState = getCrewVolunteerTokenState(row.invitation)
+  if (tokenState !== "valid") return { status: tokenState }
+
+  const metadata = parseVolunteerMetadata(row.invitation.metadata)
+  const anchors = {
+    userId: null,
+    email: metadata?.signupEmail ?? row.invitation.email,
+    phone: metadata?.signupPhone,
+  }
+
+  if (!hasIdentityAnchor(anchors)) return { status: "bad" as const }
+
+  return {
+    status: "valid" as const,
+    context: {
+      event: row.event,
+      identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE,
+      anchors,
+      sourceCompetitionId: row.event.id,
+      sourceMembershipId: null,
+      sourceInvitationId: row.invitation.id,
+    },
+  }
+}
+
+async function listCrewVolunteerConsentCenterRecords(
+  db: DbClient,
+  identityId: string,
+) {
+  return await db
+    .select({
+      id: crewVolunteerConsentsTable.id,
+      scope: crewVolunteerConsentsTable.scope,
+      status: crewVolunteerConsentsTable.status,
+      consentTextVersion: crewVolunteerConsentsTable.consentTextVersion,
+      source: crewVolunteerConsentsTable.source,
+      sourceSurface: crewVolunteerConsentsTable.sourceSurface,
+      grantedAt: crewVolunteerConsentsTable.grantedAt,
+      revokedAt: crewVolunteerConsentsTable.revokedAt,
+      supersededByConsentId: crewVolunteerConsentsTable.supersededByConsentId,
+      updatedAt: crewVolunteerConsentsTable.updatedAt,
+    })
+    .from(crewVolunteerConsentsTable)
+    .where(eq(crewVolunteerConsentsTable.identityId, identityId))
+    .orderBy(desc(crewVolunteerConsentsTable.updatedAt))
+}
+
+async function getActiveCrewVolunteerConsent(
+  db: DbClient,
+  identityId: string,
+  scope: CrewVolunteerConsentScope,
+) {
+  const [consent] = await db
+    .select({ id: crewVolunteerConsentsTable.id })
+    .from(crewVolunteerConsentsTable)
+    .where(
+      and(
+        eq(crewVolunteerConsentsTable.identityId, identityId),
+        eq(crewVolunteerConsentsTable.scope, scope),
+        eq(
+          crewVolunteerConsentsTable.status,
+          CREW_VOLUNTEER_CONSENT_STATUS.GRANTED,
+        ),
+      ),
+    )
+    .orderBy(desc(crewVolunteerConsentsTable.updatedAt))
+    .limit(1)
+
+  return consent ?? null
+}
+
+async function supersedePriorGrantedConsents(
+  db: DbClient,
+  params: {
+    identityId: string
+    scope: CrewVolunteerConsentScope
+    supersededByConsentId: string
+    now: Date
+  },
+) {
+  await db
+    .update(crewVolunteerConsentsTable)
+    .set({
+      status: CREW_VOLUNTEER_CONSENT_STATUS.SUPERSEDED,
+      supersededByConsentId: params.supersededByConsentId,
+      updatedAt: params.now,
+    })
+    .where(
+      and(
+        eq(crewVolunteerConsentsTable.identityId, params.identityId),
+        eq(crewVolunteerConsentsTable.scope, params.scope),
+        eq(
+          crewVolunteerConsentsTable.status,
+          CREW_VOLUNTEER_CONSENT_STATUS.GRANTED,
+        ),
+        ne(crewVolunteerConsentsTable.id, params.supersededByConsentId),
+      ),
+    )
+}
+
+async function revokePriorGrantedConsents(
+  db: DbClient,
+  params: {
+    identityId: string
+    scope: CrewVolunteerConsentScope
+    supersededByConsentId: string
+    revokedByUserId: string | null
+    now: Date
+  },
+) {
+  await db
+    .update(crewVolunteerConsentsTable)
+    .set({
+      status: CREW_VOLUNTEER_CONSENT_STATUS.REVOKED,
+      revokedAt: params.now,
+      revokedByUserId: params.revokedByUserId,
+      revocationSource: CREW_VOLUNTEER_CONSENT_CENTER_SURFACE,
+      supersededByConsentId: params.supersededByConsentId,
+      updatedAt: params.now,
+    })
+    .where(
+      and(
+        eq(crewVolunteerConsentsTable.identityId, params.identityId),
+        eq(crewVolunteerConsentsTable.scope, params.scope),
+        eq(
+          crewVolunteerConsentsTable.status,
+          CREW_VOLUNTEER_CONSENT_STATUS.GRANTED,
+        ),
+      ),
+    )
+}
+
+async function findCrewVolunteerIdentityByAnchors(
+  db: DbClient,
+  teamId: string,
+  anchors: CrewVolunteerIdentityAnchors,
+) {
+  const conditions = [
+    anchors.userId
+      ? eq(crewVolunteerIdentitiesTable.userId, anchors.userId)
+      : null,
+    anchors.emailHash
+      ? and(
+          eq(crewVolunteerIdentitiesTable.emailHash, anchors.emailHash),
+          eq(
+            crewVolunteerIdentitiesTable.contactHashVersion,
+            anchors.contactHashVersion,
+          ),
+        )
+      : null,
+    anchors.phoneHash
+      ? and(
+          eq(crewVolunteerIdentitiesTable.phoneHash, anchors.phoneHash),
+          eq(
+            crewVolunteerIdentitiesTable.contactHashVersion,
+            anchors.contactHashVersion,
+          ),
+        )
+      : null,
+  ].filter((condition): condition is NonNullable<typeof condition> =>
+    Boolean(condition),
+  )
+
+  if (conditions.length === 0) return null
+
+  const [identity] = await db
+    .select({
+      id: crewVolunteerIdentitiesTable.id,
+      discoveryAgeStatus: crewVolunteerIdentitiesTable.discoveryAgeStatus,
+    })
+    .from(crewVolunteerIdentitiesTable)
+    .where(
+      and(
+        eq(crewVolunteerIdentitiesTable.teamId, teamId),
+        conditions.length === 1 ? conditions[0] : or(...conditions),
+      ),
+    )
+    .limit(1)
+
+  return identity ?? null
+}
+
+function hasIdentityAnchor(anchors: CrewVolunteerIdentityAnchorInput) {
+  return Boolean(
+    anchors.userId?.trim() || anchors.email?.trim() || anchors.phone?.trim(),
+  )
+}
+
+function parseVolunteerMetadata(
+  metadata: string | null,
+): CrewVolunteerSignupMetadata | null {
+  if (!metadata) return null
+  try {
+    return JSON.parse(metadata) as CrewVolunteerSignupMetadata
+  } catch {
+    return null
+  }
+}
+
+function messageForInvalidTokenStatus(status: "missing" | "expired" | "bad") {
+  if (status === "missing") return "Consent center link was not found."
+  if (status === "expired") return "Consent center link has expired."
+  return "Consent center link is no longer valid."
+}


### PR DESCRIPTION
## Summary

Adds a narrow token-gated Crew volunteer consent center for the merged volunteer-intelligence/privacy schema.

- Adds a standalone `/e/$slug/consent/$token` public-token route for volunteers to view communication-history and regional-discovery consent state without returning raw contact fields or private metadata.
- Adds server-only consent resolution/mutation support that reuses assignment confirmation tokens and volunteer invitation tokens, resolves identities only from safe anchors, and fails closed when a token only proves a name.
- Records consent text, version, hash, source, surface, scope, grant, revocation, and supersession data using existing `crew_volunteer_consents` / identity tables; no schema changes.
- Keeps regional discovery opt-in only and blocks new regional grants unless the identity is already `adult_confirmed`; revocation remains allowed and preserves audit history.
- Adds a small `Consent` link from existing volunteer schedule token pages.

## Changed files

- `apps/crew/src/lib/crew/volunteer-consent-center.ts`
- `apps/crew/src/lib/crew/volunteer-consent-center.test.ts`
- `apps/crew/src/server/crew-volunteer-consent.server.ts`
- `apps/crew/src/server-fns/crew-volunteer-consent-fns.ts`
- `apps/crew/src/routes/e/$slug/consent/$token.tsx`
- `apps/crew/src/routes/e/$slug/schedule/$token.tsx`
- `apps/crew/src/routeTree.gen.ts`

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/volunteer-consent-center.test.ts` passed.
- `pnpm --filter crew type-check` passed.
- `pnpm --filter crew lint` exited 0; it still reports existing unrelated warnings in legacy files.
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` passed after adding an ignored local `.alchemy/local/wrangler.jsonc` validation scaffold from the existing placeholder Wrangler config.
- `git diff --check` passed.

## Notes

No migrations, deploy, queue/email/SMS sending, regional discovery behavior, intro request flow, analytics, or production data/backfill changes are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a token-gated volunteer consent center so Crew volunteers can view and manage communication-history and regional-discovery consents without exposing contact data. Reuses existing tokens, records versioned consent audits, and enforces adult-only opt-in for regional discovery.

- New Features
  - Public route `/e/$slug/consent/$token` to view/update consents; no raw contact or private metadata is shown.
  - Server-only consent resolution/mutation using assignment confirmation and volunteer invitation tokens; identities resolved from safe anchors and fail closed on weak proofs.
  - Audit logging stores consent text, version, SHA-256 hash, source/surface, scope, and grant/revoke/supersession timestamps using existing tables.
  - Policy: regional discovery is opt-in only and requires `adult_confirmed`; revocation is always allowed and keeps history.
  - UI: adds a "Consent" link from volunteer schedule token pages.
  - Tests cover view model, mutation policy, and consent text hashing.

- Migration
  - No schema changes or migrations.

<sup>Written for commit 3b4634802739e9a1a9622e4babb2035d79991c05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/587?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a volunteer consent center where volunteers can manage consent preferences for communication history and regional discovery
  * Added "Consent" button on schedule pages for quick access to consent management
  * Consent decisions are tracked with timestamps and status indicators for transparency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->