### PR TITLE
[codex] feat(crew): support series crew pools

### DIFF
--- a/apps/crew/src/lib/crew/series-crew-pools.test.ts
+++ b/apps/crew/src/lib/crew/series-crew-pools.test.ts
@@ -1,0 +1,295 @@
+// @lat: [[crew#Series Crew Pools]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_CREDENTIAL_TYPE,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+} from "../../db/schemas/crew-volunteer-intelligence"
+import { buildSeriesCrewPoolViewModel } from "./series-crew-pools"
+
+const competitions = [
+  {
+    id: "comp_alpha",
+    name: "Alpha Throwdown",
+    slug: "alpha",
+    startDate: "2026-03-01",
+    endDate: "2026-03-02",
+  },
+  {
+    id: "comp_bravo",
+    name: "Bravo Throwdown",
+    slug: "bravo",
+    startDate: "2026-04-01",
+    endDate: "2026-04-02",
+  },
+]
+
+describe("series crew pools", () => {
+  it("dedupes volunteers across same-group competitions and summarizes factual history", () => {
+    const pool = buildSeriesCrewPoolViewModel({
+      organizerTeamId: "team_organizer",
+      groupId: "cgrp_series",
+      competitions,
+      selectedCompetitionIds: ["comp_bravo"],
+      roster: [
+        {
+          rosterVolunteerId: "comp_alpha:membership:tmem_ada_alpha",
+          competitionId: "comp_alpha",
+          volunteerName: "Ada Lovelace",
+          rosterStatus: "active",
+          availability: "morning",
+          roleTypes: ["judge"],
+        },
+        {
+          rosterVolunteerId: "comp_bravo:membership:tmem_ada_bravo",
+          competitionId: "comp_bravo",
+          volunteerName: "Ada Lovelace",
+          rosterStatus: "active",
+          availability: "all_day",
+          roleTypes: ["judge", "staff"],
+        },
+      ],
+      identities: [
+        {
+          id: "cvid_ada",
+          teamId: "team_organizer",
+          rosterVolunteerId: "comp_alpha:membership:tmem_ada_alpha",
+        },
+        {
+          id: "cvid_ada",
+          teamId: "team_organizer",
+          rosterVolunteerId: "comp_bravo:membership:tmem_ada_bravo",
+        },
+      ],
+      historyEvents: [
+        {
+          identityId: "cvid_ada",
+          teamId: "team_organizer",
+          competitionId: "comp_alpha",
+          groupId: "cgrp_series",
+          competitionName: "Alpha Throwdown",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+          visibilityScope:
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          roleType: "judge",
+          occurredAt: "2026-03-01T15:00:00.000Z",
+        },
+        {
+          identityId: "cvid_ada",
+          teamId: "team_organizer",
+          competitionId: "comp_bravo",
+          groupId: "cgrp_series",
+          competitionName: "Bravo Throwdown",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW,
+          visibilityScope:
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          roleType: "staff",
+          occurredAt: "2026-04-01T15:00:00.000Z",
+        },
+      ],
+      credentials: [
+        {
+          identityId: "cvid_ada",
+          teamId: "team_organizer",
+          credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.JUDGE_COURSE,
+          credentialLabel: "L1 Judge",
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+          visibilityScope:
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        },
+      ],
+    })
+
+    expect(pool.summary).toMatchObject({
+      totalVolunteers: 1,
+      rosterPlacements: 2,
+      selectedCompetitions: 1,
+      volunteersInSelectedCompetitions: 1,
+      volunteersWithHistory: 1,
+      safeCredentialCount: 1,
+    })
+    expect(pool.entries[0]).toMatchObject({
+      volunteerName: "Ada Lovelace",
+      selectedCompetitionIds: ["comp_bravo"],
+      priorEventCount: 1,
+      lastEvent: {
+        competitionId: "comp_alpha",
+        label: "Alpha Throwdown",
+      },
+      reliability: {
+        signedUp: 0,
+        imported: 0,
+        assigned: 0,
+        confirmed: 1,
+        declined: 0,
+        changeRequested: 0,
+        noShow: 0,
+        completed: 0,
+      },
+      credentials: [
+        {
+          credentialType: "judge_course",
+          credentialLabel: "L1 Judge",
+          status: "verified",
+        },
+      ],
+    })
+  })
+
+  it("keeps history scoped to the same organizer and same competition group", () => {
+    const pool = buildSeriesCrewPoolViewModel({
+      organizerTeamId: "team_organizer",
+      groupId: "cgrp_series",
+      competitions,
+      selectedCompetitionIds: ["comp_alpha"],
+      roster: [
+        {
+          rosterVolunteerId: "comp_alpha:membership:tmem_grace",
+          competitionId: "comp_alpha",
+          volunteerName: "Grace Hopper",
+          rosterStatus: "active",
+          availability: null,
+          roleTypes: ["general"],
+        },
+      ],
+      identities: [
+        {
+          id: "cvid_grace",
+          teamId: "team_organizer",
+          rosterVolunteerId: "comp_alpha:membership:tmem_grace",
+        },
+      ],
+      historyEvents: [
+        {
+          identityId: "cvid_grace",
+          teamId: "team_organizer",
+          competitionId: "comp_other_group",
+          groupId: "cgrp_other",
+          competitionName: "Other Series",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+          visibilityScope:
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          roleType: "judge",
+          occurredAt: "2026-02-01T12:00:00.000Z",
+        },
+        {
+          identityId: "cvid_grace",
+          teamId: "team_other",
+          competitionId: "comp_bravo",
+          groupId: "cgrp_series",
+          competitionName: "Other Organizer",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+          visibilityScope:
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+          roleType: "judge",
+          occurredAt: "2026-03-01T12:00:00.000Z",
+        },
+      ],
+      credentials: [
+        {
+          identityId: "cvid_grace",
+          teamId: "team_other",
+          credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.MEDICAL,
+          credentialLabel: "Private EMT",
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+          visibilityScope:
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        },
+      ],
+    })
+
+    expect(pool.entries[0]?.priorEventCount).toBe(0)
+    expect(pool.entries[0]?.lastEvent).toBeNull()
+    expect(pool.entries[0]?.credentials).toEqual([])
+  })
+
+  it("omits raw contact and private metadata while preserving safe counts", () => {
+    const pool = buildSeriesCrewPoolViewModel({
+      organizerTeamId: "team_organizer",
+      groupId: "cgrp_series",
+      competitions,
+      selectedCompetitionIds: ["comp_alpha"],
+      roster: [
+        {
+          rosterVolunteerId: "comp_alpha:invitation:tinv_katherine",
+          competitionId: "comp_alpha",
+          volunteerName: "Katherine Johnson",
+          rosterStatus: "pending",
+          availability: "afternoon",
+          roleTypes: ["staff"],
+        },
+      ],
+      identities: [
+        {
+          id: "cvid_katherine",
+          teamId: "team_organizer",
+          rosterVolunteerId: "comp_alpha:invitation:tinv_katherine",
+        },
+      ],
+      historyEvents: [
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.SIGNED_UP,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CHANGE_REQUESTED,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW,
+        CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+      ].map((eventType, index) => ({
+        identityId: "cvid_katherine",
+        teamId: "team_organizer",
+        competitionId: "comp_bravo",
+        groupId: "cgrp_series",
+        competitionName: "Bravo Throwdown",
+        eventType,
+        visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        roleType: "staff" as const,
+        occurredAt: `2026-04-0${index + 1}T12:00:00.000Z`,
+      })),
+      credentials: [
+        {
+          identityId: "cvid_katherine",
+          teamId: "team_organizer",
+          credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.MEDICAL,
+          credentialLabel: "EMT",
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED,
+          visibilityScope:
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        },
+        {
+          identityId: "cvid_katherine",
+          teamId: "team_organizer",
+          credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.EQUIPMENT,
+          credentialLabel: "Revoked rigging",
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.REVOKED,
+          visibilityScope:
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+        },
+      ],
+    })
+
+    expect(pool.entries[0]?.reliability).toEqual({
+      signedUp: 1,
+      imported: 1,
+      assigned: 1,
+      confirmed: 1,
+      declined: 1,
+      changeRequested: 1,
+      noShow: 1,
+      completed: 1,
+    })
+    expect(pool.entries[0]?.credentials).toEqual([
+      {
+        credentialType: "medical",
+        credentialLabel: "EMT",
+        status: "self_reported",
+      },
+    ])
+    const serialized = JSON.stringify(pool)
+    expect(serialized).not.toContain("katherine@example.com")
+    expect(serialized).not.toContain("555")
+    expect(serialized).not.toContain("internalNotes")
+    expect(serialized).not.toContain("stripe")
+  })
+})

