### PR TITLE
[codex] Add persona-aware Crew event navigation

### DIFF
--- a/apps/crew/src/lib/crew/navigation.ts
+++ b/apps/crew/src/lib/crew/navigation.ts
@@ -1,0 +1,186 @@
+export type CrewViewerRole =
+  | 'wodsmith_operator'
+  | 'organizer_admin'
+  | 'department_lead'
+  | 'volunteer_public'
+
+export type CrewEventNavRoute =
+  | '/events/$eventId'
+  | '/events/$eventId/readiness'
+  | '/events/$eventId/staffing'
+  | '/events/$eventId/setup'
+  | '/events/$eventId/billing'
+  | '/events/$eventId/convert'
+  | '/events/$eventId/imports'
+  | '/events/$eventId/volunteers'
+  | '/events/$eventId/shifts'
+  | '/events/$eventId/judges'
+  | '/events/$eventId/discovery/judges'
+  | '/events/$eventId/day-of'
+  | '/events/$eventId/exports'
+  | '/events/$eventId/schedule'
+
+export type CrewEventRequirement =
+  | 'has_assignments'
+  | 'has_event_day_data'
+  | 'has_print_packet_data'
+
+export interface CrewEventNavigationState {
+  assignmentCount?: number
+  shiftCount?: number
+  hasEventDayData?: boolean
+  hasPrintPacketData?: boolean
+}
+
+export interface CrewNavItem {
+  key: string
+  label: string
+  to: CrewEventNavRoute
+  persona: readonly CrewViewerRole[]
+  requires?: readonly CrewEventRequirement[]
+  hiddenWhenEmpty?: boolean
+}
+
+export interface CrewEventNavigationInput {
+  viewerRole: CrewViewerRole
+  state?: CrewEventNavigationState
+}
+
+export const CREW_EVENT_NAV_ITEMS = [
+  {
+    key: 'home',
+    label: 'Home',
+    to: '/events/$eventId',
+    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+  },
+  {
+    key: 'setup',
+    label: 'Setup',
+    to: '/events/$eventId/setup',
+    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+  },
+  {
+    key: 'imports',
+    label: 'Imports',
+    to: '/events/$eventId/imports',
+    persona: ['wodsmith_operator', 'organizer_admin'],
+  },
+  {
+    key: 'staffing',
+    label: 'Staffing Plan',
+    to: '/events/$eventId/staffing',
+    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+  },
+  {
+    key: 'assignments',
+    label: 'Assignments',
+    to: '/events/$eventId/shifts',
+    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+  },
+  {
+    key: 'confirmations',
+    label: 'Confirmations',
+    to: '/events/$eventId/shifts',
+    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+    requires: ['has_assignments'],
+    hiddenWhenEmpty: true,
+  },
+  {
+    key: 'event-day',
+    label: 'Event Day',
+    to: '/events/$eventId/day-of',
+    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+    requires: ['has_event_day_data'],
+    hiddenWhenEmpty: true,
+  },
+  {
+    key: 'print-packet',
+    label: 'Print Packet',
+    to: '/events/$eventId/exports',
+    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+    requires: ['has_print_packet_data'],
+    hiddenWhenEmpty: true,
+  },
+  {
+    key: 'readiness',
+    label: 'Readiness',
+    to: '/events/$eventId/readiness',
+    persona: ['wodsmith_operator'],
+  },
+  {
+    key: 'billing',
+    label: 'Billing',
+    to: '/events/$eventId/billing',
+    persona: ['wodsmith_operator'],
+  },
+  {
+    key: 'convert',
+    label: 'Convert',
+    to: '/events/$eventId/convert',
+    persona: ['wodsmith_operator'],
+  },
+  {
+    key: 'volunteers',
+    label: 'Volunteers',
+    to: '/events/$eventId/volunteers',
+    persona: ['wodsmith_operator'],
+  },
+  {
+    key: 'judges',
+    label: 'Judges',
+    to: '/events/$eventId/judges',
+    persona: ['wodsmith_operator'],
+  },
+  {
+    key: 'discovery',
+    label: 'Discovery',
+    to: '/events/$eventId/discovery/judges',
+    persona: ['wodsmith_operator'],
+  },
+  {
+    key: 'schedule',
+    label: 'Schedule',
+    to: '/events/$eventId/schedule',
+    persona: ['wodsmith_operator'],
+  },
+] as const satisfies readonly CrewNavItem[]
+
+export function getCrewEventNavItems({
+  viewerRole,
+  state = {},
+}: CrewEventNavigationInput): readonly CrewNavItem[] {
+  return CREW_EVENT_NAV_ITEMS.filter((item) =>
+    canViewCrewNavItem(item, viewerRole, state),
+  )
+}
+
+export function canViewCrewNavItem(
+  item: CrewNavItem,
+  viewerRole: CrewViewerRole,
+  state: CrewEventNavigationState = {},
+) {
+  if (!item.persona.includes(viewerRole)) return false
+  if (viewerRole === 'wodsmith_operator') return true
+
+  return (item.requires ?? []).every((requirement) =>
+    crewEventRequirementIsMet(requirement, state),
+  )
+}
+
+function crewEventRequirementIsMet(
+  requirement: CrewEventRequirement,
+  state: CrewEventNavigationState,
+) {
+  switch (requirement) {
+    case 'has_assignments':
+      return hasAssignments(state)
+    case 'has_event_day_data':
+      return state.hasEventDayData ?? hasAssignments(state)
+    case 'has_print_packet_data':
+      return state.hasPrintPacketData ?? hasAssignments(state)
+  }
+}
+
+function hasAssignments(state: CrewEventNavigationState) {
+  return (state.assignmentCount ?? 0) > 0 || (state.shiftCount ?? 0) > 0
+}

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -5,148 +5,53 @@
 // @lat: [[crew#Billing Page And Upgrade CTA]]
 // @lat: [[crew#Full WODsmith Conversion Assistant]]
 // @lat: [[crew#Regional Judge Discovery Pilot]]
