### PR TITLE
[codex] feat(crew): pilot regional judge discovery

### DIFF
--- a/apps/crew/src/lib/crew/regional-judge-discovery.test.ts
+++ b/apps/crew/src/lib/crew/regional-judge-discovery.test.ts
@@ -1,0 +1,298 @@
+// @lat: [[crew#Regional Judge Discovery Pilot]]
+import { describe, expect, it } from "vitest"
+import {
+  CREW_VOLUNTEER_CONSENT_SCOPE,
+  CREW_VOLUNTEER_CONSENT_STATUS,
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_CREDENTIAL_TYPE,
+  CREW_VOLUNTEER_DISCOVERY_AGE_STATUS,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+  CREW_VOLUNTEER_IDENTITY_STATUS,
+  CREW_VOLUNTEER_INTRO_REQUEST_STATUS,
+} from "../../db/schemas/crew-volunteer-intelligence"
+import {
+  buildCrewRegionalJudgeDiscoveryViewModel,
+  buildCrewRegionalJudgeIntroRequestView,
+  resolveCrewRegionalJudgeDiscoveryGate,
+  type CrewRegionalJudgeDiscoveryConsentRecord,
+  type CrewRegionalJudgeDiscoveryCredentialRecord,
+  type CrewRegionalJudgeDiscoveryHistoryRecord,
+  type CrewRegionalJudgeDiscoveryIdentityRecord,
+} from "./regional-judge-discovery"
+
+const enabledGate = resolveCrewRegionalJudgeDiscoveryGate("enabled")
+
+describe("regional judge discovery", () => {
+  it("stays inert when the feature gate is not explicitly enabled", () => {
+    const gate = resolveCrewRegionalJudgeDiscoveryGate(undefined)
+    const view = buildCrewRegionalJudgeDiscoveryViewModel({
+      gate,
+      requestingTeamId: "team_requester",
+      currentCompetitionId: "comp_current",
+      identities: [adultIdentity("cvid_ada")],
+      consents: [regionalConsent("cvc_ada", "cvid_ada")],
+      historyEvents: [judgeHistory("cvid_ada")],
+      credentials: [],
+    })
+
+    expect(gate.enabled).toBe(false)
+    expect(view.candidates).toEqual([])
+    expect(view.summary).toEqual({
+      candidateCount: 0,
+      pendingIntroRequestCount: 0,
+      safeCredentialCount: 0,
+    })
+    expect(view.notices.join(" ")).toContain(
+      "CREW_REGIONAL_JUDGE_DISCOVERY_ENABLED",
+    )
+  })
+
+  it("requires current regional consent, adult eligibility, active identity, and cross-organizer scope", () => {
+    const view = buildCrewRegionalJudgeDiscoveryViewModel({
+      gate: enabledGate,
+      requestingTeamId: "team_requester",
+      currentCompetitionId: "comp_current",
+      identities: [
+        adultIdentity("cvid_eligible"),
+        adultIdentity("cvid_same_team", { teamId: "team_requester" }),
+        adultIdentity("cvid_import", {
+          identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.IMPORT,
+        }),
+        adultIdentity("cvid_minor", {
+          discoveryAgeStatus: CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.MINOR_BLOCKED,
+        }),
+        adultIdentity("cvid_archived", {
+          status: CREW_VOLUNTEER_IDENTITY_STATUS.ARCHIVED,
+        }),
+        adultIdentity("cvid_revoked"),
+        adultIdentity("cvid_superseded"),
+      ],
+      consents: [
+        regionalConsent("cvc_eligible", "cvid_eligible"),
+        regionalConsent("cvc_same_team", "cvid_same_team", {
+          teamId: "team_requester",
+        }),
+        regionalConsent("cvc_import", "cvid_import"),
+        regionalConsent("cvc_minor", "cvid_minor"),
+        regionalConsent("cvc_archived", "cvid_archived"),
+        regionalConsent("cvc_revoked", "cvid_revoked", {
+          status: CREW_VOLUNTEER_CONSENT_STATUS.REVOKED,
+          revokedAt: "2026-06-20T12:00:00.000Z",
+        }),
+        regionalConsent("cvc_superseded", "cvid_superseded", {
+          supersededByConsentId: "cvc_later_revoke",
+        }),
+      ],
+      historyEvents: [
+        judgeHistory("cvid_eligible"),
+        judgeHistory("cvid_same_team"),
+        judgeHistory("cvid_import"),
+        judgeHistory("cvid_minor"),
+        judgeHistory("cvid_archived"),
+        judgeHistory("cvid_revoked"),
+        judgeHistory("cvid_superseded"),
+      ],
+      credentials: [],
+    })
+
+    expect(view.candidates.map((candidate) => candidate.candidateId)).toEqual([
+      "cvid_eligible",
+    ])
+  })
+
+  it("excludes import-only history while preserving safe regional judge aggregates", () => {
+    const view = buildCrewRegionalJudgeDiscoveryViewModel({
+      gate: enabledGate,
+      requestingTeamId: "team_requester",
+      currentCompetitionId: "comp_current",
+      identities: [
+        adultIdentity("cvid_import_only"),
+        adultIdentity("cvid_ada"),
+      ],
+      consents: [
+        regionalConsent("cvc_import_only", "cvid_import_only"),
+        regionalConsent("cvc_ada", "cvid_ada"),
+      ],
+      historyEvents: [
+        judgeHistory("cvid_import_only", {
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.IMPORTED,
+        }),
+        judgeHistory("cvid_ada", {
+          competitionId: "comp_prior_a",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED,
+          occurredAt: "2026-05-01T12:00:00.000Z",
+        }),
+        judgeHistory("cvid_ada", {
+          competitionId: "comp_prior_a",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+          occurredAt: "2026-05-02T12:00:00.000Z",
+        }),
+        judgeHistory("cvid_ada", {
+          competitionId: "comp_prior_b",
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+          occurredAt: "2026-05-03T12:00:00.000Z",
+        }),
+        judgeHistory("cvid_ada", {
+          eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.NO_SHOW,
+          occurredAt: "2026-05-04T12:00:00.000Z",
+        }),
+      ],
+      credentials: [
+        judgeCredential("cvid_ada", "L1 Judge"),
+        judgeCredential("cvid_ada", "Revoked Judge", {
+          status: CREW_VOLUNTEER_CREDENTIAL_STATUS.REVOKED,
+          revokedAt: "2026-05-01T12:00:00.000Z",
+        }),
+      ],
+    })
+
+    expect(view.candidates).toHaveLength(1)
+    expect(view.candidates[0]).toMatchObject({
+      candidateId: "cvid_ada",
+      regionLabel: "ID, US",
+      availabilitySummary: "Not shared in this pilot",
+      roleTypes: ["judge"],
+      factualHistory: {
+        priorEventCount: 2,
+        assignedCount: 1,
+        confirmedCount: 1,
+        completedCount: 1,
+        lastActivityAt: "2026-05-03T12:00:00.000Z",
+      },
+      credentialSummary: [
+        {
+          credentialType: "judge_course",
+          credentialLabel: "L1 Judge",
+          status: "verified",
+        },
+      ],
+    })
+    expect(JSON.stringify(view)).not.toContain("import_only")
+    expect(JSON.stringify(view)).not.toContain("NO_SHOW")
+    expect(JSON.stringify(view)).not.toContain("Revoked Judge")
+  })
+
+  it("serializes only privacy-safe candidate facts", () => {
+    const view = buildCrewRegionalJudgeDiscoveryViewModel({
+      gate: enabledGate,
+      requestingTeamId: "team_requester",
+      currentCompetitionId: "comp_current",
+      identities: [adultIdentity("cvid_privacy")],
+      consents: [regionalConsent("cvc_privacy", "cvid_privacy")],
+      historyEvents: [judgeHistory("cvid_privacy")],
+      credentials: [judgeCredential("cvid_privacy", "L1 Judge")],
+      introRequests: [
+        {
+          id: "cvir_pending",
+          volunteerIdentityId: "cvid_privacy",
+          status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+          requestedAt: "2026-06-21T12:00:00.000Z",
+        },
+      ],
+    })
+
+    expect(view.candidates[0]?.displayLabel).toBe("Opted-in judge 1")
+    expect(view.candidates[0]?.introRequest).toEqual({
+      id: "cvir_pending",
+      status: "pending",
+      requestedAt: "2026-06-21T12:00:00.000Z",
+      directContactShared: false,
+    })
+
+    const serialized = JSON.stringify(view)
+    expect(serialized).not.toContain("ada@example.com")
+    expect(serialized).not.toContain("555-1234")
+    expect(serialized).not.toContain("emergencyContact")
+    expect(serialized).not.toContain("internalNotes")
+    expect(serialized).not.toContain("stripe")
+    expect(serialized).not.toContain("rating")
+    expect(serialized).not.toContain("ranking")
+    expect(serialized).not.toContain("top judge")
+  })
+
+  it("keeps intro requests blind until a later acceptance flow exists", () => {
+    expect(
+      buildCrewRegionalJudgeIntroRequestView({
+        requestId: "cvir_123",
+        status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+        outcome: "created",
+      }),
+    ).toEqual({
+      requestId: "cvir_123",
+      status: "pending",
+      outcome: "created",
+      directContactShared: false,
+      contactReveal: "deferred_until_volunteer_accepts",
+    })
+  })
+})
+
+function adultIdentity(
+  id: string,
+  overrides: Partial<CrewRegionalJudgeDiscoveryIdentityRecord> = {},
+): CrewRegionalJudgeDiscoveryIdentityRecord {
+  return {
+    id,
+    teamId: "team_source",
+    identitySource: CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE,
+    discoveryAgeStatus: CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.ADULT_CONFIRMED,
+    status: CREW_VOLUNTEER_IDENTITY_STATUS.ACTIVE,
+    ...overrides,
+  }
+}
+
+function regionalConsent(
+  id: string,
+  identityId: string,
+  overrides: Partial<CrewRegionalJudgeDiscoveryConsentRecord> = {},
+): CrewRegionalJudgeDiscoveryConsentRecord {
+  return {
+    id,
+    identityId,
+    teamId: "team_source",
+    scope: CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+    status: CREW_VOLUNTEER_CONSENT_STATUS.GRANTED,
+    grantedAt: "2026-06-01T12:00:00.000Z",
+    revokedAt: null,
+    supersededByConsentId: null,
+    ...overrides,
+  }
+}
+
+function judgeHistory(
+  identityId: string,
+  overrides: Partial<CrewRegionalJudgeDiscoveryHistoryRecord> = {},
+): CrewRegionalJudgeDiscoveryHistoryRecord {
+  return {
+    identityId,
+    teamId: "team_source",
+    competitionId: "comp_prior",
+    competitionName: "Boise Throwdown",
+    eventType: CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+    visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.CONSENTED_INTRO,
+    roleType: "judge",
+    occurredAt: "2026-05-01T12:00:00.000Z",
+    regionLabel: "ID, US",
+    ...overrides,
+  }
+}
+
+function judgeCredential(
+  identityId: string,
+  label: string,
+  overrides: Partial<CrewRegionalJudgeDiscoveryCredentialRecord> = {},
+): CrewRegionalJudgeDiscoveryCredentialRecord {
+  return {
+    identityId,
+    teamId: "team_source",
+    credentialType: CREW_VOLUNTEER_CREDENTIAL_TYPE.JUDGE_COURSE,
+    credentialLabel: label,
+    status: CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+    visibilityScope: CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.CONSENTED_INTRO,
+    expiresAt: null,
+    revokedAt: null,
+    ...overrides,
+  }
+}

