### PR TITLE
[codex] feat(crew): add conversion assistant

### DIFF
--- a/apps/crew/src/lib/crew/conversion-assistant.test.ts
+++ b/apps/crew/src/lib/crew/conversion-assistant.test.ts
@@ -94,6 +94,27 @@ describe("Crew conversion assistant view model", () => {
     })
   })
 
+  it("reports partial division fee coverage without mirroring the division count", () => {
+    const viewModel = buildCrewConversionAssistantViewModel({
+      ...readyInput,
+      counts: {
+        ...readyInput.counts,
+        divisionCount: 4,
+        divisionFeeCount: 2,
+        paidDivisionCount: 2,
+      },
+    })
+
+    expect(
+      viewModel.fullSetup.items.find((item) => item.key === "pricing"),
+    ).toMatchObject({
+      status: "ready",
+      details: expect.arrayContaining([
+        "2/4 divisions have configured paid fees.",
+      ]),
+    })
+  })
+
   it("preserves Crew inventory with aggregate counts only", () => {
     const viewModel = buildCrewConversionAssistantViewModel(readyInput)
     const serialized = JSON.stringify(viewModel)

--- a/apps/crew/src/lib/crew/conversion-assistant.test.ts
+++ b/apps/crew/src/lib/crew/conversion-assistant.test.ts
@@ -1,0 +1,284 @@
+// @lat: [[crew#Full WODsmith Conversion Assistant]]
+import { describe, expect, it } from "vitest"
+import { CREW_BILLING_STATE } from "../../db/schemas/crew-event-settings"
+import type { CrewReadinessPageData } from "../../server/crew-readiness.server"
+import {
+  buildCrewConversionAssistantViewModel,
+  type BuildCrewConversionAssistantInput,
+} from "./conversion-assistant"
+
+describe("Crew conversion assistant view model", () => {
+  it("keeps conversion read-only and assumes the existing competition is reused", () => {
+    const viewModel = buildCrewConversionAssistantViewModel(readyInput)
+
+    expect(viewModel.conversion).toMatchObject({
+      status: "privacy_reviewed",
+      label: "Privacy reviewed",
+      readOnly: true,
+      duplicateCompetition: false,
+    })
+    expect(
+      viewModel.preservation.items.find((item) => item.key === "competition"),
+    ).toMatchObject({
+      status: "ready",
+      summary: "Reuses comp_123.",
+      details: expect.arrayContaining([
+        "No second competition is created by this assistant.",
+      ]),
+    })
+  })
+
+  it("detects missing full-WODsmith setup before athlete registration can launch", () => {
+    const viewModel = buildCrewConversionAssistantViewModel({
+      ...readyInput,
+      event: {
+        ...readyInput.event,
+        status: "draft",
+        registrationOpensAt: null,
+        registrationClosesAt: null,
+        settings: null,
+        defaultRegistrationFeeCents: 0,
+      },
+      team: {
+        ...readyInput.team,
+        stripeAccountStatus: null,
+      },
+      counts: {
+        ...readyInput.counts,
+        divisionCount: 0,
+        divisionFeeCount: 0,
+        paidDivisionCount: 0,
+        athleteWaiverCount: 0,
+        activeRegistrationCount: 0,
+      },
+    })
+
+    expect(viewModel.fullSetup.summary).toMatchObject({
+      total: 8,
+      ready: 0,
+      blocked: 6,
+      highestStatus: "blocked",
+    })
+    expect(statusesByKey(viewModel.fullSetup.items)).toMatchObject({
+      divisions: "blocked",
+      registration_window: "blocked",
+      pricing: "blocked",
+      scoring: "needs_attention",
+      public_page: "blocked",
+      waivers: "blocked",
+      payouts: "needs_attention",
+      athlete_registration: "blocked",
+    })
+  })
+
+  it("marks athlete registration ready when full setup is complete without requiring registrations to already exist", () => {
+    const viewModel = buildCrewConversionAssistantViewModel(readyInput)
+
+    expect(viewModel.fullSetup.summary).toMatchObject({
+      total: 8,
+      ready: 8,
+      blocked: 0,
+      highestStatus: "ready",
+    })
+    expect(
+      viewModel.fullSetup.items.find(
+        (item) => item.key === "athlete_registration",
+      ),
+    ).toMatchObject({
+      status: "ready",
+      summary: "Registration prerequisites are ready.",
+      action: {
+        href: "https://wodsmith.com/compete/summer-throwdown/register",
+        kind: "public_route",
+      },
+    })
+  })
+
+  it("preserves Crew inventory with aggregate counts only", () => {
+    const viewModel = buildCrewConversionAssistantViewModel(readyInput)
+    const serialized = JSON.stringify(viewModel)
+
+    expect(statusesByKey(viewModel.preservation.items)).toMatchObject({
+      volunteers: "ready",
+      shifts: "ready",
+      heat_schedule: "ready",
+      judge_assignments: "ready",
+      confirmations: "ready",
+      imports: "ready",
+      credits: "ready",
+    })
+    expect(serialized).toContain("16 volunteers")
+    expect(serialized).toContain("Full-platform credit is recorded.")
+    expect(serialized).not.toContain("sam@example.com")
+    expect(serialized).not.toContain("555-")
+    expect(serialized).not.toContain("cs_test")
+    expect(serialized).not.toContain("pi_test")
+    expect(serialized).not.toContain("internal organizer note")
+  })
+
+  it("keeps safe links on existing Crew and WODsmith surfaces", () => {
+    const viewModel = buildCrewConversionAssistantViewModel(readyInput)
+
+    expect(
+      viewModel.fullSetup.items.find((item) => item.key === "divisions")
+        ?.action,
+    ).toMatchObject({
+      href: "https://wodsmith.com/compete/organizer/comp_123/divisions",
+      kind: "wodsmith_route",
+    })
+    expect(
+      viewModel.preservation.items.find((item) => item.key === "volunteers")
+        ?.action,
+    ).toMatchObject({
+      href: "/events/comp_123/volunteers",
+      kind: "crew_route",
+    })
+  })
+})
+
+function statusesByKey(items: Array<{ key: string; status: string }>) {
+  return Object.fromEntries(items.map((item) => [item.key, item.status]))
+}
+
+const readyInput: BuildCrewConversionAssistantInput = {
+  event: {
+    id: "comp_123",
+    name: "Summer Throwdown",
+    slug: "summer-throwdown",
+    crewOnly: true,
+    status: "published",
+    visibility: "public",
+    registrationOpensAt: "2026-07-01",
+    registrationClosesAt: "2026-08-01",
+    defaultRegistrationFeeCents: 12000,
+    settings: JSON.stringify({
+      scoringConfig: { algorithm: "points", tiebreakers: [] },
+    }),
+  },
+  team: {
+    slug: "summit-gym",
+    stripeAccountStatus: "VERIFIED",
+  },
+  counts: {
+    divisionCount: 4,
+    divisionFeeCount: 4,
+    paidDivisionCount: 4,
+    athleteWaiverCount: 1,
+    activeRegistrationCount: 0,
+  },
+  readiness: readyReadinessFixture(),
+  billing: {
+    state: CREW_BILLING_STATE.PAID,
+    planId: "crew_pro",
+    creditCents: 0,
+    fullPlatformCreditCents: 50000,
+  },
+  conversionStatus: "privacy_reviewed",
+  links: {
+    crewEvent: "/events/comp_123",
+    crewSetup: "/events/comp_123/setup",
+    crewImports: "/events/comp_123/imports",
+    crewVolunteers: "/events/comp_123/volunteers",
+    crewShifts: "/events/comp_123/shifts",
+    crewJudges: "/events/comp_123/judges",
+    crewBilling: "/events/comp_123/billing",
+    wodsmithOverview: "https://wodsmith.com/compete/organizer/comp_123",
+    wodsmithDivisions:
+      "https://wodsmith.com/compete/organizer/comp_123/divisions",
+    wodsmithEdit: "https://wodsmith.com/compete/organizer/comp_123/edit",
+    wodsmithPricing:
+      "https://wodsmith.com/compete/organizer/comp_123/pricing",
+    wodsmithScoring:
+      "https://wodsmith.com/compete/organizer/comp_123/scoring",
+    wodsmithWaivers:
+      "https://wodsmith.com/compete/organizer/comp_123/waivers",
+    wodsmithRevenue:
+      "https://wodsmith.com/compete/organizer/comp_123/revenue",
+    wodsmithPayouts:
+      "https://wodsmith.com/compete/organizer/settings/payouts/summit-gym",
+    publicPage: "https://wodsmith.com/compete/summer-throwdown",
+    athleteRegistration:
+      "https://wodsmith.com/compete/summer-throwdown/register",
+  },
+}
+
+function readyReadinessFixture(): CrewReadinessPageData {
+  return {
+    readiness: {
+      items: [],
+      summary: {
+        total: 7,
+        ready: 7,
+        needsAttention: 0,
+        blocked: 0,
+        progressPercent: 100,
+        highestStatus: "ready",
+      },
+    },
+    facts: {
+      setup: {
+        completed: 5,
+        total: 5,
+        percent: 100,
+      },
+      venues: {
+        venueCount: 2,
+        totalLaneCount: 12,
+      },
+      schedule: {
+        workoutCount: 4,
+        publishedWorkoutCount: 4,
+        heatCount: 24,
+        scheduledHeatCount: 24,
+        publishedHeatCount: 24,
+      },
+      imports: {
+        volunteerImportCount: 1,
+        appliedVolunteerImportCount: 1,
+        heatScheduleImportCount: 1,
+        appliedHeatScheduleImportCount: 1,
+      },
+      roster: {
+        total: 16,
+        pending: 2,
+        accepted: 0,
+        active: 14,
+        inactive: 0,
+        expired: 0,
+        assignable: 14,
+      },
+      shifts: {
+        totalShifts: 5,
+        assignedSlots: 8,
+        capacity: 8,
+        openSlots: 0,
+        confirmationSummary: {
+          pending: 0,
+          confirmed: 8,
+          declined: 0,
+          changeRequested: 0,
+          noShow: 0,
+          cancelled: 0,
+        },
+        confirmationOperationalSummary: {
+          missing: 0,
+          pending: 0,
+          sent: 0,
+          confirmed: 8,
+          declined: 0,
+          changeRequested: 0,
+          noShow: 0,
+          replaced: 0,
+          total: 8,
+          responseNeeded: 0,
+          organizerActionNeeded: 0,
+        },
+      },
+      judge: {
+        rotationCount: 4,
+        assignmentCount: 28,
+        activeVersionCount: 1,
+      },
+    },
+  }
+}

--- a/apps/crew/src/lib/crew/conversion-assistant.ts
+++ b/apps/crew/src/lib/crew/conversion-assistant.ts
@@ -279,7 +279,7 @@ function buildFullSetupItems(
         : "Pricing is currently free or unconfirmed.",
       details: [
         `Default fee: ${formatMoney(input.event.defaultRegistrationFeeCents)}.`,
-        `${input.counts.divisionFeeCount}/${input.counts.divisionCount} divisions have explicit fee rows.`,
+        `${input.counts.divisionFeeCount}/${input.counts.divisionCount} divisions have configured paid fees.`,
       ],
       action: wodsmithAction("Open pricing", input.links.wodsmithPricing),
     },

--- a/apps/crew/src/lib/crew/conversion-assistant.ts
+++ b/apps/crew/src/lib/crew/conversion-assistant.ts
@@ -1,0 +1,506 @@
+// @lat: [[crew#Full WODsmith Conversion Assistant]]
+import type { CrewEventConversionStatus } from "../../db/schemas/crew-volunteer-intelligence"
+import type { CrewBillingState } from "../../db/schemas/crew-event-settings"
+import type { CrewReadinessPageData } from "../../server/crew-readiness.server"
+
+export type CrewConversionChecklistStatus =
+  | "ready"
+  | "needs_attention"
+  | "blocked"
+
+export type CrewConversionFullSetupKey =
+  | "divisions"
+  | "registration_window"
+  | "pricing"
+  | "scoring"
+  | "public_page"
+  | "waivers"
+  | "payouts"
+  | "athlete_registration"
+
+export type CrewConversionPreservationKey =
+  | "competition"
+  | "volunteers"
+  | "shifts"
+  | "heat_schedule"
+  | "judge_assignments"
+  | "confirmations"
+  | "imports"
+  | "credits"
+
+export type CrewConversionActionKind =
+  | "crew_route"
+  | "wodsmith_route"
+  | "public_route"
+  | "deferred"
+
+export interface CrewConversionAction {
+  label: string
+  href: string | null
+  kind: CrewConversionActionKind
+}
+
+export interface CrewConversionChecklistItem<
+  TKey extends string = string,
+> {
+  key: TKey
+  label: string
+  status: CrewConversionChecklistStatus
+  summary: string
+  details: string[]
+  action: CrewConversionAction
+}
+
+export interface CrewConversionSummary {
+  total: number
+  ready: number
+  needsAttention: number
+  blocked: number
+  progressPercent: number
+  highestStatus: CrewConversionChecklistStatus
+}
+
+export interface CrewConversionAssistantViewModel {
+  event: {
+    id: string
+    name: string
+    slug: string
+    crewOnly: boolean
+    status: "draft" | "published"
+    visibility: "public" | "private"
+  }
+  conversion: {
+    status: CrewEventConversionStatus | null
+    label: string
+    readOnly: true
+    duplicateCompetition: false
+  }
+  fullSetup: {
+    items: CrewConversionChecklistItem<CrewConversionFullSetupKey>[]
+    summary: CrewConversionSummary
+  }
+  preservation: {
+    items: CrewConversionChecklistItem<CrewConversionPreservationKey>[]
+    summary: CrewConversionSummary
+  }
+}
+
+export interface BuildCrewConversionAssistantInput {
+  event: {
+    id: string
+    name: string
+    slug: string
+    crewOnly: boolean
+    status: "draft" | "published"
+    visibility: "public" | "private"
+    registrationOpensAt: string | null
+    registrationClosesAt: string | null
+    defaultRegistrationFeeCents: number
+    settings: string | null
+  }
+  team: {
+    slug: string
+    stripeAccountStatus: string | null
+  }
+  counts: {
+    divisionCount: number
+    divisionFeeCount: number
+    paidDivisionCount: number
+    athleteWaiverCount: number
+    activeRegistrationCount: number
+  }
+  readiness: CrewReadinessPageData
+  billing: {
+    state: CrewBillingState
+    planId: string | null
+    creditCents: number
+    fullPlatformCreditCents: number
+  }
+  conversionStatus: CrewEventConversionStatus | null
+  links: {
+    crewEvent: string
+    crewSetup: string
+    crewImports: string
+    crewVolunteers: string
+    crewShifts: string
+    crewJudges: string
+    crewBilling: string
+    wodsmithOverview: string
+    wodsmithDivisions: string
+    wodsmithEdit: string
+    wodsmithPricing: string
+    wodsmithScoring: string
+    wodsmithWaivers: string
+    wodsmithRevenue: string
+    wodsmithPayouts: string
+    publicPage: string
+    athleteRegistration: string
+  }
+}
+
+const conversionStatusLabels: Record<CrewEventConversionStatus, string> = {
+  requested: "Requested",
+  privacy_reviewed: "Privacy reviewed",
+  in_progress: "In progress",
+  completed: "Completed",
+  cancelled: "Cancelled",
+}
+
+export const crewConversionChecklistStatusLabels: Record<
+  CrewConversionChecklistStatus,
+  string
+> = {
+  ready: "Ready",
+  needs_attention: "Needs attention",
+  blocked: "Blocked",
+}
+
+export function buildCrewConversionAssistantViewModel(
+  input: BuildCrewConversionAssistantInput,
+): CrewConversionAssistantViewModel {
+  const fullSetupItems = buildFullSetupItems(input)
+  const preservationItems = buildPreservationItems(input)
+
+  return {
+    event: {
+      id: input.event.id,
+      name: input.event.name,
+      slug: input.event.slug,
+      crewOnly: input.event.crewOnly,
+      status: input.event.status,
+      visibility: input.event.visibility,
+    },
+    conversion: {
+      status: input.conversionStatus,
+      label: input.conversionStatus
+        ? conversionStatusLabels[input.conversionStatus]
+        : "Not requested",
+      readOnly: true,
+      duplicateCompetition: false,
+    },
+    fullSetup: {
+      items: fullSetupItems,
+      summary: summarizeConversionChecklist(fullSetupItems),
+    },
+    preservation: {
+      items: preservationItems,
+      summary: summarizeConversionChecklist(preservationItems),
+    },
+  }
+}
+
+export function summarizeConversionChecklist(
+  items: CrewConversionChecklistItem[],
+): CrewConversionSummary {
+  const ready = items.filter((item) => item.status === "ready").length
+  const needsAttention = items.filter(
+    (item) => item.status === "needs_attention",
+  ).length
+  const blocked = items.filter((item) => item.status === "blocked").length
+  const total = items.length
+
+  return {
+    total,
+    ready,
+    needsAttention,
+    blocked,
+    progressPercent: total === 0 ? 0 : Math.round((ready / total) * 100),
+    highestStatus:
+      blocked > 0
+        ? "blocked"
+        : needsAttention > 0
+          ? "needs_attention"
+          : "ready",
+  }
+}
+
+function buildFullSetupItems(
+  input: BuildCrewConversionAssistantInput,
+): CrewConversionChecklistItem<CrewConversionFullSetupKey>[] {
+  const hasRegistrationWindow = Boolean(
+    input.event.registrationOpensAt && input.event.registrationClosesAt,
+  )
+  const hasScoringConfig = hasJsonObjectKey(input.event.settings, "scoringConfig")
+  const hasPaidPricing =
+    input.event.defaultRegistrationFeeCents > 0 ||
+    input.counts.paidDivisionCount > 0
+  const hasPayouts = input.team.stripeAccountStatus === "VERIFIED"
+  const publicPageReady = input.event.status === "published"
+  const registrationSetupReady =
+    publicPageReady &&
+    hasRegistrationWindow &&
+    input.counts.divisionCount > 0 &&
+    input.counts.athleteWaiverCount > 0 &&
+    (!hasPaidPricing || hasPayouts)
+
+  return [
+    {
+      key: "divisions",
+      label: "Divisions",
+      status: input.counts.divisionCount > 0 ? "ready" : "blocked",
+      summary:
+        input.counts.divisionCount > 0
+          ? `${input.counts.divisionCount} division${plural(input.counts.divisionCount)} configured`
+          : "No athlete divisions are configured.",
+      details: [
+        "Uses the existing competition division model.",
+        "No duplicate competition is required.",
+      ],
+      action: wodsmithAction("Open divisions", input.links.wodsmithDivisions),
+    },
+    {
+      key: "registration_window",
+      label: "Registration window",
+      status: hasRegistrationWindow ? "ready" : "blocked",
+      summary: hasRegistrationWindow
+        ? `${input.event.registrationOpensAt} to ${input.event.registrationClosesAt}`
+        : "Athlete registration dates are missing.",
+      details: [
+        input.event.registrationOpensAt
+          ? `Opens: ${input.event.registrationOpensAt}`
+          : "Registration open date is not set.",
+        input.event.registrationClosesAt
+          ? `Closes: ${input.event.registrationClosesAt}`
+          : "Registration close date is not set.",
+      ],
+      action: wodsmithAction("Open event settings", input.links.wodsmithEdit),
+    },
+    {
+      key: "pricing",
+      label: "Pricing",
+      status:
+        input.counts.divisionCount === 0
+          ? "blocked"
+          : hasPaidPricing
+            ? "ready"
+            : "needs_attention",
+      summary: hasPaidPricing
+        ? "Paid registration pricing is configured."
+        : "Pricing is currently free or unconfirmed.",
+      details: [
+        `Default fee: ${formatMoney(input.event.defaultRegistrationFeeCents)}.`,
+        `${input.counts.divisionFeeCount}/${input.counts.divisionCount} divisions have explicit fee rows.`,
+      ],
+      action: wodsmithAction("Open pricing", input.links.wodsmithPricing),
+    },
+    {
+      key: "scoring",
+      label: "Scoring",
+      status: hasScoringConfig ? "ready" : "needs_attention",
+      summary: hasScoringConfig
+        ? "Scoring configuration is saved."
+        : "Scoring should be confirmed before launch.",
+      details: [
+        "The assistant checks for saved competition scoring configuration.",
+      ],
+      action: wodsmithAction("Open scoring", input.links.wodsmithScoring),
+    },
+    {
+      key: "public_page",
+      label: "Public page",
+      status: publicPageReady ? "ready" : "blocked",
+      summary: publicPageReady
+        ? `Competition page is ${input.event.visibility}.`
+        : "Competition is still in draft.",
+      details: [
+        `Status: ${input.event.status}.`,
+        `Visibility: ${input.event.visibility}.`,
+      ],
+      action: publicAction("Open public page", input.links.publicPage),
+    },
+    {
+      key: "waivers",
+      label: "Waivers",
+      status: input.counts.athleteWaiverCount > 0 ? "ready" : "blocked",
+      summary:
+        input.counts.athleteWaiverCount > 0
+          ? `${input.counts.athleteWaiverCount} athlete waiver${plural(input.counts.athleteWaiverCount)} required`
+          : "No required athlete waivers are configured.",
+      details: ["Volunteer waivers stay separate from athlete waivers."],
+      action: wodsmithAction("Open waivers", input.links.wodsmithWaivers),
+    },
+    {
+      key: "payouts",
+      label: "Payouts",
+      status: hasPayouts ? "ready" : hasPaidPricing ? "blocked" : "needs_attention",
+      summary: hasPayouts
+        ? "Organizer payouts are connected."
+        : hasPaidPricing
+          ? "Paid registration needs a verified payout account."
+          : "Payout setup can wait while registration remains free.",
+      details: [
+        `Stripe account status: ${input.team.stripeAccountStatus ?? "not connected"}.`,
+      ],
+      action: wodsmithAction("Open payouts", input.links.wodsmithPayouts),
+    },
+    {
+      key: "athlete_registration",
+      label: "Athlete registration",
+      status:
+        input.counts.activeRegistrationCount > 0 || registrationSetupReady
+          ? "ready"
+          : "blocked",
+      summary:
+        input.counts.activeRegistrationCount > 0
+          ? `${input.counts.activeRegistrationCount} active athlete registration${plural(input.counts.activeRegistrationCount)}`
+          : registrationSetupReady
+            ? "Registration prerequisites are ready."
+            : "Registration cannot open until blocked setup items are resolved.",
+      details: [
+        "Uses the existing WODsmith athlete registration flow.",
+        `${input.counts.activeRegistrationCount} active registration${plural(input.counts.activeRegistrationCount)} on this competition.`,
+      ],
+      action: publicAction(
+        "Open registration",
+        input.links.athleteRegistration,
+      ),
+    },
+  ]
+}
+
+function buildPreservationItems(
+  input: BuildCrewConversionAssistantInput,
+): CrewConversionChecklistItem<CrewConversionPreservationKey>[] {
+  const facts = input.readiness.facts
+
+  return [
+    {
+      key: "competition",
+      label: "Competition record",
+      status: "ready",
+      summary: `Reuses ${input.event.id}.`,
+      details: [
+        "Conversion is modeled on the existing competition row.",
+        "No second competition is created by this assistant.",
+      ],
+      action: crewAction("Open Crew overview", input.links.crewEvent),
+    },
+    {
+      key: "volunteers",
+      label: "Volunteers",
+      status: facts.roster.total > 0 ? "ready" : "needs_attention",
+      summary: `${facts.roster.total} volunteer${plural(facts.roster.total)}, ${facts.roster.assignable} assignable`,
+      details: [
+        `${facts.roster.active} active, ${facts.roster.pending} pending.`,
+        "Contact fields remain server-side and are not included here.",
+      ],
+      action: crewAction("Open volunteers", input.links.crewVolunteers),
+    },
+    {
+      key: "shifts",
+      label: "Shifts",
+      status: facts.shifts.totalShifts > 0 ? "ready" : "needs_attention",
+      summary: `${facts.shifts.assignedSlots}/${facts.shifts.capacity} shift slots assigned`,
+      details: [
+        `${facts.shifts.totalShifts} shift${plural(facts.shifts.totalShifts)} stay on the same event.`,
+      ],
+      action: crewAction("Open shifts", input.links.crewShifts),
+    },
+    {
+      key: "heat_schedule",
+      label: "Heat schedule",
+      status: facts.schedule.heatCount > 0 ? "ready" : "needs_attention",
+      summary: `${facts.schedule.scheduledHeatCount}/${facts.schedule.heatCount} heats scheduled`,
+      details: [
+        `${facts.schedule.publishedHeatCount}/${facts.schedule.heatCount} heat schedules published.`,
+        `${facts.schedule.workoutCount} workout${plural(facts.schedule.workoutCount)} on this competition.`,
+      ],
+      action: crewAction("Open schedule", input.links.crewSetup),
+    },
+    {
+      key: "judge_assignments",
+      label: "Judge assignments",
+      status: facts.judge.assignmentCount > 0 ? "ready" : "needs_attention",
+      summary: `${facts.judge.assignmentCount} judge heat assignment${plural(facts.judge.assignmentCount)}`,
+      details: [
+        `${facts.judge.activeVersionCount} active published version${plural(facts.judge.activeVersionCount)}.`,
+        "Published assignment rows are preserved, not rewritten.",
+      ],
+      action: crewAction("Open judges", input.links.crewJudges),
+    },
+    {
+      key: "confirmations",
+      label: "Confirmations",
+      status:
+        facts.shifts.confirmationSummary.confirmed > 0
+          ? "ready"
+          : "needs_attention",
+      summary: `${facts.shifts.confirmationSummary.confirmed}/${facts.shifts.assignedSlots} assignments confirmed`,
+      details: [
+        `${facts.shifts.confirmationSummary.pending} pending responses.`,
+        `${facts.shifts.confirmationSummary.changeRequested} change requests.`,
+      ],
+      action: crewAction("Open shifts", input.links.crewShifts),
+    },
+    {
+      key: "imports",
+      label: "Imports",
+      status:
+        facts.imports.appliedVolunteerImportCount > 0 ||
+        facts.imports.appliedHeatScheduleImportCount > 0
+          ? "ready"
+          : "needs_attention",
+      summary: `${facts.imports.appliedVolunteerImportCount + facts.imports.appliedHeatScheduleImportCount} applied Crew import${plural(facts.imports.appliedVolunteerImportCount + facts.imports.appliedHeatScheduleImportCount)}`,
+      details: [
+        `${facts.imports.appliedVolunteerImportCount}/${facts.imports.volunteerImportCount} volunteer imports applied.`,
+        `${facts.imports.appliedHeatScheduleImportCount}/${facts.imports.heatScheduleImportCount} heat imports applied.`,
+      ],
+      action: crewAction("Open imports", input.links.crewImports),
+    },
+    {
+      key: "credits",
+      label: "Credits",
+      status:
+        input.billing.fullPlatformCreditCents > 0 || input.billing.creditCents > 0
+          ? "ready"
+          : "needs_attention",
+      summary:
+        input.billing.fullPlatformCreditCents > 0
+          ? "Full-platform credit is recorded."
+          : input.billing.creditCents > 0
+            ? "Crew credit is recorded."
+            : "No conversion credit is recorded.",
+      details: [
+        `Crew billing state: ${input.billing.state}.`,
+        input.billing.planId
+          ? "Crew event plan is recorded on event settings."
+          : "No Crew event plan is recorded.",
+      ],
+      action: crewAction("Open billing", input.links.crewBilling),
+    },
+  ]
+}
+
+function crewAction(label: string, href: string): CrewConversionAction {
+  return { label, href, kind: "crew_route" }
+}
+
+function wodsmithAction(label: string, href: string): CrewConversionAction {
+  return { label, href, kind: "wodsmith_route" }
+}
+
+function publicAction(label: string, href: string): CrewConversionAction {
+  return { label, href, kind: "public_route" }
+}
+
+function hasJsonObjectKey(settingsText: string | null, key: string) {
+  if (!settingsText) return false
+
+  try {
+    const parsed = JSON.parse(settingsText) as Record<string, unknown>
+    return Boolean(parsed && typeof parsed === "object" && parsed[key])
+  } catch {
+    return false
+  }
+}
+
+function formatMoney(cents: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(cents / 100)
+}
+
+function plural(count: number) {
+  return count === 1 ? "" : "s"
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -26,6 +26,7 @@ import { Route as EventsEventIdJudgesRouteImport } from './routes/events/$eventI
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
 import { Route as EventsEventIdExportsRouteImport } from './routes/events/$eventId/exports'
 import { Route as EventsEventIdDayOfRouteImport } from './routes/events/$eventId/day-of'
+import { Route as EventsEventIdConvertRouteImport } from './routes/events/$eventId/convert'
 import { Route as EventsEventIdBillingRouteImport } from './routes/events/$eventId/billing'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
@@ -119,6 +120,11 @@ const EventsEventIdDayOfRoute = EventsEventIdDayOfRouteImport.update({
   path: '/day-of',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdConvertRoute = EventsEventIdConvertRouteImport.update({
+  id: '/convert',
+  path: '/convert',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const EventsEventIdBillingRoute = EventsEventIdBillingRouteImport.update({
   id: '/billing',
   path: '/billing',
@@ -165,6 +171,7 @@ export interface FileRoutesByFullPath {
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
+  '/events/$eventId/convert': typeof EventsEventIdConvertRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
@@ -190,6 +197,7 @@ export interface FileRoutesByTo {
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
+  '/events/$eventId/convert': typeof EventsEventIdConvertRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
@@ -217,6 +225,7 @@ export interface FileRoutesById {
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
+  '/events/$eventId/convert': typeof EventsEventIdConvertRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
@@ -245,6 +254,7 @@ export interface FileRouteTypes {
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/billing'
+    | '/events/$eventId/convert'
     | '/events/$eventId/day-of'
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
@@ -270,6 +280,7 @@ export interface FileRouteTypes {
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/billing'
+    | '/events/$eventId/convert'
     | '/events/$eventId/day-of'
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
@@ -296,6 +307,7 @@ export interface FileRouteTypes {
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/billing'
+    | '/events/$eventId/convert'
     | '/events/$eventId/day-of'
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
@@ -447,6 +459,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdDayOfRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/convert': {
+      id: '/events/$eventId/convert'
+      path: '/convert'
+      fullPath: '/events/$eventId/convert'
+      preLoaderRoute: typeof EventsEventIdConvertRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/events/$eventId/billing': {
       id: '/events/$eventId/billing'
       path: '/billing'
@@ -501,6 +520,7 @@ declare module '@tanstack/react-router' {
 
 interface EventsEventIdRouteChildren {
   EventsEventIdBillingRoute: typeof EventsEventIdBillingRoute
+  EventsEventIdConvertRoute: typeof EventsEventIdConvertRoute
   EventsEventIdDayOfRoute: typeof EventsEventIdDayOfRoute
   EventsEventIdExportsRoute: typeof EventsEventIdExportsRoute
   EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
@@ -516,6 +536,7 @@ interface EventsEventIdRouteChildren {
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdBillingRoute: EventsEventIdBillingRoute,
+  EventsEventIdConvertRoute: EventsEventIdConvertRoute,
   EventsEventIdDayOfRoute: EventsEventIdDayOfRoute,
   EventsEventIdExportsRoute: EventsEventIdExportsRoute,
   EventsEventIdImportsRoute: EventsEventIdImportsRoute,

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -3,6 +3,7 @@
 // @lat: [[crew#Day Of Operations Board]]
 // @lat: [[crew#Pilot Exports]]
 // @lat: [[crew#Billing Page And Upgrade CTA]]
+// @lat: [[crew#Full WODsmith Conversion Assistant]]
 import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
 import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
 
@@ -72,6 +73,14 @@ function EventShell() {
             className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             Billing
+          </Link>
+          <Link
+            to="/events/$eventId/convert"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Convert
           </Link>
           <Link
             to="/events/$eventId/imports"

--- a/apps/crew/src/routes/events/$eventId/convert.tsx
+++ b/apps/crew/src/routes/events/$eventId/convert.tsx
@@ -1,0 +1,228 @@
+// @lat: [[crew#Full WODsmith Conversion Assistant]]
+import { createFileRoute } from "@tanstack/react-router"
+import {
+  ArrowUpRight,
+  CheckCircle2,
+  CircleAlert,
+  LockKeyhole,
+  ShieldCheck,
+} from "lucide-react"
+import type { ReactNode } from "react"
+import {
+  crewConversionChecklistStatusLabels,
+  type CrewConversionAction,
+  type CrewConversionChecklistItem,
+  type CrewConversionChecklistStatus,
+  type CrewConversionSummary,
+} from "@/lib/crew/conversion-assistant"
+import { getCrewConversionAssistantPageFn } from "@/server-fns/crew-conversion-fns"
+
+export const Route = createFileRoute("/events/$eventId/convert")({
+  loader: async ({ params }) =>
+    await getCrewConversionAssistantPageFn({
+      data: { eventId: params.eventId },
+    }),
+  component: CrewConversionAssistantPage,
+})
+
+function CrewConversionAssistantPage() {
+  const { viewModel } = Route.useLoaderData()
+
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <Metric label="Competition" value={viewModel.event.id} mono />
+        <Metric
+          label="Crew-only"
+          value={viewModel.event.crewOnly ? "Yes" : "No"}
+        />
+        <Metric label="Conversion" value={viewModel.conversion.label} />
+        <Metric
+          label="Full setup"
+          value={`${viewModel.fullSetup.summary.ready}/${viewModel.fullSetup.summary.total}`}
+        />
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm font-medium text-primary">
+              <ShieldCheck className="size-4" aria-hidden="true" />
+              Full WODsmith conversion
+            </div>
+            <h2 className="text-xl font-semibold">
+              Convert without duplicating the event
+            </h2>
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              This assistant inventories what stays on the current competition
+              and points missing full-platform setup to existing WODsmith
+              organizer surfaces.
+            </p>
+          </div>
+          <div className="rounded-md border bg-background p-4 text-sm">
+            <div className="flex items-center gap-2 font-medium">
+              <LockKeyhole className="size-4 text-muted-foreground" />
+              Read-only
+            </div>
+            <p className="mt-2 text-muted-foreground">
+              No conversion mutation, checkout, registration launch, payout
+              setup, deploy, import apply, or public activation happens here.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <ChecklistSection
+        title="Missing full WODsmith setup"
+        summary={viewModel.fullSetup.summary}
+        items={viewModel.fullSetup.items}
+      />
+
+      <ChecklistSection
+        title="Crew data preserved"
+        summary={viewModel.preservation.summary}
+        items={viewModel.preservation.items}
+      />
+    </section>
+  )
+}
+
+function ChecklistSection({
+  title,
+  summary,
+  items,
+}: {
+  title: string
+  summary: CrewConversionSummary
+  items: CrewConversionChecklistItem[]
+}) {
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">{title}</h2>
+          <p className="text-sm text-muted-foreground">
+            {summary.ready}/{summary.total} ready, {summary.blocked} blocked.
+          </p>
+        </div>
+        <StatusBadge status={summary.highestStatus} />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {items.map((item) => (
+          <ChecklistCard item={item} key={item.key} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ChecklistCard({ item }: { item: CrewConversionChecklistItem }) {
+  const Icon = item.status === "ready" ? CheckCircle2 : CircleAlert
+
+  return (
+    <article className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 gap-3">
+          <Icon
+            className={`mt-0.5 size-5 shrink-0 ${statusIconClass(item.status)}`}
+            aria-hidden="true"
+          />
+          <div className="min-w-0">
+            <h3 className="font-semibold">{item.label}</h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {item.summary}
+            </p>
+          </div>
+        </div>
+        <StatusBadge status={item.status} compact />
+      </div>
+
+      <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+        {item.details.map((detail) => (
+          <li key={detail}>{detail}</li>
+        ))}
+      </ul>
+
+      <ActionLink action={item.action} />
+    </article>
+  )
+}
+
+function ActionLink({ action }: { action: CrewConversionAction }) {
+  if (!action.href) {
+    return (
+      <span className="mt-5 inline-flex rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground">
+        {action.label}
+      </span>
+    )
+  }
+
+  const external =
+    action.kind === "wodsmith_route" || action.kind === "public_route"
+
+  return (
+    <a
+      href={action.href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noreferrer" : undefined}
+      className="mt-5 inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      {action.label}
+      {external ? <ArrowUpRight className="size-4" aria-hidden="true" /> : null}
+    </a>
+  )
+}
+
+function Metric({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: ReactNode
+  mono?: boolean
+}) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p
+        className={`mt-2 break-words text-lg font-semibold ${mono ? "font-mono text-sm" : ""}`}
+      >
+        {value}
+      </p>
+    </section>
+  )
+}
+
+function StatusBadge({
+  status,
+  compact = false,
+}: {
+  status: CrewConversionChecklistStatus
+  compact?: boolean
+}) {
+  return (
+    <span
+      className={`inline-flex shrink-0 rounded-md border px-2 py-1 text-xs font-medium ${statusBadgeClass(status)} ${compact ? "" : "self-start"}`}
+    >
+      {crewConversionChecklistStatusLabels[status]}
+    </span>
+  )
+}
+
+function statusBadgeClass(status: CrewConversionChecklistStatus) {
+  if (status === "ready") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "blocked") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+}
+
+function statusIconClass(status: CrewConversionChecklistStatus) {
+  if (status === "ready") return "text-emerald-600"
+  if (status === "blocked") return "text-destructive"
+  return "text-amber-600"
+}

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -2,6 +2,7 @@
 // @lat: [[crew#Staffing Page Gap Report]]
 // @lat: [[crew#Day Of Operations Board]]
 // @lat: [[crew#Billing Page And Upgrade CTA]]
+// @lat: [[crew#Full WODsmith Conversion Assistant]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import { formatCrewValue, getSafeHttpUrl } from "@/lib/crew-event-display"
 import {
@@ -92,6 +93,25 @@ function EventOverviewPage() {
             className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
           >
             Open billing
+          </Link>
+        </div>
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Full WODsmith conversion</h2>
+            <p className="text-sm text-muted-foreground">
+              Inventory preserved Crew data and missing full-platform setup
+              before handoff.
+            </p>
+          </div>
+          <Link
+            to="/events/$eventId/convert"
+            params={{ eventId }}
+            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Open assistant
           </Link>
         </div>
       </section>

--- a/apps/crew/src/server-fns/crew-conversion-fns.ts
+++ b/apps/crew/src/server-fns/crew-conversion-fns.ts
@@ -1,0 +1,23 @@
+// @lat: [[crew#Full WODsmith Conversion Assistant]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type { CrewConversionAssistantPageData } from "../server/crew-conversion.server"
+
+const getCrewConversionAssistantPageInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+export const getCrewConversionAssistantPageFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) =>
+    getCrewConversionAssistantPageInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewConversionAssistantPage } = await import(
+      "../server/crew-conversion.server"
+    )
+    return getCrewConversionAssistantPage(data)
+  })

--- a/apps/crew/src/server/crew-conversion.server.ts
+++ b/apps/crew/src/server/crew-conversion.server.ts
@@ -1,0 +1,230 @@
+// @lat: [[crew#Full WODsmith Conversion Assistant]]
+import { and, count, eq, gt } from "drizzle-orm"
+import { getDb } from "../db"
+import {
+  competitionRegistrationsTable,
+  competitionsTable,
+  REGISTRATION_STATUS,
+} from "../db/schemas/competitions"
+import { competitionDivisionsTable } from "../db/schemas/commerce"
+import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import {
+  crewEventConversionsTable,
+  type CrewEventConversionStatus,
+} from "../db/schemas/crew-volunteer-intelligence"
+import { teamTable } from "../db/schemas/teams"
+import { waiversTable } from "../db/schemas/waivers"
+import {
+  buildCrewConversionAssistantViewModel,
+  type CrewConversionAssistantViewModel,
+} from "../lib/crew/conversion-assistant"
+import { getSiteUrl } from "../lib/env"
+import { getCrewEvent } from "./crew-event-settings.server"
+import { getCrewReadinessPage } from "./crew-readiness.server"
+
+export interface CrewConversionAssistantPageData {
+  viewModel: CrewConversionAssistantViewModel
+}
+
+export async function getCrewConversionAssistantPage(data: {
+  eventId: string
+}): Promise<CrewConversionAssistantPageData> {
+  const [{ event }, readiness] = await Promise.all([
+    getCrewEvent({ eventId: data.eventId }),
+    getCrewReadinessPage({ eventId: data.eventId }),
+  ])
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  const [fullEvent, counts, conversionStatus] = await Promise.all([
+    loadCrewConversionEvent(data.eventId),
+    loadCrewConversionCounts(data.eventId),
+    loadCrewConversionStatus(data.eventId),
+  ])
+
+  if (!fullEvent) {
+    throw new Error("Crew event not found")
+  }
+
+  const links = buildCrewConversionLinks({
+    eventId: fullEvent.id,
+    slug: fullEvent.slug,
+    teamSlug: fullEvent.teamSlug,
+    wodsmithBaseUrl: getSiteUrl(),
+  })
+
+  return {
+    viewModel: buildCrewConversionAssistantViewModel({
+      event: {
+        id: fullEvent.id,
+        name: fullEvent.name,
+        slug: fullEvent.slug,
+        crewOnly: fullEvent.crewOnly,
+        status: fullEvent.status,
+        visibility: fullEvent.visibility,
+        registrationOpensAt: fullEvent.registrationOpensAt,
+        registrationClosesAt: fullEvent.registrationClosesAt,
+        defaultRegistrationFeeCents: fullEvent.defaultRegistrationFeeCents ?? 0,
+        settings: fullEvent.settings,
+      },
+      team: {
+        slug: fullEvent.teamSlug,
+        stripeAccountStatus: fullEvent.stripeAccountStatus,
+      },
+      counts,
+      readiness,
+      billing: {
+        state: fullEvent.crewBillingState,
+        planId: fullEvent.crewBillingPlanId,
+        creditCents: fullEvent.crewCreditCents,
+        fullPlatformCreditCents: fullEvent.fullPlatformCreditCents,
+      },
+      conversionStatus,
+      links,
+    }),
+  }
+}
+
+async function loadCrewConversionEvent(eventId: string) {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      name: competitionsTable.name,
+      slug: competitionsTable.slug,
+      status: competitionsTable.status,
+      visibility: competitionsTable.visibility,
+      registrationOpensAt: competitionsTable.registrationOpensAt,
+      registrationClosesAt: competitionsTable.registrationClosesAt,
+      defaultRegistrationFeeCents:
+        competitionsTable.defaultRegistrationFeeCents,
+      settings: competitionsTable.settings,
+      teamSlug: teamTable.slug,
+      stripeAccountStatus: teamTable.stripeAccountStatus,
+      crewOnly: crewEventSettingsTable.crewOnly,
+      crewBillingState: crewEventSettingsTable.crewBillingState,
+      crewBillingPlanId: crewEventSettingsTable.crewBillingPlanId,
+      crewCreditCents: crewEventSettingsTable.crewCreditCents,
+      fullPlatformCreditCents: crewEventSettingsTable.fullPlatformCreditCents,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .innerJoin(teamTable, eq(competitionsTable.organizingTeamId, teamTable.id))
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  return event ?? null
+}
+
+async function loadCrewConversionCounts(competitionId: string) {
+  const db = getDb()
+  const [
+    divisionRows,
+    divisionFeeRows,
+    paidDivisionRows,
+    athleteWaiverRows,
+    activeRegistrationRows,
+  ] = await Promise.all([
+    db
+      .select({ count: count() })
+      .from(competitionDivisionsTable)
+      .where(eq(competitionDivisionsTable.competitionId, competitionId)),
+    db
+      .select({ count: count() })
+      .from(competitionDivisionsTable)
+      .where(eq(competitionDivisionsTable.competitionId, competitionId)),
+    db
+      .select({ count: count() })
+      .from(competitionDivisionsTable)
+      .where(
+        and(
+          eq(competitionDivisionsTable.competitionId, competitionId),
+          gt(competitionDivisionsTable.feeCents, 0),
+        ),
+      ),
+    db
+      .select({ count: count() })
+      .from(waiversTable)
+      .where(
+        and(
+          eq(waiversTable.competitionId, competitionId),
+          eq(waiversTable.required, true),
+        ),
+      ),
+    db
+      .select({ count: count() })
+      .from(competitionRegistrationsTable)
+      .where(
+        and(
+          eq(competitionRegistrationsTable.eventId, competitionId),
+          eq(competitionRegistrationsTable.status, REGISTRATION_STATUS.ACTIVE),
+        ),
+      ),
+  ])
+
+  return {
+    divisionCount: divisionRows[0]?.count ?? 0,
+    divisionFeeCount: divisionFeeRows[0]?.count ?? 0,
+    paidDivisionCount: paidDivisionRows[0]?.count ?? 0,
+    athleteWaiverCount: athleteWaiverRows[0]?.count ?? 0,
+    activeRegistrationCount: activeRegistrationRows[0]?.count ?? 0,
+  }
+}
+
+async function loadCrewConversionStatus(
+  competitionId: string,
+): Promise<CrewEventConversionStatus | null> {
+  const db = getDb()
+  const [conversion] = await db
+    .select({ status: crewEventConversionsTable.status })
+    .from(crewEventConversionsTable)
+    .where(eq(crewEventConversionsTable.competitionId, competitionId))
+    .limit(1)
+
+  return conversion?.status ?? null
+}
+
+function buildCrewConversionLinks({
+  eventId,
+  slug,
+  teamSlug,
+  wodsmithBaseUrl,
+}: {
+  eventId: string
+  slug: string
+  teamSlug: string
+  wodsmithBaseUrl: string
+}) {
+  const base = trimTrailingSlash(wodsmithBaseUrl)
+  const organizer = `${base}/compete/organizer/${eventId}`
+  const publicCompetition = `${base}/compete/${slug}`
+
+  return {
+    crewEvent: `/events/${eventId}`,
+    crewSetup: `/events/${eventId}/setup`,
+    crewImports: `/events/${eventId}/imports`,
+    crewVolunteers: `/events/${eventId}/volunteers`,
+    crewShifts: `/events/${eventId}/shifts`,
+    crewJudges: `/events/${eventId}/judges`,
+    crewBilling: `/events/${eventId}/billing`,
+    wodsmithOverview: organizer,
+    wodsmithDivisions: `${organizer}/divisions`,
+    wodsmithEdit: `${organizer}/edit`,
+    wodsmithPricing: `${organizer}/pricing`,
+    wodsmithScoring: `${organizer}/scoring`,
+    wodsmithWaivers: `${organizer}/waivers`,
+    wodsmithRevenue: `${organizer}/revenue`,
+    wodsmithPayouts: `${base}/compete/organizer/settings/payouts/${teamSlug}?returnTo=${encodeURIComponent(`${organizer}/revenue`)}`,
+    publicPage: publicCompetition,
+    athleteRegistration: `${publicCompetition}/register`,
+  }
+}
+
+function trimTrailingSlash(value: string) {
+  return value.endsWith("/") ? value.slice(0, -1) : value
+}

--- a/apps/crew/src/server/crew-conversion.server.ts
+++ b/apps/crew/src/server/crew-conversion.server.ts
@@ -126,14 +126,9 @@ async function loadCrewConversionCounts(competitionId: string) {
   const [
     divisionRows,
     divisionFeeRows,
-    paidDivisionRows,
     athleteWaiverRows,
     activeRegistrationRows,
   ] = await Promise.all([
-    db
-      .select({ count: count() })
-      .from(competitionDivisionsTable)
-      .where(eq(competitionDivisionsTable.competitionId, competitionId)),
     db
       .select({ count: count() })
       .from(competitionDivisionsTable)
@@ -170,7 +165,7 @@ async function loadCrewConversionCounts(competitionId: string) {
   return {
     divisionCount: divisionRows[0]?.count ?? 0,
     divisionFeeCount: divisionFeeRows[0]?.count ?? 0,
-    paidDivisionCount: paidDivisionRows[0]?.count ?? 0,
+    paidDivisionCount: divisionFeeRows[0]?.count ?? 0,
     athleteWaiverCount: athleteWaiverRows[0]?.count ?? 0,
     activeRegistrationCount: activeRegistrationRows[0]?.count ?? 0,
   }

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -96,6 +96,14 @@ Series crew pools reuse existing `competition_groups` plus the normal competitio
 
 [[apps/crew/src/server/crew-series.server.ts]] keeps the loader server-only, requires organizer dashboard access to the competition group, scopes competitions by the group's organizing team, and reads only Crew-enabled competitions in that group. [[apps/crew/src/server-fns/crew-series-fns.ts]] is the route-safe wrapper, and [[apps/crew/src/routes/series/$groupId/crew.tsx]] renders the organizer-only read model with links back to existing per-event roster and shift surfaces.
 
+## Full WODsmith Conversion Assistant
+
+The conversion assistant is a read-only organizer surface for turning a Crew-only event into the full WODsmith setup without creating a second competition.
+
+[[apps/crew/src/routes/events/$eventId/convert.tsx]] renders missing full-platform setup items plus Crew preservation checks for the selected competition. [[apps/crew/src/server/crew-conversion.server.ts]] loads only aggregate counts and safe status fields from existing competitions, Crew settings, readiness, imports, roster, shifts, judge assignments, confirmations, billing credit state, and conversion status. [[apps/crew/src/lib/crew/conversion-assistant.ts]] owns deterministic checklist derivation and excludes raw volunteer contact details, internal notes, private metadata, invoices, and Stripe references from the route view model.
+
+The assistant links to existing Crew and WODsmith organizer/public routes for follow-up. It does not mutate conversion rows, flip `crewOnly`, duplicate competitions, launch athlete registration, activate public pages, apply imports, rewrite published judge assignments, send messages, deploy, or change billing.
+
 ## Event Setup Dashboard
 
 Crew event setup pages let an operator create and review a normal competition with one `crew_event_settings` row for lifecycle, source platform URLs, concierge status, crew plan, setup checklist progress, assumptions, and internal handoff notes.


### PR DESCRIPTION
## Summary

Adds a read-only Crew conversion assistant at `/events/$eventId/convert` for turning a Crew-only event into full WODsmith setup without creating a second competition.

The assistant:
- inventories missing full-WODsmith setup items: divisions, registration window, pricing, scoring, public page, waivers, payouts, and athlete registration
- inventories preserved Crew data using aggregate counts only: competition row, volunteers, shifts, heat schedule, judge assignments, confirmations, imports, and credits
- links to existing Crew and WODsmith organizer/public routes for follow-up instead of adding mutation surfaces
- keeps conversion status read-only and does not flip `crewOnly`, mutate conversion rows, launch registration, activate public pages, rewrite judge assignments, send messages, or change billing

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/conversion-assistant.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; existing repo warnings remain)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `pnpm dlx lat.md locate 'crew#Full WODsmith Conversion Assistant'`
- `git diff --check`

## Notes

No shared schema or DB files were changed; the existing merged conversion schema is read only in this slice.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read-only Crew conversion assistant at /events/$eventId/convert to guide turning a Crew-only event into a full WODsmith setup without duplicating the competition. It inventories missing full-setup items and shows preserved Crew data with safe links for follow-up.

- **New Features**
  - New route with checklist UI for full-setup status and Crew preservation.
  - Read-only by design; does not flip `crewOnly`, create competitions, launch registration, or change billing.
  - Links to existing WODsmith organizer/public pages and Crew pages for next steps.
  - Server-only loader returns aggregate counts and status; checklist logic lives in a view-model builder. No schema changes.
  - Event navigation updated to include “Convert”; added unit tests for checklist logic.

- **Bug Fixes**
  - Correctly count paid division fees for pricing readiness and details in the checklist.

<sup>Written for commit 0471735eb9640d64ffb573752d30bc25a67e9049. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Full WODsmith Conversion Assistant—a read-only organizer tool displaying checklists for missing setup items and preserved Crew data when converting Crew-only events to full WODsmith
  * Added navigation link and overview card to access the conversion assistant from the event page

* **Tests**
  * Added comprehensive test suite for the conversion assistant

* **Documentation**
  * Added feature documentation for Full WODsmith Conversion Assistant

<!-- end of auto-generated comment: release notes by coderabbit.ai -->