-import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
-import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
+import {createFileRoute, Link, notFound, Outlet} from '@tanstack/react-router'
+import {getCrewEventNavItems} from '@/lib/crew/navigation'
+import {getCrewEventFn} from '@/server-fns/crew-event-settings-fns'
+import {resolveCrewViewer} from '@/utils/crew-access'
 
-export const Route = createFileRoute("/events/$eventId")({
-  loader: async ({ params }) => {
-    const result = await getCrewEventFn({ data: { eventId: params.eventId } })
+export const Route = createFileRoute('/events/$eventId')({
+  loader: async ({params}) => {
+    const result = await getCrewEventFn({data: {eventId: params.eventId}})
     if (!result.event) {
       throw notFound()
     }
-    return { event: result.event }
+    return {event: result.event}
   },
   component: EventShell,
 })
 
 function EventShell() {
-  const { eventId } = Route.useParams()
-  const { event } = Route.useLoaderData()
+  const {eventId} = Route.useParams()
+  const {event} = Route.useLoaderData()
+  const viewer = resolveCrewViewer()
+  const navItems = getCrewEventNavItems({viewerRole: viewer.role})
 
   return (
     <main className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:px-6">
       <div className="flex flex-col justify-between gap-4 border-b pb-6 md:flex-row md:items-end">
         <div>
-          <p className="font-mono text-sm text-muted-foreground">{eventId}</p>
+          {viewer.isWodsmithOperator && (
+            <p className="font-mono text-sm text-muted-foreground">{eventId}</p>
+          )}
           <h1 className="text-3xl font-semibold">{event.competition.name}</h1>
           <p className="text-muted-foreground">
             {event.competition.startDate} to {event.competition.endDate}
           </p>
         </div>
         <nav className="flex flex-wrap gap-2 text-sm">
-          <Link
-            to="/events/$eventId"
-            params={{ eventId }}
-            activeOptions={{ exact: true }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Overview
-          </Link>
-          <Link
-            to="/events/$eventId/readiness"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Readiness
-          </Link>
-          <Link
-            to="/events/$eventId/staffing"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Staffing
-          </Link>
-          <Link
-            to="/events/$eventId/setup"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Setup
-          </Link>
-          <Link
-            to="/events/$eventId/billing"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Billing
-          </Link>
-          <Link
-            to="/events/$eventId/convert"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Convert
-          </Link>
-          <Link
-            to="/events/$eventId/imports"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Imports
-          </Link>
-          <Link
-            to="/events/$eventId/volunteers"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Volunteers
-          </Link>
-          <Link
-            to="/events/$eventId/shifts"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Shifts
-          </Link>
-          <Link
-            to="/events/$eventId/judges"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Judges
-          </Link>
-          <Link
-            to="/events/$eventId/discovery/judges"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Discovery
-          </Link>
-          <Link
-            to="/events/$eventId/day-of"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Day-of
-          </Link>
-          <Link
-            to="/events/$eventId/exports"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Exports
-          </Link>
-          <Link
-            to="/events/$eventId/schedule"
-            params={{ eventId }}
-            activeProps={{ className: "bg-muted text-foreground" }}
-            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Schedule
-          </Link>
+          {navItems.map((item) => (
+            <Link
+              key={item.key}
+              to={item.to}
+              params={{eventId}}
+              activeOptions={item.key === 'home' ? {exact: true} : undefined}
+              activeProps={{className: 'bg-muted text-foreground'}}
+              className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              {item.label}
+            </Link>
+          ))}
         </nav>
       </div>
 

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -8,6 +8,7 @@
 import {createFileRoute, Link, notFound, Outlet} from '@tanstack/react-router'
 import {getCrewEventNavItems} from '@/lib/crew/navigation'
 import {getCrewEventFn} from '@/server-fns/crew-event-settings-fns'
+import {useSession} from '@/utils/auth-client'
 import {resolveCrewViewer} from '@/utils/crew-access'
 
 export const Route = createFileRoute('/events/$eventId')({
@@ -24,7 +25,8 @@ export const Route = createFileRoute('/events/$eventId')({
 function EventShell() {
   const {eventId} = Route.useParams()
   const {event} = Route.useLoaderData()
-  const viewer = resolveCrewViewer()
+  const session = useSession()
+  const viewer = resolveCrewViewer({session})
   const navItems = getCrewEventNavItems({viewerRole: viewer.role})
 
   return (

--- a/apps/crew/src/utils/auth-client.ts
+++ b/apps/crew/src/utils/auth-client.ts
@@ -3,7 +3,15 @@
  * Provides hooks to access session data from route context
  */
 
-import { useRouteContext } from "@tanstack/react-router"
+import {useRouteContext} from '@tanstack/react-router'
+
+interface CrewSessionContext {
+  session?: {
+    user?: {
+      role?: string | null
+    } | null
+  } | null
+}
 
 /**
  * Hook to access the current session from route context.
@@ -12,6 +20,6 @@ import { useRouteContext } from "@tanstack/react-router"
  * @returns The current session or null if not authenticated
  */
 export function useSession() {
-  const context = useRouteContext({ from: "__root__" })
-  return context.session
+  const context = useRouteContext({from: '__root__'}) as CrewSessionContext
+  return context.session ?? null
 }

--- a/apps/crew/src/utils/crew-access.ts
+++ b/apps/crew/src/utils/crew-access.ts
@@ -1,0 +1,42 @@
+import type {CrewViewerRole} from '@/lib/crew/navigation'
+
+export interface CrewViewerInput {
+  role?: CrewViewerRole | null
+  isWodsmithOperator?: boolean
+  isDepartmentLead?: boolean
+  isVolunteerPublic?: boolean
+}
+
+export interface CrewViewer {
+  role: CrewViewerRole
+  isWodsmithOperator: boolean
+  isOrganizer: boolean
+  isDepartmentLead: boolean
+  isVolunteerPublic: boolean
+}
+
+export function resolveCrewViewer(input: CrewViewerInput = {}): CrewViewer {
+  const role = resolveCrewViewerRole(input)
+
+  return {
+    role,
+    isWodsmithOperator: role === 'wodsmith_operator',
+    isOrganizer: role === 'organizer_admin',
+    isDepartmentLead: role === 'department_lead',
+    isVolunteerPublic: role === 'volunteer_public',
+  }
+}
+
+export function resolveCrewViewerRole({
+  role,
+  isWodsmithOperator = false,
+  isDepartmentLead = false,
+  isVolunteerPublic = false,
+}: CrewViewerInput = {}): CrewViewerRole {
+  if (role) return role
+  if (isWodsmithOperator) return 'wodsmith_operator'
+  if (isDepartmentLead) return 'department_lead'
+  if (isVolunteerPublic) return 'volunteer_public'
+
+  return 'organizer_admin'
+}

--- a/apps/crew/src/utils/crew-access.ts
+++ b/apps/crew/src/utils/crew-access.ts
@@ -2,9 +2,16 @@ import type {CrewViewerRole} from '@/lib/crew/navigation'
 
 export interface CrewViewerInput {
   role?: CrewViewerRole | null
+  session?: CrewSessionLike | null
   isWodsmithOperator?: boolean
   isDepartmentLead?: boolean
   isVolunteerPublic?: boolean
+}
+
+interface CrewSessionLike {
+  user?: {
+    role?: string | null
+  } | null
 }
 
 export interface CrewViewer {
@@ -15,6 +22,11 @@ export interface CrewViewer {
   isVolunteerPublic: boolean
 }
 
+/**
+ * Resolves the crew viewer role and derives all boolean flags from it.
+ * Explicit role inputs win, boolean inputs are fallbacks, and missing sessions
+ * default to the least-privileged public volunteer persona.
+ */
 export function resolveCrewViewer(input: CrewViewerInput = {}): CrewViewer {
   const role = resolveCrewViewerRole(input)
 
@@ -29,6 +41,7 @@ export function resolveCrewViewer(input: CrewViewerInput = {}): CrewViewer {
 
 export function resolveCrewViewerRole({
   role,
+  session,
   isWodsmithOperator = false,
   isDepartmentLead = false,
   isVolunteerPublic = false,
@@ -37,6 +50,8 @@ export function resolveCrewViewerRole({
   if (isWodsmithOperator) return 'wodsmith_operator'
   if (isDepartmentLead) return 'department_lead'
   if (isVolunteerPublic) return 'volunteer_public'
+  if (session?.user?.role === 'admin') return 'wodsmith_operator'
+  if (session?.user) return 'organizer_admin'
 
-  return 'organizer_admin'
+  return 'volunteer_public'
 }


### PR DESCRIPTION
## Scope
- Add client-safe Crew event navigation primitives in `apps/crew/src/lib/crew/navigation.ts`.
- Add minimal viewer role utilities in `apps/crew/src/utils/crew-access.ts`.
- Replace the hardcoded event shell nav in `apps/crew/src/routes/events/$eventId.tsx` with persona-aware navigation.

## Acceptance
- Organizer/default event shell nav now moves toward `Home`, `Setup`, `Imports`, `Staffing Plan`, and `Assignments`.
- State-gated organizer items for `Confirmations`, `Event Day`, and `Print Packet` stay hidden for empty/new events until assignment/event-day/packet state is available.
- Organizer-visible nav no longer shows Billing, Convert, Discovery, Schedule, Volunteers, Judges, Readiness, route placeholders, or the raw event id.
- WODsmith-operator nav items remain defined for existing internal routes so the PR 2 admin-shell migration can remap them without losing the current surfaces.

## Validation
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH /Users/ianjones/wodsmith/node_modules/.bin/prettier --check apps/crew/src/lib/crew/navigation.ts apps/crew/src/utils/crew-access.ts 'apps/crew/src/routes/events/$eventId.tsx'` passed.\n- Attempted `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm install --frozen-lockfile` in the isolated archive so `pnpm --filter crew type-check` / lint could run, but local Git/filesystem operations entered an uninterruptible OS wait in this task directory. Full Crew type/lint/build should run in CI or a healthy checkout.\n\n## Out of scope / PR 2+ follow-ups\n- Admin shell migration to `/admin/crew/*`.\n- Schema changes, billing implementation, conversion workflow changes, and broad UI redesign.\n- Dedicated organizer `Assignments` / `Confirmations` route consolidation. Current labels intentionally point at existing shift/confirmation-capable routes until those routes land.\n- Organizer home/next-action redesign and deeper client-safe view-model cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds persona-aware navigation to the Crew event shell, replacing hardcoded links. Viewer role is inferred from session so organizers and leads see a focused menu, while operators keep full internal routes.

- **New Features**
  - Role is resolved with `resolveCrewViewer` (`admin` → `wodsmith_operator`, signed-in → `organizer_admin`, otherwise `volunteer_public`) and per-role nav is computed via `getCrewEventNavItems`/`canViewCrewNavItem`.
  - Organizer view shows Home, Setup, Imports, Staffing Plan, and Assignments; Confirmations, Event Day, and Print Packet stay hidden until data exists; admin-only items are removed; `eventId` is shown only to operators.

- **Bug Fixes**
  - Fixed session context typing in `useSession` to return a safe shape/null, preventing nav crashes and ensuring correct role inference.

<sup>Written for commit 89944bd8988e2865893f15c7f0140823befabcf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added role-based crew navigation system that dynamically displays event management sections based on user permissions, including setup, staffing, assignments, and reporting features.

* **Improvements**
  * Event information and controls now display conditionally based on user access level and authorization role.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->