--- a/apps/crew/src/lib/crew/regional-judge-discovery.test.ts
+++ b/apps/crew/src/lib/crew/regional-judge-discovery.test.ts
@@ -16,6 +16,7 @@ import {
   buildCrewRegionalJudgeDiscoveryViewModel,
   buildCrewRegionalJudgeIntroRequestView,
   resolveCrewRegionalJudgeDiscoveryGate,
+  resolveCrewRegionalJudgeIntroRequestedRole,
   type CrewRegionalJudgeDiscoveryConsentRecord,
   type CrewRegionalJudgeDiscoveryCredentialRecord,
   type CrewRegionalJudgeDiscoveryHistoryRecord,
@@ -226,6 +227,27 @@ describe("regional judge discovery", () => {
       directContactShared: false,
       contactReveal: "deferred_until_volunteer_accepts",
     })
+  })
+
+  it("normalizes intro requested roles to the candidate's eligible regional roles", () => {
+    expect(
+      resolveCrewRegionalJudgeIntroRequestedRole({
+        requestedRoleType: null,
+        eligibleRoleTypes: ["head_judge", "judge"],
+      }),
+    ).toBe("head_judge")
+    expect(
+      resolveCrewRegionalJudgeIntroRequestedRole({
+        requestedRoleType: "head_judge",
+        eligibleRoleTypes: ["head_judge", "judge"],
+      }),
+    ).toBe("head_judge")
+    expect(
+      resolveCrewRegionalJudgeIntroRequestedRole({
+        requestedRoleType: "head_judge",
+        eligibleRoleTypes: ["judge"],
+      }),
+    ).toBeNull()
   })
 })
 

--- a/apps/crew/src/lib/crew/regional-judge-discovery.ts
+++ b/apps/crew/src/lib/crew/regional-judge-discovery.ts
@@ -31,6 +31,10 @@ export const crewRegionalJudgeDiscoveryRoleTypes = [
   "head_judge",
 ] satisfies VolunteerRoleType[]
 
