### PR TITLE
[codex] Add Crew organizer next-action home

### DIFF
--- a/apps/crew/src/lib/crew/organizer-next-action.test.ts
+++ b/apps/crew/src/lib/crew/organizer-next-action.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest"
+import {
+  type CrewOrganizerNextActionInput,
+  deriveCrewOrganizerNextAction,
+} from "./organizer-next-action"
+
+describe("deriveCrewOrganizerNextAction", () => {
+  it("points a new event at setup first", () => {
+    expect(
+      deriveCrewOrganizerNextAction({
+        ...readyInput,
+        setup: { completed: 0, total: 5 },
+        roster: { total: 0, assignable: 0 },
+        shifts: { totalShifts: 0, assignedSlots: 0, capacity: 0 },
+      }),
+    ).toEqual({ key: "finish_setup", ctaTo: "/setup" })
+  })
+
+  it("asks for a staffing plan after volunteers and heat schedule exist but shifts do not", () => {
+    expect(
+      deriveCrewOrganizerNextAction({
+        ...readyInput,
+        shifts: { totalShifts: 0, assignedSlots: 0, capacity: 0 },
+      }),
+    ).toEqual({ key: "build_staffing_plan", ctaTo: "/staffing" })
+  })
+
+  it("asks for confirmations when assignments exist but unsent confirmations remain", () => {
+    expect(
+      deriveCrewOrganizerNextAction({
+        ...readyInput,
+        shifts: { totalShifts: 8, assignedSlots: 32, capacity: 40 },
+        confirmations: {
+          ...readyInput.confirmations,
+          missing: 32,
+          pending: 0,
+          sent: 0,
+          confirmed: 0,
+        },
+      }),
+    ).toEqual({ key: "send_confirmations", ctaTo: "/messages" })
+  })
+
+  it("moves to event day after assignments are sent", () => {
+    expect(
+      deriveCrewOrganizerNextAction({
+        ...readyInput,
+        shifts: { totalShifts: 8, assignedSlots: 32, capacity: 40 },
+        confirmations: {
+          ...readyInput.confirmations,
+          sent: 20,
+          confirmed: 12,
+        },
+      }),
+    ).toEqual({ key: "run_day_of", ctaTo: "/day-of" })
+  })
+})
+
+const readyInput: CrewOrganizerNextActionInput = {
+  setup: { completed: 5, total: 5 },
+  imports: {
+    appliedVolunteerImportCount: 1,
+    appliedHeatScheduleImportCount: 1,
+  },
+  roster: { total: 24, assignable: 24 },
+  heatSchedule: { heatCount: 16, scheduledHeatCount: 16 },
+  shifts: { totalShifts: 6, assignedSlots: 0, capacity: 32 },
+  confirmations: {
+    missing: 0,
+    pending: 0,
+    sent: 0,
+    confirmed: 0,
+    declined: 0,
+    changeRequested: 0,
+    noShow: 0,
+    replaced: 0,
+  },
+  dayOfState: {
+    hasActiveDayOfData: false,
+    isComplete: false,
+  },
+}

