### PR TITLE
Add Crew admin shell

### DIFF
--- a/apps/crew/src/lib/crew/navigation.ts
+++ b/apps/crew/src/lib/crew/navigation.ts
@@ -1,9 +1,11 @@
+// @lat: [[crew#Event Setup Dashboard]]
 export type CrewViewerRole =
   | "wodsmith_operator"
   | "organizer_admin"
   | "department_lead"
   | "volunteer_public"
 
+// @lat: [[crew#Event Setup Dashboard]]
 export type CrewEventNavRoute =
   | "/events/$eventId"
   | "/events/$eventId/staffing"
@@ -13,6 +15,7 @@ export type CrewEventNavRoute =
   | "/events/$eventId/day-of"
   | "/events/$eventId/exports"
 
+// @lat: [[crew#Event Setup Dashboard]]
 export type CrewEventRequirement =
   | "has_assignments"
   | "has_event_day_data"

--- a/apps/crew/src/lib/crew/navigation.ts
+++ b/apps/crew/src/lib/crew/navigation.ts
@@ -1,29 +1,22 @@
 export type CrewViewerRole =
-  | 'wodsmith_operator'
-  | 'organizer_admin'
-  | 'department_lead'
-  | 'volunteer_public'
+  | "wodsmith_operator"
+  | "organizer_admin"
+  | "department_lead"
+  | "volunteer_public"
 
 export type CrewEventNavRoute =
-  | '/events/$eventId'
-  | '/events/$eventId/readiness'
-  | '/events/$eventId/staffing'
-  | '/events/$eventId/setup'
-  | '/events/$eventId/billing'
-  | '/events/$eventId/convert'
-  | '/events/$eventId/imports'
-  | '/events/$eventId/volunteers'
-  | '/events/$eventId/shifts'
-  | '/events/$eventId/judges'
-  | '/events/$eventId/discovery/judges'
-  | '/events/$eventId/day-of'
-  | '/events/$eventId/exports'
-  | '/events/$eventId/schedule'
+  | "/events/$eventId"
+  | "/events/$eventId/staffing"
+  | "/events/$eventId/setup"
+  | "/events/$eventId/imports"
+  | "/events/$eventId/shifts"
+  | "/events/$eventId/day-of"
+  | "/events/$eventId/exports"
 
 export type CrewEventRequirement =