+const crewRegionalJudgeDiscoveryRoleTypeSet = new Set<VolunteerRoleType>(
+  crewRegionalJudgeDiscoveryRoleTypes,
+)
+
 export interface CrewRegionalJudgeDiscoveryIdentityRecord {
   id: string
   teamId: string
@@ -262,6 +266,24 @@ export function buildCrewRegionalJudgeIntroRequestView({
     directContactShared: false,
     contactReveal: "deferred_until_volunteer_accepts",
   }
+}
+
+export function resolveCrewRegionalJudgeIntroRequestedRole({
+  requestedRoleType,
+  eligibleRoleTypes,
+}: {
+  requestedRoleType?: VolunteerRoleType | null
+  eligibleRoleTypes: VolunteerRoleType[]
+}): VolunteerRoleType | null {
+  const eligibleRegionalRoleTypes = eligibleRoleTypes.filter((roleType) =>
+    crewRegionalJudgeDiscoveryRoleTypeSet.has(roleType),
+  )
+  if (requestedRoleType == null) {
+    return eligibleRegionalRoleTypes[0] ?? null
+  }
+  return eligibleRegionalRoleTypes.includes(requestedRoleType)
+    ? requestedRoleType
+    : null
 }
 
 function buildDiscoveryCandidate({

--- a/apps/crew/src/lib/crew/regional-judge-discovery.ts
+++ b/apps/crew/src/lib/crew/regional-judge-discovery.ts
@@ -1,0 +1,510 @@
+// @lat: [[crew#Regional Judge Discovery Pilot]]
+import {
+  CREW_VOLUNTEER_CONSENT_SCOPE,
+  CREW_VOLUNTEER_CONSENT_STATUS,
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_CREDENTIAL_TYPE,
+  CREW_VOLUNTEER_DISCOVERY_AGE_STATUS,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+  CREW_VOLUNTEER_IDENTITY_STATUS,
+  CREW_VOLUNTEER_INTRO_REQUEST_STATUS,
+  type CrewVolunteerConsentScope,
+  type CrewVolunteerConsentStatus,
+  type CrewVolunteerCredentialStatus,
+  type CrewVolunteerCredentialType,
+  type CrewVolunteerDiscoveryAgeStatus,
+  type CrewVolunteerHistoryEventType,
+  type CrewVolunteerHistoryVisibilityScope,
+  type CrewVolunteerIdentitySource,
+  type CrewVolunteerIdentityStatus,
+  type CrewVolunteerIntroRequestStatus,
+} from "../../db/schemas/crew-volunteer-intelligence"
+import type { VolunteerRoleType } from "../../db/schemas/volunteers"
+
+export const CREW_REGIONAL_JUDGE_DISCOVERY_FLAG =
+  "CREW_REGIONAL_JUDGE_DISCOVERY_ENABLED"
+
+export const crewRegionalJudgeDiscoveryRoleTypes = [
+  "judge",
+  "head_judge",
+] satisfies VolunteerRoleType[]
+
+export interface CrewRegionalJudgeDiscoveryIdentityRecord {
+  id: string
+  teamId: string
+  identitySource: CrewVolunteerIdentitySource
+  discoveryAgeStatus: CrewVolunteerDiscoveryAgeStatus
+  status: CrewVolunteerIdentityStatus
+}
+
+export interface CrewRegionalJudgeDiscoveryConsentRecord {
+  id: string
+  identityId: string
+  teamId: string
+  scope: CrewVolunteerConsentScope
+  status: CrewVolunteerConsentStatus
+  grantedAt: Date | string
+  revokedAt?: Date | string | null
+  supersededByConsentId?: string | null
+}
+
+export interface CrewRegionalJudgeDiscoveryHistoryRecord {
+  identityId: string
+  teamId: string
+  competitionId: string | null
+  competitionName: string | null
+  eventType: CrewVolunteerHistoryEventType
+  visibilityScope: CrewVolunteerHistoryVisibilityScope
+  roleType: VolunteerRoleType | null
+  occurredAt: Date | string
+  regionLabel?: string | null
+}
+
+export interface CrewRegionalJudgeDiscoveryCredentialRecord {
+  identityId: string
+  teamId: string
+  credentialType: CrewVolunteerCredentialType
+  credentialLabel: string
+  status: CrewVolunteerCredentialStatus
+  visibilityScope: CrewVolunteerHistoryVisibilityScope
+  expiresAt?: Date | string | null
+  revokedAt?: Date | string | null
+}
+
+export interface CrewRegionalJudgeDiscoveryIntroRequestRecord {
+  id: string
+  volunteerIdentityId: string
+  status: CrewVolunteerIntroRequestStatus
+  requestedAt: Date | string
+}
+
+export interface CrewRegionalJudgeDiscoveryGate {
+  enabled: boolean
+  flagName: typeof CREW_REGIONAL_JUDGE_DISCOVERY_FLAG
+  disabledReason: string | null
+}
+
+export interface CrewRegionalJudgeDiscoveryCandidate {
+  candidateId: string
+  displayLabel: string
+  regionLabel: string
+  availabilitySummary: string
+  roleTypes: VolunteerRoleType[]
+  credentialSummary: Array<{
+    credentialType: CrewVolunteerCredentialType
+    credentialLabel: string
+    status: Extract<CrewVolunteerCredentialStatus, "self_reported" | "verified">
+  }>
+  factualHistory: {
+    priorEventCount: number
+    assignedCount: number
+    confirmedCount: number
+    completedCount: number
+    lastActivityAt: string | null
+  }
+  introRequest: {
+    id: string
+    status: Extract<CrewVolunteerIntroRequestStatus, "pending">
+    requestedAt: string
+    directContactShared: false
+  } | null
+}
+
+export interface CrewRegionalJudgeDiscoveryViewModel {
+  gate: CrewRegionalJudgeDiscoveryGate
+  summary: {
+    candidateCount: number
+    pendingIntroRequestCount: number
+    safeCredentialCount: number
+  }
+  candidates: CrewRegionalJudgeDiscoveryCandidate[]
+  notices: string[]
+}
+
+export interface CrewRegionalJudgeDiscoveryInput {
+  gate: CrewRegionalJudgeDiscoveryGate
+  requestingTeamId: string
+  currentCompetitionId: string
+  identities: CrewRegionalJudgeDiscoveryIdentityRecord[]
+  consents: CrewRegionalJudgeDiscoveryConsentRecord[]
+  historyEvents: CrewRegionalJudgeDiscoveryHistoryRecord[]
+  credentials: CrewRegionalJudgeDiscoveryCredentialRecord[]
+  introRequests?: CrewRegionalJudgeDiscoveryIntroRequestRecord[]
+  requestedRoleTypes?: VolunteerRoleType[]
+  maxResults?: number
+  now?: Date | string
+}
+
+export interface CrewRegionalJudgeIntroRequestView {
+  requestId: string
+  status: CrewVolunteerIntroRequestStatus
+  outcome: "created" | "existing"
+  directContactShared: false
+  contactReveal: "deferred_until_volunteer_accepts"
+}
+
+const discoverableHistoryEventTypes = new Set<CrewVolunteerHistoryEventType>([
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.SIGNED_UP,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED,
+  CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED,
+])
+
+const safeCredentialStatuses = new Set<CrewVolunteerCredentialStatus>([
+  CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED,
+  CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+])
+
+export function resolveCrewRegionalJudgeDiscoveryGate(
+  value: unknown,
+): CrewRegionalJudgeDiscoveryGate {
+  const enabled = isCrewRegionalJudgeDiscoveryEnabledValue(value)
+  return {
+    enabled,
+    flagName: CREW_REGIONAL_JUDGE_DISCOVERY_FLAG,
+    disabledReason: enabled
+      ? null
+      : `${CREW_REGIONAL_JUDGE_DISCOVERY_FLAG} must be explicitly enabled before regional judge discovery returns candidates or records intro requests.`,
+  }
+}
+
+export function isCrewRegionalJudgeDiscoveryEnabledValue(value: unknown) {
+  return (
+    value === true ||
+    ["1", "true", "yes", "enabled"].includes(String(value ?? "").toLowerCase())
+  )
+}
+
+export function buildCrewRegionalJudgeDiscoveryViewModel({
+  gate,
+  requestingTeamId,
+  currentCompetitionId,
+  identities,
+  consents,
+  historyEvents,
+  credentials,
+  introRequests = [],
+  requestedRoleTypes = crewRegionalJudgeDiscoveryRoleTypes,
+  maxResults = 25,
+  now = new Date(),
+}: CrewRegionalJudgeDiscoveryInput): CrewRegionalJudgeDiscoveryViewModel {
+  if (!gate.enabled) {
+    return {
+      gate,
+      summary: {
+        candidateCount: 0,
+        pendingIntroRequestCount: 0,
+        safeCredentialCount: 0,
+      },
+      candidates: [],
+      notices: disabledNotices(gate),
+    }
+  }
+
+  const nowMs = toTime(now)
+  const requestedRoles = new Set(requestedRoleTypes)
+  const candidates = identities
+    .flatMap((identity) =>
+      buildDiscoveryCandidate({
+        identity,
+        requestingTeamId,
+        currentCompetitionId,
+        consents,
+        historyEvents,
+        credentials,
+        introRequests,
+        requestedRoles,
+        nowMs,
+      }),
+    )
+    .sort(compareCandidates)
+    .slice(0, maxResults)
+    .map((candidate, index) => ({
+      ...candidate,
+      displayLabel: `${candidate.roleTypes.includes("head_judge") ? "Opted-in head judge" : "Opted-in judge"} ${index + 1}`,
+    }))
+
+  return {
+    gate,
+    summary: {
+      candidateCount: candidates.length,
+      pendingIntroRequestCount: candidates.filter(
+        (candidate) => candidate.introRequest?.status === "pending",
+      ).length,
+      safeCredentialCount: candidates.reduce(
+        (total, candidate) => total + candidate.credentialSummary.length,
+        0,
+      ),
+    },
+    candidates,
+    notices: [
+      "Regional discovery is opt-in and blind: direct contact stays hidden until a later volunteer acceptance flow exists.",
+      "Results use consented regional facts only and exclude raw contact details, private notes, billing data, public reputation labels, and negative badges.",
+    ],
+  }
+}
+
+export function buildCrewRegionalJudgeIntroRequestView({
+  requestId,
+  status,
+  outcome,
+}: {
+  requestId: string
+  status: CrewVolunteerIntroRequestStatus
+  outcome: "created" | "existing"
+}): CrewRegionalJudgeIntroRequestView {
+  return {
+    requestId,
+    status,
+    outcome,
+    directContactShared: false,
+    contactReveal: "deferred_until_volunteer_accepts",
+  }
+}
+
+function buildDiscoveryCandidate({
+  identity,
+  requestingTeamId,
+  currentCompetitionId,
+  consents,
+  historyEvents,
+  credentials,
+  introRequests,
+  requestedRoles,
+  nowMs,
+}: {
+  identity: CrewRegionalJudgeDiscoveryIdentityRecord
+  requestingTeamId: string
+  currentCompetitionId: string
+  consents: CrewRegionalJudgeDiscoveryConsentRecord[]
+  historyEvents: CrewRegionalJudgeDiscoveryHistoryRecord[]
+  credentials: CrewRegionalJudgeDiscoveryCredentialRecord[]
+  introRequests: CrewRegionalJudgeDiscoveryIntroRequestRecord[]
+  requestedRoles: Set<VolunteerRoleType>
+  nowMs: number
+}): CrewRegionalJudgeDiscoveryCandidate[] {
+  if (identity.teamId === requestingTeamId) return []
+  if (identity.status !== CREW_VOLUNTEER_IDENTITY_STATUS.ACTIVE) return []
+  if (identity.identitySource === CREW_VOLUNTEER_IDENTITY_SOURCE.IMPORT) {
+    return []
+  }
+  if (
+    identity.discoveryAgeStatus !==
+    CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.ADULT_CONFIRMED
+  ) {
+    return []
+  }
+
+  const activeConsent = findActiveRegionalDiscoveryConsent(identity, consents)
+  if (!activeConsent) return []
+
+  const safeHistory = historyEvents
+    .filter((event) => {
+      if (event.identityId !== identity.id) return false
+      if (event.teamId !== identity.teamId) return false
+      if (event.competitionId === currentCompetitionId) return false
+      if (
+        event.visibilityScope !==
+        CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.CONSENTED_INTRO
+      ) {
+        return false
+      }
+      if (!discoverableHistoryEventTypes.has(event.eventType)) return false
+      return event.roleType ? requestedRoles.has(event.roleType) : false
+    })
+    .sort((left, right) => toTime(right.occurredAt) - toTime(left.occurredAt))
+  const safeCredentials = credentials
+    .filter((credential) => {
+      if (credential.identityId !== identity.id) return false
+      if (credential.teamId !== identity.teamId) return false
+      if (
+        credential.visibilityScope !==
+        CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.CONSENTED_INTRO
+      ) {
+        return false
+      }
+      if (!safeCredentialStatuses.has(credential.status)) return false
+      if (credential.revokedAt) return false
+      if (credential.expiresAt && toTime(credential.expiresAt) < nowMs) {
+        return false
+      }
+      return (
+        credential.credentialType ===
+          CREW_VOLUNTEER_CREDENTIAL_TYPE.JUDGE_COURSE || safeHistory.length > 0
+      )
+    })
+    .map((credential) => ({
+      credentialType: credential.credentialType,
+      credentialLabel: credential.credentialLabel,
+      status: credential.status as Extract<
+        CrewVolunteerCredentialStatus,
+        "self_reported" | "verified"
+      >,
+    }))
+
+  const hasJudgeCredential = safeCredentials.some(
+    (credential) =>
+      credential.credentialType === CREW_VOLUNTEER_CREDENTIAL_TYPE.JUDGE_COURSE,
+  )
+  if (safeHistory.length === 0 && !hasJudgeCredential) return []
+
+  const roleTypes = uniqueRoleTypes(safeHistory)
+  if (roleTypes.length === 0 && hasJudgeCredential) {
+    roleTypes.push("judge")
+  }
+  if (!roleTypes.some((roleType) => requestedRoles.has(roleType))) return []
+
+  const introRequest = introRequests
+    .filter(
+      (request) =>
+        request.volunteerIdentityId === identity.id &&
+        request.status === CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+    )
+    .sort((left, right) => toTime(right.requestedAt) - toTime(left.requestedAt))
+    .at(0)
+
+  return [
+    {
+      candidateId: identity.id,
+      displayLabel: "Opted-in judge",
+      regionLabel: getRegionLabel(safeHistory),
+      availabilitySummary: "Not shared in this pilot",
+      roleTypes,
+      credentialSummary: dedupeCredentials(safeCredentials),
+      factualHistory: summarizeHistory(safeHistory),
+      introRequest: introRequest
+        ? {
+            id: introRequest.id,
+            status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+            requestedAt: toIsoString(introRequest.requestedAt),
+            directContactShared: false,
+          }
+        : null,
+    },
+  ]
+}
+
+function findActiveRegionalDiscoveryConsent(
+  identity: CrewRegionalJudgeDiscoveryIdentityRecord,
+  consents: CrewRegionalJudgeDiscoveryConsentRecord[],
+) {
+  return consents
+    .filter((consent) => {
+      if (consent.identityId !== identity.id) return false
+      if (consent.teamId !== identity.teamId) return false
+      if (consent.scope !== CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY) {
+        return false
+      }
+      if (consent.status !== CREW_VOLUNTEER_CONSENT_STATUS.GRANTED) {
+        return false
+      }
+      if (consent.revokedAt) return false
+      if (consent.supersededByConsentId) return false
+      return true
+    })
+    .sort((left, right) => toTime(right.grantedAt) - toTime(left.grantedAt))
+    .at(0)
+}
+
+function summarizeHistory(events: CrewRegionalJudgeDiscoveryHistoryRecord[]) {
+  const summary = {
+    priorEventCount: new Set(
+      events.map((event) => event.competitionId).filter(Boolean),
+    ).size,
+    assignedCount: 0,
+    confirmedCount: 0,
+    completedCount: 0,
+    lastActivityAt: events[0] ? toIsoString(events[0].occurredAt) : null,
+  }
+
+  for (const event of events) {
+    if (event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.ASSIGNED) {
+      summary.assignedCount += 1
+    } else if (
+      event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED
+    ) {
+      summary.confirmedCount += 1
+    } else if (
+      event.eventType === CREW_VOLUNTEER_HISTORY_EVENT_TYPE.COMPLETED
+    ) {
+      summary.completedCount += 1
+    }
+  }
+
+  return summary
+}
+
+function getRegionLabel(events: CrewRegionalJudgeDiscoveryHistoryRecord[]) {
+  return (
+    events.find((event) => event.regionLabel?.trim())?.regionLabel?.trim() ??
+    "Region not shared"
+  )
+}
+
+function uniqueRoleTypes(events: CrewRegionalJudgeDiscoveryHistoryRecord[]) {
+  return [
+    ...new Set(events.map((event) => event.roleType).filter(Boolean)),
+  ] as VolunteerRoleType[]
+}
+
+function dedupeCredentials(
+  credentials: CrewRegionalJudgeDiscoveryCandidate["credentialSummary"],
+) {
+  const seen = new Set<string>()
+  return credentials.filter((credential) => {
+    const key = [
+      credential.credentialType,
+      credential.credentialLabel.toLowerCase(),
+      credential.status,
+    ].join("|")
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
+function compareCandidates(
+  left: CrewRegionalJudgeDiscoveryCandidate,
+  right: CrewRegionalJudgeDiscoveryCandidate,
+) {
+  const pendingDelta =
+    Number(Boolean(left.introRequest)) - Number(Boolean(right.introRequest))
+  if (pendingDelta !== 0) return pendingDelta
+
+  const credentialDelta =
+    right.credentialSummary.length - left.credentialSummary.length
+  if (credentialDelta !== 0) return credentialDelta
+
+  const eventCountDelta =
+    right.factualHistory.priorEventCount - left.factualHistory.priorEventCount
+  if (eventCountDelta !== 0) return eventCountDelta
+
+  return (
+    toTime(right.factualHistory.lastActivityAt) -
+    toTime(left.factualHistory.lastActivityAt)
+  )
+}
+
+function disabledNotices(gate: CrewRegionalJudgeDiscoveryGate) {
+  return [
+    gate.disabledReason ??
+      "Regional judge discovery is disabled until explicitly enabled.",
+    "No discovery candidates are loaded and no intro requests can be recorded while this gate is off.",
+  ]
+}
+
+function toIsoString(value: Date | string) {
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime())
+    ? new Date(0).toISOString()
+    : date.toISOString()
+}
+
+function toTime(value: Date | string | null | undefined) {
+  if (!value) return 0
+  const date = value instanceof Date ? value : new Date(value)
+  const time = date.getTime()
+  return Number.isNaN(time) ? 0 : time
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as EventsEventIdBillingRouteImport } from './routes/events/$event
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
+import { Route as EventsEventIdDiscoveryJudgesRouteImport } from './routes/events/$eventId/discovery/judges'
 import { Route as ESlugScheduleTokenRouteImport } from './routes/e/$slug/schedule/$token'
 import { Route as ESlugConsentTokenRouteImport } from './routes/e/$slug/consent/$token'
 import { Route as ESlugConfirmTokenRouteImport } from './routes/e/$slug/confirm/$token'
@@ -145,6 +146,12 @@ const ApiCrewImportRoute = ApiCrewImportRouteImport.update({
   path: '/api/crew/import',
   getParentRoute: () => rootRouteImport,
 } as any)
+const EventsEventIdDiscoveryJudgesRoute =
+  EventsEventIdDiscoveryJudgesRouteImport.update({
+    id: '/discovery/judges',
+    path: '/discovery/judges',
+    getParentRoute: () => EventsEventIdRoute,
+  } as any)
 const ESlugScheduleTokenRoute = ESlugScheduleTokenRouteImport.update({
   id: '/e/$slug/schedule/$token',
   path: '/e/$slug/schedule/$token',
@@ -187,6 +194,7 @@ export interface FileRoutesByFullPath {
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
+  '/events/$eventId/discovery/judges': typeof EventsEventIdDiscoveryJudgesRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -213,6 +221,7 @@ export interface FileRoutesByTo {
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
+  '/events/$eventId/discovery/judges': typeof EventsEventIdDiscoveryJudgesRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -241,6 +250,7 @@ export interface FileRoutesById {
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
+  '/events/$eventId/discovery/judges': typeof EventsEventIdDiscoveryJudgesRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -270,6 +280,7 @@ export interface FileRouteTypes {
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
+    | '/events/$eventId/discovery/judges'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -296,6 +307,7 @@ export interface FileRouteTypes {
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
+    | '/events/$eventId/discovery/judges'
   id:
     | '__root__'
     | '/'
@@ -323,6 +335,7 @@ export interface FileRouteTypes {
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
+    | '/events/$eventId/discovery/judges'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -494,6 +507,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiCrewImportRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/events/$eventId/discovery/judges': {
+      id: '/events/$eventId/discovery/judges'
+      path: '/discovery/judges'
+      fullPath: '/events/$eventId/discovery/judges'
+      preLoaderRoute: typeof EventsEventIdDiscoveryJudgesRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/e/$slug/schedule/$token': {
       id: '/e/$slug/schedule/$token'
       path: '/e/$slug/schedule/$token'
@@ -532,6 +552,7 @@ interface EventsEventIdRouteChildren {
   EventsEventIdStaffingRoute: typeof EventsEventIdStaffingRoute
   EventsEventIdVolunteersRoute: typeof EventsEventIdVolunteersRoute
   EventsEventIdIndexRoute: typeof EventsEventIdIndexRoute
+  EventsEventIdDiscoveryJudgesRoute: typeof EventsEventIdDiscoveryJudgesRoute
 }
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
@@ -548,6 +569,7 @@ const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdStaffingRoute: EventsEventIdStaffingRoute,
   EventsEventIdVolunteersRoute: EventsEventIdVolunteersRoute,
   EventsEventIdIndexRoute: EventsEventIdIndexRoute,
+  EventsEventIdDiscoveryJudgesRoute: EventsEventIdDiscoveryJudgesRoute,
 }
 
 const EventsEventIdRouteWithChildren = EventsEventIdRoute._addFileChildren(

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -4,6 +4,7 @@
 // @lat: [[crew#Pilot Exports]]
 // @lat: [[crew#Billing Page And Upgrade CTA]]
 // @lat: [[crew#Full WODsmith Conversion Assistant]]
+// @lat: [[crew#Regional Judge Discovery Pilot]]
 import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
 import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
 
@@ -113,6 +114,14 @@ function EventShell() {
             className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
           >
             Judges
+          </Link>
+          <Link
+            to="/events/$eventId/discovery/judges"
+            params={{ eventId }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Discovery
           </Link>
           <Link
             to="/events/$eventId/day-of"

--- a/apps/crew/src/routes/events/$eventId/discovery/judges.tsx
+++ b/apps/crew/src/routes/events/$eventId/discovery/judges.tsx
@@ -122,13 +122,9 @@ function CandidateCard({
           ? "Intro request already pending."
           : "Intro request recorded.",
       )
-      await router.invalidate()
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Intro request could not be recorded.",
-      )
+      await router.invalidate().catch(() => undefined)
+    } catch {
+      toast.error("Intro request could not be recorded. Please try again.")
     } finally {
       setIsSubmitting(false)
     }

--- a/apps/crew/src/routes/events/$eventId/discovery/judges.tsx
+++ b/apps/crew/src/routes/events/$eventId/discovery/judges.tsx
@@ -1,0 +1,309 @@
+// @lat: [[crew#Regional Judge Discovery Pilot]]
+import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import { LockKeyhole, MapPin, Search, Send, ShieldCheck } from "lucide-react"
+import { useState } from "react"
+import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { VOLUNTEER_ROLE_LABELS } from "@/db/schemas/volunteers"
+import type { CrewRegionalJudgeDiscoveryCandidate } from "@/lib/crew/regional-judge-discovery"
+import {
+  getCrewRegionalJudgeDiscoveryPageFn,
+  requestCrewRegionalJudgeIntroFn,
+} from "@/server-fns/crew-discovery-fns"
+
+export const Route = createFileRoute("/events/$eventId/discovery/judges")({
+  loader: async ({ params }) =>
+    await getCrewRegionalJudgeDiscoveryPageFn({
+      data: { eventId: params.eventId },
+    }),
+  component: RegionalJudgeDiscoveryPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+function RegionalJudgeDiscoveryPage() {
+  const { eventId } = parentRoute.useParams()
+  const { viewModel } = Route.useLoaderData()
+
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <Metric
+          label="Pilot gate"
+          value={viewModel.gate.enabled ? "Enabled" : "Disabled"}
+        />
+        <Metric
+          label="Candidates"
+          value={viewModel.summary.candidateCount.toString()}
+        />
+        <Metric
+          label="Pending intros"
+          value={viewModel.summary.pendingIntroRequestCount.toString()}
+        />
+        <Metric
+          label="Credentials"
+          value={viewModel.summary.safeCredentialCount.toString()}
+        />
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm font-medium text-primary">
+              <ShieldCheck className="size-4" aria-hidden="true" />
+              Regional judge discovery
+            </div>
+            <h2 className="text-xl font-semibold">
+              Opt-in, blind intro requests
+            </h2>
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              Candidate cards show consented regional facts only. Contact
+              details remain hidden.
+            </p>
+          </div>
+          <div className="rounded-md border bg-background p-4 text-sm">
+            <div className="flex items-center gap-2 font-medium">
+              <LockKeyhole className="size-4 text-muted-foreground" />
+              Contact reveal deferred
+            </div>
+            <p className="mt-2 text-muted-foreground">
+              Intro requests create audit records without email, phone, SMS, or
+              acceptance delivery.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {!viewModel.gate.enabled ? (
+        <DisabledPanel notices={viewModel.notices} />
+      ) : viewModel.candidates.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-2">
+          {viewModel.candidates.map((candidate) => (
+            <CandidateCard
+              candidate={candidate}
+              eventId={eventId}
+              key={candidate.candidateId}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function CandidateCard({
+  candidate,
+  eventId,
+}: {
+  candidate: CrewRegionalJudgeDiscoveryCandidate
+  eventId: string
+}) {
+  const router = useRouter()
+  const requestIntro = useServerFn(requestCrewRegionalJudgeIntroFn)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const primaryRole = candidate.roleTypes[0] ?? "judge"
+
+  async function handleRequestIntro() {
+    setIsSubmitting(true)
+    try {
+      const result = await requestIntro({
+        data: {
+          eventId,
+          candidateId: candidate.candidateId,
+          requestedRoleType:
+            primaryRole === "head_judge" ? primaryRole : "judge",
+        },
+      })
+      toast.success(
+        result.request.outcome === "existing"
+          ? "Intro request already pending."
+          : "Intro request recorded.",
+      )
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "Intro request could not be recorded.",
+      )
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <article className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="font-semibold">{candidate.displayLabel}</h3>
+          <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+            <MapPin className="size-4" aria-hidden="true" />
+            <span>{candidate.regionLabel}</span>
+          </div>
+        </div>
+        <StatusPill
+          label={candidate.introRequest ? "Requested" : "Available"}
+          tone={candidate.introRequest ? "muted" : "ready"}
+        />
+      </div>
+
+      <dl className="mt-5 grid gap-3 text-sm sm:grid-cols-2">
+        <Fact
+          label="Roles"
+          value={candidate.roleTypes.map(formatRoleType).join(", ")}
+        />
+        <Fact label="Availability" value={candidate.availabilitySummary} />
+        <Fact
+          label="Prior events"
+          value={candidate.factualHistory.priorEventCount.toString()}
+        />
+        <Fact
+          label="Confirmed"
+          value={candidate.factualHistory.confirmedCount.toString()}
+        />
+        <Fact
+          label="Completed"
+          value={candidate.factualHistory.completedCount.toString()}
+        />
+        <Fact
+          label="Last activity"
+          value={formatDate(candidate.factualHistory.lastActivityAt)}
+        />
+      </dl>
+
+      <div className="mt-5 space-y-2">
+        <h4 className="text-sm font-medium">Credentials</h4>
+        {candidate.credentialSummary.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {candidate.credentialSummary.map((credential) => (
+              <span
+                className="rounded-md border px-2 py-1 text-xs text-muted-foreground"
+                key={`${credential.credentialType}:${credential.credentialLabel}:${credential.status}`}
+              >
+                {credential.credentialLabel} ·{" "}
+                {formatCredentialStatus(credential.status)}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No consented credential facts shared.
+          </p>
+        )}
+      </div>
+
+      <Button
+        className="mt-5"
+        disabled={Boolean(candidate.introRequest) || isSubmitting}
+        onClick={handleRequestIntro}
+        type="button"
+      >
+        <Send className="size-4" aria-hidden="true" />
+        {candidate.introRequest
+          ? "Intro request pending"
+          : isSubmitting
+            ? "Recording..."
+            : "Request intro"}
+      </Button>
+    </article>
+  )
+}
+
+function DisabledPanel({ notices }: { notices: string[] }) {
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex items-start gap-3">
+        <LockKeyhole className="mt-0.5 size-5 text-muted-foreground" />
+        <div>
+          <h2 className="font-semibold">Pilot disabled</h2>
+          <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+            {notices.map((notice) => (
+              <li key={notice}>{notice}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function EmptyState() {
+  return (
+    <section className="rounded-md border bg-card p-8 text-center shadow-sm">
+      <Search className="mx-auto size-8 text-muted-foreground" />
+      <h2 className="mt-4 font-semibold">No eligible regional judges</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        No adult, opted-in judges with consented regional facts are available
+        for blind intro requests.
+      </p>
+    </section>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 break-words text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background p-3">
+      <dt className="text-xs font-medium uppercase text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="mt-1 font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function StatusPill({
+  label,
+  tone,
+}: {
+  label: string
+  tone: "ready" | "muted"
+}) {
+  return (
+    <span
+      className={`shrink-0 rounded-md border px-2 py-1 text-xs font-medium ${
+        tone === "ready"
+          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+          : "border-muted bg-muted text-muted-foreground"
+      }`}
+    >
+      {label}
+    </span>
+  )
+}
+
+function formatRoleType(roleType: string) {
+  return (
+    VOLUNTEER_ROLE_LABELS[roleType as keyof typeof VOLUNTEER_ROLE_LABELS] ??
+    roleType
+  )
+}
+
+function formatCredentialStatus(status: string) {
+  return status
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}
+
+function formatDate(value: string | null) {
+  if (!value) return "Not shared"
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return "Not shared"
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(date)
+}

--- a/apps/crew/src/server-fns/crew-discovery-fns.ts
+++ b/apps/crew/src/server-fns/crew-discovery-fns.ts
@@ -15,7 +15,7 @@ const getCrewRegionalJudgeDiscoveryPageInputSchema = z.object({
 const requestCrewRegionalJudgeIntroInputSchema =
   getCrewRegionalJudgeDiscoveryPageInputSchema.extend({
     candidateId: z.string().min(1, "Candidate ID is required"),
-    requestedRoleType: z.enum(["judge", "head_judge"]).optional(),
+    requestedRoleType: z.enum(["judge", "head_judge"]).nullable().optional(),
   })
 
 export const getCrewRegionalJudgeDiscoveryPageFn = createServerFn({

--- a/apps/crew/src/server-fns/crew-discovery-fns.ts
+++ b/apps/crew/src/server-fns/crew-discovery-fns.ts
@@ -1,0 +1,45 @@
+// @lat: [[crew#Regional Judge Discovery Pilot]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type {
+  CrewRegionalJudgeDiscoveryPageData,
+  CrewRegionalJudgeIntroRequestResult,
+} from "../server/crew-discovery.server"
+
+const getCrewRegionalJudgeDiscoveryPageInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+const requestCrewRegionalJudgeIntroInputSchema =
+  getCrewRegionalJudgeDiscoveryPageInputSchema.extend({
+    candidateId: z.string().min(1, "Candidate ID is required"),
+    requestedRoleType: z.enum(["judge", "head_judge"]).optional(),
+  })
+
+export const getCrewRegionalJudgeDiscoveryPageFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) =>
+    getCrewRegionalJudgeDiscoveryPageInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewRegionalJudgeDiscoveryPage } = await import(
+      "../server/crew-discovery.server"
+    )
+    return getCrewRegionalJudgeDiscoveryPage(data)
+  })
+
+export const requestCrewRegionalJudgeIntroFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) =>
+    requestCrewRegionalJudgeIntroInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { requestCrewRegionalJudgeIntro } = await import(
+      "../server/crew-discovery.server"
+    )
+    return requestCrewRegionalJudgeIntro(data)
+  })

--- a/apps/crew/src/server/crew-discovery.server.ts
+++ b/apps/crew/src/server/crew-discovery.server.ts
@@ -1,0 +1,465 @@
+// @lat: [[crew#Regional Judge Discovery Pilot]]
+import { env } from "cloudflare:workers"
+import { and, desc, eq, gt, inArray, isNull, ne, or } from "drizzle-orm"
+import { getDb } from "../db"
+import { addressesTable } from "../db/schemas/addresses"
+import { competitionsTable } from "../db/schemas/competitions"
+import { createCrewVolunteerIntroRequestId } from "../db/schemas/common"
+import {
+  CREW_VOLUNTEER_CONSENT_SCOPE,
+  CREW_VOLUNTEER_CONSENT_STATUS,
+  CREW_VOLUNTEER_CREDENTIAL_STATUS,
+  CREW_VOLUNTEER_DISCOVERY_AGE_STATUS,
+  CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE,
+  CREW_VOLUNTEER_IDENTITY_SOURCE,
+  CREW_VOLUNTEER_IDENTITY_STATUS,
+  CREW_VOLUNTEER_INTRO_REQUEST_STATUS,
+  crewVolunteerConsentsTable,
+  crewVolunteerCredentialsTable,
+  crewVolunteerHistoryEventsTable,
+  crewVolunteerIdentitiesTable,
+  crewVolunteerIntroRequestsTable,
+} from "../db/schemas/crew-volunteer-intelligence"
+import type { VolunteerRoleType } from "../db/schemas/volunteers"
+import {
+  buildCrewRegionalJudgeDiscoveryViewModel,
+  buildCrewRegionalJudgeIntroRequestView,
+  crewRegionalJudgeDiscoveryRoleTypes,
+  resolveCrewRegionalJudgeDiscoveryGate,
+  type CrewRegionalJudgeDiscoveryViewModel,
+  type CrewRegionalJudgeIntroRequestView,
+} from "../lib/crew/regional-judge-discovery"
+import { getSessionFromCookie } from "../utils/auth"
+import {
+  requireCrewDepartmentLeadEvent,
+  requireCrewDepartmentLeadFullAccess,
+  type CrewDepartmentLeadEvent,
+} from "./crew-department-lead.server"
+
+type CrewDiscoveryRuntimeEnv = typeof env & {
+  CREW_REGIONAL_JUDGE_DISCOVERY_ENABLED?: string | boolean
+}
+
+export interface CrewRegionalJudgeDiscoveryPageData {
+  viewModel: CrewRegionalJudgeDiscoveryViewModel
+}
+
+export interface CrewRegionalJudgeIntroRequestResult {
+  success: true
+  request: CrewRegionalJudgeIntroRequestView
+}
+
+export async function getCrewRegionalJudgeDiscoveryPage(data: {
+  eventId: string
+}): Promise<CrewRegionalJudgeDiscoveryPageData> {
+  const scope = await requireCrewRegionalJudgeDiscoveryScope(data.eventId)
+  const gate = getCrewRegionalJudgeDiscoveryGate()
+
+  if (!gate.enabled) {
+    return {
+      viewModel: buildCrewRegionalJudgeDiscoveryViewModel({
+        gate,
+        requestingTeamId: scope.organizingTeamId,
+        currentCompetitionId: scope.id,
+        identities: [],
+        consents: [],
+        historyEvents: [],
+        credentials: [],
+      }),
+    }
+  }
+
+  const viewModel = await loadCrewRegionalJudgeDiscoveryView(scope)
+  return { viewModel }
+}
+
+export async function requestCrewRegionalJudgeIntro(data: {
+  eventId: string
+  candidateId: string
+  requestedRoleType?: VolunteerRoleType | null
+}): Promise<CrewRegionalJudgeIntroRequestResult> {
+  const scope = await requireCrewRegionalJudgeDiscoveryScope(data.eventId)
+  const gate = getCrewRegionalJudgeDiscoveryGate()
+  if (!gate.enabled) {
+    throw new Error(
+      "Regional judge discovery is disabled. No intro request was recorded.",
+    )
+  }
+
+  const viewModel = await loadCrewRegionalJudgeDiscoveryView(scope)
+  const candidate = viewModel.candidates.find(
+    (item) => item.candidateId === data.candidateId,
+  )
+  if (!candidate) {
+    throw new Error("That regional judge candidate is no longer eligible.")
+  }
+
+  const activeConsent = await findActiveDiscoveryConsentForCandidate({
+    scope,
+    candidateId: data.candidateId,
+  })
+  if (!activeConsent) {
+    throw new Error("That regional judge candidate is no longer eligible.")
+  }
+
+  const db = getDb()
+  const [existing] = await db
+    .select({
+      id: crewVolunteerIntroRequestsTable.id,
+      status: crewVolunteerIntroRequestsTable.status,
+    })
+    .from(crewVolunteerIntroRequestsTable)
+    .where(
+      and(
+        eq(
+          crewVolunteerIntroRequestsTable.requestingTeamId,
+          scope.organizingTeamId,
+        ),
+        eq(crewVolunteerIntroRequestsTable.requestingCompetitionId, scope.id),
+        eq(
+          crewVolunteerIntroRequestsTable.volunteerIdentityId,
+          data.candidateId,
+        ),
+        eq(
+          crewVolunteerIntroRequestsTable.status,
+          CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+        ),
+      ),
+    )
+    .orderBy(desc(crewVolunteerIntroRequestsTable.requestedAt))
+    .limit(1)
+
+  if (existing) {
+    return {
+      success: true,
+      request: buildCrewRegionalJudgeIntroRequestView({
+        requestId: existing.id,
+        status: existing.status,
+        outcome: "existing",
+      }),
+    }
+  }
+
+  const session = await getSessionFromCookie().catch(() => null)
+  const now = new Date()
+  const requestId = createCrewVolunteerIntroRequestId()
+  await db.insert(crewVolunteerIntroRequestsTable).values({
+    id: requestId,
+    requestingTeamId: scope.organizingTeamId,
+    requestingCompetitionId: scope.id,
+    volunteerIdentityId: data.candidateId,
+    discoveryConsentId: activeConsent.consentId,
+    requestedRoleType:
+      data.requestedRoleType ?? candidate.roleTypes[0] ?? "judge",
+    startsAt: null,
+    endsAt: null,
+    status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+    requestedByUserId: session?.userId ?? null,
+    requestedAt: now,
+    respondedByUserId: null,
+    respondedAt: null,
+    expiresAt: null,
+    resultInvitationId: null,
+    resultMembershipId: null,
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  return {
+    success: true,
+    request: buildCrewRegionalJudgeIntroRequestView({
+      requestId,
+      status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+      outcome: "created",
+    }),
+  }
+}
+
+async function requireCrewRegionalJudgeDiscoveryScope(eventId: string) {
+  const event = await requireCrewDepartmentLeadEvent(eventId)
+  await requireCrewDepartmentLeadFullAccess(event)
+  return event
+}
+
+async function loadCrewRegionalJudgeDiscoveryView(
+  scope: CrewDepartmentLeadEvent,
+) {
+  const gate = getCrewRegionalJudgeDiscoveryGate()
+  const db = getDb()
+  const now = new Date()
+  const identityConsentRows = await db
+    .select({
+      identity: {
+        id: crewVolunteerIdentitiesTable.id,
+        teamId: crewVolunteerIdentitiesTable.teamId,
+        identitySource: crewVolunteerIdentitiesTable.identitySource,
+        discoveryAgeStatus: crewVolunteerIdentitiesTable.discoveryAgeStatus,
+        status: crewVolunteerIdentitiesTable.status,
+      },
+      consent: {
+        id: crewVolunteerConsentsTable.id,
+        identityId: crewVolunteerConsentsTable.identityId,
+        teamId: crewVolunteerConsentsTable.teamId,
+        scope: crewVolunteerConsentsTable.scope,
+        status: crewVolunteerConsentsTable.status,
+        grantedAt: crewVolunteerConsentsTable.grantedAt,
+        revokedAt: crewVolunteerConsentsTable.revokedAt,
+        supersededByConsentId: crewVolunteerConsentsTable.supersededByConsentId,
+      },
+    })
+    .from(crewVolunteerIdentitiesTable)
+    .innerJoin(
+      crewVolunteerConsentsTable,
+      and(
+        eq(
+          crewVolunteerConsentsTable.identityId,
+          crewVolunteerIdentitiesTable.id,
+        ),
+        eq(
+          crewVolunteerConsentsTable.teamId,
+          crewVolunteerIdentitiesTable.teamId,
+        ),
+      ),
+    )
+    .where(
+      and(
+        ne(crewVolunteerIdentitiesTable.teamId, scope.organizingTeamId),
+        eq(
+          crewVolunteerIdentitiesTable.status,
+          CREW_VOLUNTEER_IDENTITY_STATUS.ACTIVE,
+        ),
+        ne(
+          crewVolunteerIdentitiesTable.identitySource,
+          CREW_VOLUNTEER_IDENTITY_SOURCE.IMPORT,
+        ),
+        eq(
+          crewVolunteerIdentitiesTable.discoveryAgeStatus,
+          CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.ADULT_CONFIRMED,
+        ),
+        eq(
+          crewVolunteerConsentsTable.scope,
+          CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+        ),
+        eq(
+          crewVolunteerConsentsTable.status,
+          CREW_VOLUNTEER_CONSENT_STATUS.GRANTED,
+        ),
+        isNull(crewVolunteerConsentsTable.revokedAt),
+        isNull(crewVolunteerConsentsTable.supersededByConsentId),
+      ),
+    )
+    .orderBy(desc(crewVolunteerConsentsTable.grantedAt))
+    .limit(250)
+
+  const identitiesById = new Map(
+    identityConsentRows.map((row) => [row.identity.id, row.identity]),
+  )
+  const identities = [...identitiesById.values()]
+  const identityIds = [...identitiesById.keys()]
+  if (identityIds.length === 0) {
+    return buildCrewRegionalJudgeDiscoveryViewModel({
+      gate,
+      requestingTeamId: scope.organizingTeamId,
+      currentCompetitionId: scope.id,
+      identities: [],
+      consents: [],
+      historyEvents: [],
+      credentials: [],
+      now,
+    })
+  }
+
+  const [historyRows, credentialRows, introRequests] = await Promise.all([
+    db
+      .select({
+        identityId: crewVolunteerHistoryEventsTable.identityId,
+        teamId: crewVolunteerHistoryEventsTable.teamId,
+        competitionId: crewVolunteerHistoryEventsTable.competitionId,
+        competitionName: competitionsTable.name,
+        eventType: crewVolunteerHistoryEventsTable.eventType,
+        visibilityScope: crewVolunteerHistoryEventsTable.visibilityScope,
+        roleType: crewVolunteerHistoryEventsTable.roleType,
+        occurredAt: crewVolunteerHistoryEventsTable.occurredAt,
+        stateProvince: addressesTable.stateProvince,
+        countryCode: addressesTable.countryCode,
+        timezone: competitionsTable.timezone,
+      })
+      .from(crewVolunteerHistoryEventsTable)
+      .leftJoin(
+        competitionsTable,
+        eq(crewVolunteerHistoryEventsTable.competitionId, competitionsTable.id),
+      )
+      .leftJoin(
+        addressesTable,
+        eq(competitionsTable.primaryAddressId, addressesTable.id),
+      )
+      .where(
+        and(
+          inArray(crewVolunteerHistoryEventsTable.identityId, identityIds),
+          eq(
+            crewVolunteerHistoryEventsTable.visibilityScope,
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.CONSENTED_INTRO,
+          ),
+        ),
+      ),
+    db
+      .select({
+        identityId: crewVolunteerCredentialsTable.identityId,
+        teamId: crewVolunteerCredentialsTable.teamId,
+        credentialType: crewVolunteerCredentialsTable.credentialType,
+        credentialLabel: crewVolunteerCredentialsTable.credentialLabel,
+        status: crewVolunteerCredentialsTable.status,
+        visibilityScope: crewVolunteerCredentialsTable.visibilityScope,
+        expiresAt: crewVolunteerCredentialsTable.expiresAt,
+        revokedAt: crewVolunteerCredentialsTable.revokedAt,
+      })
+      .from(crewVolunteerCredentialsTable)
+      .where(
+        and(
+          inArray(crewVolunteerCredentialsTable.identityId, identityIds),
+          eq(
+            crewVolunteerCredentialsTable.visibilityScope,
+            CREW_VOLUNTEER_HISTORY_VISIBILITY_SCOPE.CONSENTED_INTRO,
+          ),
+          inArray(crewVolunteerCredentialsTable.status, [
+            CREW_VOLUNTEER_CREDENTIAL_STATUS.SELF_REPORTED,
+            CREW_VOLUNTEER_CREDENTIAL_STATUS.VERIFIED,
+          ]),
+          isNull(crewVolunteerCredentialsTable.revokedAt),
+          or(
+            isNull(crewVolunteerCredentialsTable.expiresAt),
+            gt(crewVolunteerCredentialsTable.expiresAt, now),
+          ),
+        ),
+      ),
+    db
+      .select({
+        id: crewVolunteerIntroRequestsTable.id,
+        volunteerIdentityId:
+          crewVolunteerIntroRequestsTable.volunteerIdentityId,
+        status: crewVolunteerIntroRequestsTable.status,
+        requestedAt: crewVolunteerIntroRequestsTable.requestedAt,
+      })
+      .from(crewVolunteerIntroRequestsTable)
+      .where(
+        and(
+          eq(
+            crewVolunteerIntroRequestsTable.requestingTeamId,
+            scope.organizingTeamId,
+          ),
+          eq(crewVolunteerIntroRequestsTable.requestingCompetitionId, scope.id),
+          inArray(
+            crewVolunteerIntroRequestsTable.volunteerIdentityId,
+            identityIds,
+          ),
+          eq(
+            crewVolunteerIntroRequestsTable.status,
+            CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+          ),
+        ),
+      ),
+  ])
+
+  return buildCrewRegionalJudgeDiscoveryViewModel({
+    gate,
+    requestingTeamId: scope.organizingTeamId,
+    currentCompetitionId: scope.id,
+    identities,
+    consents: identityConsentRows.map((row) => row.consent),
+    historyEvents: historyRows.map((row) => ({
+      identityId: row.identityId,
+      teamId: row.teamId,
+      competitionId: row.competitionId,
+      competitionName: row.competitionName,
+      eventType: row.eventType,
+      visibilityScope: row.visibilityScope,
+      roleType: row.roleType,
+      occurredAt: row.occurredAt,
+      regionLabel: formatRegionalDiscoveryRegion(row),
+    })),
+    credentials: credentialRows,
+    introRequests,
+    requestedRoleTypes: crewRegionalJudgeDiscoveryRoleTypes,
+    now,
+  })
+}
+
+async function findActiveDiscoveryConsentForCandidate({
+  scope,
+  candidateId,
+}: {
+  scope: CrewDepartmentLeadEvent
+  candidateId: string
+}) {
+  const db = getDb()
+  const [row] = await db
+    .select({
+      identityId: crewVolunteerIdentitiesTable.id,
+      consentId: crewVolunteerConsentsTable.id,
+    })
+    .from(crewVolunteerIdentitiesTable)
+    .innerJoin(
+      crewVolunteerConsentsTable,
+      and(
+        eq(
+          crewVolunteerConsentsTable.identityId,
+          crewVolunteerIdentitiesTable.id,
+        ),
+        eq(
+          crewVolunteerConsentsTable.teamId,
+          crewVolunteerIdentitiesTable.teamId,
+        ),
+      ),
+    )
+    .where(
+      and(
+        eq(crewVolunteerIdentitiesTable.id, candidateId),
+        ne(crewVolunteerIdentitiesTable.teamId, scope.organizingTeamId),
+        eq(
+          crewVolunteerIdentitiesTable.status,
+          CREW_VOLUNTEER_IDENTITY_STATUS.ACTIVE,
+        ),
+        ne(
+          crewVolunteerIdentitiesTable.identitySource,
+          CREW_VOLUNTEER_IDENTITY_SOURCE.IMPORT,
+        ),
+        eq(
+          crewVolunteerIdentitiesTable.discoveryAgeStatus,
+          CREW_VOLUNTEER_DISCOVERY_AGE_STATUS.ADULT_CONFIRMED,
+        ),
+        eq(
+          crewVolunteerConsentsTable.scope,
+          CREW_VOLUNTEER_CONSENT_SCOPE.REGIONAL_DISCOVERY,
+        ),
+        eq(
+          crewVolunteerConsentsTable.status,
+          CREW_VOLUNTEER_CONSENT_STATUS.GRANTED,
+        ),
+        isNull(crewVolunteerConsentsTable.revokedAt),
+        isNull(crewVolunteerConsentsTable.supersededByConsentId),
+      ),
+    )
+    .orderBy(desc(crewVolunteerConsentsTable.grantedAt))
+    .limit(1)
+
+  return row ?? null
+}
+
+function getCrewRegionalJudgeDiscoveryGate() {
+  const runtimeEnv = env as CrewDiscoveryRuntimeEnv
+  return resolveCrewRegionalJudgeDiscoveryGate(
+    runtimeEnv.CREW_REGIONAL_JUDGE_DISCOVERY_ENABLED,
+  )
+}
+
+function formatRegionalDiscoveryRegion(row: {
+  stateProvince: string | null
+  countryCode: string | null
+  timezone: string | null
+}) {
+  const parts = [row.stateProvince, row.countryCode]
+    .map((part) => part?.trim())
+    .filter((part): part is string => Boolean(part))
+  if (parts.length > 0) return parts.join(", ")
+  return row.timezone?.replaceAll("_", " ") ?? null
+}

--- a/apps/crew/src/server/crew-discovery.server.ts
+++ b/apps/crew/src/server/crew-discovery.server.ts
@@ -1,6 +1,6 @@
 // @lat: [[crew#Regional Judge Discovery Pilot]]
 import { env } from "cloudflare:workers"
-import { and, desc, eq, gt, inArray, isNull, ne, or } from "drizzle-orm"
+import { and, desc, eq, gt, inArray, isNull, ne, or, sql } from "drizzle-orm"
 import { getDb } from "../db"
 import { addressesTable } from "../db/schemas/addresses"
 import { competitionsTable } from "../db/schemas/competitions"
@@ -26,9 +26,11 @@ import {
   buildCrewRegionalJudgeIntroRequestView,
   crewRegionalJudgeDiscoveryRoleTypes,
   resolveCrewRegionalJudgeDiscoveryGate,
+  resolveCrewRegionalJudgeIntroRequestedRole,
   type CrewRegionalJudgeDiscoveryViewModel,
   type CrewRegionalJudgeIntroRequestView,
 } from "../lib/crew/regional-judge-discovery"
+import { getFirstExecuteValue } from "../server-fns/db-execute"
 import { getSessionFromCookie } from "../utils/auth"
 import {
   requireCrewDepartmentLeadEvent,
@@ -39,6 +41,8 @@ import {
 type CrewDiscoveryRuntimeEnv = typeof env & {
   CREW_REGIONAL_JUDGE_DISCOVERY_ENABLED?: string | boolean
 }
+
+type DbClient = ReturnType<typeof getDb>
 
 export interface CrewRegionalJudgeDiscoveryPageData {
   viewModel: CrewRegionalJudgeDiscoveryViewModel
@@ -102,77 +106,94 @@ export async function requestCrewRegionalJudgeIntro(data: {
     throw new Error("That regional judge candidate is no longer eligible.")
   }
 
-  const db = getDb()
-  const [existing] = await db
-    .select({
-      id: crewVolunteerIntroRequestsTable.id,
-      status: crewVolunteerIntroRequestsTable.status,
-    })
-    .from(crewVolunteerIntroRequestsTable)
-    .where(
-      and(
-        eq(
-          crewVolunteerIntroRequestsTable.requestingTeamId,
-          scope.organizingTeamId,
-        ),
-        eq(crewVolunteerIntroRequestsTable.requestingCompetitionId, scope.id),
-        eq(
-          crewVolunteerIntroRequestsTable.volunteerIdentityId,
-          data.candidateId,
-        ),
-        eq(
-          crewVolunteerIntroRequestsTable.status,
-          CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
-        ),
-      ),
-    )
-    .orderBy(desc(crewVolunteerIntroRequestsTable.requestedAt))
-    .limit(1)
-
-  if (existing) {
-    return {
-      success: true,
-      request: buildCrewRegionalJudgeIntroRequestView({
-        requestId: existing.id,
-        status: existing.status,
-        outcome: "existing",
-      }),
-    }
-  }
-
-  const session = await getSessionFromCookie().catch(() => null)
-  const now = new Date()
-  const requestId = createCrewVolunteerIntroRequestId()
-  await db.insert(crewVolunteerIntroRequestsTable).values({
-    id: requestId,
-    requestingTeamId: scope.organizingTeamId,
-    requestingCompetitionId: scope.id,
-    volunteerIdentityId: data.candidateId,
-    discoveryConsentId: activeConsent.consentId,
-    requestedRoleType:
-      data.requestedRoleType ?? candidate.roleTypes[0] ?? "judge",
-    startsAt: null,
-    endsAt: null,
-    status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
-    requestedByUserId: session?.userId ?? null,
-    requestedAt: now,
-    respondedByUserId: null,
-    respondedAt: null,
-    expiresAt: null,
-    resultInvitationId: null,
-    resultMembershipId: null,
-    createdAt: now,
-    updatedAt: now,
+  const requestedRoleType = resolveCrewRegionalJudgeIntroRequestedRole({
+    requestedRoleType: data.requestedRoleType,
+    eligibleRoleTypes: candidate.roleTypes,
   })
-
-  return {
-    success: true,
-    request: buildCrewRegionalJudgeIntroRequestView({
-      requestId,
-      status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
-      outcome: "created",
-    }),
+  if (!requestedRoleType) {
+    throw new Error("That requested judge role is no longer eligible.")
   }
+
+  const db = getDb()
+  return await withCrewRegionalJudgeIntroRequestLock({
+    db,
+    scope,
+    candidateId: data.candidateId,
+    callback: async () => {
+      const [existing] = await db
+        .select({
+          id: crewVolunteerIntroRequestsTable.id,
+          status: crewVolunteerIntroRequestsTable.status,
+        })
+        .from(crewVolunteerIntroRequestsTable)
+        .where(
+          and(
+            eq(
+              crewVolunteerIntroRequestsTable.requestingTeamId,
+              scope.organizingTeamId,
+            ),
+            eq(
+              crewVolunteerIntroRequestsTable.requestingCompetitionId,
+              scope.id,
+            ),
+            eq(
+              crewVolunteerIntroRequestsTable.volunteerIdentityId,
+              data.candidateId,
+            ),
+            eq(
+              crewVolunteerIntroRequestsTable.status,
+              CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+            ),
+          ),
+        )
+        .orderBy(desc(crewVolunteerIntroRequestsTable.requestedAt))
+        .limit(1)
+
+      if (existing) {
+        return {
+          success: true,
+          request: buildCrewRegionalJudgeIntroRequestView({
+            requestId: existing.id,
+            status: existing.status,
+            outcome: "existing",
+          }),
+        }
+      }
+
+      const session = await getSessionFromCookie().catch(() => null)
+      const now = new Date()
+      const requestId = createCrewVolunteerIntroRequestId()
+      await db.insert(crewVolunteerIntroRequestsTable).values({
+        id: requestId,
+        requestingTeamId: scope.organizingTeamId,
+        requestingCompetitionId: scope.id,
+        volunteerIdentityId: data.candidateId,
+        discoveryConsentId: activeConsent.consentId,
+        requestedRoleType,
+        startsAt: null,
+        endsAt: null,
+        status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+        requestedByUserId: session?.userId ?? null,
+        requestedAt: now,
+        respondedByUserId: null,
+        respondedAt: null,
+        expiresAt: null,
+        resultInvitationId: null,
+        resultMembershipId: null,
+        createdAt: now,
+        updatedAt: now,
+      })
+
+      return {
+        success: true,
+        request: buildCrewRegionalJudgeIntroRequestView({
+          requestId,
+          status: CREW_VOLUNTEER_INTRO_REQUEST_STATUS.PENDING,
+          outcome: "created",
+        }),
+      }
+    },
+  })
 }
 
 async function requireCrewRegionalJudgeDiscoveryScope(eventId: string) {
@@ -443,6 +464,59 @@ async function findActiveDiscoveryConsentForCandidate({
     .limit(1)
 
   return row ?? null
+}
+
+async function withCrewRegionalJudgeIntroRequestLock({
+  db,
+  scope,
+  candidateId,
+  callback,
+}: {
+  db: DbClient
+  scope: CrewDepartmentLeadEvent
+  candidateId: string
+  callback: () => Promise<CrewRegionalJudgeIntroRequestResult>
+}) {
+  let acquired = false
+  const lockName = await createCrewRegionalJudgeIntroRequestLockName({
+    requestingTeamId: scope.organizingTeamId,
+    requestingCompetitionId: scope.id,
+    candidateId,
+  })
+
+  try {
+    const result = await db.execute(
+      sql`SELECT GET_LOCK(${lockName}, 5) FROM dual`,
+    )
+    acquired = Number(getFirstExecuteValue(result) ?? 0) === 1
+    if (!acquired) {
+      throw new Error("Intro request could not be recorded.")
+    }
+
+    return await callback()
+  } finally {
+    if (acquired) {
+      await db.execute(sql`SELECT RELEASE_LOCK(${lockName}) FROM dual`)
+    }
+  }
+}
+
+async function createCrewRegionalJudgeIntroRequestLockName({
+  requestingTeamId,
+  requestingCompetitionId,
+  candidateId,
+}: {
+  requestingTeamId: string
+  requestingCompetitionId: string
+  candidateId: string
+}) {
+  const encoded = new TextEncoder().encode(
+    `crew-regional-judge-intro:${requestingTeamId}:${requestingCompetitionId}:${candidateId}`,
+  )
+  const digest = await crypto.subtle.digest("SHA-256", encoded)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")
 }
 
 function getCrewRegionalJudgeDiscoveryGate() {

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -409,3 +409,11 @@ Reliability is auditable fact history only: assignments, confirmations, response
 Raw email, phone, emergency contacts, internal notes, and private metadata stay in their existing source tables. Discovery, search, analytics, audit previews, and regional summaries must not expose those raw fields.
 
 Series crew pools stay constrained to the selected `competition_group`; conversion enriches an existing competition instead of cloning identities; regional discovery starts as opt-in intro requests only. Intelligence, series, conversion, discovery, and person-level analytics require privacy review notes and feature flags before implementation.
+
+## Regional Judge Discovery Pilot
+
+Regional judge discovery is an event-scoped, organizer-only pilot for blind intro requests to adult judges who explicitly opted into regional discovery.
+
+[[apps/crew/src/lib/crew/regional-judge-discovery.ts]] builds the deterministic privacy-safe view model from active volunteer identities, current regional-discovery consent, consented-intro history facts, safe credential facts, and pending intro requests. The model excludes import-only volunteers, same-team inventory, minors, revoked or superseded consent, raw contact fields, private metadata, negative badges, rankings, ratings, and global reputation.
+
+[[apps/crew/src/server/crew-discovery.server.ts]] keeps discovery server-only and disabled unless `CREW_REGIONAL_JUDGE_DISCOVERY_ENABLED` is explicitly enabled. The event route [[apps/crew/src/routes/events/$eventId/discovery/judges.tsx]] renders the gated pilot under the organizer event shell; when enabled it can record a `crew_volunteer_intro_requests` audit row without revealing direct contact, sending email/SMS, creating invitations, or implementing acceptance/contact reveal.


### PR DESCRIPTION
## Summary

- Adds a disabled-by-default Crew regional judge discovery pilot behind `CREW_REGIONAL_JUDGE_DISCOVERY_ENABLED`.
- Builds a privacy-safe discovery view model from existing volunteer identities, current regional-discovery consent, consented-intro history facts, safe credential facts, and pending intro requests.
- Adds the event-scoped organizer route `/events/$eventId/discovery/judges` plus a blind intro-request server action that writes only `crew_volunteer_intro_requests` audit rows.
- Documents the LAT anchor `crew#Regional Judge Discovery Pilot`.

## Privacy / Scope

- No schema or migration changes.
- No public directory, direct contact reveal, acceptance flow, delivery queue, email, SMS, analytics, billing, registration, import mutation, or published judge-row mutation.
- Discovery excludes same-team inventory, imported identities, import-only history, minors/non-adult identities, revoked/superseded consent, unsafe credentials, raw contact fields, private metadata, negative badges, rankings, ratings, and global reputation.

## Validation

- `pnpm --filter crew test -- src/lib/crew/regional-judge-discovery.test.ts`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (exits 0; reports existing unrelated warnings)
- `pnpm --filter crew exec biome lint ...touched files...`
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `pnpm dlx lat.md locate 'crew#Regional Judge Discovery Pilot'`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pilot an event‑scoped regional judge discovery feature so organizers can send blind intro requests to opted‑in adult judges using privacy‑safe, consented facts. The pilot is disabled by default behind `CREW_REGIONAL_JUDGE_DISCOVERY_ENABLED`.

- New Features
  - Gated route `/events/$eventId/discovery/judges` for organizers; server enforces event scope.
  - Builds a privacy‑safe candidate list from active identities, current regional consent, consented‑intro history, safe credentials, and pending intro requests; excludes minors, same‑team, imports, revoked/superseded consent, and any raw contact/private data.
  - Adds a blind intro request action that writes `crew_volunteer_intro_requests` audit rows only (no contact reveal, email/SMS, invitations, or acceptance flow). No schema changes; tests and docs included.

- Bug Fixes
  - Hardened intro requests with a DB lock and dedupe to prevent concurrent or duplicate pending requests; returns the existing request when present.
  - Revalidates eligibility at request time (gate enabled, active consent, adult non‑import identity, event scope, and an eligible `judge`/`head_judge` role); rejects when disabled or ineligible.

<sup>Written for commit ea5b14a20d418b7b934773ff95b8704dc7db9e83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Regional Judge Discovery pilot enabling organizers to discover and connect with eligible adult judges in their region
  * Discovery page displays candidate judges with credentials and regional information
  * Organizers can submit blind introduction requests to candidate judges
  * New Discovery navigation link added to event pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->