--- a/apps/crew/src/lib/crew/series-crew-pools.ts
+++ b/apps/crew/src/lib/crew/series-crew-pools.ts
@@ -1,0 +1,434 @@
+// @lat: [[crew#Series Crew Pools]]
+import {
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  type CrewVolunteerCredentialStatus,
+  type CrewVolunteerCredentialType,
+  type CrewVolunteerHistoryEventType,
+  type CrewVolunteerHistoryVisibilityScope,
+} from "../../db/schemas/crew-volunteer-intelligence"
+import type {
+  VolunteerAvailability,
+  VolunteerRoleType,
+} from "../../db/schemas/volunteers"
+
+export interface SeriesCrewPoolCompetition {
+  id: string
+  name: string
+  slug: string
+  startDate: string
+  endDate: string
+}
+
+export interface SeriesCrewPoolRosterRecord {
+  rosterVolunteerId: string
+  competitionId: string
+  volunteerName: string
+  rosterStatus: string
+  availability: VolunteerAvailability | null
+  roleTypes: VolunteerRoleType[]
+}
+
+export interface SeriesCrewPoolIdentityRecord {
+  id: string
+  teamId: string
+  rosterVolunteerId: string
+}
+
+export interface SeriesCrewPoolHistoryRecord {
+  identityId: string
+  teamId: string
+  competitionId: string | null
+  groupId: string | null
+  competitionName: string | null
+  eventType: CrewVolunteerHistoryEventType
+  visibilityScope: CrewVolunteerHistoryVisibilityScope
+  roleType: VolunteerRoleType | null
+  occurredAt: Date | string
+}
+
+export interface SeriesCrewPoolCredentialRecord {
+  identityId: string
+  teamId: string
+  credentialType: CrewVolunteerCredentialType
+  credentialLabel: string
+  status: CrewVolunteerCredentialStatus
+  visibilityScope: CrewVolunteerHistoryVisibilityScope
+  expiresAt?: Date | string | null
+  revokedAt?: Date | string | null
+}
+
+export interface SeriesCrewPoolInput {
+  organizerTeamId: string
+  groupId: string
+  competitions: SeriesCrewPoolCompetition[]
+  selectedCompetitionIds: string[]
+  roster: SeriesCrewPoolRosterRecord[]
+  identities: SeriesCrewPoolIdentityRecord[]
+  historyEvents: SeriesCrewPoolHistoryRecord[]
+  credentials: SeriesCrewPoolCredentialRecord[]
+  maxPoolSize?: number
+}
+
+export interface SeriesCrewPoolEntry {
+  poolKey: string
+  volunteerName: string
+  rosterEvents: Array<{
+    competitionId: string
+    competitionName: string
+    rosterStatus: string
+    availability: VolunteerAvailability | null
+    roleTypes: VolunteerRoleType[]
+    selected: boolean
+  }>
+  selectedCompetitionIds: string[]
+  priorEventCount: number
+  lastEvent: {
+    competitionId: string | null
+    label: string
+    occurredAt: string
+  } | null
+  priorRoleTypes: VolunteerRoleType[]
+  reliability: {
+    signedUp: number
+    imported: number
+    assigned: number
+    confirmed: number
+    declined: number
+    changeRequested: number
+    noShow: number
+    completed: number
+  }
+  credentials: Array<{
+    credentialType: CrewVolunteerCredentialType
+    credentialLabel: string
+    status: Extract<CrewVolunteerCredentialStatus, "self_reported" | "verified">
+  }>
+}
+
+export interface SeriesCrewPoolViewModel {
+  competitions: Array<
+    SeriesCrewPoolCompetition & {
+      selected: boolean
+      rosterCount: number
+    }
+  >
+  selectedCompetitionIds: string[]
+  entries: SeriesCrewPoolEntry[]
+  summary: {
+    totalVolunteers: number
+    rosterPlacements: number
+    selectedCompetitions: number
+    volunteersInSelectedCompetitions: number
+    volunteersWithHistory: number
+    safeCredentialCount: number
+  }
+}
+
+const countedEventTypes = new Set<CrewVolunteerHistoryEventType>([
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.SIGNED_UP,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CHANGE_REQUESTED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+])
+
+const safeCredentialStatuses = new Set<CrewVolunteerCredentialStatus>([
+  CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED,
+  CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+])
+
+export function buildSeriesCrewPoolViewModel({
+  organizerTeamId,
+  groupId,
+  competitions,
+  selectedCompetitionIds,
+  roster,
+  identities,
+  historyEvents,
+  credentials,
+  maxPoolSize = 100,
+}: SeriesCrewPoolInput): SeriesCrewPoolViewModel {
+  const competitionById = new Map(
+    competitions.map((competition) => [competition.id, competition]),
+  )
+  const selectedIds = new Set(
+    selectedCompetitionIds.filter((id) => competitionById.has(id)),
+  )
+  const rosterById = new Map(
+    roster
+      .filter((record) => competitionById.has(record.competitionId))
+      .map((record) => [record.rosterVolunteerId, record]),
+  )
+  const identityIdsByRosterId = new Map<string, Set<string>>()
+
+  for (const identity of identities) {
+    if (identity.teamId !== organizerTeamId) continue
+    if (!rosterById.has(identity.rosterVolunteerId)) continue
+    const identityIds =
+      identityIdsByRosterId.get(identity.rosterVolunteerId) ?? new Set<string>()
+    identityIds.add(identity.id)
+    identityIdsByRosterId.set(identity.rosterVolunteerId, identityIds)
+  }
+
+  const entriesByKey = new Map<
+    string,
+    {
+      poolKey: string
+      identityIds: Set<string>
+      rosterRecords: SeriesCrewPoolRosterRecord[]
+    }
+  >()
+
+  for (const record of rosterById.values()) {
+    const identityIds = identityIdsByRosterId.get(record.rosterVolunteerId)
+    const poolKey = identityIds?.size
+      ? `identity:${[...identityIds].sort().join(":")}`
+      : `roster:${record.rosterVolunteerId}`
+    const entry = entriesByKey.get(poolKey) ?? {
+      poolKey,
+      identityIds: new Set<string>(),
+      rosterRecords: [],
+    }
+    for (const identityId of identityIds ?? []) {
+      entry.identityIds.add(identityId)
+    }
+    entry.rosterRecords.push(record)
+    entriesByKey.set(poolKey, entry)
+  }
+
+  const entries = [...entriesByKey.values()]
+    .map((entry) => {
+      const rosterRecords = sortRosterRecords(
+        entry.rosterRecords,
+        competitionById,
+      )
+      const priorHistory = historyEvents
+        .filter((event) => {
+          if (!entry.identityIds.has(event.identityId)) return false
+          if (event.teamId !== organizerTeamId) return false
+          if (event.groupId !== groupId) return false
+          if (
+            event.visibilityScope !==
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER
+          ) {
+            return false
+          }
+          if (event.competitionId && selectedIds.has(event.competitionId)) {
+            return false
+          }
+          return countedEventTypes.has(event.eventType)
+        })
+        .sort(
+          (left, right) => toTime(right.occurredAt) - toTime(left.occurredAt),
+        )
+      const safeCredentials = credentials
+        .filter((credential) => {
+          if (!entry.identityIds.has(credential.identityId)) return false
+          if (credential.teamId !== organizerTeamId) return false
+          if (
+            credential.visibilityScope !==
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER
+          ) {
+            return false
+          }
+          if (!safeCredentialStatuses.has(credential.status)) return false
+          if (credential.revokedAt) return false
+          if (
+            credential.expiresAt &&
+            toTime(credential.expiresAt) < Date.now()
+          ) {
+            return false
+          }
+          return true
+        })
+        .map((credential) => ({
+          credentialType: credential.credentialType,
+          credentialLabel: credential.credentialLabel,
+          status: credential.status as Extract<
+            CrewVolunteerCredentialStatus,
+            "self_reported" | "verified"
+          >,
+        }))
+      const rosterEvents = rosterRecords.map((record) => {
+        const competition = competitionById.get(record.competitionId)
+        return {
+          competitionId: record.competitionId,
+          competitionName: competition?.name ?? "Series event",
+          rosterStatus: record.rosterStatus,
+          availability: record.availability,
+          roleTypes: record.roleTypes,
+          selected: selectedIds.has(record.competitionId),
+        }
+      })
+
+      return {
+        poolKey: entry.poolKey,
+        volunteerName: rosterRecords[0]?.volunteerName ?? "Volunteer",
+        rosterEvents,
+        selectedCompetitionIds: rosterEvents
+          .filter((event) => event.selected)
+          .map((event) => event.competitionId),
+        priorEventCount: countPriorEvents(priorHistory),
+        lastEvent: toLastEvent(priorHistory[0] ?? null),
+        priorRoleTypes: uniqueRoleTypes(priorHistory),
+        reliability: countReliabilityFacts(priorHistory),
+        credentials: dedupeCredentials(safeCredentials),
+      }
+    })
+    .sort(compareSeriesCrewPoolEntries)
+    .slice(0, maxPoolSize)
+
+  return {
+    competitions: competitions.map((competition) => ({
+      ...competition,
+      selected: selectedIds.has(competition.id),
+      rosterCount: new Set(
+        roster
+          .filter((record) => record.competitionId === competition.id)
+          .map((record) => record.rosterVolunteerId),
+      ).size,
+    })),
+    selectedCompetitionIds: [...selectedIds],
+    entries,
+    summary: {
+      totalVolunteers: entries.length,
+      rosterPlacements: rosterById.size,
+      selectedCompetitions: selectedIds.size,
+      volunteersInSelectedCompetitions: entries.filter(
+        (entry) => entry.selectedCompetitionIds.length > 0,
+      ).length,
+      volunteersWithHistory: entries.filter(
+        (entry) => entry.priorEventCount > 0,
+      ).length,
+      safeCredentialCount: entries.reduce(
+        (total, entry) => total + entry.credentials.length,
+        0,
+      ),
+    },
+  }
+}
+
+function sortRosterRecords(
+  records: SeriesCrewPoolRosterRecord[],
+  competitionById: Map<string, SeriesCrewPoolCompetition>,
+) {
+  return [...records].sort((left, right) => {
+    const leftCompetition = competitionById.get(left.competitionId)
+    const rightCompetition = competitionById.get(right.competitionId)
+    const dateCompare = (leftCompetition?.startDate ?? "").localeCompare(
+      rightCompetition?.startDate ?? "",
+    )
+    if (dateCompare !== 0) return dateCompare
+    return left.volunteerName.localeCompare(right.volunteerName)
+  })
+}
+
+function countPriorEvents(events: SeriesCrewPoolHistoryRecord[]) {
+  return new Set(events.map((event) => event.competitionId).filter(Boolean))
+    .size
+}
+
+function toLastEvent(event: SeriesCrewPoolHistoryRecord | null) {
+  if (!event) return null
+  return {
+    competitionId: event.competitionId,
+    label: event.competitionName ?? "Series event",
+    occurredAt: toIsoString(event.occurredAt),
+  }
+}
+
+function uniqueRoleTypes(events: SeriesCrewPoolHistoryRecord[]) {
+  return [
+    ...new Set(events.map((event) => event.roleType).filter(Boolean)),
+  ] as VolunteerRoleType[]
+}
+
+function countReliabilityFacts(events: SeriesCrewPoolHistoryRecord[]) {
+  const reliability = {
+    signedUp: 0,
+    imported: 0,
+    assigned: 0,
+    confirmed: 0,
+    declined: 0,
+    changeRequested: 0,
+    noShow: 0,
+    completed: 0,
+  }
+
+  for (const event of events) {
+    if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.SIGNED_UP) {
+      reliability.signedUp += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED) {
+      reliability.imported += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED) {
+      reliability.assigned += 1
+    } else if (
+      event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED
+    ) {
+      reliability.confirmed += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED) {
+      reliability.declined += 1
+    } else if (
+      event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CHANGE_REQUESTED
+    ) {
+      reliability.changeRequested += 1
+    } else if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW) {
+      reliability.noShow += 1
+    } else if (
+      event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED
+    ) {
+      reliability.completed += 1
+    }
+  }
+
+  return reliability
+}
+
+function dedupeCredentials(credentials: SeriesCrewPoolEntry["credentials"]) {
+  const seen = new Set<string>()
+  return credentials.filter((credential) => {
+    const key = [
+      credential.credentialType,
+      credential.credentialLabel.toLowerCase(),
+      credential.status,
+    ].join("|")
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function compareSeriesCrewPoolEntries(
+  left: SeriesCrewPoolEntry,
+  right: SeriesCrewPoolEntry,
+) {
+  const selectedDelta =
+    right.selectedCompetitionIds.length - left.selectedCompetitionIds.length
+  if (selectedDelta !== 0) return selectedDelta
+
+  const eventCountDelta = right.priorEventCount - left.priorEventCount
+  if (eventCountDelta !== 0) return eventCountDelta
+
+  const leftLast = left.lastEvent ? toTime(left.lastEvent.occurredAt) : 0
+  const rightLast = right.lastEvent ? toTime(right.lastEvent.occurredAt) : 0
+  if (rightLast !== leftLast) return rightLast - leftLast
+
+  return left.volunteerName.localeCompare(right.volunteerName)
+}
+
+function toIsoString(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime())
+    ? new Date(0).toISOString()
+    : date.toISOString()
+}
+
+function toTime(value: Date | string) {
+  const time = new Date(value).getTime()
+  return Number.isNaN(time) ? 0 : time
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as EventsNewRouteImport } from './routes/events/new'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
 import { Route as EventsEventIdIndexRouteImport } from './routes/events/$eventId/index'
+import { Route as SeriesGroupIdCrewRouteImport } from './routes/series/$groupId/crew'
 import { Route as EventsEventIdVolunteersRouteImport } from './routes/events/$eventId/volunteers'
 import { Route as EventsEventIdStaffingRouteImport } from './routes/events/$eventId/staffing'
 import { Route as EventsEventIdShiftsRouteImport } from './routes/events/$eventId/shifts'
@@ -62,6 +63,11 @@ const EventsEventIdIndexRoute = EventsEventIdIndexRouteImport.update({
   id: '/',
   path: '/',
   getParentRoute: () => EventsEventIdRoute,
+} as any)
+const SeriesGroupIdCrewRoute = SeriesGroupIdCrewRouteImport.update({
+  id: '/series/$groupId/crew',
+  path: '/series/$groupId/crew',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const EventsEventIdVolunteersRoute = EventsEventIdVolunteersRouteImport.update({
   id: '/volunteers',
@@ -169,6 +175,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/staffing': typeof EventsEventIdStaffingRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
+  '/series/$groupId/crew': typeof SeriesGroupIdCrewRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
@@ -193,6 +200,7 @@ export interface FileRoutesByTo {
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/staffing': typeof EventsEventIdStaffingRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
+  '/series/$groupId/crew': typeof SeriesGroupIdCrewRoute
   '/events/$eventId': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
@@ -219,6 +227,7 @@ export interface FileRoutesById {
   '/events/$eventId/shifts': typeof EventsEventIdShiftsRoute
   '/events/$eventId/staffing': typeof EventsEventIdStaffingRoute
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
+  '/series/$groupId/crew': typeof SeriesGroupIdCrewRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
@@ -246,6 +255,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/shifts'
     | '/events/$eventId/staffing'
     | '/events/$eventId/volunteers'
+    | '/series/$groupId/crew'
     | '/events/$eventId/'
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
@@ -270,6 +280,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/shifts'
     | '/events/$eventId/staffing'
     | '/events/$eventId/volunteers'
+    | '/series/$groupId/crew'
     | '/events/$eventId'
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
@@ -295,6 +306,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/shifts'
     | '/events/$eventId/staffing'
     | '/events/$eventId/volunteers'
+    | '/series/$groupId/crew'
     | '/events/$eventId/'
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
@@ -308,6 +320,7 @@ export interface RootRouteChildren {
   ApiCrewImportRoute: typeof ApiCrewImportRoute
   ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute
   ESlugVolunteerRoute: typeof ESlugVolunteerRoute
+  SeriesGroupIdCrewRoute: typeof SeriesGroupIdCrewRoute
   ESlugConfirmTokenRoute: typeof ESlugConfirmTokenRoute
   ESlugConsentTokenRoute: typeof ESlugConsentTokenRoute
   ESlugScheduleTokenRoute: typeof ESlugScheduleTokenRoute
@@ -356,6 +369,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/events/$eventId/'
       preLoaderRoute: typeof EventsEventIdIndexRouteImport
       parentRoute: typeof EventsEventIdRoute
+    }
+    '/series/$groupId/crew': {
+      id: '/series/$groupId/crew'
+      path: '/series/$groupId/crew'
+      fullPath: '/series/$groupId/crew'
+      preLoaderRoute: typeof SeriesGroupIdCrewRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/events/$eventId/volunteers': {
       id: '/events/$eventId/volunteers'
@@ -533,6 +553,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiCrewImportRoute: ApiCrewImportRoute,
   ApiWebhooksStripeRoute: ApiWebhooksStripeRoute,
   ESlugVolunteerRoute: ESlugVolunteerRoute,
+  SeriesGroupIdCrewRoute: SeriesGroupIdCrewRoute,
   ESlugConfirmTokenRoute: ESlugConfirmTokenRoute,
   ESlugConsentTokenRoute: ESlugConsentTokenRoute,
   ESlugScheduleTokenRoute: ESlugScheduleTokenRoute,

--- a/apps/crew/src/routes/series/$groupId/crew.tsx
+++ b/apps/crew/src/routes/series/$groupId/crew.tsx
@@ -1,0 +1,338 @@
+// @lat: [[crew#Series Crew Pools]]
+import type { ReactNode } from "react"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import {
+  CalendarCheck,
+  History,
+  ShieldCheck,
+  Users,
+  UserRoundCheck,
+} from "lucide-react"
+import type { SeriesCrewPoolEntry } from "@/lib/crew/series-crew-pools"
+import { formatCrewValue } from "@/lib/crew-event-display"
+import {
+  formatVolunteerAvailability,
+  formatVolunteerRole,
+} from "@/lib/crew/roster-shifts"
+import { getCrewSeriesCrewPoolPageFn } from "@/server-fns/crew-series-fns"
+
+export const Route = createFileRoute("/series/$groupId/crew")({
+  loader: async ({ params, location }) =>
+    await getCrewSeriesCrewPoolPageFn({
+      data: {
+        groupId: params.groupId,
+        selectedCompetitionIds: getSelectedCompetitionIdsFromSearch(
+          location.search as Record<string, unknown>,
+        ),
+      },
+    }),
+  component: SeriesCrewPoolPage,
+})
+
+function SeriesCrewPoolPage() {
+  const { groupId } = Route.useParams()
+  const { group, pool } = Route.useLoaderData()
+  const navigate = useNavigate()
+
+  function setSelectedCompetition(competitionId: string, selected: boolean) {
+    const current = new Set(pool.selectedCompetitionIds)
+    if (selected) {
+      current.add(competitionId)
+    } else if (current.size > 1) {
+      current.delete(competitionId)
+    }
+
+    void navigate({
+      to: "/series/$groupId/crew",
+      params: { groupId },
+      search: (previous: Record<string, unknown>) => ({
+        ...previous,
+        events: [...current].join(","),
+      }),
+      replace: true,
+    })
+  }
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:px-6">
+      <div className="flex flex-col justify-between gap-4 border-b pb-6 md:flex-row md:items-end">
+        <div>
+          <p className="font-mono text-sm text-muted-foreground">{group.id}</p>
+          <h1 className="text-3xl font-semibold">{group.name}</h1>
+          <p className="text-muted-foreground">Series crew pool</p>
+        </div>
+        <nav className="flex flex-wrap gap-2 text-sm">
+          <Link
+            to="/events"
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Events
+          </Link>
+        </nav>
+      </div>
+
+      <section className="grid gap-4 md:grid-cols-5">
+        <Metric
+          icon={<Users className="size-4" />}
+          label="Pool"
+          value={pool.summary.totalVolunteers}
+        />
+        <Metric
+          icon={<CalendarCheck className="size-4" />}
+          label="Placements"
+          value={pool.summary.rosterPlacements}
+        />
+        <Metric
+          icon={<UserRoundCheck className="size-4" />}
+          label="Selected"
+          value={pool.summary.volunteersInSelectedCompetitions}
+        />
+        <Metric
+          icon={<History className="size-4" />}
+          label="History"
+          value={pool.summary.volunteersWithHistory}
+        />
+        <Metric
+          icon={<ShieldCheck className="size-4" />}
+          label="Credentials"
+          value={pool.summary.safeCredentialCount}
+        />
+      </section>
+
+      <section className="rounded-md border bg-card shadow-sm">
+        <div className="border-b px-4 py-3">
+          <h2 className="font-semibold">Selected competitions</h2>
+        </div>
+        <div className="grid gap-0 divide-y md:grid-cols-2 md:divide-x md:divide-y-0">
+          {pool.competitions.map((competition) => (
+            <label
+              key={competition.id}
+              className="flex cursor-pointer items-start gap-3 p-4 hover:bg-muted/50"
+            >
+              <input
+                type="checkbox"
+                checked={competition.selected}
+                disabled={
+                  competition.selected &&
+                  pool.selectedCompetitionIds.length <= 1
+                }
+                onChange={(event) =>
+                  setSelectedCompetition(competition.id, event.target.checked)
+                }
+                className="mt-1 size-4"
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block font-medium">{competition.name}</span>
+                <span className="block text-sm text-muted-foreground">
+                  {competition.startDate} to {competition.endDate} -{" "}
+                  {competition.rosterCount} rostered
+                </span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </section>
+
+      <section className="overflow-hidden rounded-md border bg-card shadow-sm">
+        {pool.entries.length > 0 ? (
+          <div className="divide-y">
+            {pool.entries.map((entry) => (
+              <SeriesCrewPoolRow key={entry.poolKey} entry={entry} />
+            ))}
+          </div>
+        ) : (
+          <div className="p-8 text-center">
+            <h2 className="font-semibold">No rostered volunteers</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Add volunteers on an event roster to build the series pool.
+            </p>
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}
+
+function SeriesCrewPoolRow({ entry }: { entry: SeriesCrewPoolEntry }) {
+  const facts = buildSeriesCrewPoolFacts(entry)
+
+  return (
+    <article className="grid gap-4 p-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
+      <div className="space-y-3">
+        <div>
+          <h3 className="font-semibold">{entry.volunteerName}</h3>
+          <p className="text-sm text-muted-foreground">
+            {entry.rosterEvents.length} roster placement
+            {entry.rosterEvents.length === 1 ? "" : "s"} -{" "}
+            {entry.priorEventCount} prior series event
+            {entry.priorEventCount === 1 ? "" : "s"}
+          </p>
+        </div>
+        <div className="space-y-2">
+          {entry.rosterEvents.map((event) => (
+            <div
+              key={`${entry.poolKey}:${event.competitionId}`}
+              className="rounded-md border bg-background p-3 text-sm"
+            >
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <span className="font-medium">{event.competitionName}</span>
+                <span className="rounded-md bg-muted px-2 py-1 text-xs">
+                  {event.selected
+                    ? "Selected"
+                    : formatCrewValue(event.rosterStatus)}
+                </span>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-1">
+                {event.roleTypes.map((roleType) => (
+                  <span
+                    key={roleType}
+                    className="rounded-md border px-2 py-1 text-xs"
+                  >
+                    {formatVolunteerRole(roleType)}
+                  </span>
+                ))}
+                <span className="rounded-md border px-2 py-1 text-xs">
+                  {formatVolunteerAvailability(event.availability)}
+                </span>
+              </div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Link
+                  to="/events/$eventId/volunteers"
+                  params={{ eventId: event.competitionId }}
+                  className="rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  Roster
+                </Link>
+                <Link
+                  to="/events/$eventId/shifts"
+                  params={{ eventId: event.competitionId }}
+                  className="rounded-md border px-2 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+                >
+                  Shifts
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <FactList facts={facts} />
+        {entry.lastEvent ? (
+          <p className="text-sm text-muted-foreground">
+            Last series event: {entry.lastEvent.label},{" "}
+            {formatSeriesPoolDate(entry.lastEvent.occurredAt)}
+          </p>
+        ) : null}
+        {entry.priorRoleTypes.length > 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Prior roles:{" "}
+            {entry.priorRoleTypes.map(formatVolunteerRole).join(", ")}
+          </p>
+        ) : null}
+        {entry.credentials.length > 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Credentials:{" "}
+            {entry.credentials
+              .map(
+                (credential) =>
+                  `${credential.credentialLabel} (${formatCrewValue(
+                    credential.status,
+                  )})`,
+              )
+              .join(", ")}
+          </p>
+        ) : null}
+      </div>
+    </article>
+  )
+}
+
+function Metric({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode
+  label: string
+  value: number
+}) {
+  return (
+    <div className="rounded-md border bg-card p-4 shadow-sm">
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="mt-2 text-2xl font-semibold">{value}</div>
+    </div>
+  )
+}
+
+function FactList({ facts }: { facts: string[] }) {
+  if (facts.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap gap-2 text-xs">
+      {facts.map((fact) => (
+        <span key={fact} className="rounded-md bg-muted px-2 py-1">
+          {fact}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+function buildSeriesCrewPoolFacts(entry: SeriesCrewPoolEntry) {
+  const facts = [
+    entry.reliability.signedUp
+      ? `${entry.reliability.signedUp} signup${plural(entry.reliability.signedUp)}`
+      : null,
+    entry.reliability.imported
+      ? `${entry.reliability.imported} import${plural(entry.reliability.imported)}`
+      : null,
+    entry.reliability.assigned
+      ? `${entry.reliability.assigned} assignment${plural(entry.reliability.assigned)}`
+      : null,
+    entry.reliability.confirmed
+      ? `${entry.reliability.confirmed} confirmed`
+      : null,
+    entry.reliability.declined
+      ? `${entry.reliability.declined} declined`
+      : null,
+    entry.reliability.changeRequested
+      ? `${entry.reliability.changeRequested} change request${plural(
+          entry.reliability.changeRequested,
+        )}`
+      : null,
+    entry.reliability.noShow
+      ? `${entry.reliability.noShow} no-show${plural(entry.reliability.noShow)}`
+      : null,
+    entry.reliability.completed
+      ? `${entry.reliability.completed} completed`
+      : null,
+  ]
+
+  return facts.filter((fact): fact is string => Boolean(fact))
+}
+
+function getSelectedCompetitionIdsFromSearch(search: Record<string, unknown>) {
+  const value = search.events
+  if (typeof value !== "string") return undefined
+  const selected = value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean)
+  return selected.length > 0 ? selected : undefined
+}
+
+function formatSeriesPoolDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value))
+}
+
+function plural(count: number) {
+  return count === 1 ? "" : "s"
+}

--- a/apps/crew/src/server-fns/crew-series-fns.ts
+++ b/apps/crew/src/server-fns/crew-series-fns.ts
@@ -1,0 +1,27 @@
+// @lat: [[crew#Series Crew Pools]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type { CrewSeriesCrewPoolPageData } from "../server/crew-series.server"
+
+const groupIdSchema = z.string().startsWith("cgrp_", "Invalid group ID")
+
+const selectedCompetitionIdsSchema = z
+  .array(z.string().startsWith("comp_", "Invalid competition ID"))
+  .max(50)
+  .optional()
+
+const crewSeriesCrewPoolInputSchema = z.object({
+  groupId: groupIdSchema,
+  selectedCompetitionIds: selectedCompetitionIdsSchema,
+})
+
+export const getCrewSeriesCrewPoolPageFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => crewSeriesCrewPoolInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { getCrewSeriesCrewPoolPage } = await import(
+      "../server/crew-series.server"
+    )
+    return getCrewSeriesCrewPoolPage(data)
+  })

--- a/apps/crew/src/server/crew-series.server.ts
+++ b/apps/crew/src/server/crew-series.server.ts
@@ -1,0 +1,358 @@
+// @lat: [[crew#Series Crew Pools]]
+import { and, asc, eq, gt, inArray, isNull, or } from "drizzle-orm"
+import { getDb } from "../db"
+import {
+  competitionGroupsTable,
+  competitionsTable,
+} from "../db/schemas/competitions"
+import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import {
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  crewVolunteerCredentialsTable,
+  crewVolunteerHistoryEventsTable,
+  crewVolunteerIdentitiesTable,
+} from "../db/schemas/crew-volunteer-intelligence"
+import { TEAM_PERMISSIONS } from "../db/schemas/teams"
+import {
+  buildSeriesCrewPoolViewModel,
+  type SeriesCrewPoolIdentityRecord,
+  type SeriesCrewPoolViewModel,
+} from "../lib/crew/series-crew-pools"
+import type { CrewRosterVolunteer } from "../lib/crew/roster-shifts"
+import { requireTeamPermission } from "../utils/team-auth"
+import { hashCrewVolunteerContactAnchor } from "./crew-volunteer-history.server"
+import { loadCrewRoster } from "./crew-roster-shift.server"
+
+export interface CrewSeriesCrewPoolPageData {
+  group: {
+    id: string
+    name: string
+    slug: string
+    description: string | null
+  }
+  selectedCompetitionIds: string[]
+  pool: SeriesCrewPoolViewModel
+}
+
+interface CrewSeriesCrewPoolInput {
+  groupId: string
+  selectedCompetitionIds?: string[]
+}
+
+interface SeriesCrewPoolRosterSource {
+  rosterVolunteerId: string
+  emailHash: string | null
+  membershipId: string | null
+  invitationId: string | null
+}
+
+export async function getCrewSeriesCrewPoolPage(
+  data: CrewSeriesCrewPoolInput,
+): Promise<CrewSeriesCrewPoolPageData> {
+  const db = getDb()
+  const [group] = await db
+    .select({
+      id: competitionGroupsTable.id,
+      name: competitionGroupsTable.name,
+      slug: competitionGroupsTable.slug,
+      description: competitionGroupsTable.description,
+      organizingTeamId: competitionGroupsTable.organizingTeamId,
+    })
+    .from(competitionGroupsTable)
+    .where(eq(competitionGroupsTable.id, data.groupId))
+    .limit(1)
+
+  if (!group) {
+    throw new Error("Series group not found")
+  }
+
+  await requireTeamPermission(
+    group.organizingTeamId,
+    TEAM_PERMISSIONS.ACCESS_DASHBOARD,
+  )
+
+  const competitions = await db
+    .select({
+      id: competitionsTable.id,
+      name: competitionsTable.name,
+      slug: competitionsTable.slug,
+      startDate: competitionsTable.startDate,
+      endDate: competitionsTable.endDate,
+      organizingTeamId: competitionsTable.organizingTeamId,
+      competitionTeamId: competitionsTable.competitionTeamId,
+    })
+    .from(competitionsTable)
+    .innerJoin(
+      crewEventSettingsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(
+      and(
+        eq(competitionsTable.groupId, group.id),
+        eq(competitionsTable.organizingTeamId, group.organizingTeamId),
+      ),
+    )
+    .orderBy(asc(competitionsTable.startDate), asc(competitionsTable.name))
+
+  const selectedCompetitionIds = normalizeSelectedCompetitionIds(
+    data.selectedCompetitionIds,
+    competitions.map((competition) => competition.id),
+  )
+  const rosterLoads = await Promise.all(
+    competitions.map(async (competition) => ({
+      competition,
+      roster: await loadCrewRoster(competition.competitionTeamId),
+    })),
+  )
+  const rosterRecords = rosterLoads.flatMap(({ competition, roster }) =>
+    roster.map((volunteer) => ({
+      rosterVolunteerId: toSeriesRosterVolunteerId(competition.id, volunteer),
+      competitionId: competition.id,
+      volunteerName: volunteer.name,
+      rosterStatus: volunteer.status,
+      availability: volunteer.availability,
+      roleTypes: volunteer.roleTypes,
+    })),
+  )
+  const rosterSources = await buildSeriesCrewPoolRosterSources(rosterLoads)
+  const identities = await loadSeriesCrewPoolIdentityMatches({
+    organizerTeamId: group.organizingTeamId,
+    rosterSources,
+  })
+  const identityIds = uniqueText(identities.map((identity) => identity.id))
+  const [historyEvents, credentials] =
+    identityIds.length > 0
+      ? await Promise.all([
+          db
+            .select({
+              identityId: crewVolunteerHistoryEventsTable.identityId,
+              teamId: crewVolunteerHistoryEventsTable.teamId,
+              competitionId: crewVolunteerHistoryEventsTable.competitionId,
+              groupId: crewVolunteerHistoryEventsTable.groupId,
+              competitionName: competitionsTable.name,
+              eventType: crewVolunteerHistoryEventsTable.eventType,
+              visibilityScope: crewVolunteerHistoryEventsTable.visibilityScope,
+              roleType: crewVolunteerHistoryEventsTable.roleType,
+              occurredAt: crewVolunteerHistoryEventsTable.occurredAt,
+            })
+            .from(crewVolunteerHistoryEventsTable)
+            .leftJoin(
+              competitionsTable,
+              eq(
+                crewVolunteerHistoryEventsTable.competitionId,
+                competitionsTable.id,
+              ),
+            )
+            .where(
+              and(
+                eq(
+                  crewVolunteerHistoryEventsTable.teamId,
+                  group.organizingTeamId,
+                ),
+                eq(crewVolunteerHistoryEventsTable.groupId, group.id),
+                inArray(
+                  crewVolunteerHistoryEventsTable.identityId,
+                  identityIds,
+                ),
+                eq(
+                  crewVolunteerHistoryEventsTable.visibilityScope,
+                  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+                ),
+              ),
+            ),
+          db
+            .select({
+              identityId: crewVolunteerCredentialsTable.identityId,
+              teamId: crewVolunteerCredentialsTable.teamId,
+              credentialType: crewVolunteerCredentialsTable.credentialType,
+              credentialLabel: crewVolunteerCredentialsTable.credentialLabel,
+              status: crewVolunteerCredentialsTable.status,
+              visibilityScope: crewVolunteerCredentialsTable.visibilityScope,
+              expiresAt: crewVolunteerCredentialsTable.expiresAt,
+              revokedAt: crewVolunteerCredentialsTable.revokedAt,
+            })
+            .from(crewVolunteerCredentialsTable)
+            .where(
+              and(
+                eq(
+                  crewVolunteerCredentialsTable.teamId,
+                  group.organizingTeamId,
+                ),
+                inArray(crewVolunteerCredentialsTable.identityId, identityIds),
+                eq(
+                  crewVolunteerCredentialsTable.visibilityScope,
+                  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.SAME_ORGANIZER,
+                ),
+                inArray(crewVolunteerCredentialsTable.status, [
+                  CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED,
+                  CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+                ]),
+                isNull(crewVolunteerCredentialsTable.revokedAt),
+                or(
+                  isNull(crewVolunteerCredentialsTable.expiresAt),
+                  gt(crewVolunteerCredentialsTable.expiresAt, new Date()),
+                ),
+              ),
+            ),
+        ])
+      : [[], []]
+  const pool = buildSeriesCrewPoolViewModel({
+    organizerTeamId: group.organizingTeamId,
+    groupId: group.id,
+    competitions: competitions.map((competition) => ({
+      id: competition.id,
+      name: competition.name,
+      slug: competition.slug,
+      startDate: competition.startDate,
+      endDate: competition.endDate,
+    })),
+    selectedCompetitionIds,
+    roster: rosterRecords,
+    identities,
+    historyEvents,
+    credentials,
+  })
+
+  return {
+    group: {
+      id: group.id,
+      name: group.name,
+      slug: group.slug,
+      description: group.description,
+    },
+    selectedCompetitionIds: pool.selectedCompetitionIds,
+    pool,
+  }
+}
+
+function normalizeSelectedCompetitionIds(
+  selectedCompetitionIds: string[] | undefined,
+  competitionIds: string[],
+) {
+  const competitionIdSet = new Set(competitionIds)
+  const selected = uniqueText(selectedCompetitionIds ?? []).filter((id) =>
+    competitionIdSet.has(id),
+  )
+
+  return selected.length > 0 ? selected : competitionIds.slice(0, 1)
+}
+
+async function buildSeriesCrewPoolRosterSources(
+  rosterLoads: Array<{
+    competition: { id: string }
+    roster: CrewRosterVolunteer[]
+  }>,
+) {
+  const sources: SeriesCrewPoolRosterSource[] = []
+
+  for (const { competition, roster } of rosterLoads) {
+    for (const volunteer of roster) {
+      sources.push({
+        rosterVolunteerId: toSeriesRosterVolunteerId(competition.id, volunteer),
+        emailHash: await hashCrewVolunteerContactAnchor(
+          "email",
+          volunteer.email,
+        ),
+        membershipId: volunteer.membershipId,
+        invitationId: volunteer.invitationId,
+      })
+    }
+  }
+
+  return sources
+}
+
+async function loadSeriesCrewPoolIdentityMatches({
+  organizerTeamId,
+  rosterSources,
+}: {
+  organizerTeamId: string
+  rosterSources: SeriesCrewPoolRosterSource[]
+}) {
+  const emailHashes = uniqueText(
+    rosterSources.map((source) => source.emailHash),
+  )
+  const membershipIds = uniqueText(
+    rosterSources.map((source) => source.membershipId),
+  )
+  const invitationIds = uniqueText(
+    rosterSources.map((source) => source.invitationId),
+  )
+  const identityConditions = [
+    emailHashes.length > 0
+      ? inArray(crewVolunteerIdentitiesTable.emailHash, emailHashes)
+      : null,
+    membershipIds.length > 0
+      ? inArray(crewVolunteerIdentitiesTable.sourceMembershipId, membershipIds)
+      : null,
+    invitationIds.length > 0
+      ? inArray(crewVolunteerIdentitiesTable.sourceInvitationId, invitationIds)
+      : null,
+  ].filter((condition): condition is NonNullable<typeof condition> =>
+    Boolean(condition),
+  )
+
+  if (identityConditions.length === 0) return []
+
+  const db = getDb()
+  const identityRows = await db
+    .select({
+      id: crewVolunteerIdentitiesTable.id,
+      teamId: crewVolunteerIdentitiesTable.teamId,
+      emailHash: crewVolunteerIdentitiesTable.emailHash,
+      sourceMembershipId: crewVolunteerIdentitiesTable.sourceMembershipId,
+      sourceInvitationId: crewVolunteerIdentitiesTable.sourceInvitationId,
+    })
+    .from(crewVolunteerIdentitiesTable)
+    .where(
+      and(
+        eq(crewVolunteerIdentitiesTable.teamId, organizerTeamId),
+        identityConditions.length === 1
+          ? identityConditions[0]
+          : or(...identityConditions),
+      ),
+    )
+
+  const matches: SeriesCrewPoolIdentityRecord[] = []
+  const seen = new Set<string>()
+
+  for (const source of rosterSources) {
+    for (const identity of identityRows) {
+      const matchedByEmail =
+        source.emailHash !== null && identity.emailHash === source.emailHash
+      const matchedByMembership =
+        source.membershipId !== null &&
+        identity.sourceMembershipId === source.membershipId
+      const matchedByInvitation =
+        source.invitationId !== null &&
+        identity.sourceInvitationId === source.invitationId
+
+      if (!matchedByEmail && !matchedByMembership && !matchedByInvitation) {
+        continue
+      }
+
+      const key = `${source.rosterVolunteerId}:${identity.id}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      matches.push({
+        id: identity.id,
+        teamId: identity.teamId,
+        rosterVolunteerId: source.rosterVolunteerId,
+      })
+    }
+  }
+
+  return matches
+}
+
+function toSeriesRosterVolunteerId(
+  competitionId: string,
+  volunteer: Pick<CrewRosterVolunteer, "id">,
+) {
+  return `${competitionId}:${volunteer.id}`
+}
+
+function uniqueText(values: Array<string | null | undefined>) {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))]
+}

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -88,6 +88,14 @@ Those wrappers may validate input, but DB and Workers-runtime-backed implementat
 
 This prevents Vite client import analysis from walking through [[apps/crew/src/db/index.ts]] to `cloudflare:workers` while preserving stable server-function import paths.
 
+## Series Crew Pools
+
+Series crew pools reuse existing `competition_groups` plus the normal competitions inside the group to show organizer-owned volunteer coverage across a series.
+
+[[apps/crew/src/lib/crew/series-crew-pools.ts]] builds the deterministic view model from group competitions, event rosters, same-organizer volunteer identities, same-group history events, and safe credential facts. It excludes selected/current competitions from prior-history counts and never includes raw contact fields, internal notes, private metadata, discovery details, or billing references in the pool output.
+
+[[apps/crew/src/server/crew-series.server.ts]] keeps the loader server-only, requires organizer dashboard access to the competition group, scopes competitions by the group's organizing team, and reads only Crew-enabled competitions in that group. [[apps/crew/src/server-fns/crew-series-fns.ts]] is the route-safe wrapper, and [[apps/crew/src/routes/series/$groupId/crew.tsx]] renders the organizer-only read model with links back to existing per-event roster and shift surfaces.
+
 ## Event Setup Dashboard
 
 Crew event setup pages let an operator create and review a normal competition with one `crew_event_settings` row for lifecycle, source platform URLs, concierge status, crew plan, setup checklist progress, assumptions, and internal handoff notes.


### PR DESCRIPTION
## What changed

- Added a read-only organizer series crew pool at `/series/$groupId/crew` using existing `competition_groups` and Crew-enabled competitions.
- Added a server-only loader plus thin `createServerFn` wrapper for group-scoped roster, same-organizer identity, same-group history, and safe credential hydration.
- Added deterministic helper coverage for selected/current competition handling, same-organizer/same-group scoping, factual reliability counts, safe credential filtering, and no raw contact/private metadata leakage.
- Added LAT anchor `crew#Series Crew Pools`.

## Guardrails

- No schema or migration changes.
- No regional discovery, public volunteer search/profile, rankings, intro requests, analytics, queue/email/SMS sending, or consent mutation changes.
- No invite-send or copy-template mutation was added; selected competitions are used only to scope the read model and link back to existing per-event roster/shifts surfaces.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/series-crew-pools.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; reports existing unrelated warnings)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `pnpm dlx lat.md locate 'crew#Series Crew Pools'`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Series Crew Pool for organizers to view deduped volunteers across a competition group with reliability history and safe credentials. Available at `/series/$groupId/crew`, scoped to the same organizer and group.

- **New Features**
  - New page at `/series/$groupId/crew` showing series-wide volunteer pool with metrics, selectable competitions, and links to per-event roster/shifts.
  - Server-only loader with `createServerFn` wrapper enforces organizer dashboard access and reads Crew-enabled competitions in the group.
  - Deterministic view model (`buildSeriesCrewPoolViewModel`) dedupes by identity, counts prior events outside the selected competitions, and summarizes reliability and roles.
  - Privacy: only `self_reported`/`verified` non-expired, non-revoked credentials; no contact, internal, or billing data in output.
  - No schema/migration changes; read-only surface (no invites, consent, search, or messaging).
  - Tests cover dedupe, scoping (same organizer/group), reliability counts, safe credential filtering, and no private data leakage.

<sup>Written for commit 64a0d96831c94c6ded68ca98e8608b89d999f264. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Series Crew Pools page allowing organizers to view volunteer coverage and reliability metrics across multiple competitions within a competition group.
  * Displays volunteer availability, event history, credentials, and role information with privacy protections (sensitive contact details excluded).
  * Implemented competition filtering to customize pool views by selected events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->