--- a/apps/crew/src/lib/crew/organizer-next-action.test.ts
+++ b/apps/crew/src/lib/crew/organizer-next-action.test.ts
@@ -5,6 +5,7 @@ import {
 } from "./organizer-next-action"
 
 describe("deriveCrewOrganizerNextAction", () => {
+  // @lat: [[crew#Organizer Home Next Action]]
   it("points a new event at setup first", () => {
     expect(
       deriveCrewOrganizerNextAction({

--- a/apps/crew/src/lib/crew/organizer-next-action.ts
+++ b/apps/crew/src/lib/crew/organizer-next-action.ts
@@ -1,3 +1,4 @@
+// @lat: [[crew#Organizer Home Next Action]]
 export type CrewOrganizerNextAction =
   | { key: "finish_setup"; ctaTo: "/setup" }
   | { key: "import_volunteers"; ctaTo: "/imports?tab=volunteers" }

--- a/apps/crew/src/lib/crew/organizer-next-action.ts
+++ b/apps/crew/src/lib/crew/organizer-next-action.ts
@@ -1,0 +1,98 @@
+export type CrewOrganizerNextAction =
+  | { key: "finish_setup"; ctaTo: "/setup" }
+  | { key: "import_volunteers"; ctaTo: "/imports?tab=volunteers" }
+  | { key: "import_heat_schedule"; ctaTo: "/imports?tab=heat_schedule" }
+  | { key: "build_staffing_plan"; ctaTo: "/staffing" }
+  | { key: "create_assignments"; ctaTo: "/assignments" }
+  | { key: "send_confirmations"; ctaTo: "/messages" }
+  | { key: "run_day_of"; ctaTo: "/day-of" }
+  | { key: "print_packet"; ctaTo: "/exports" }
+
+export interface CrewOrganizerNextActionInput {
+  setup: {
+    completed: number
+    total: number
+  }
+  imports: {
+    appliedVolunteerImportCount: number
+    appliedHeatScheduleImportCount: number
+  }
+  roster: {
+    total: number
+    assignable: number
+  }
+  heatSchedule: {
+    heatCount: number
+    scheduledHeatCount: number
+  }
+  shifts: {
+    totalShifts: number
+    assignedSlots: number
+    capacity: number
+  }
+  confirmations: {
+    pending: number
+    missing: number
+    sent: number
+    confirmed: number
+    declined: number
+    changeRequested: number
+    noShow: number
+    replaced: number
+  }
+  dayOfState: {
+    hasActiveDayOfData: boolean
+    isComplete: boolean
+  }
+}
+
+export function deriveCrewOrganizerNextAction({
+  setup,
+  imports,
+  roster,
+  heatSchedule,
+  shifts,
+  confirmations,
+  dayOfState,
+}: CrewOrganizerNextActionInput): CrewOrganizerNextAction {
+  if (setup.completed < setup.total) {
+    return { key: "finish_setup", ctaTo: "/setup" }
+  }
+
+  if (
+    imports.appliedVolunteerImportCount === 0 &&
+    roster.total === 0 &&
+    roster.assignable === 0
+  ) {
+    return { key: "import_volunteers", ctaTo: "/imports?tab=volunteers" }
+  }
+
+  if (
+    imports.appliedHeatScheduleImportCount === 0 &&
+    heatSchedule.heatCount === 0 &&
+    heatSchedule.scheduledHeatCount === 0
+  ) {
+    return {
+      key: "import_heat_schedule",
+      ctaTo: "/imports?tab=heat_schedule",
+    }
+  }
+
+  if (shifts.totalShifts === 0 || shifts.capacity === 0) {
+    return { key: "build_staffing_plan", ctaTo: "/staffing" }
+  }
+
+  if (shifts.assignedSlots === 0) {
+    return { key: "create_assignments", ctaTo: "/assignments" }
+  }
+
+  if (confirmations.missing > 0 || confirmations.pending > 0) {
+    return { key: "send_confirmations", ctaTo: "/messages" }
+  }
+
+  if (!dayOfState.hasActiveDayOfData || !dayOfState.isComplete) {
+    return { key: "run_day_of", ctaTo: "/day-of" }
+  }
+
+  return { key: "print_packet", ctaTo: "/exports" }
+}

--- a/apps/crew/src/routes/events/$eventId/imports.tsx
+++ b/apps/crew/src/routes/events/$eventId/imports.tsx
@@ -1,6 +1,9 @@
-import type { ChangeEvent, FormEvent, ReactNode } from "react"
-import { useEffect, useMemo, useState } from "react"
-import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
+import {
+  createFileRoute,
+  getRouteApi,
+  useRouter,
+  useSearch,
+} from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import {
   AlertTriangle,
@@ -11,12 +14,15 @@ import {
   Save,
   Upload,
 } from "lucide-react"
+import type { ChangeEvent, FormEvent, ReactNode } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import {
   getImportFields,
   inferColumnMapping,
 } from "@/lib/crew/imports/column-mapping"
 import { parseCsv } from "@/lib/crew/imports/csv"
+import type { CrewImportMappingSuggestion } from "@/lib/crew/imports/mapping-memory"
 import type {
   ColumnMapping,
   CrewImportKind,
@@ -25,16 +31,15 @@ import type {
   PreviewImportRow,
   VolunteerImportRow,
 } from "@/lib/crew/imports/types"
-import type { CrewImportMappingSuggestion } from "@/lib/crew/imports/mapping-memory"
 import {
   applyCrewImportFn,
-  getCrewImportMappingSuggestionFn,
-  getCrewImportsPageFn,
-  saveCrewImportMappingPresetFn,
   type CrewImportApplyResult,
   type CrewImportHistoryItem,
   type CrewImportReferenceData,
+  getCrewImportMappingSuggestionFn,
+  getCrewImportsPageFn,
   type PersistedCrewImportPreview,
+  saveCrewImportMappingPresetFn,
 } from "@/server-fns/crew-import-fns"
 
 export const Route = createFileRoute("/events/$eventId/imports")({
@@ -46,10 +51,12 @@ export const Route = createFileRoute("/events/$eventId/imports")({
 const parentRoute = getRouteApi("/events/$eventId")
 
 type ImportsTab = CrewImportKind | "roles" | "history"
+type ImportSearchTab = Extract<ImportsTab, "volunteers" | "heat_schedule">
 
 function EventImportsPage() {
   const router = useRouter()
   const { eventId } = parentRoute.useParams()
+  const search = useSearch({ strict: false }) as { tab?: unknown }
   const { history, reference } = Route.useLoaderData()
   const handleHistoryRefresh = async () => {
     await router.invalidate()
@@ -63,6 +70,7 @@ function EventImportsPage() {
     <EventImportTabs
       eventId={eventId}
       history={history}
+      initialTab={normalizeImportSearchTab(search.tab)}
       reference={reference}
       onApplyComplete={handleApplyComplete}
       onHistoryRefresh={handleHistoryRefresh}
@@ -73,19 +81,25 @@ function EventImportsPage() {
 export function EventImportTabs({
   eventId,
   history,
+  initialTab,
   reference,
   onApplyComplete,
   onHistoryRefresh,
 }: {
   eventId: string
   history: CrewImportHistoryItem[]
+  initialTab: ImportSearchTab
   reference: CrewImportReferenceData
   onApplyComplete: (result: CrewImportApplyResult) => Promise<void>
   onHistoryRefresh: () => Promise<void>
 }) {
-  const [activeTab, setActiveTab] = useState<ImportsTab>("volunteers")
+  const [activeTab, setActiveTab] = useState<ImportsTab>(initialTab)
   const [latestPreview, setLatestPreview] =
     useState<PersistedCrewImportPreview | null>(null)
+
+  useEffect(() => {
+    setActiveTab(initialTab)
+  }, [initialTab])
 
   function handlePreviewComplete(preview: PersistedCrewImportPreview) {
     setLatestPreview(preview)
@@ -147,6 +161,14 @@ export function EventImportTabs({
       />
     </section>
   )
+}
+
+function isImportSearchTab(value: unknown): value is ImportSearchTab {
+  return value === "volunteers" || value === "heat_schedule"
+}
+
+function normalizeImportSearchTab(value: unknown): ImportSearchTab {
+  return isImportSearchTab(value) ? value : "volunteers"
 }
 
 function ImportTabContent({

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -100,11 +100,13 @@ function ActionLink({
   variant?: "primary" | "secondary"
 }) {
   const to = toEventRoute(action.ctaTo)
+  const search = toEventRouteSearch(action.ctaTo)
 
   return (
     <Link
       to={to}
       params={{ eventId }}
+      search={search}
       className={
         variant === "primary"
           ? "w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
@@ -132,5 +134,18 @@ function toEventRoute(ctaTo: CrewOrganizerHomeView["nextAction"]["ctaTo"]) {
       return "/events/$eventId/day-of"
     case "/exports":
       return "/events/$eventId/exports"
+  }
+}
+
+function toEventRouteSearch(
+  ctaTo: CrewOrganizerHomeView["nextAction"]["ctaTo"],
+) {
+  switch (ctaTo) {
+    case "/imports?tab=volunteers":
+      return { tab: "volunteers" }
+    case "/imports?tab=heat_schedule":
+      return { tab: "heat_schedule" }
+    default:
+      return undefined
   }
 }

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -1,16 +1,14 @@
 // @lat: [[crew#Pilot Readiness Checklist]]
 // @lat: [[crew#Staffing Page Gap Report]]
 // @lat: [[crew#Day Of Operations Board]]
+// @lat: [[crew#Organizer Home Next Action]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
-import {
-  calculateSetupProgress,
-  parseCrewSettings,
-} from "@/lib/crew-event-setup"
-import { getCrewEventRosterShiftSummaryFn } from "@/server-fns/crew-roster-shift-fns"
+import type { CrewOrganizerHomeView } from "@/server/crew-organizer-home.server"
+import { getCrewOrganizerHomeFn } from "@/server-fns/crew-organizer-home-fns"
 
 export const Route = createFileRoute("/events/$eventId/")({
   loader: async ({ params }) =>
-    await getCrewEventRosterShiftSummaryFn({
+    await getCrewOrganizerHomeFn({
       data: { eventId: params.eventId },
     }),
   component: EventOverviewPage,
@@ -20,82 +18,56 @@ const parentRoute = getRouteApi("/events/$eventId")
 
 function EventOverviewPage() {
   const { eventId } = parentRoute.useParams()
-  const { event } = parentRoute.useLoaderData()
-  const { rosterSummary, shiftSummary } = Route.useLoaderData()
-  const parsedSettings = parseCrewSettings(event.settings.settings)
-  const setupProgress = calculateSetupProgress(parsedSettings.setup)
+  const { view } = Route.useLoaderData()
 
   return (
     <section className="space-y-6">
-      <div className="grid gap-4 md:grid-cols-4">
-        <StatusPanel
-          label="Setup"
-          value={`${setupProgress.completed}/${setupProgress.total}`}
-        />
-        <StatusPanel label="Roster" value={rosterSummary.total.toString()} />
-        <StatusPanel
-          label="Shift slots"
-          value={`${shiftSummary.assignedSlots}/${shiftSummary.capacity}`}
-        />
-        <StatusPanel
-          label="Confirmed"
-          value={`${shiftSummary.confirmationSummary.confirmed}/${shiftSummary.assignedSlots}`}
-        />
-      </div>
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <div className="flex flex-col gap-5 md:flex-row md:items-start md:justify-between">
+          <div className="max-w-2xl">
+            <p className="text-sm font-medium text-muted-foreground">
+              Next step
+            </p>
+            <h2 className="mt-2 text-2xl font-semibold">
+              {view.nextAction.title}
+            </h2>
+            <p className="mt-2 text-muted-foreground">
+              {view.nextAction.description}
+            </p>
+          </div>
+          <ActionLink
+            action={view.nextAction}
+            eventId={eventId}
+            variant="primary"
+          />
+        </div>
+      </section>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <WorkflowCard
-          title="Setup"
-          description={`${setupProgress.percent}% complete`}
-          to="/events/$eventId/setup"
-          eventId={eventId}
-          action="Open setup"
-        />
-        <WorkflowCard
-          title="Imports"
-          description="Bring in volunteer lists and heat schedules."
-          to="/events/$eventId/imports"
-          eventId={eventId}
-          action="Open imports"
-        />
-        <WorkflowCard
-          title="Staffing Plan"
-          description="Review coverage gaps and role-level staffing needs."
-          to="/events/$eventId/staffing"
-          eventId={eventId}
-          action="Open staffing"
-        />
-        <WorkflowCard
-          title="Assignments"
-          description={`${shiftSummary.assignedSlots}/${shiftSummary.capacity} shift slots assigned.`}
-          to="/events/$eventId/shifts"
-          eventId={eventId}
-          action="Open assignments"
-        />
-        <WorkflowCard
-          title="Confirmations"
-          description={`${shiftSummary.confirmationSummary.confirmed}/${shiftSummary.assignedSlots} assigned volunteers confirmed.`}
-          to="/events/$eventId/shifts"
-          eventId={eventId}
-          action="Open confirmations"
-        />
-        <WorkflowCard
-          title="Event Day"
-          description="Run day-of staffing, coverage, and replacement workflows."
-          to="/events/$eventId/day-of"
-          eventId={eventId}
-          action="Open event day"
-        />
-        <WorkflowCard
-          title="Print Packet"
-          description="Prepare the event-day staffing export packet."
-          to="/events/$eventId/exports"
-          eventId={eventId}
-          action="Open exports"
-        />
-      </div>
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">Current snapshot</h2>
+        <div className="grid gap-3 sm:grid-cols-3">
+          {view.supportingFacts.map((fact) => (
+            <StatusPanel
+              key={fact.label}
+              label={fact.label}
+              value={fact.value}
+            />
+          ))}
+        </div>
+      </section>
 
-      {parsedSettings.parseError ? (
+      {view.secondaryActions.length > 0 ? (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold">Also useful</h2>
+          <div className="flex flex-wrap gap-2">
+            {view.secondaryActions.map((action) => (
+              <ActionLink key={action.key} action={action} eventId={eventId} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {view.setupParseError ? (
         <p className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
           Setup settings need attention before the checklist can be edited.
         </p>
@@ -111,47 +83,54 @@ interface StatusPanelProps {
 
 function StatusPanel({ label, value }: StatusPanelProps) {
   return (
-    <section className="rounded-md border bg-card p-4 shadow-sm">
+    <section className="rounded-md border bg-background p-4">
       <p className="text-sm text-muted-foreground">{label}</p>
       <p className="mt-2 text-lg font-semibold">{value}</p>
     </section>
   )
 }
 
-function WorkflowCard({
-  title,
-  description,
-  to,
-  eventId,
+function ActionLink({
   action,
+  eventId,
+  variant = "secondary",
 }: {
-  title: string
-  description: string
-  to:
-    | "/events/$eventId/setup"
-    | "/events/$eventId/imports"
-    | "/events/$eventId/staffing"
-    | "/events/$eventId/shifts"
-    | "/events/$eventId/day-of"
-    | "/events/$eventId/exports"
+  action: CrewOrganizerHomeView["nextAction"]
   eventId: string
-  action: string
+  variant?: "primary" | "secondary"
 }) {
+  const to = toEventRoute(action.ctaTo)
+
   return (
-    <section className="rounded-md border bg-card p-5 shadow-sm">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="text-xl font-semibold">{title}</h2>
-          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
-        </div>
-        <Link
-          to={to}
-          params={{ eventId }}
-          className="w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-        >
-          {action}
-        </Link>
-      </div>
-    </section>
+    <Link
+      to={to}
+      params={{ eventId }}
+      className={
+        variant === "primary"
+          ? "w-fit rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          : "w-fit rounded-md border px-4 py-2 text-sm font-medium text-foreground hover:bg-muted"
+      }
+    >
+      {action.ctaLabel}
+    </Link>
   )
+}
+
+function toEventRoute(ctaTo: CrewOrganizerHomeView["nextAction"]["ctaTo"]) {
+  switch (ctaTo) {
+    case "/setup":
+      return "/events/$eventId/setup"
+    case "/imports?tab=volunteers":
+    case "/imports?tab=heat_schedule":
+      return "/events/$eventId/imports"
+    case "/staffing":
+      return "/events/$eventId/staffing"
+    case "/assignments":
+    case "/messages":
+      return "/events/$eventId/shifts"
+    case "/day-of":
+      return "/events/$eventId/day-of"
+    case "/exports":
+      return "/events/$eventId/exports"
+  }
 }

--- a/apps/crew/src/server-fns/crew-organizer-home-fns.ts
+++ b/apps/crew/src/server-fns/crew-organizer-home-fns.ts
@@ -1,0 +1,21 @@
+// @lat: [[crew#Organizer Home Next Action]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+import { createServerFn } from "@tanstack/react-start"
+import { z } from "zod"
+
+export type { CrewOrganizerHomeView } from "../server/crew-organizer-home.server"
+
+const getCrewOrganizerHomeInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
+
+export const getCrewOrganizerHomeFn = createServerFn({ method: "GET" })
+  .inputValidator((data: unknown) =>
+    getCrewOrganizerHomeInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { getCrewOrganizerHome } = await import(
+      "../server/crew-organizer-home.server"
+    )
+    return getCrewOrganizerHome(data)
+  })

--- a/apps/crew/src/server/crew-organizer-home.server.ts
+++ b/apps/crew/src/server/crew-organizer-home.server.ts
@@ -1,0 +1,284 @@
+// @lat: [[crew#Organizer Home Next Action]]
+import { eq } from "drizzle-orm"
+import { getDb } from "../db"
+import { competitionHeatsTable } from "../db/schemas/competitions"
+import {
+  CREW_IMPORT_KIND,
+  CREW_IMPORT_STATUS,
+  crewImportsTable,
+} from "../db/schemas/crew-imports"
+import {
+  type CrewOrganizerNextAction,
+  deriveCrewOrganizerNextAction,
+} from "../lib/crew/organizer-next-action"
+import {
+  calculateSetupProgress,
+  parseCrewSettings,
+} from "../lib/crew-event-setup"
+import { getCrewEvent } from "./crew-event-settings.server"
+import { getCrewEventRosterShiftSummary } from "./crew-roster-shift.server"
+
+export interface CrewOrganizerHomeFact {
+  label: string
+  value: string
+}
+
+export interface CrewOrganizerHomeActionView {
+  key: CrewOrganizerNextAction["key"]
+  ctaTo: CrewOrganizerNextAction["ctaTo"]
+  title: string
+  description: string
+  ctaLabel: string
+}
+
+export interface CrewOrganizerHomeView {
+  nextAction: CrewOrganizerHomeActionView
+  supportingFacts: CrewOrganizerHomeFact[]
+  secondaryActions: CrewOrganizerHomeActionView[]
+  setupParseError: boolean
+}
+
+export async function getCrewOrganizerHome(data: {
+  eventId: string
+}): Promise<{ view: CrewOrganizerHomeView }> {
+  const { event } = await getCrewEvent({ eventId: data.eventId })
+
+  if (!event) {
+    throw new Error("Crew event not found")
+  }
+
+  const [rosterShiftSummary, imports, heatSchedule] = await Promise.all([
+    getCrewEventRosterShiftSummary(data),
+    loadOrganizerImportSummary(data.eventId),
+    loadOrganizerHeatScheduleSummary(data.eventId),
+  ])
+
+  const parsedSettings = parseCrewSettings(event.settings.settings)
+  const setup = calculateSetupProgress(parsedSettings.setup)
+  const confirmations =
+    rosterShiftSummary.shiftSummary.confirmationOperationalSummary
+  const nextAction = deriveCrewOrganizerNextAction({
+    setup,
+    imports,
+    roster: {
+      total: rosterShiftSummary.rosterSummary.total,
+      assignable: rosterShiftSummary.rosterSummary.assignable,
+    },
+    heatSchedule,
+    shifts: rosterShiftSummary.shiftSummary,
+    confirmations: {
+      missing: confirmations.missing,
+      pending: confirmations.pending,
+      sent: confirmations.sent,
+      confirmed: confirmations.confirmed,
+      declined: confirmations.declined,
+      changeRequested: confirmations.changeRequested,
+      noShow: confirmations.noShow,
+      replaced: confirmations.replaced,
+    },
+    dayOfState: {
+      hasActiveDayOfData: rosterShiftSummary.shiftSummary.assignedSlots > 0,
+      isComplete: false,
+    },
+  })
+
+  const actionView = toActionView(nextAction)
+
+  return {
+    view: {
+      nextAction: actionView,
+      supportingFacts: buildSupportingFacts({
+        rosterTotal: rosterShiftSummary.rosterSummary.total,
+        totalShifts: rosterShiftSummary.shiftSummary.totalShifts,
+        assignedSlots: rosterShiftSummary.shiftSummary.assignedSlots,
+        sentAssignments: countSentAssignments({
+          assignedSlots: rosterShiftSummary.shiftSummary.assignedSlots,
+          missing: confirmations.missing,
+          pending: confirmations.pending,
+        }),
+        confirmedAssignments:
+          rosterShiftSummary.shiftSummary.confirmationSummary.confirmed,
+        setup,
+      }),
+      secondaryActions: buildSecondaryActions(nextAction.key),
+      setupParseError: Boolean(parsedSettings.parseError),
+    },
+  }
+}
+
+async function loadOrganizerImportSummary(competitionId: string) {
+  const db = getDb()
+  const imports = await db
+    .select({
+      kind: crewImportsTable.kind,
+      status: crewImportsTable.status,
+    })
+    .from(crewImportsTable)
+    .where(eq(crewImportsTable.competitionId, competitionId))
+
+  return imports.reduce(
+    (summary, row) => {
+      if (row.kind === CREW_IMPORT_KIND.VOLUNTEERS) {
+        if (row.status === CREW_IMPORT_STATUS.APPLIED) {
+          summary.appliedVolunteerImportCount += 1
+        }
+      } else if (
+        row.kind === CREW_IMPORT_KIND.HEAT_SCHEDULE &&
+        row.status === CREW_IMPORT_STATUS.APPLIED
+      ) {
+        summary.appliedHeatScheduleImportCount += 1
+      }
+      return summary
+    },
+    {
+      appliedVolunteerImportCount: 0,
+      appliedHeatScheduleImportCount: 0,
+    },
+  )
+}
+
+async function loadOrganizerHeatScheduleSummary(competitionId: string) {
+  const db = getDb()
+  const heats = await db
+    .select({
+      id: competitionHeatsTable.id,
+      scheduledTime: competitionHeatsTable.scheduledTime,
+    })
+    .from(competitionHeatsTable)
+    .where(eq(competitionHeatsTable.competitionId, competitionId))
+
+  return {
+    heatCount: heats.length,
+    scheduledHeatCount: heats.filter((heat) => Boolean(heat.scheduledTime))
+      .length,
+  }
+}
+
+function buildSupportingFacts(input: {
+  rosterTotal: number
+  totalShifts: number
+  assignedSlots: number
+  sentAssignments: number
+  confirmedAssignments: number
+  setup: {
+    completed: number
+    total: number
+  }
+}): CrewOrganizerHomeFact[] {
+  if (input.assignedSlots > 0) {
+    return [
+      { label: "Assigned", value: input.assignedSlots.toString() },
+      { label: "Sent", value: input.sentAssignments.toString() },
+      { label: "Confirmed", value: input.confirmedAssignments.toString() },
+    ]
+  }
+
+  if (input.setup.completed < input.setup.total) {
+    return [
+      {
+        label: "Setup",
+        value: `${input.setup.completed}/${input.setup.total}`,
+      },
+      { label: "Volunteers imported", value: input.rosterTotal.toString() },
+      { label: "Shifts created", value: input.totalShifts.toString() },
+    ]
+  }
+
+  return [
+    { label: "Volunteers imported", value: input.rosterTotal.toString() },
+    { label: "Shifts created", value: input.totalShifts.toString() },
+    { label: "Assignments sent", value: input.sentAssignments.toString() },
+  ]
+}
+
+function buildSecondaryActions(
+  primaryKey: CrewOrganizerNextAction["key"],
+): CrewOrganizerHomeActionView[] {
+  if (primaryKey !== "finish_setup") return []
+
+  return (["import_volunteers", "import_heat_schedule"] as const).map((key) =>
+    toActionView({ key, ctaTo: actionCtaByKey[key] }),
+  )
+}
+
+function countSentAssignments(input: {
+  assignedSlots: number
+  missing: number
+  pending: number
+}) {
+  return Math.max(input.assignedSlots - input.missing - input.pending, 0)
+}
+
+const actionCtaByKey: Record<
+  CrewOrganizerNextAction["key"],
+  CrewOrganizerNextAction["ctaTo"]
+> = {
+  finish_setup: "/setup",
+  import_volunteers: "/imports?tab=volunteers",
+  import_heat_schedule: "/imports?tab=heat_schedule",
+  build_staffing_plan: "/staffing",
+  create_assignments: "/assignments",
+  send_confirmations: "/messages",
+  run_day_of: "/day-of",
+  print_packet: "/exports",
+}
+
+const actionCopy: Record<
+  CrewOrganizerNextAction["key"],
+  Omit<CrewOrganizerHomeActionView, "key" | "ctaTo">
+> = {
+  finish_setup: {
+    title: "Finish event setup",
+    description:
+      "Confirm the event basics, floor layout, and staffing assumptions.",
+    ctaLabel: "Finish setup",
+  },
+  import_volunteers: {
+    title: "Import volunteers",
+    description: "Bring in the volunteer list so Crew can build assignments.",
+    ctaLabel: "Import volunteers",
+  },
+  import_heat_schedule: {
+    title: "Import heat schedule",
+    description: "Add the heat schedule so staffing can follow the event flow.",
+    ctaLabel: "Import heat schedule",
+  },
+  build_staffing_plan: {
+    title: "Create your first staffing plan",
+    description: "Set up shifts and coverage before assigning volunteers.",
+    ctaLabel: "Open staffing plan",
+  },
+  create_assignments: {
+    title: "Assign volunteers",
+    description:
+      "Fill the staffing plan with the volunteers who are ready to help.",
+    ctaLabel: "Open assignments",
+  },
+  send_confirmations: {
+    title: "Send confirmations",
+    description:
+      "Email assignments so volunteers can confirm, decline, or request changes.",
+    ctaLabel: "Open confirmations",
+  },
+  run_day_of: {
+    title: "Run event day",
+    description:
+      "Track responses and keep staffing coverage moving during the event.",
+    ctaLabel: "Open event day",
+  },
+  print_packet: {
+    title: "Print packet",
+    description: "Prepare the event-day staffing packet for leads and judges.",
+    ctaLabel: "Open exports",
+  },
+}
+
+function toActionView(
+  action: Pick<CrewOrganizerHomeActionView, "key" | "ctaTo">,
+): CrewOrganizerHomeActionView {
+  return {
+    key: action.key,
+    ctaTo: action.ctaTo,
+    ...actionCopy[action.key],
+  }
+}

--- a/apps/crew/test/routes/event-import-tabs.test.tsx
+++ b/apps/crew/test/routes/event-import-tabs.test.tsx
@@ -27,6 +27,7 @@ describe("EventImportTabs", () => {
       <EventImportTabs
         eventId="comp_crew_demo"
         history={[]}
+        initialTab="volunteers"
         reference={reference}
         onApplyComplete={async () => {}}
         onHistoryRefresh={async () => {}}
@@ -54,6 +55,21 @@ describe("EventImportTabs", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Volunteers" }))
     expectUploadPanel("Volunteers CSV")
+  })
+
+  it("opens the heat schedule panel when the route search selects it", () => {
+    render(
+      <EventImportTabs
+        eventId="comp_crew_demo"
+        history={[]}
+        initialTab="heat_schedule"
+        reference={reference}
+        onApplyComplete={async () => {}}
+        onHistoryRefresh={async () => {}}
+      />,
+    )
+
+    expectUploadPanel("Heat schedule CSV")
   })
 })
 


### PR DESCRIPTION
## Scope

Implements cleanup PR 3: organizer home and next action.

- Adds `deriveCrewOrganizerNextAction(...)` as a pure client-safe helper for the organizer workflow sequence.
- Adds a server-only organizer home view-model boundary plus a thin `createServerFn` wrapper.
- Replaces the organizer event overview grid with one primary next step, concise supporting facts, and setup-only secondary import CTAs.

## Acceptance

- Empty/new events resolve to `finish_setup` with a primary `Finish setup` CTA and optional import CTAs.
- Events with volunteers/schedule but no shifts resolve to `build_staffing_plan` and show facts like volunteers imported, shifts created, and assignments sent.
- Events with assigned slots and unsent confirmations resolve to `send_confirmations` and show assigned/sent/confirmed counts.
- Organizer home view model omits raw IDs, source counts, internal notes, concierge status, billing/conversion state, Stripe references, and admin diagnostics.
- PR #591/#592 persona split remains intact; admin diagnostics remain under `/admin/crew/*`.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/organizer-next-action.test.ts`
- `pnpm --filter crew exec biome check src/lib/crew/organizer-next-action.ts src/lib/crew/organizer-next-action.test.ts src/server/crew-organizer-home.server.ts src/server-fns/crew-organizer-home-fns.ts 'src/routes/events/$eventId/index.tsx'`
- `pnpm --filter crew type-check`
- `pnpm --filter crew lint` (passes with existing repo warnings)
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` (passes; required ignored local Wrangler config copy)
- `pnpm check:schema-ownership`
- `git diff --check`

## Out of scope for PR 4+

- Setup checklist refactor.
- Imports route redesign or query-tab behavior.
- Assignments consolidation / dedicated messages page behavior.
- Volunteer public flow changes.
- Schema changes, Stripe/webhook behavior, or day-of persistence.
- Public pricing/marketing or admin diagnostic expansion.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces an organizer home “next action” that replaces the overview grid with one clear primary step, supporting facts, and optional import CTAs. Centralizes next-step logic in a server-backed view model and deep-links to the correct imports tab.

- **New Features**
  - Added `deriveCrewOrganizerNextAction` to compute the next step from setup, imports, roster, shifts, confirmations, and day-of state.
  - Added server view model (`crew-organizer-home.server`) and GET server function `getCrewOrganizerHomeFn` for the route loader.
  - Updated `/events/$eventId` to show a primary next action with a clear CTA, concise snapshot facts, and setup-only secondary import links.
  - Preserved import next actions: `/events/$eventId/imports` now honors `?tab=volunteers|heat_schedule`, and home CTAs pass the tab to open the correct panel.
  - View model omits IDs, source counts, billing/Stripe, concierge/admin diagnostics; admin views remain under `/admin/crew/*`.
  - Added `@lat` references in key files for internal traceability.

<sup>Written for commit 2621b42598fe897f5030e2b5101d25915b3149e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned organizer home page with an updated workflow interface that displays your next recommended action, current progress snapshot, supporting facts, and available secondary actions to guide your tasks.
  * Implemented URL-based deep-linking for import tabs, enabling direct navigation to specific import types (volunteers or heat schedule) through URL search parameters for easier access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->