-  | 'has_assignments'
-  | 'has_event_day_data'
-  | 'has_print_packet_data'
+  | "has_assignments"
+  | "has_event_day_data"
+  | "has_print_packet_data"
 
 export interface CrewEventNavigationState {
   assignmentCount?: number
@@ -48,100 +41,58 @@ export interface CrewEventNavigationInput {
 
 export const CREW_EVENT_NAV_ITEMS = [
   {
-    key: 'home',
-    label: 'Home',
-    to: '/events/$eventId',
-    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+    key: "home",
+    label: "Home",
+    to: "/events/$eventId",
+    persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
   },
   {
-    key: 'setup',
-    label: 'Setup',
-    to: '/events/$eventId/setup',
-    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+    key: "setup",
+    label: "Setup",
+    to: "/events/$eventId/setup",
+    persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
   },
   {
-    key: 'imports',
-    label: 'Imports',
-    to: '/events/$eventId/imports',
-    persona: ['wodsmith_operator', 'organizer_admin'],
+    key: "imports",
+    label: "Imports",
+    to: "/events/$eventId/imports",
+    persona: ["wodsmith_operator", "organizer_admin"],
   },
   {
-    key: 'staffing',
-    label: 'Staffing Plan',
-    to: '/events/$eventId/staffing',
-    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+    key: "staffing",
+    label: "Staffing Plan",
+    to: "/events/$eventId/staffing",
+    persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
   },
   {
-    key: 'assignments',
-    label: 'Assignments',
-    to: '/events/$eventId/shifts',
-    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
+    key: "assignments",
+    label: "Assignments",
+    to: "/events/$eventId/shifts",
+    persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
   },
   {
-    key: 'confirmations',
-    label: 'Confirmations',
-    to: '/events/$eventId/shifts',
-    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
-    requires: ['has_assignments'],
+    key: "confirmations",
+    label: "Confirmations",
+    to: "/events/$eventId/shifts",
+    persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
+    requires: ["has_assignments"],
     hiddenWhenEmpty: true,
   },
   {
-    key: 'event-day',
-    label: 'Event Day',
-    to: '/events/$eventId/day-of',
-    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
-    requires: ['has_event_day_data'],
+    key: "event-day",
+    label: "Event Day",
+    to: "/events/$eventId/day-of",
+    persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
+    requires: ["has_event_day_data"],
     hiddenWhenEmpty: true,
   },
   {
-    key: 'print-packet',
-    label: 'Print Packet',
-    to: '/events/$eventId/exports',
-    persona: ['wodsmith_operator', 'organizer_admin', 'department_lead'],
-    requires: ['has_print_packet_data'],
+    key: "print-packet",
+    label: "Print Packet",
+    to: "/events/$eventId/exports",
+    persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
+    requires: ["has_print_packet_data"],
     hiddenWhenEmpty: true,
-  },
-  {
-    key: 'readiness',
-    label: 'Readiness',
-    to: '/events/$eventId/readiness',
-    persona: ['wodsmith_operator'],
-  },
-  {
-    key: 'billing',
-    label: 'Billing',
-    to: '/events/$eventId/billing',
-    persona: ['wodsmith_operator'],
-  },
-  {
-    key: 'convert',
-    label: 'Convert',
-    to: '/events/$eventId/convert',
-    persona: ['wodsmith_operator'],
-  },
-  {
-    key: 'volunteers',
-    label: 'Volunteers',
-    to: '/events/$eventId/volunteers',
-    persona: ['wodsmith_operator'],
-  },
-  {
-    key: 'judges',
-    label: 'Judges',
-    to: '/events/$eventId/judges',
-    persona: ['wodsmith_operator'],
-  },
-  {
-    key: 'discovery',
-    label: 'Discovery',
-    to: '/events/$eventId/discovery/judges',
-    persona: ['wodsmith_operator'],
-  },
-  {
-    key: 'schedule',
-    label: 'Schedule',
-    to: '/events/$eventId/schedule',
-    persona: ['wodsmith_operator'],
   },
 ] as const satisfies readonly CrewNavItem[]
 
@@ -160,7 +111,7 @@ export function canViewCrewNavItem(
   state: CrewEventNavigationState = {},
 ) {
   if (!item.persona.includes(viewerRole)) return false
-  if (viewerRole === 'wodsmith_operator') return true
+  if (viewerRole === "wodsmith_operator") return true
 
   return (item.requires ?? []).every((requirement) =>
     crewEventRequirementIsMet(requirement, state),
@@ -172,11 +123,11 @@ function crewEventRequirementIsMet(
   state: CrewEventNavigationState,
 ) {
   switch (requirement) {
-    case 'has_assignments':
+    case "has_assignments":
       return hasAssignments(state)
-    case 'has_event_day_data':
+    case "has_event_day_data":
       return state.hasEventDayData ?? hasAssignments(state)
-    case 'has_print_packet_data':
+    case "has_print_packet_data":
       return state.hasPrintPacketData ?? hasAssignments(state)
   }
 }

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -765,3 +765,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as CalculatorRouteImport } from './routes/calculator'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as EventsNewRouteImport } from './routes/events/new'
 import { Route as EventsEventIdRouteImport } from './routes/events/$eventId'
+import { Route as AdminCrewRouteImport } from './routes/admin/crew'
 import { Route as EventsEventIdIndexRouteImport } from './routes/events/$eventId/index'
 import { Route as SeriesGroupIdCrewRouteImport } from './routes/series/$groupId/crew'
 import { Route as EventsEventIdVolunteersRouteImport } from './routes/events/$eventId/volunteers'
@@ -31,10 +32,15 @@ import { Route as EventsEventIdBillingRouteImport } from './routes/events/$event
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
+import { Route as AdminCrewEventsRouteImport } from './routes/admin/crew/events'
 import { Route as EventsEventIdDiscoveryJudgesRouteImport } from './routes/events/$eventId/discovery/judges'
 import { Route as ESlugScheduleTokenRouteImport } from './routes/e/$slug/schedule/$token'
 import { Route as ESlugConsentTokenRouteImport } from './routes/e/$slug/consent/$token'
 import { Route as ESlugConfirmTokenRouteImport } from './routes/e/$slug/confirm/$token'
+import { Route as AdminCrewEventsEventIdRouteImport } from './routes/admin/crew/events/$eventId'
+import { Route as AdminCrewEventsEventIdReadinessRouteImport } from './routes/admin/crew/events/$eventId/readiness'
+import { Route as AdminCrewEventsEventIdConvertRouteImport } from './routes/admin/crew/events/$eventId/convert'
+import { Route as AdminCrewEventsEventIdBillingRouteImport } from './routes/admin/crew/events/$eventId/billing'
 
 const EventsRoute = EventsRouteImport.update({
   id: '/events',
@@ -60,6 +66,11 @@ const EventsEventIdRoute = EventsEventIdRouteImport.update({
   id: '/$eventId',
   path: '/$eventId',
   getParentRoute: () => EventsRoute,
+} as any)
+const AdminCrewRoute = AdminCrewRouteImport.update({
+  id: '/admin/crew',
+  path: '/admin/crew',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const EventsEventIdIndexRoute = EventsEventIdIndexRouteImport.update({
   id: '/',
@@ -146,6 +157,11 @@ const ApiCrewImportRoute = ApiCrewImportRouteImport.update({
   path: '/api/crew/import',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminCrewEventsRoute = AdminCrewEventsRouteImport.update({
+  id: '/events',
+  path: '/events',
+  getParentRoute: () => AdminCrewRoute,
+} as any)
 const EventsEventIdDiscoveryJudgesRoute =
   EventsEventIdDiscoveryJudgesRouteImport.update({
     id: '/discovery/judges',
@@ -167,13 +183,38 @@ const ESlugConfirmTokenRoute = ESlugConfirmTokenRouteImport.update({
   path: '/e/$slug/confirm/$token',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AdminCrewEventsEventIdRoute = AdminCrewEventsEventIdRouteImport.update({
+  id: '/$eventId',
+  path: '/$eventId',
+  getParentRoute: () => AdminCrewEventsRoute,
+} as any)
+const AdminCrewEventsEventIdReadinessRoute =
+  AdminCrewEventsEventIdReadinessRouteImport.update({
+    id: '/readiness',
+    path: '/readiness',
+    getParentRoute: () => AdminCrewEventsEventIdRoute,
+  } as any)
+const AdminCrewEventsEventIdConvertRoute =
+  AdminCrewEventsEventIdConvertRouteImport.update({
+    id: '/convert',
+    path: '/convert',
+    getParentRoute: () => AdminCrewEventsEventIdRoute,
+  } as any)
+const AdminCrewEventsEventIdBillingRoute =
+  AdminCrewEventsEventIdBillingRouteImport.update({
+    id: '/billing',
+    path: '/billing',
+    getParentRoute: () => AdminCrewEventsEventIdRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/calculator': typeof CalculatorRoute
   '/events': typeof EventsRouteWithChildren
+  '/admin/crew': typeof AdminCrewRouteWithChildren
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
+  '/admin/crew/events': typeof AdminCrewEventsRouteWithChildren
   '/api/crew/import': typeof ApiCrewImportRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
@@ -191,16 +232,22 @@ export interface FileRoutesByFullPath {
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/series/$groupId/crew': typeof SeriesGroupIdCrewRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
+  '/admin/crew/events/$eventId': typeof AdminCrewEventsEventIdRouteWithChildren
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
   '/events/$eventId/discovery/judges': typeof EventsEventIdDiscoveryJudgesRoute
+  '/admin/crew/events/$eventId/billing': typeof AdminCrewEventsEventIdBillingRoute
+  '/admin/crew/events/$eventId/convert': typeof AdminCrewEventsEventIdConvertRoute
+  '/admin/crew/events/$eventId/readiness': typeof AdminCrewEventsEventIdReadinessRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/calculator': typeof CalculatorRoute
   '/events': typeof EventsRouteWithChildren
+  '/admin/crew': typeof AdminCrewRouteWithChildren
   '/events/new': typeof EventsNewRoute
+  '/admin/crew/events': typeof AdminCrewEventsRouteWithChildren
   '/api/crew/import': typeof ApiCrewImportRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
@@ -218,18 +265,24 @@ export interface FileRoutesByTo {
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/series/$groupId/crew': typeof SeriesGroupIdCrewRoute
   '/events/$eventId': typeof EventsEventIdIndexRoute
+  '/admin/crew/events/$eventId': typeof AdminCrewEventsEventIdRouteWithChildren
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
   '/events/$eventId/discovery/judges': typeof EventsEventIdDiscoveryJudgesRoute
+  '/admin/crew/events/$eventId/billing': typeof AdminCrewEventsEventIdBillingRoute
+  '/admin/crew/events/$eventId/convert': typeof AdminCrewEventsEventIdConvertRoute
+  '/admin/crew/events/$eventId/readiness': typeof AdminCrewEventsEventIdReadinessRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/calculator': typeof CalculatorRoute
   '/events': typeof EventsRouteWithChildren
+  '/admin/crew': typeof AdminCrewRouteWithChildren
   '/events/$eventId': typeof EventsEventIdRouteWithChildren
   '/events/new': typeof EventsNewRoute
+  '/admin/crew/events': typeof AdminCrewEventsRouteWithChildren
   '/api/crew/import': typeof ApiCrewImportRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
@@ -247,10 +300,14 @@ export interface FileRoutesById {
   '/events/$eventId/volunteers': typeof EventsEventIdVolunteersRoute
   '/series/$groupId/crew': typeof SeriesGroupIdCrewRoute
   '/events/$eventId/': typeof EventsEventIdIndexRoute
+  '/admin/crew/events/$eventId': typeof AdminCrewEventsEventIdRouteWithChildren
   '/e/$slug/confirm/$token': typeof ESlugConfirmTokenRoute
   '/e/$slug/consent/$token': typeof ESlugConsentTokenRoute
   '/e/$slug/schedule/$token': typeof ESlugScheduleTokenRoute
   '/events/$eventId/discovery/judges': typeof EventsEventIdDiscoveryJudgesRoute
+  '/admin/crew/events/$eventId/billing': typeof AdminCrewEventsEventIdBillingRoute
+  '/admin/crew/events/$eventId/convert': typeof AdminCrewEventsEventIdConvertRoute
+  '/admin/crew/events/$eventId/readiness': typeof AdminCrewEventsEventIdReadinessRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -258,8 +315,10 @@ export interface FileRouteTypes {
     | '/'
     | '/calculator'
     | '/events'
+    | '/admin/crew'
     | '/events/$eventId'
     | '/events/new'
+    | '/admin/crew/events'
     | '/api/crew/import'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
@@ -277,16 +336,22 @@ export interface FileRouteTypes {
     | '/events/$eventId/volunteers'
     | '/series/$groupId/crew'
     | '/events/$eventId/'
+    | '/admin/crew/events/$eventId'
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
     | '/events/$eventId/discovery/judges'
+    | '/admin/crew/events/$eventId/billing'
+    | '/admin/crew/events/$eventId/convert'
+    | '/admin/crew/events/$eventId/readiness'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/calculator'
     | '/events'
+    | '/admin/crew'
     | '/events/new'
+    | '/admin/crew/events'
     | '/api/crew/import'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
@@ -304,17 +369,23 @@ export interface FileRouteTypes {
     | '/events/$eventId/volunteers'
     | '/series/$groupId/crew'
     | '/events/$eventId'
+    | '/admin/crew/events/$eventId'
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
     | '/events/$eventId/discovery/judges'
+    | '/admin/crew/events/$eventId/billing'
+    | '/admin/crew/events/$eventId/convert'
+    | '/admin/crew/events/$eventId/readiness'
   id:
     | '__root__'
     | '/'
     | '/calculator'
     | '/events'
+    | '/admin/crew'
     | '/events/$eventId'
     | '/events/new'
+    | '/admin/crew/events'
     | '/api/crew/import'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
@@ -332,16 +403,21 @@ export interface FileRouteTypes {
     | '/events/$eventId/volunteers'
     | '/series/$groupId/crew'
     | '/events/$eventId/'
+    | '/admin/crew/events/$eventId'
     | '/e/$slug/confirm/$token'
     | '/e/$slug/consent/$token'
     | '/e/$slug/schedule/$token'
     | '/events/$eventId/discovery/judges'
+    | '/admin/crew/events/$eventId/billing'
+    | '/admin/crew/events/$eventId/convert'
+    | '/admin/crew/events/$eventId/readiness'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   CalculatorRoute: typeof CalculatorRoute
   EventsRoute: typeof EventsRouteWithChildren
+  AdminCrewRoute: typeof AdminCrewRouteWithChildren
   ApiCrewImportRoute: typeof ApiCrewImportRoute
   ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute
   ESlugVolunteerRoute: typeof ESlugVolunteerRoute
@@ -387,6 +463,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/events/$eventId'
       preLoaderRoute: typeof EventsEventIdRouteImport
       parentRoute: typeof EventsRoute
+    }
+    '/admin/crew': {
+      id: '/admin/crew'
+      path: '/admin/crew'
+      fullPath: '/admin/crew'
+      preLoaderRoute: typeof AdminCrewRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/events/$eventId/': {
       id: '/events/$eventId/'
@@ -507,6 +590,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiCrewImportRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/admin/crew/events': {
+      id: '/admin/crew/events'
+      path: '/events'
+      fullPath: '/admin/crew/events'
+      preLoaderRoute: typeof AdminCrewEventsRouteImport
+      parentRoute: typeof AdminCrewRoute
+    }
     '/events/$eventId/discovery/judges': {
       id: '/events/$eventId/discovery/judges'
       path: '/discovery/judges'
@@ -534,6 +624,34 @@ declare module '@tanstack/react-router' {
       fullPath: '/e/$slug/confirm/$token'
       preLoaderRoute: typeof ESlugConfirmTokenRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/admin/crew/events/$eventId': {
+      id: '/admin/crew/events/$eventId'
+      path: '/$eventId'
+      fullPath: '/admin/crew/events/$eventId'
+      preLoaderRoute: typeof AdminCrewEventsEventIdRouteImport
+      parentRoute: typeof AdminCrewEventsRoute
+    }
+    '/admin/crew/events/$eventId/readiness': {
+      id: '/admin/crew/events/$eventId/readiness'
+      path: '/readiness'
+      fullPath: '/admin/crew/events/$eventId/readiness'
+      preLoaderRoute: typeof AdminCrewEventsEventIdReadinessRouteImport
+      parentRoute: typeof AdminCrewEventsEventIdRoute
+    }
+    '/admin/crew/events/$eventId/convert': {
+      id: '/admin/crew/events/$eventId/convert'
+      path: '/convert'
+      fullPath: '/admin/crew/events/$eventId/convert'
+      preLoaderRoute: typeof AdminCrewEventsEventIdConvertRouteImport
+      parentRoute: typeof AdminCrewEventsEventIdRoute
+    }
+    '/admin/crew/events/$eventId/billing': {
+      id: '/admin/crew/events/$eventId/billing'
+      path: '/billing'
+      fullPath: '/admin/crew/events/$eventId/billing'
+      preLoaderRoute: typeof AdminCrewEventsEventIdBillingRouteImport
+      parentRoute: typeof AdminCrewEventsEventIdRoute
     }
   }
 }
@@ -589,10 +707,53 @@ const EventsRouteChildren: EventsRouteChildren = {
 const EventsRouteWithChildren =
   EventsRoute._addFileChildren(EventsRouteChildren)
 
+interface AdminCrewEventsEventIdRouteChildren {
+  AdminCrewEventsEventIdBillingRoute: typeof AdminCrewEventsEventIdBillingRoute
+  AdminCrewEventsEventIdConvertRoute: typeof AdminCrewEventsEventIdConvertRoute
+  AdminCrewEventsEventIdReadinessRoute: typeof AdminCrewEventsEventIdReadinessRoute
+}
+
+const AdminCrewEventsEventIdRouteChildren: AdminCrewEventsEventIdRouteChildren =
+  {
+    AdminCrewEventsEventIdBillingRoute: AdminCrewEventsEventIdBillingRoute,
+    AdminCrewEventsEventIdConvertRoute: AdminCrewEventsEventIdConvertRoute,
+    AdminCrewEventsEventIdReadinessRoute: AdminCrewEventsEventIdReadinessRoute,
+  }
+
+const AdminCrewEventsEventIdRouteWithChildren =
+  AdminCrewEventsEventIdRoute._addFileChildren(
+    AdminCrewEventsEventIdRouteChildren,
+  )
+
+interface AdminCrewEventsRouteChildren {
+  AdminCrewEventsEventIdRoute: typeof AdminCrewEventsEventIdRouteWithChildren
+}
+
+const AdminCrewEventsRouteChildren: AdminCrewEventsRouteChildren = {
+  AdminCrewEventsEventIdRoute: AdminCrewEventsEventIdRouteWithChildren,
+}
+
+const AdminCrewEventsRouteWithChildren = AdminCrewEventsRoute._addFileChildren(
+  AdminCrewEventsRouteChildren,
+)
+
+interface AdminCrewRouteChildren {
+  AdminCrewEventsRoute: typeof AdminCrewEventsRouteWithChildren
+}
+
+const AdminCrewRouteChildren: AdminCrewRouteChildren = {
+  AdminCrewEventsRoute: AdminCrewEventsRouteWithChildren,
+}
+
+const AdminCrewRouteWithChildren = AdminCrewRoute._addFileChildren(
+  AdminCrewRouteChildren,
+)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CalculatorRoute: CalculatorRoute,
   EventsRoute: EventsRouteWithChildren,
+  AdminCrewRoute: AdminCrewRouteWithChildren,
   ApiCrewImportRoute: ApiCrewImportRoute,
   ApiWebhooksStripeRoute: ApiWebhooksStripeRoute,
   ESlugVolunteerRoute: ESlugVolunteerRoute,
@@ -604,12 +765,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/apps/crew/src/routes/admin/crew.tsx
+++ b/apps/crew/src/routes/admin/crew.tsx
@@ -1,0 +1,96 @@
+// @lat: [[crew#Crew Admin Shell]]
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useRouterState,
+} from "@tanstack/react-router"
+import {
+  type CrewAdminEventListItem,
+  getCrewAdminEventListFn,
+} from "@/server-fns/crew-admin-event-fns"
+
+export const Route = createFileRoute("/admin/crew")({
+  loader: async () => await getCrewAdminEventListFn(),
+  component: CrewAdminShell,
+})
+
+function CrewAdminShell() {
+  const { events } = Route.useLoaderData() as {
+    events: CrewAdminEventListItem[]
+  }
+  const isAdminIndex = useRouterState({
+    select: (state) =>
+      state.location.pathname.replace(/\/$/, "") === "/admin/crew",
+  })
+
+  return (
+    <main className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:px-6">
+      <div className="flex flex-col justify-between gap-4 border-b pb-6 md:flex-row md:items-end">
+        <div>
+          <p className="text-sm font-medium uppercase text-muted-foreground">
+            WODsmith Admin
+          </p>
+          <h1 className="text-3xl font-semibold">Crew control room</h1>
+          <p className="text-muted-foreground">
+            Internal operator surface for pilots, diagnostics, billing, and
+            conversion handoff.
+          </p>
+        </div>
+        <nav className="flex flex-wrap gap-2 text-sm">
+          <Link
+            to="/admin/crew"
+            activeOptions={{ exact: true }}
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Overview
+          </Link>
+          <Link
+            to="/admin/crew/events"
+            activeProps={{ className: "bg-muted text-foreground" }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Events
+          </Link>
+        </nav>
+      </div>
+
+      {isAdminIndex ? (
+        <section className="grid gap-4 md:grid-cols-3">
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <p className="text-sm text-muted-foreground">Crew events</p>
+            <p className="mt-2 text-2xl font-semibold">{events.length}</p>
+          </section>
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <p className="text-sm text-muted-foreground">Needs setup</p>
+            <p className="mt-2 text-2xl font-semibold">
+              {
+                events.filter((event) => event.setupProgress.percent < 100)
+                  .length
+              }
+            </p>
+          </section>
+          <section className="rounded-md border bg-card p-5 shadow-sm">
+            <p className="text-sm text-muted-foreground">Unpaid</p>
+            <p className="mt-2 text-2xl font-semibold">
+              {events.filter((event) => event.billingState === "unpaid").length}
+            </p>
+          </section>
+          <Link
+            to="/admin/crew/events"
+            className="rounded-md border bg-card p-5 shadow-sm transition-colors hover:bg-muted/50 md:col-span-3"
+          >
+            <h2 className="text-lg font-semibold">Open event admin</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Inspect pilot status, source context, billing state, readiness
+              diagnostics, and conversion readiness.
+            </p>
+          </Link>
+        </section>
+      ) : (
+        <Outlet />
+      )}
+    </main>
+  )
+}

--- a/apps/crew/src/routes/admin/crew/events.tsx
+++ b/apps/crew/src/routes/admin/crew/events.tsx
@@ -1,0 +1,129 @@
+// @lat: [[crew#Crew Admin Shell]]
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useRouterState,
+} from "@tanstack/react-router"
+import { formatCrewValue } from "@/lib/crew-event-display"
+import {
+  type CrewAdminEventListItem,
+  getCrewAdminEventListFn,
+} from "@/server-fns/crew-admin-event-fns"
+
+export const Route = createFileRoute("/admin/crew/events")({
+  loader: async () => await getCrewAdminEventListFn(),
+  component: CrewAdminEventsPage,
+})
+
+function CrewAdminEventsPage() {
+  const { events } = Route.useLoaderData() as {
+    events: CrewAdminEventListItem[]
+  }
+  const isEventsIndex = useRouterState({
+    select: (state) =>
+      state.location.pathname.replace(/\/$/, "") === "/admin/crew/events",
+  })
+
+  if (!isEventsIndex) {
+    return <Outlet />
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col justify-between gap-4 sm:flex-row sm:items-end">
+        <div>
+          <h2 className="text-2xl font-semibold">Admin events</h2>
+          <p className="text-sm text-muted-foreground">
+            Operator-only event list with setup, billing, source, and concierge
+            state.
+          </p>
+        </div>
+        <Link
+          to="/events/new"
+          className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          New event
+        </Link>
+      </div>
+
+      {events.length === 0 ? (
+        <section className="rounded-md border bg-card p-6 shadow-sm">
+          <h3 className="text-lg font-semibold">No Crew events yet</h3>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Create the first Crew event to add a competition and Crew settings
+            record.
+          </p>
+        </section>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {events.map((event) => (
+            <Link
+              key={event.id}
+              to="/admin/crew/events/$eventId"
+              params={{ eventId: event.id }}
+              className="rounded-md border bg-card p-5 shadow-sm transition-colors hover:bg-muted/50"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <h3 className="text-lg font-semibold">{event.name}</h3>
+                  <p className="text-sm text-muted-foreground">
+                    {event.startDate} to {event.endDate}
+                  </p>
+                </div>
+                <span className="rounded-md bg-muted px-2 py-1 text-xs font-medium">
+                  {formatCrewValue(event.lifecycle)}
+                </span>
+              </div>
+
+              <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-3">
+                <Fact
+                  label="Concierge"
+                  value={formatCrewValue(event.conciergeStatus)}
+                />
+                <Fact
+                  label="Billing"
+                  value={formatCrewValue(event.billingState)}
+                />
+                <Fact
+                  label="Source"
+                  value={event.sourcePlatform ?? "Not set"}
+                />
+              </dl>
+
+              <div className="mt-4 space-y-2">
+                <div className="flex items-center justify-between gap-4 text-sm">
+                  <span className="text-muted-foreground">Setup progress</span>
+                  <span className="font-medium">
+                    {event.setupProgress.completed}/{event.setupProgress.total}
+                  </span>
+                </div>
+                <ProgressBar value={event.setupProgress.percent} />
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Fact({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function ProgressBar({ value }: { value: number }) {
+  return (
+    <div className="h-2 overflow-hidden rounded-full bg-muted">
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  )
+}

--- a/apps/crew/src/routes/admin/crew/events.tsx
+++ b/apps/crew/src/routes/admin/crew/events.tsx
@@ -118,11 +118,13 @@ function Fact({ label, value }: { label: string; value: string }) {
 }
 
 function ProgressBar({ value }: { value: number }) {
+  const clampedValue = Math.max(0, Math.min(100, value))
+
   return (
     <div className="h-2 overflow-hidden rounded-full bg-muted">
       <div
         className="h-full rounded-full bg-primary transition-all"
-        style={{ width: `${value}%` }}
+        style={{ width: `${clampedValue}%` }}
       />
     </div>
   )

--- a/apps/crew/src/routes/admin/crew/events/$eventId.tsx
+++ b/apps/crew/src/routes/admin/crew/events/$eventId.tsx
@@ -1,0 +1,350 @@
+// @lat: [[crew#Crew Admin Shell]]
+import {
+  createFileRoute,
+  Link,
+  Outlet,
+  useRouterState,
+} from "@tanstack/react-router"
+import type { ReactNode } from "react"
+import { formatCrewValue, getSafeHttpUrl } from "@/lib/crew-event-display"
+import {
+  type CrewAdminEventDetailView,
+  getCrewAdminEventDetailFn,
+} from "@/server-fns/crew-admin-event-fns"
+
+export const Route = createFileRoute("/admin/crew/events/$eventId")({
+  loader: async ({ params }) =>
+    await getCrewAdminEventDetailFn({ data: { eventId: params.eventId } }),
+  component: CrewAdminEventShell,
+})
+
+function CrewAdminEventShell() {
+  const { eventId } = Route.useParams()
+  const { view } = Route.useLoaderData()
+  const isOverview = useRouterState({
+    select: (state) =>
+      state.location.pathname.replace(/\/$/, "") ===
+      `/admin/crew/events/${eventId}`,
+  })
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col justify-between gap-4 border-b pb-6 md:flex-row md:items-end">
+        <div>
+          <p className="font-mono text-sm text-muted-foreground">{eventId}</p>
+          <h2 className="text-2xl font-semibold">{view.event.name}</h2>
+          <p className="text-sm text-muted-foreground">
+            {view.event.startDate} to {view.event.endDate}
+          </p>
+        </div>
+        <nav className="flex flex-wrap gap-2 text-sm">
+          <AdminTab
+            to="/admin/crew/events/$eventId"
+            eventId={eventId}
+            label="Overview"
+            exact
+          />
+          <AdminTab
+            to="/admin/crew/events/$eventId/readiness"
+            eventId={eventId}
+            label="Readiness"
+          />
+          <AdminTab
+            to="/admin/crew/events/$eventId/billing"
+            eventId={eventId}
+            label="Billing"
+          />
+          <AdminTab
+            to="/admin/crew/events/$eventId/convert"
+            eventId={eventId}
+            label="Conversion"
+          />
+          <Link
+            to="/events/$eventId"
+            params={{ eventId }}
+            className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+          >
+            Organizer view
+          </Link>
+        </nav>
+      </div>
+
+      {isOverview ? <CrewAdminEventOverview view={view} /> : <Outlet />}
+    </section>
+  )
+}
+
+function CrewAdminEventOverview({ view }: { view: CrewAdminEventDetailView }) {
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <Metric
+          label="Lifecycle"
+          value={formatCrewValue(view.event.lifecycle)}
+        />
+        <Metric
+          label="Concierge"
+          value={formatCrewValue(view.event.conciergeStatus)}
+        />
+        <Metric label="Plan" value={formatCrewValue(view.event.crewPlan)} />
+        <Metric label="Payment" value={view.billing.stateLabel} />
+        <Metric
+          label="Setup"
+          value={`${view.setup.completed}/${view.setup.total}`}
+        />
+        <Metric label="Roster" value={view.diagnostics.roster} />
+        <Metric label="Assignments" value={view.diagnostics.shiftCoverage} />
+        <Metric label="Confirmed" value={view.diagnostics.confirmations} />
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h3 className="text-lg font-semibold">Next admin action</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {view.readiness.nextAction}
+        </p>
+      </section>
+
+      <section className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+        <div className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h3 className="text-lg font-semibold">Readiness diagnostics</h3>
+              <p className="text-sm text-muted-foreground">
+                Source counts and readiness details stay in the operator shell.
+              </p>
+            </div>
+            <Link
+              to="/admin/crew/events/$eventId/readiness"
+              params={{ eventId: view.event.id }}
+              className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            >
+              Open readiness
+            </Link>
+          </div>
+
+          <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
+            <Fact label="Setup checks" value={view.diagnostics.setupChecks} />
+            <Fact
+              label="Venues and lanes"
+              value={view.diagnostics.venuesAndLanes}
+            />
+            <Fact
+              label="Workouts and heats"
+              value={view.diagnostics.workoutsAndHeats}
+            />
+            <Fact label="Imports" value={view.diagnostics.imports} />
+            <Fact label="Roster" value={view.diagnostics.roster} />
+            <Fact
+              label="Shift coverage"
+              value={view.diagnostics.shiftCoverage}
+            />
+            <Fact
+              label="Confirmations"
+              value={view.diagnostics.confirmations}
+            />
+            <Fact
+              label="Judge versions"
+              value={view.diagnostics.judgeVersions}
+            />
+          </dl>
+        </div>
+
+        <aside className="rounded-md border bg-card p-5 shadow-sm">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Raw IDs
+          </h3>
+          <dl className="mt-4 space-y-4 text-sm">
+            <Fact label="Competition" value={view.event.id} mono />
+            <Fact label="Slug" value={view.event.slug} />
+            <Fact
+              label="Organizer team"
+              value={view.event.organizingTeamId}
+              mono
+            />
+            <Fact
+              label="Event team"
+              value={view.event.competitionTeamId ?? "Not set"}
+              mono
+            />
+          </dl>
+        </aside>
+      </section>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <h3 className="text-lg font-semibold">Setup and source</h3>
+          <dl className="mt-4 grid gap-4 text-sm">
+            <Fact
+              label="Source platform"
+              value={view.source.platform ?? "Not set"}
+            />
+            <Fact
+              label="Source event URL"
+              value={view.source.eventUrl ?? "Not set"}
+              link={view.source.eventUrl}
+            />
+            <Fact
+              label="External registration URL"
+              value={view.source.externalRegistrationUrl ?? "Not set"}
+              link={view.source.externalRegistrationUrl}
+            />
+            <Fact
+              label="Acquisition source"
+              value={view.source.acquisitionSource ?? "Not set"}
+            />
+            <Fact
+              label="Desired go-live date"
+              value={view.setup.desiredGoLiveDate ?? "Not set"}
+            />
+            <Fact
+              label="Source contact"
+              value={view.setup.sourceContact ?? "Not set"}
+            />
+          </dl>
+        </section>
+
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <h3 className="text-lg font-semibold">Billing and conversion</h3>
+              <p className="text-sm text-muted-foreground">
+                Event-level Crew billing state and full-platform handoff.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Link
+                to="/admin/crew/events/$eventId/billing"
+                params={{ eventId: view.event.id }}
+                className="rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                Billing
+              </Link>
+              <Link
+                to="/admin/crew/events/$eventId/convert"
+                params={{ eventId: view.event.id }}
+                className="rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+              >
+                Conversion
+              </Link>
+            </div>
+          </div>
+          <dl className="mt-4 grid gap-4 text-sm">
+            <Fact label="Billing plan" value={view.billing.planLabel} />
+            <Fact label="Billing source" value={view.billing.sourceLabel} />
+            <Fact label="Amount" value={view.billing.amountLabel} />
+            <Fact
+              label="Upgrade credit"
+              value={view.billing.upgradeCreditLabel}
+            />
+            <Fact
+              label="Stripe Payment Link"
+              value={view.billing.paymentLinkId ?? "Not recorded"}
+              mono
+            />
+            <Fact
+              label="Stripe Checkout Session"
+              value={view.billing.checkoutSessionId ?? "Not recorded"}
+              mono
+            />
+          </dl>
+        </section>
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h3 className="text-lg font-semibold">Operator notes</h3>
+        <div className="mt-4 grid gap-4 text-sm lg:grid-cols-2">
+          <NoteBlock
+            label="Assumptions"
+            value={view.operatorNotes.assumptions}
+          />
+          <NoteBlock
+            label="Internal notes"
+            value={view.operatorNotes.internalNotes}
+          />
+        </div>
+      </section>
+    </section>
+  )
+}
+
+function AdminTab({
+  to,
+  eventId,
+  label,
+  exact = false,
+}: {
+  to:
+    | "/admin/crew/events/$eventId"
+    | "/admin/crew/events/$eventId/readiness"
+    | "/admin/crew/events/$eventId/billing"
+    | "/admin/crew/events/$eventId/convert"
+  eventId: string
+  label: string
+  exact?: boolean
+}) {
+  return (
+    <Link
+      to={to}
+      params={{ eventId }}
+      activeOptions={exact ? { exact: true } : undefined}
+      activeProps={{ className: "bg-muted text-foreground" }}
+      className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      {label}
+    </Link>
+  )
+}
+
+function Metric({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 break-words text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function Fact({
+  label,
+  value,
+  link,
+  mono = false,
+}: {
+  label: string
+  value: ReactNode
+  link?: string | null
+  mono?: boolean
+}) {
+  const safeLink = typeof value === "string" ? getSafeHttpUrl(link) : null
+
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd
+        className={`break-words font-medium ${mono ? "break-all font-mono text-xs" : ""}`}
+      >
+        {safeLink && typeof value === "string" ? (
+          <a
+            href={safeLink}
+            target="_blank"
+            rel="noreferrer"
+            className="text-primary underline-offset-4 hover:underline"
+          >
+            {value}
+          </a>
+        ) : (
+          value
+        )}
+      </dd>
+    </div>
+  )
+}
+
+function NoteBlock({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border bg-background p-3">
+      <h4 className="font-medium">{label}</h4>
+      <p className="mt-2 whitespace-pre-wrap text-muted-foreground">{value}</p>
+    </div>
+  )
+}

--- a/apps/crew/src/routes/admin/crew/events/$eventId/billing.tsx
+++ b/apps/crew/src/routes/admin/crew/events/$eventId/billing.tsx
@@ -15,6 +15,12 @@ export const Route = createFileRoute("/admin/crew/events/$eventId/billing")({
   component: CrewAdminBillingPage,
 })
 
+const auditTimestampFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "medium",
+  timeStyle: "short",
+  timeZone: "UTC",
+})
+
 function CrewAdminBillingPage() {
   const { event, billing, auditEvents, viewModel } =
     Route.useLoaderData() as CrewAdminBillingData
@@ -115,7 +121,7 @@ function CrewAdminBillingPage() {
                 {auditEvents.map((event) => (
                   <tr key={event.id} className="border-b last:border-b-0">
                     <td className="py-3 pr-4 text-muted-foreground">
-                      {String(event.createdAt)}
+                      {formatAuditTimestamp(event.createdAt)}
                     </td>
                     <td className="py-3 pr-4 font-medium">{event.eventType}</td>
                     <td className="py-3 pr-4">{event.billingState}</td>
@@ -143,6 +149,10 @@ function BillingMetric({ label, value }: { label: string; value: string }) {
       <p className="mt-2 break-words text-lg font-semibold">{value}</p>
     </section>
   )
+}
+
+function formatAuditTimestamp(value: Date | string) {
+  return auditTimestampFormatter.format(new Date(value))
 }
 
 function BillingFact({

--- a/apps/crew/src/routes/admin/crew/events/$eventId/billing.tsx
+++ b/apps/crew/src/routes/admin/crew/events/$eventId/billing.tsx
@@ -1,0 +1,201 @@
+// @lat: [[crew#Crew Admin Shell]]
+// @lat: [[crew#Billing Page And Upgrade CTA]]
+import { createFileRoute } from "@tanstack/react-router"
+import { CreditCard, ExternalLink } from "lucide-react"
+import type { ReactNode } from "react"
+import type { CrewBillingActionViewModel } from "@/lib/crew/billing-page"
+import {
+  type CrewAdminBillingData,
+  getCrewAdminBillingFn,
+} from "@/server-fns/crew-admin-event-fns"
+
+export const Route = createFileRoute("/admin/crew/events/$eventId/billing")({
+  loader: async ({ params }) =>
+    await getCrewAdminBillingFn({ data: { eventId: params.eventId } }),
+  component: CrewAdminBillingPage,
+})
+
+function CrewAdminBillingPage() {
+  const { event, billing, auditEvents, viewModel } =
+    Route.useLoaderData() as CrewAdminBillingData
+
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <BillingMetric label="Plan" value={viewModel.plan.label} />
+        <BillingMetric
+          label="Billing status"
+          value={viewModel.billing.stateLabel}
+        />
+        <BillingMetric label="Source" value={viewModel.billing.sourceLabel} />
+        <BillingMetric
+          label="Upgrade credit"
+          value={viewModel.billing.upgradeCreditLabel}
+        />
+      </div>
+
+      <section className="grid gap-6 lg:grid-cols-[1fr_20rem]">
+        <div className="rounded-md border bg-card p-5 shadow-sm">
+          <h3 className="text-xl font-semibold">Event billing</h3>
+          <dl className="mt-4 grid gap-4 text-sm sm:grid-cols-2">
+            <BillingFact label="Event" value={event.name} />
+            <BillingFact label="Event ID" value={event.id} mono />
+            <BillingFact
+              label="Event access"
+              value={
+                viewModel.plan.hasCrewEventAccess ? "Active" : "Not active yet"
+              }
+            />
+            <BillingFact
+              label="Fulfillment"
+              value={viewModel.billing.fulfillmentLabel}
+            />
+            <BillingFact label="Amount" value={viewModel.billing.amountLabel} />
+            <BillingFact
+              label="Refund state"
+              value={viewModel.billing.refundedLabel}
+            />
+            <BillingFact
+              label="Payment Link ID"
+              value={billing.stripe.paymentLinkId ?? "Not recorded"}
+              mono
+            />
+            <BillingFact
+              label="Checkout Session ID"
+              value={billing.stripe.checkoutSessionId ?? "Not recorded"}
+              mono
+            />
+            <BillingFact
+              label="Payment Intent ID"
+              value={billing.stripe.paymentIntentId ?? "Not recorded"}
+              mono
+            />
+            <BillingFact
+              label="Organizer team"
+              value={event.organizingTeamId}
+              mono
+            />
+          </dl>
+        </div>
+
+        <aside className="rounded-md border bg-card p-5 shadow-sm">
+          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
+            Operator actions
+          </h3>
+          <div className="mt-4 flex flex-col gap-2">
+            <BillingAction action={viewModel.paymentLink} />
+            <BillingAction action={viewModel.checkout} />
+          </div>
+          <p className="mt-4 text-sm text-muted-foreground">
+            Mutating admin billing actions remain in the existing billing
+            service layer; this PR exposes the guarded admin read surface.
+          </p>
+        </aside>
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h3 className="text-xl font-semibold">Billing audit</h3>
+        {auditEvents.length === 0 ? (
+          <p className="mt-4 text-sm text-muted-foreground">
+            No billing audit events recorded yet.
+          </p>
+        ) : (
+          <div className="mt-4 overflow-x-auto">
+            <table className="w-full min-w-[48rem] text-left text-sm">
+              <thead className="border-b text-muted-foreground">
+                <tr>
+                  <th className="py-2 pr-4 font-medium">Created</th>
+                  <th className="py-2 pr-4 font-medium">Type</th>
+                  <th className="py-2 pr-4 font-medium">State</th>
+                  <th className="py-2 pr-4 font-medium">Plan</th>
+                  <th className="py-2 pr-4 font-medium">Actor</th>
+                </tr>
+              </thead>
+              <tbody>
+                {auditEvents.map((event) => (
+                  <tr key={event.id} className="border-b last:border-b-0">
+                    <td className="py-3 pr-4 text-muted-foreground">
+                      {String(event.createdAt)}
+                    </td>
+                    <td className="py-3 pr-4 font-medium">{event.eventType}</td>
+                    <td className="py-3 pr-4">{event.billingState}</td>
+                    <td className="py-3 pr-4">
+                      {event.planId ?? "Not recorded"}
+                    </td>
+                    <td className="py-3 pr-4">
+                      {event.actorLabel ?? "System"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </section>
+  )
+}
+
+function BillingMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 break-words text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function BillingFact({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: ReactNode
+  mono?: boolean
+}) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd
+        className={`break-words font-medium ${mono ? "break-all font-mono text-xs" : ""}`}
+      >
+        {value}
+      </dd>
+    </div>
+  )
+}
+
+function BillingAction({ action }: { action: CrewBillingActionViewModel }) {
+  if (action.status === "hidden") {
+    return null
+  }
+
+  if (action.status === "available" && action.href) {
+    return (
+      <a
+        href={action.href}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        title={action.helperText}
+      >
+        <CreditCard className="size-4" aria-hidden="true" />
+        {action.label}
+        <ExternalLink className="size-4" aria-hidden="true" />
+      </a>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      disabled
+      className="inline-flex items-center justify-center gap-2 rounded-md border px-4 py-2 text-sm font-medium text-muted-foreground"
+      title={action.helperText}
+    >
+      <CreditCard className="size-4" aria-hidden="true" />
+      {action.label}
+    </button>
+  )
+}

--- a/apps/crew/src/routes/admin/crew/events/$eventId/convert.tsx
+++ b/apps/crew/src/routes/admin/crew/events/$eventId/convert.tsx
@@ -1,0 +1,225 @@
+// @lat: [[crew#Crew Admin Shell]]
+// @lat: [[crew#Full WODsmith Conversion Assistant]]
+import { createFileRoute } from "@tanstack/react-router"
+import {
+  ArrowUpRight,
+  CheckCircle2,
+  CircleAlert,
+  LockKeyhole,
+  ShieldCheck,
+} from "lucide-react"
+import type { ReactNode } from "react"
+import {
+  type CrewConversionAction,
+  type CrewConversionChecklistItem,
+  type CrewConversionChecklistStatus,
+  type CrewConversionSummary,
+  crewConversionChecklistStatusLabels,
+} from "@/lib/crew/conversion-assistant"
+import { getCrewAdminConversionFn } from "@/server-fns/crew-admin-event-fns"
+
+export const Route = createFileRoute("/admin/crew/events/$eventId/convert")({
+  loader: async ({ params }) =>
+    await getCrewAdminConversionFn({ data: { eventId: params.eventId } }),
+  component: CrewAdminConversionPage,
+})
+
+function CrewAdminConversionPage() {
+  const { viewModel } = Route.useLoaderData()
+
+  return (
+    <section className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-4">
+        <Metric label="Competition" value={viewModel.event.id} mono />
+        <Metric
+          label="Crew-only"
+          value={viewModel.event.crewOnly ? "Yes" : "No"}
+        />
+        <Metric label="Conversion" value={viewModel.conversion.label} />
+        <Metric
+          label="Full setup"
+          value={`${viewModel.fullSetup.summary.ready}/${viewModel.fullSetup.summary.total}`}
+        />
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 text-sm font-medium text-primary">
+              <ShieldCheck className="size-4" aria-hidden="true" />
+              Full WODsmith conversion
+            </div>
+            <h3 className="text-xl font-semibold">
+              Convert without duplicating the event
+            </h3>
+            <p className="max-w-3xl text-sm text-muted-foreground">
+              This operator assistant inventories what stays on the current
+              competition and points missing full-platform setup to existing
+              WODsmith organizer surfaces.
+            </p>
+          </div>
+          <div className="rounded-md border bg-background p-4 text-sm">
+            <div className="flex items-center gap-2 font-medium">
+              <LockKeyhole className="size-4 text-muted-foreground" />
+              Read-only
+            </div>
+            <p className="mt-2 text-muted-foreground">
+              No conversion mutation, checkout, registration launch, payout
+              setup, deploy, import apply, or public activation happens here.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <ChecklistSection
+        title="Missing full WODsmith setup"
+        summary={viewModel.fullSetup.summary}
+        items={viewModel.fullSetup.items}
+      />
+
+      <ChecklistSection
+        title="Crew data preserved"
+        summary={viewModel.preservation.summary}
+        items={viewModel.preservation.items}
+      />
+    </section>
+  )
+}
+
+function ChecklistSection({
+  title,
+  summary,
+  items,
+}: {
+  title: string
+  summary: CrewConversionSummary
+  items: CrewConversionChecklistItem[]
+}) {
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">{title}</h3>
+          <p className="text-sm text-muted-foreground">
+            {summary.ready}/{summary.total} ready, {summary.blocked} blocked.
+          </p>
+        </div>
+        <StatusBadge status={summary.highestStatus} />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {items.map((item) => (
+          <ChecklistCard item={item} key={item.key} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ChecklistCard({ item }: { item: CrewConversionChecklistItem }) {
+  const Icon = item.status === "ready" ? CheckCircle2 : CircleAlert
+
+  return (
+    <article className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 gap-3">
+          <Icon
+            className={`mt-0.5 size-5 shrink-0 ${statusIconClass(item.status)}`}
+            aria-hidden="true"
+          />
+          <div className="min-w-0">
+            <h3 className="font-semibold">{item.label}</h3>
+            <p className="mt-1 text-sm text-muted-foreground">{item.summary}</p>
+          </div>
+        </div>
+        <StatusBadge status={item.status} compact />
+      </div>
+
+      <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+        {item.details.map((detail) => (
+          <li key={detail}>{detail}</li>
+        ))}
+      </ul>
+
+      <ActionLink action={item.action} />
+    </article>
+  )
+}
+
+function ActionLink({ action }: { action: CrewConversionAction }) {
+  if (!action.href) {
+    return (
+      <span className="mt-5 inline-flex rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground">
+        {action.label}
+      </span>
+    )
+  }
+
+  const external =
+    action.kind === "wodsmith_route" || action.kind === "public_route"
+
+  return (
+    <a
+      href={action.href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noreferrer" : undefined}
+      className="mt-5 inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      {action.label}
+      {external ? <ArrowUpRight className="size-4" aria-hidden="true" /> : null}
+    </a>
+  )
+}
+
+function Metric({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string
+  value: ReactNode
+  mono?: boolean
+}) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p
+        className={`mt-2 break-words text-lg font-semibold ${mono ? "font-mono text-sm" : ""}`}
+      >
+        {value}
+      </p>
+    </section>
+  )
+}
+
+function StatusBadge({
+  status,
+  compact = false,
+}: {
+  status: CrewConversionChecklistStatus
+  compact?: boolean
+}) {
+  return (
+    <span
+      className={`inline-flex shrink-0 rounded-md border px-2 py-1 text-xs font-medium ${statusBadgeClass(status)} ${compact ? "" : "self-start"}`}
+    >
+      {crewConversionChecklistStatusLabels[status]}
+    </span>
+  )
+}
+
+function statusBadgeClass(status: CrewConversionChecklistStatus) {
+  if (status === "ready") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "blocked") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+}
+
+function statusIconClass(status: CrewConversionChecklistStatus) {
+  if (status === "ready") return "text-emerald-600"
+  if (status === "blocked") return "text-destructive"
+  return "text-amber-600"
+}

--- a/apps/crew/src/routes/admin/crew/events/$eventId/readiness.tsx
+++ b/apps/crew/src/routes/admin/crew/events/$eventId/readiness.tsx
@@ -1,0 +1,216 @@
+// @lat: [[crew#Crew Admin Shell]]
+// @lat: [[crew#Pilot Readiness Checklist]]
+import { createFileRoute, Link } from "@tanstack/react-router"
+import { AlertCircle, CheckCircle2, CircleAlert } from "lucide-react"
+import {
+  type CrewReadinessChecklistItem,
+  type CrewReadinessStatus,
+  crewReadinessStatusLabels,
+} from "@/lib/crew/readiness"
+import {
+  type CrewAdminReadinessData,
+  getCrewAdminReadinessFn,
+} from "@/server-fns/crew-admin-event-fns"
+
+export const Route = createFileRoute("/admin/crew/events/$eventId/readiness")({
+  loader: async ({ params }) =>
+    await getCrewAdminReadinessFn({ data: { eventId: params.eventId } }),
+  component: CrewAdminReadinessPage,
+})
+
+function CrewAdminReadinessPage() {
+  const { eventId } = Route.useParams()
+  const { readiness, facts } = Route.useLoaderData() as CrewAdminReadinessData
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-xl font-semibold">Admin readiness</h3>
+          <p className="text-sm text-muted-foreground">
+            Operator diagnostic detail for setup, source data, imports,
+            schedule, roster, shifts, judge publishing, and confirmations.
+          </p>
+        </div>
+        <StatusBadge status={readiness.summary.highestStatus} />
+      </div>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <div className="grid gap-4 md:grid-cols-4">
+          <StatusPanel
+            label="Ready"
+            value={`${readiness.summary.ready}/${readiness.summary.total}`}
+          />
+          <StatusPanel
+            label="Needs attention"
+            value={readiness.summary.needsAttention}
+          />
+          <StatusPanel label="Blocked" value={readiness.summary.blocked} />
+          <StatusPanel
+            label="Progress"
+            value={`${readiness.summary.progressPercent}%`}
+          />
+        </div>
+        <ProgressBar value={readiness.summary.progressPercent} />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        {readiness.items.map((item) => (
+          <ReadinessItemCard
+            key={item.category}
+            eventId={eventId}
+            item={item}
+          />
+        ))}
+      </section>
+
+      <section className="rounded-md border bg-card p-5 shadow-sm">
+        <h3 className="font-semibold">Source counts</h3>
+        <dl className="mt-4 grid gap-4 text-sm sm:grid-cols-2 lg:grid-cols-4">
+          <Fact
+            label="Setup checks"
+            value={`${facts.setup.completed}/${facts.setup.total}`}
+          />
+          <Fact
+            label="Venues and lanes"
+            value={`${facts.venues.venueCount} / ${facts.venues.totalLaneCount}`}
+          />
+          <Fact
+            label="Workouts and heats"
+            value={`${facts.schedule.workoutCount} / ${facts.schedule.heatCount}`}
+          />
+          <Fact
+            label="Roster"
+            value={`${facts.roster.total} total, ${facts.roster.assignable} assignable`}
+          />
+          <Fact
+            label="Shift coverage"
+            value={`${facts.shifts.assignedSlots}/${facts.shifts.capacity}`}
+          />
+          <Fact
+            label="Confirmations"
+            value={`${facts.shifts.confirmationSummary.confirmed}/${facts.shifts.assignedSlots}`}
+          />
+          <Fact
+            label="No response"
+            value={facts.shifts.confirmationSummary.pending}
+          />
+          <Fact label="Judge versions" value={facts.judge.activeVersionCount} />
+        </dl>
+      </section>
+    </section>
+  )
+}
+
+function ReadinessItemCard({
+  eventId,
+  item,
+}: {
+  eventId: string
+  item: CrewReadinessChecklistItem
+}) {
+  const Icon =
+    item.status === "ready"
+      ? CheckCircle2
+      : item.status === "blocked"
+        ? AlertCircle
+        : CircleAlert
+
+  return (
+    <article className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 gap-3">
+          <Icon
+            className={`mt-0.5 size-5 shrink-0 ${statusIconClass(item.status)}`}
+          />
+          <div className="min-w-0">
+            <h3 className="font-semibold">{item.label}</h3>
+            <p className="mt-1 text-sm text-muted-foreground">{item.summary}</p>
+          </div>
+        </div>
+        <StatusBadge status={item.status} compact />
+      </div>
+
+      <ul className="mt-4 space-y-2 text-sm text-muted-foreground">
+        {item.details.map((detail) => (
+          <li key={detail}>{detail}</li>
+        ))}
+      </ul>
+
+      <Link
+        to={item.action.to}
+        params={{ eventId }}
+        className="mt-5 inline-flex rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        {item.action.label}
+      </Link>
+    </article>
+  )
+}
+
+function StatusPanel({
+  label,
+  value,
+}: {
+  label: string
+  value: number | string
+}) {
+  return (
+    <section className="rounded-md border bg-background p-4">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function StatusBadge({
+  status,
+  compact = false,
+}: {
+  status: CrewReadinessStatus
+  compact?: boolean
+}) {
+  return (
+    <span
+      className={`inline-flex shrink-0 rounded-md border px-2 py-1 text-xs font-medium ${statusBadgeClass(status)} ${compact ? "" : "self-start"}`}
+    >
+      {crewReadinessStatusLabels[status]}
+    </span>
+  )
+}
+
+function Fact({ label, value }: { label: string; value: number | string }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="mt-1 font-medium">{value}</dd>
+    </div>
+  )
+}
+
+function ProgressBar({ value }: { value: number }) {
+  return (
+    <div className="mt-5 h-2 overflow-hidden rounded-full bg-muted">
+      <div
+        className="h-full rounded-full bg-primary transition-all"
+        style={{ width: `${value}%` }}
+      />
+    </div>
+  )
+}
+
+function statusBadgeClass(status: CrewReadinessStatus) {
+  if (status === "ready") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+  }
+  if (status === "blocked") {
+    return "border-destructive/30 bg-destructive/10 text-destructive"
+  }
+  return "border-amber-500/30 bg-amber-500/10 text-amber-700"
+}
+
+function statusIconClass(status: CrewReadinessStatus) {
+  if (status === "ready") return "text-emerald-600"
+  if (status === "blocked") return "text-destructive"
+  return "text-amber-600"
+}

--- a/apps/crew/src/routes/events/$eventId.tsx
+++ b/apps/crew/src/routes/events/$eventId.tsx
@@ -2,32 +2,29 @@
 // @lat: [[crew#Staffing Page Gap Report]]
 // @lat: [[crew#Day Of Operations Board]]
 // @lat: [[crew#Pilot Exports]]
-// @lat: [[crew#Billing Page And Upgrade CTA]]
-// @lat: [[crew#Full WODsmith Conversion Assistant]]
-// @lat: [[crew#Regional Judge Discovery Pilot]]
-import {createFileRoute, Link, notFound, Outlet} from '@tanstack/react-router'
-import {getCrewEventNavItems} from '@/lib/crew/navigation'
-import {getCrewEventFn} from '@/server-fns/crew-event-settings-fns'
-import {useSession} from '@/utils/auth-client'
-import {resolveCrewViewer} from '@/utils/crew-access'
+import { createFileRoute, Link, notFound, Outlet } from "@tanstack/react-router"
+import { getCrewEventNavItems } from "@/lib/crew/navigation"
+import { getCrewEventFn } from "@/server-fns/crew-event-settings-fns"
+import { useSession } from "@/utils/auth-client"
+import { resolveCrewViewer } from "@/utils/crew-access"
 
-export const Route = createFileRoute('/events/$eventId')({
-  loader: async ({params}) => {
-    const result = await getCrewEventFn({data: {eventId: params.eventId}})
+export const Route = createFileRoute("/events/$eventId")({
+  loader: async ({ params }) => {
+    const result = await getCrewEventFn({ data: { eventId: params.eventId } })
     if (!result.event) {
       throw notFound()
     }
-    return {event: result.event}
+    return { event: result.event }
   },
   component: EventShell,
 })
 
 function EventShell() {
-  const {eventId} = Route.useParams()
-  const {event} = Route.useLoaderData()
+  const { eventId } = Route.useParams()
+  const { event } = Route.useLoaderData()
   const session = useSession()
-  const viewer = resolveCrewViewer({session})
-  const navItems = getCrewEventNavItems({viewerRole: viewer.role})
+  const viewer = resolveCrewViewer({ session })
+  const navItems = getCrewEventNavItems({ viewerRole: viewer.role })
 
   return (
     <main className="mx-auto max-w-6xl space-y-6 px-4 py-8 sm:px-6">
@@ -42,13 +39,23 @@ function EventShell() {
           </p>
         </div>
         <nav className="flex flex-wrap gap-2 text-sm">
+          {viewer.isWodsmithOperator ? (
+            <Link
+              to="/admin/crew/events/$eventId"
+              params={{ eventId }}
+              activeProps={{ className: "bg-muted text-foreground" }}
+              className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+            >
+              Admin cockpit
+            </Link>
+          ) : null}
           {navItems.map((item) => (
             <Link
               key={item.key}
               to={item.to}
-              params={{eventId}}
-              activeOptions={item.key === 'home' ? {exact: true} : undefined}
-              activeProps={{className: 'bg-muted text-foreground'}}
+              params={{ eventId }}
+              activeOptions={item.key === "home" ? { exact: true } : undefined}
+              activeProps={{ className: "bg-muted text-foreground" }}
               className="rounded-md border px-3 py-2 text-muted-foreground hover:bg-muted hover:text-foreground"
             >
               {item.label}

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -1,13 +1,9 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
 // @lat: [[crew#Staffing Page Gap Report]]
 // @lat: [[crew#Day Of Operations Board]]
-// @lat: [[crew#Billing Page And Upgrade CTA]]
-// @lat: [[crew#Full WODsmith Conversion Assistant]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
-import { formatCrewValue, getSafeHttpUrl } from "@/lib/crew-event-display"
 import {
   calculateSetupProgress,
-  crewSetupChecklistItems,
   parseCrewSettings,
 } from "@/lib/crew-event-setup"
 import { getCrewEventRosterShiftSummaryFn } from "@/server-fns/crew-roster-shift-fns"
@@ -31,19 +27,7 @@ function EventOverviewPage() {
 
   return (
     <section className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-7">
-        <StatusPanel
-          label="Lifecycle"
-          value={formatCrewValue(event.settings.lifecycle)}
-        />
-        <StatusPanel
-          label="Concierge"
-          value={formatCrewValue(event.settings.conciergeStatus)}
-        />
-        <StatusPanel
-          label="Plan"
-          value={formatCrewValue(event.settings.crewPlan)}
-        />
+      <div className="grid gap-4 md:grid-cols-4">
         <StatusPanel
           label="Setup"
           value={`${setupProgress.completed}/${setupProgress.total}`}
@@ -59,242 +43,63 @@ function EventOverviewPage() {
         />
       </div>
 
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">Pilot readiness</h2>
-            <p className="text-sm text-muted-foreground">
-              Check event setup, imports, schedule, roster, shifts, judge
-              publishing, and assignment confirmations before handoff.
-            </p>
-          </div>
-          <Link
-            to="/events/$eventId/readiness"
-            params={{ eventId }}
-            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Open checklist
-          </Link>
-        </div>
-      </section>
-
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">Billing</h2>
-            <p className="text-sm text-muted-foreground">
-              Review event plan status, upgrade credit, and available upgrade
-              actions.
-            </p>
-          </div>
-          <Link
-            to="/events/$eventId/billing"
-            params={{ eventId }}
-            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Open billing
-          </Link>
-        </div>
-      </section>
-
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">Full WODsmith conversion</h2>
-            <p className="text-sm text-muted-foreground">
-              Inventory preserved Crew data and missing full-platform setup
-              before handoff.
-            </p>
-          </div>
-          <Link
-            to="/events/$eventId/convert"
-            params={{ eventId }}
-            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Open assistant
-          </Link>
-        </div>
-      </section>
-
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">Staffing report</h2>
-            <p className="text-sm text-muted-foreground">
-              Review coverage, judge lane gaps, conflicts, availability
-              warnings, and confirmation gaps.
-            </p>
-          </div>
-          <Link
-            to="/events/$eventId/staffing"
-            params={{ eventId }}
-            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Open staffing
-          </Link>
-        </div>
-      </section>
-
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">Day-of operations</h2>
-            <p className="text-sm text-muted-foreground">
-              Scan current blocks, response queues, no-shows, replacements, and
-              judge lane coverage.
-            </p>
-          </div>
-          <Link
-            to="/events/$eventId/day-of"
-            params={{ eventId }}
-            className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-          >
-            Open day-of
-          </Link>
-        </div>
-      </section>
-
-      <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h2 className="text-xl font-semibold">Concierge dashboard</h2>
-              <p className="text-sm text-muted-foreground">
-                Operator view for source data, setup progress, and handoff
-                notes.
-              </p>
-            </div>
-            <Link
-              to="/events/$eventId/setup"
-              params={{ eventId }}
-              className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-            >
-              Edit setup
-            </Link>
-          </div>
-
-          <div className="mt-6 space-y-3">
-            <div className="flex items-center justify-between gap-4 text-sm">
-              <span className="font-medium">Setup progress</span>
-              <span className="text-muted-foreground">
-                {setupProgress.percent}%
-              </span>
-            </div>
-            <ProgressBar value={setupProgress.percent} />
-          </div>
-
-          <div className="mt-6 grid gap-4 sm:grid-cols-2">
-            {crewSetupChecklistItems.map((item) => (
-              <div
-                key={item.key}
-                className="flex items-center gap-3 rounded-md border bg-background px-3 py-2 text-sm"
-              >
-                <span
-                  className={
-                    parsedSettings.setup.checklist[item.key]
-                      ? "size-2 rounded-full bg-emerald-500"
-                      : "size-2 rounded-full bg-muted-foreground/35"
-                  }
-                />
-                <span>{item.label}</span>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <aside className="rounded-md border bg-card p-5 shadow-sm">
-          <h2 className="text-sm font-semibold uppercase text-muted-foreground">
-            Competition
-          </h2>
-          <dl className="mt-4 space-y-4 text-sm">
-            <Fact label="ID" value={event.competition.id} mono />
-            <Fact label="Slug" value={event.competition.slug} />
-            <Fact
-              label="Team"
-              value={event.competition.organizingTeamId}
-              mono
-            />
-            <Fact label="Status" value={event.competition.status} />
-          </dl>
-        </aside>
+      <div className="grid gap-4 md:grid-cols-2">
+        <WorkflowCard
+          title="Setup"
+          description={`${setupProgress.percent}% complete`}
+          to="/events/$eventId/setup"
+          eventId={eventId}
+          action="Open setup"
+        />
+        <WorkflowCard
+          title="Imports"
+          description="Bring in volunteer lists and heat schedules."
+          to="/events/$eventId/imports"
+          eventId={eventId}
+          action="Open imports"
+        />
+        <WorkflowCard
+          title="Staffing Plan"
+          description="Review coverage gaps and role-level staffing needs."
+          to="/events/$eventId/staffing"
+          eventId={eventId}
+          action="Open staffing"
+        />
+        <WorkflowCard
+          title="Assignments"
+          description={`${shiftSummary.assignedSlots}/${shiftSummary.capacity} shift slots assigned.`}
+          to="/events/$eventId/shifts"
+          eventId={eventId}
+          action="Open assignments"
+        />
+        <WorkflowCard
+          title="Confirmations"
+          description={`${shiftSummary.confirmationSummary.confirmed}/${shiftSummary.assignedSlots} assigned volunteers confirmed.`}
+          to="/events/$eventId/shifts"
+          eventId={eventId}
+          action="Open confirmations"
+        />
+        <WorkflowCard
+          title="Event Day"
+          description="Run day-of staffing, coverage, and replacement workflows."
+          to="/events/$eventId/day-of"
+          eventId={eventId}
+          action="Open event day"
+        />
+        <WorkflowCard
+          title="Print Packet"
+          description="Prepare the event-day staffing export packet."
+          to="/events/$eventId/exports"
+          eventId={eventId}
+          action="Open exports"
+        />
       </div>
 
-      <div className="grid gap-6 lg:grid-cols-2">
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <h2 className="text-xl font-semibold">Source</h2>
-          <dl className="mt-4 grid gap-4 text-sm">
-            <Fact
-              label="Platform"
-              value={event.settings.sourcePlatform ?? "Not set"}
-            />
-            <Fact
-              label="Source event URL"
-              value={event.settings.sourceEventUrl ?? "Not set"}
-              link={event.settings.sourceEventUrl}
-            />
-            <Fact
-              label="External registration URL"
-              value={event.settings.externalRegistrationUrl ?? "Not set"}
-              link={event.settings.externalRegistrationUrl}
-            />
-            <Fact
-              label="Acquisition source"
-              value={event.settings.acquisitionSource ?? "Not set"}
-            />
-          </dl>
-        </section>
-
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <h2 className="text-xl font-semibold">Operator notes</h2>
-          <dl className="mt-4 grid gap-4 text-sm">
-            <Fact
-              label="Desired go-live date"
-              value={parsedSettings.setup.desiredGoLiveDate || "Not set"}
-            />
-            <Fact
-              label="Staffing lead"
-              value={parsedSettings.setup.staffingLead || "Not set"}
-            />
-            <Fact
-              label="Volunteer target"
-              value={parsedSettings.setup.volunteerTarget || "Not set"}
-            />
-            <Fact
-              label="Source contact"
-              value={
-                [
-                  parsedSettings.setup.sourceContactName,
-                  parsedSettings.setup.sourceContactEmail,
-                ]
-                  .filter(Boolean)
-                  .join(" | ") || "Not set"
-              }
-            />
-          </dl>
-          {parsedSettings.parseError ? (
-            <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              Settings JSON could not be parsed. Saving setup will preserve the
-              previous text under legacySettingsText.
-            </p>
-          ) : null}
-        </section>
-      </div>
-
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <h2 className="text-xl font-semibold">Internal notes</h2>
-        <div className="mt-4 grid gap-4 text-sm lg:grid-cols-2">
-          <NoteBlock
-            label="Assumptions"
-            value={
-              parsedSettings.setup.assumptions || "No assumptions recorded."
-            }
-          />
-          <NoteBlock
-            label="Notes"
-            value={parsedSettings.setup.internalNotes || "No notes recorded."}
-          />
-        </div>
-      </section>
+      {parsedSettings.parseError ? (
+        <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          Setup settings need attention before the checklist can be edited.
+        </p>
+      ) : null}
     </section>
   )
 }
@@ -313,63 +118,40 @@ function StatusPanel({ label, value }: StatusPanelProps) {
   )
 }
 
-interface FactProps {
-  label: string
-  value: string
-  link?: string | null
-  mono?: boolean
-}
-
-function Fact({ label, value, link, mono = false }: FactProps) {
-  const className = mono ? "break-all font-mono" : "break-words font-medium"
-  const safeLink = getSafeHttpUrl(link)
-
+function WorkflowCard({
+  title,
+  description,
+  to,
+  eventId,
+  action,
+}: {
+  title: string
+  description: string
+  to:
+    | "/events/$eventId/setup"
+    | "/events/$eventId/imports"
+    | "/events/$eventId/staffing"
+    | "/events/$eventId/shifts"
+    | "/events/$eventId/day-of"
+    | "/events/$eventId/exports"
+  eventId: string
+  action: string
+}) {
   return (
-    <div>
-      <dt className="text-muted-foreground">{label}</dt>
-      <dd className={className}>
-        {safeLink ? (
-          <a
-            href={safeLink}
-            target="_blank"
-            rel="noreferrer"
-            className="text-primary underline-offset-4 hover:underline"
-          >
-            {value}
-          </a>
-        ) : (
-          value
-        )}
-      </dd>
-    </div>
-  )
-}
-
-interface NoteBlockProps {
-  label: string
-  value: string
-}
-
-function NoteBlock({ label, value }: NoteBlockProps) {
-  return (
-    <div className="rounded-md border bg-background p-3">
-      <h3 className="font-medium">{label}</h3>
-      <p className="mt-2 whitespace-pre-wrap text-muted-foreground">{value}</p>
-    </div>
-  )
-}
-
-interface ProgressBarProps {
-  value: number
-}
-
-function ProgressBar({ value }: ProgressBarProps) {
-  return (
-    <div className="h-2 overflow-hidden rounded-full bg-muted">
-      <div
-        className="h-full rounded-full bg-primary transition-all"
-        style={{ width: `${value}%` }}
-      />
-    </div>
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">{title}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        </div>
+        <Link
+          to={to}
+          params={{ eventId }}
+          className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+        >
+          {action}
+        </Link>
+      </div>
+    </section>
   )
 }

--- a/apps/crew/src/server-fns/crew-admin-event-fns.ts
+++ b/apps/crew/src/server-fns/crew-admin-event-fns.ts
@@ -1,0 +1,60 @@
+// @lat: [[crew#Crew Admin Shell]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type {
+  CrewAdminBillingData,
+  CrewAdminConversionData,
+  CrewAdminEventDetailView,
+  CrewAdminEventListItem,
+  CrewAdminReadinessData,
+} from "../server/crew-admin-event.server"
+
+const adminEventInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+export const getCrewAdminEventListFn = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  const { getCrewAdminEventList } = await import(
+    "../server/crew-admin-event.server"
+  )
+  return getCrewAdminEventList()
+})
+
+export const getCrewAdminEventDetailFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => adminEventInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { getCrewAdminEventDetail } = await import(
+      "../server/crew-admin-event.server"
+    )
+    return getCrewAdminEventDetail(data)
+  })
+
+export const getCrewAdminReadinessFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => adminEventInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { getCrewAdminReadiness } = await import(
+      "../server/crew-admin-event.server"
+    )
+    return getCrewAdminReadiness(data)
+  })
+
+export const getCrewAdminBillingFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => adminEventInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { getCrewAdminBilling } = await import(
+      "../server/crew-admin-event.server"
+    )
+    return getCrewAdminBilling(data)
+  })
+
+export const getCrewAdminConversionFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) => adminEventInputSchema.parse(data))
+  .handler(async ({ data }) => {
+    const { getCrewAdminConversion } = await import(
+      "../server/crew-admin-event.server"
+    )
+    return getCrewAdminConversion(data)
+  })

--- a/apps/crew/src/server/crew-admin-event.server.ts
+++ b/apps/crew/src/server/crew-admin-event.server.ts
@@ -1,0 +1,339 @@
+// @lat: [[crew#Crew Admin Shell]]
+import { eq } from "drizzle-orm"
+import { getDb } from "../db"
+import { competitionsTable } from "../db/schemas/competitions"
+import { crewEventSettingsTable } from "../db/schemas/crew-event-settings"
+import { buildCrewBillingPageViewModel } from "../lib/crew/billing-page"
+import { getCrewPaymentLinkUrlFromSettings } from "../lib/crew/payment-link-sales"
+import { formatCrewValue } from "../lib/crew-event-display"
+import {
+  calculateSetupProgress,
+  parseCrewSettings,
+} from "../lib/crew-event-setup"
+import { getCrewBillingPage } from "./crew-billing.server"
+import { getCrewConversionAssistantPage } from "./crew-conversion.server"
+import { listCrewEvents } from "./crew-event-settings.server"
+import { requireLocalCrewOperatorAccess } from "./crew-local-access"
+import { getCrewReadinessPage } from "./crew-readiness.server"
+import { getCrewEventRosterShiftSummary } from "./crew-roster-shift.server"
+
+export interface CrewAdminEventListItem {
+  id: string
+  name: string
+  slug: string
+  startDate: string
+  endDate: string
+  lifecycle: string
+  conciergeStatus: string
+  crewPlan: string
+  setupProgress: {
+    completed: number
+    total: number
+    percent: number
+  }
+  billingState: string
+  billingPlanId: string | null
+  sourcePlatform: string | null
+}
+
+export interface CrewAdminEventHeader {
+  id: string
+  name: string
+  slug: string
+  startDate: string
+  endDate: string
+  status: string
+  visibility: string
+  organizingTeamId: string
+  competitionTeamId: string | null
+  lifecycle: string
+  conciergeStatus: string
+  crewPlan: string
+  crewOnly: boolean
+}
+
+export interface CrewAdminEventDetailView {
+  event: CrewAdminEventHeader
+  setup: {
+    completed: number
+    total: number
+    percent: number
+    desiredGoLiveDate: string | null
+    staffingLead: string | null
+    volunteerTarget: string | null
+    sourceContact: string | null
+    parseError: string | null
+  }
+  billing: {
+    planId: string | null
+    planLabel: string
+    stateLabel: string
+    sourceLabel: string
+    amountLabel: string
+    upgradeCreditLabel: string
+    refundedLabel: string
+    paymentLinkId: string | null
+    checkoutSessionId: string | null
+    paymentIntentId: string | null
+    auditEventCount: number
+  }
+  source: {
+    platform: string | null
+    eventUrl: string | null
+    externalRegistrationUrl: string | null
+    acquisitionSource: string | null
+  }
+  readiness: {
+    highestStatus: string
+    ready: number
+    total: number
+    needsAttention: number
+    blocked: number
+    progressPercent: number
+    nextAction: string
+  }
+  diagnostics: {
+    setupChecks: string
+    venuesAndLanes: string
+    workoutsAndHeats: string
+    imports: string
+    roster: string
+    shiftCoverage: string
+    confirmations: string
+    judgeVersions: number
+  }
+  operatorNotes: {
+    assumptions: string
+    internalNotes: string
+  }
+}
+
+export type CrewAdminReadinessData = Awaited<
+  ReturnType<typeof getCrewReadinessPage>
+>
+
+export type CrewAdminBillingData = Awaited<
+  ReturnType<typeof getCrewBillingPage>
+> & {
+  viewModel: ReturnType<typeof buildCrewBillingPageViewModel>
+}
+
+export type CrewAdminConversionData = Awaited<
+  ReturnType<typeof getCrewConversionAssistantPage>
+>
+
+export async function getCrewAdminEventList(): Promise<{
+  events: CrewAdminEventListItem[]
+}> {
+  requireLocalCrewOperatorAccess("Crew admin")
+
+  const { events } = await listCrewEvents()
+  return {
+    events: events.map((event) => {
+      const setupProgress = calculateSetupProgress(
+        parseCrewSettings(event.settings.settings).setup,
+      )
+
+      return {
+        id: event.competition.id,
+        name: event.competition.name,
+        slug: event.competition.slug,
+        startDate: event.competition.startDate,
+        endDate: event.competition.endDate,
+        lifecycle: event.settings.lifecycle,
+        conciergeStatus: event.settings.conciergeStatus,
+        crewPlan: event.settings.crewPlan,
+        setupProgress,
+        billingState: event.settings.crewBillingState,
+        billingPlanId: event.settings.crewBillingPlanId,
+        sourcePlatform: event.settings.sourcePlatform,
+      }
+    }),
+  }
+}
+
+export async function getCrewAdminEventDetail(data: {
+  eventId: string
+}): Promise<{ view: CrewAdminEventDetailView }> {
+  requireLocalCrewOperatorAccess("Crew admin")
+
+  const event = await requireCrewAdminEvent(data.eventId)
+  const [rosterShiftSummary, readiness, billing] = await Promise.all([
+    getCrewEventRosterShiftSummary({ eventId: data.eventId }),
+    getCrewReadinessPage({ eventId: data.eventId }),
+    getCrewAdminBilling(data),
+  ])
+  const parsedSettings = parseCrewSettings(event.settingsText)
+  const setupProgress = calculateSetupProgress(parsedSettings.setup)
+  const readinessNextAction =
+    readiness.readiness.items.find((item) => item.status === "blocked") ??
+    readiness.readiness.items.find((item) => item.status === "needs_attention")
+
+  return {
+    view: {
+      event: {
+        id: event.id,
+        name: event.name,
+        slug: event.slug,
+        startDate: event.startDate,
+        endDate: event.endDate,
+        status: event.status,
+        visibility: event.visibility,
+        organizingTeamId: event.organizingTeamId,
+        competitionTeamId: event.competitionTeamId,
+        lifecycle: event.lifecycle,
+        conciergeStatus: event.conciergeStatus,
+        crewPlan: event.crewPlan,
+        crewOnly: event.crewOnly,
+      },
+      setup: {
+        completed: setupProgress.completed,
+        total: setupProgress.total,
+        percent: setupProgress.percent,
+        desiredGoLiveDate: nullableText(parsedSettings.setup.desiredGoLiveDate),
+        staffingLead: nullableText(parsedSettings.setup.staffingLead),
+        volunteerTarget: nullableText(parsedSettings.setup.volunteerTarget),
+        sourceContact: nullableText(
+          [
+            parsedSettings.setup.sourceContactName,
+            parsedSettings.setup.sourceContactEmail,
+          ]
+            .filter(Boolean)
+            .join(" | "),
+        ),
+        parseError: parsedSettings.parseError,
+      },
+      billing: {
+        planId: billing.billing.planId,
+        planLabel: billing.viewModel.plan.label,
+        stateLabel: billing.viewModel.billing.stateLabel,
+        sourceLabel: billing.viewModel.billing.sourceLabel,
+        amountLabel: billing.viewModel.billing.amountLabel,
+        upgradeCreditLabel: billing.viewModel.billing.upgradeCreditLabel,
+        refundedLabel: billing.viewModel.billing.refundedLabel,
+        paymentLinkId: billing.billing.stripe.paymentLinkId,
+        checkoutSessionId: billing.billing.stripe.checkoutSessionId,
+        paymentIntentId: billing.billing.stripe.paymentIntentId,
+        auditEventCount: billing.auditEvents.length,
+      },
+      source: {
+        platform: event.sourcePlatform,
+        eventUrl: event.sourceEventUrl,
+        externalRegistrationUrl: event.externalRegistrationUrl,
+        acquisitionSource: event.acquisitionSource,
+      },
+      readiness: {
+        highestStatus: readiness.readiness.summary.highestStatus,
+        ready: readiness.readiness.summary.ready,
+        total: readiness.readiness.summary.total,
+        needsAttention: readiness.readiness.summary.needsAttention,
+        blocked: readiness.readiness.summary.blocked,
+        progressPercent: readiness.readiness.summary.progressPercent,
+        nextAction: readinessNextAction
+          ? `${readinessNextAction.label}: ${readinessNextAction.summary}`
+          : "No blocking admin action found.",
+      },
+      diagnostics: {
+        setupChecks: `${readiness.facts.setup.completed}/${readiness.facts.setup.total}`,
+        venuesAndLanes: `${readiness.facts.venues.venueCount} / ${readiness.facts.venues.totalLaneCount}`,
+        workoutsAndHeats: `${readiness.facts.schedule.workoutCount} / ${readiness.facts.schedule.heatCount}`,
+        imports: `${readiness.facts.imports.appliedVolunteerImportCount}/${readiness.facts.imports.volunteerImportCount} volunteer, ${readiness.facts.imports.appliedHeatScheduleImportCount}/${readiness.facts.imports.heatScheduleImportCount} heat`,
+        roster: `${rosterShiftSummary.rosterSummary.total} total, ${readiness.facts.roster.assignable} assignable`,
+        shiftCoverage: `${rosterShiftSummary.shiftSummary.assignedSlots}/${rosterShiftSummary.shiftSummary.capacity}`,
+        confirmations: `${rosterShiftSummary.shiftSummary.confirmationSummary.confirmed}/${rosterShiftSummary.shiftSummary.assignedSlots}`,
+        judgeVersions: readiness.facts.judge.activeVersionCount,
+      },
+      operatorNotes: {
+        assumptions:
+          parsedSettings.setup.assumptions || "No assumptions recorded.",
+        internalNotes:
+          parsedSettings.setup.internalNotes || "No internal notes recorded.",
+      },
+    },
+  }
+}
+
+export async function getCrewAdminReadiness(data: {
+  eventId: string
+}): Promise<CrewAdminReadinessData> {
+  requireLocalCrewOperatorAccess("Crew admin readiness")
+  return getCrewReadinessPage(data)
+}
+
+export async function getCrewAdminBilling(data: {
+  eventId: string
+}): Promise<CrewAdminBillingData> {
+  requireLocalCrewOperatorAccess("Crew admin billing")
+
+  const [billing, event] = await Promise.all([
+    getCrewBillingPage(data),
+    requireCrewAdminEvent(data.eventId),
+  ])
+  const paymentLinkUrl = getCrewPaymentLinkUrlFromSettings(event.settingsText)
+
+  return {
+    ...billing,
+    viewModel: buildCrewBillingPageViewModel({
+      billing: billing.billing,
+      paymentLink: {
+        id: billing.billing.stripe.paymentLinkId,
+        url: paymentLinkUrl,
+      },
+      checkoutEnabled: false,
+    }),
+  }
+}
+
+export async function getCrewAdminConversion(data: {
+  eventId: string
+}): Promise<CrewAdminConversionData> {
+  requireLocalCrewOperatorAccess("Crew admin conversion")
+  return getCrewConversionAssistantPage(data)
+}
+
+async function requireCrewAdminEvent(eventId: string) {
+  const db = getDb()
+  const [event] = await db
+    .select({
+      id: competitionsTable.id,
+      name: competitionsTable.name,
+      slug: competitionsTable.slug,
+      startDate: competitionsTable.startDate,
+      endDate: competitionsTable.endDate,
+      status: competitionsTable.status,
+      visibility: competitionsTable.visibility,
+      organizingTeamId: competitionsTable.organizingTeamId,
+      competitionTeamId: competitionsTable.competitionTeamId,
+      crewOnly: crewEventSettingsTable.crewOnly,
+      lifecycle: crewEventSettingsTable.lifecycle,
+      conciergeStatus: crewEventSettingsTable.conciergeStatus,
+      crewPlan: crewEventSettingsTable.crewPlan,
+      sourcePlatform: crewEventSettingsTable.sourcePlatform,
+      sourceEventUrl: crewEventSettingsTable.sourceEventUrl,
+      externalRegistrationUrl: crewEventSettingsTable.externalRegistrationUrl,
+      acquisitionSource: crewEventSettingsTable.acquisitionSource,
+      settingsText: crewEventSettingsTable.settings,
+    })
+    .from(crewEventSettingsTable)
+    .innerJoin(
+      competitionsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(eq(crewEventSettingsTable.competitionId, eventId))
+    .limit(1)
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  return event
+}
+
+function nullableText(value: string) {
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function formatCrewAdminValue(value: string | null | undefined) {
+  return value ? formatCrewValue(value) : "Not set"
+}

--- a/apps/crew/src/utils/crew-access.ts
+++ b/apps/crew/src/utils/crew-access.ts
@@ -1,4 +1,4 @@
-import type {CrewViewerRole} from '@/lib/crew/navigation'
+import type { CrewViewerRole } from "@/lib/crew/navigation"
 
 export interface CrewViewerInput {
   role?: CrewViewerRole | null
@@ -22,6 +22,15 @@ export interface CrewViewer {
   isVolunteerPublic: boolean
 }
 
+export class CrewAccessDeniedError extends Error {
+  constructor(
+    message = "FORBIDDEN: You do not have access to this Crew area.",
+  ) {
+    super(message)
+    this.name = "CrewAccessDeniedError"
+  }
+}
+
 /**
  * Resolves the crew viewer role and derives all boolean flags from it.
  * Explicit role inputs win, boolean inputs are fallbacks, and missing sessions
@@ -32,10 +41,10 @@ export function resolveCrewViewer(input: CrewViewerInput = {}): CrewViewer {
 
   return {
     role,
-    isWodsmithOperator: role === 'wodsmith_operator',
-    isOrganizer: role === 'organizer_admin',
-    isDepartmentLead: role === 'department_lead',
-    isVolunteerPublic: role === 'volunteer_public',
+    isWodsmithOperator: role === "wodsmith_operator",
+    isOrganizer: role === "organizer_admin",
+    isDepartmentLead: role === "department_lead",
+    isVolunteerPublic: role === "volunteer_public",
   }
 }
 
@@ -47,11 +56,52 @@ export function resolveCrewViewerRole({
   isVolunteerPublic = false,
 }: CrewViewerInput = {}): CrewViewerRole {
   if (role) return role
-  if (isWodsmithOperator) return 'wodsmith_operator'
-  if (isDepartmentLead) return 'department_lead'
-  if (isVolunteerPublic) return 'volunteer_public'
-  if (session?.user?.role === 'admin') return 'wodsmith_operator'
-  if (session?.user) return 'organizer_admin'
+  if (isWodsmithOperator) return "wodsmith_operator"
+  if (isDepartmentLead) return "department_lead"
+  if (isVolunteerPublic) return "volunteer_public"
+  if (session?.user?.role === "admin") return "wodsmith_operator"
+  if (session?.user) return "organizer_admin"
 
-  return 'volunteer_public'
+  return "volunteer_public"
+}
+
+export async function requireCrewOperatorAccess(
+  input: CrewViewerInput | CrewViewer = {},
+) {
+  const viewer = isResolvedCrewViewer(input) ? input : resolveCrewViewer(input)
+  if (!viewer.isWodsmithOperator) {
+    throw new CrewAccessDeniedError(
+      "FORBIDDEN: Crew admin is available to WODsmith operators only.",
+    )
+  }
+
+  return viewer
+}
+
+export async function requireCrewOrganizerAccess(
+  eventId: string,
+  input: CrewViewerInput | CrewViewer = {},
+) {
+  if (!eventId) {
+    throw new CrewAccessDeniedError("FORBIDDEN: Crew event access is required.")
+  }
+
+  const viewer = isResolvedCrewViewer(input) ? input : resolveCrewViewer(input)
+  if (
+    viewer.isWodsmithOperator ||
+    viewer.isOrganizer ||
+    viewer.isDepartmentLead
+  ) {
+    return viewer
+  }
+
+  throw new CrewAccessDeniedError(
+    "FORBIDDEN: Crew event access is available to event staff only.",
+  )
+}
+
+function isResolvedCrewViewer(
+  input: CrewViewerInput | CrewViewer,
+): input is CrewViewer {
+  return "isOrganizer" in input
 }


### PR DESCRIPTION
## Scope
- Adds the guarded WODsmith Crew admin surface at `/admin/crew`, `/admin/crew/events`, and `/admin/crew/events/$eventId`.
- Adds admin event view models/server functions for event overview, readiness, billing, and conversion data.
- Adds admin child pages for readiness diagnostics, billing/audit context, and the read-only full WODsmith conversion assistant.
- Trims the organizer event nav/home so Billing, Conversion, Discovery, source counts, raw IDs, concierge status, and internal notes are no longer presented on the organizer event surface.

## Acceptance
- WODsmith operators have an admin event cockpit with lifecycle, concierge, plan/payment, setup, roster/assignment/confirmation, source, billing, conversion, raw ID, operator-note, and readiness diagnostic context.
- `/admin/crew/*` loaders go through the operator-only Crew admin server boundary.
- Normal organizer nav no longer includes Billing, Convert, Discovery, Readiness, Schedule, Judges, or operator-only tabs.
- Organizer event home no longer renders concierge status, billing/conversion cards, source details, raw IDs, source counts, or internal/operator notes.
- Admin readiness preserves the detailed diagnostic/source-count view from the previous client-facing readiness page.

## Validation
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH node --input-type=module -e "import { Generator, getConfig } from './node_modules/.pnpm/@tanstack+router-generator@1.144.0/node_modules/@tanstack/router-generator/dist/esm/index.js'; const config = getConfig({ target: 'react', routesDirectory: './apps/crew/src/routes', generatedRouteTree: './apps/crew/src/routeTree.gen.ts', quoteStyle: 'single', semicolons: false, disableLogging: true }, process.cwd()); const generator = new Generator({ config, root: process.cwd() }); await generator.run();"`
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew exec biome check src/routes/admin/crew.tsx src/routes/admin/crew/events.tsx 'src/routes/admin/crew/events/$eventId.tsx' 'src/routes/admin/crew/events/$eventId/readiness.tsx' 'src/routes/admin/crew/events/$eventId/billing.tsx' 'src/routes/admin/crew/events/$eventId/convert.tsx' 'src/routes/events/$eventId.tsx' 'src/routes/events/$eventId/index.tsx' src/server/crew-admin-event.server.ts src/server-fns/crew-admin-event-fns.ts src/utils/crew-access.ts src/lib/crew/navigation.ts`

## Validation caveats
- Full `pnpm --filter crew check` still fails on existing unrelated Biome issues outside this PR, including index keys/import ordering/formatting in older `src/components/*` files.
- Full `pnpm --filter crew type-check` still fails on existing unrelated implicit-any and staffing/shifts typing issues outside this PR; the new admin files were cleared from the error list after fixes.
- `pnpm --filter crew build` is blocked in this fresh worktree because `apps/crew/.alchemy/local/wrangler.jsonc` is missing. `pnpm --filter crew alchemy:configure` also cannot complete locally without real Alchemy secret configuration (`Cannot serialize secret without password`).
- Initial `pnpm install` completed with exit code 0, but optional/native `better-sqlite3` rebuild logged a Python 3.7 syntax failure while installing against Node 24.

## Out of scope / PR 3+
- Organizer next-action home/checklist polish beyond removing internal cockpit content.
- Setup/import redesign or splitting all operator setup form fields out of the existing setup route.
- Assignments consolidation, messages page, volunteer flow, day-of persistence, schema changes, Stripe/webhook behavior, or public pricing/marketing surfaces.
- Broad repo-wide Biome/typecheck cleanup unrelated to the admin-shell split.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operator-only Crew admin shell at `/admin/crew` with an event cockpit (Overview, Readiness, Billing, Conversion). Organizer pages are simplified to hide operator-only content; operators see an “Admin cockpit” link from organizer event pages.

- **New Features**
  - Admin routes: `/admin/crew`, `/admin/crew/events`, `/admin/crew/events/$eventId`, plus `/readiness`, `/billing`, `/convert`.
  - Guarded server boundary and fns: `getCrewAdminEventListFn`, `getCrewAdminEventDetailFn`, `getCrewAdminReadinessFn`, `getCrewAdminBillingFn`, `getCrewAdminConversionFn`.
  - Event cockpit shows metrics, diagnostics, billing audit context, and a read-only conversion assistant; events index lists setup progress and billing state.
  - Access utilities added: `CrewAccessDeniedError`, `requireCrewOperatorAccess`, `requireCrewOrganizerAccess`.

- **Refactors**
  - Organizer nav/home trimmed: removed Billing, Convert, Discovery, Schedule, Judges, Readiness, and internal/operator-only cards; home now focuses on workflow cards (Setup, Imports, Staffing Plan, Assignments, Confirmations, Event Day, Print Packet).
  - Navigation/types updated to exclude operator-only routes; route tree regenerated with new admin routes and restored start types.

<sup>Written for commit 1b3c594a7c94828954ea41adb9ca04ef70e9f3ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added crew admin control room for operators to manage events, view setup progress, and track billing status.
  * Introduced operator dashboard displaying event lists with lifecycle status and setup completion metrics.
  * Added event admin tabs for readiness tracking, billing management, and conversion assistance.
  * Added admin cockpit link in event views for operator access.

* **Refactor**
  * Simplified event overview with streamlined workflow navigation cards.
  * Streamlined crew event navigation structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->