### PR TITLE
[codex] Make Crew setup checklist client-safe

### DIFF
--- a/apps/crew/src/lib/crew-event-setup.test.ts
+++ b/apps/crew/src/lib/crew-event-setup.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import {
+  adminOnlyCrewSetupFieldKeys,
+  crewSetupChecklistItems,
+  mergeOrganizerCrewSetupState,
+  organizerCrewSetupFieldKeys,
+  parseCrewSettings,
+  serializeCrewSettings,
+  toOrganizerCrewSetupState,
+} from "./crew-event-setup"
+
+describe("Crew event setup", () => {
+  it("splits organizer setup fields from admin-only setup fields", () => {
+    expect(organizerCrewSetupFieldKeys).toEqual([
+      "volunteerTarget",
+      "staffingLead",
+      "assumptions",
+    ])
+    expect(adminOnlyCrewSetupFieldKeys).toEqual([
+      "desiredGoLiveDate",
+      "sourceContactName",
+      "sourceContactEmail",
+      "internalNotes",
+    ])
+  })
+
+  it("keeps organizer checklist labels client-safe", () => {
+    const labels = crewSetupChecklistItems.map((item) => item.label).join(" ")
+
+    expect(labels).not.toMatch(
+      /concierge|operator|billing|conversion|internal|handoff|source access/i,
+    )
+  })
+
+  it("preserves admin-only setup values when organizer fields are saved", () => {
+    const originalSettings = JSON.stringify({
+      arbitrary: { keep: true },
+      setup: {
+        desiredGoLiveDate: "2026-08-01",
+        sourceContactName: "Taylor",
+        sourceContactEmail: "taylor@example.com",
+        volunteerTarget: "24",
+        staffingLead: "Sam",
+        checklist: {
+          eventBasicsConfirmed: true,
+          sourceAccessConfirmed: false,
+          volunteerNeedsDrafted: false,
+          staffingPlanDrafted: false,
+          operatorHandoffReady: false,
+        },
+        internalNotes: "Private operator note.",
+        assumptions: "One judge per lane.",
+      },
+    })
+    const parsed = parseCrewSettings(originalSettings)
+    const organizerSetup = toOrganizerCrewSetupState(parsed.setup)
+
+    const serialized = serializeCrewSettings(
+      originalSettings,
+      mergeOrganizerCrewSetupState(parsed.setup, {
+        ...organizerSetup,
+        volunteerTarget: "32",
+        assumptions: "Two judges per lane.",
+        checklist: {
+          ...organizerSetup.checklist,
+          volunteerNeedsDrafted: true,
+        },
+      }),
+    )
+    const next = JSON.parse(serialized)
+
+    expect(next.arbitrary.keep).toBe(true)
+    expect(next.setup).toMatchObject({
+      desiredGoLiveDate: "2026-08-01",
+      sourceContactName: "Taylor",
+      sourceContactEmail: "taylor@example.com",
+      internalNotes: "Private operator note.",
+      volunteerTarget: "32",
+      assumptions: "Two judges per lane.",
+      checklist: {
+        eventBasicsConfirmed: true,
+        volunteerNeedsDrafted: true,
+      },
+    })
+  })
+})

--- a/apps/crew/src/lib/crew-event-setup.test.ts
+++ b/apps/crew/src/lib/crew-event-setup.test.ts
@@ -1,3 +1,5 @@
+// @lat: [[crew#Event Setup Dashboard]]
+// @lat: [[crew#Pilot Readiness Checklist]]
 import { describe, expect, it } from "vitest"
 import {
   adminOnlyCrewSetupFieldKeys,
@@ -76,10 +78,14 @@ describe("Crew event setup", () => {
       sourceContactEmail: "taylor@example.com",
       internalNotes: "Private operator note.",
       volunteerTarget: "32",
+      staffingLead: "Sam",
       assumptions: "Two judges per lane.",
       checklist: {
         eventBasicsConfirmed: true,
+        sourceAccessConfirmed: false,
         volunteerNeedsDrafted: true,
+        staffingPlanDrafted: false,
+        operatorHandoffReady: false,
       },
     })
   })

--- a/apps/crew/src/lib/crew-event-setup.ts
+++ b/apps/crew/src/lib/crew-event-setup.ts
@@ -16,21 +16,53 @@ export interface CrewSetupState {
   assumptions: string
 }
 
+export interface CrewOrganizerSetupState {
+  volunteerTarget: string
+  staffingLead: string
+  assumptions: string
+  checklist: Record<CrewSetupChecklistKey, boolean>
+}
+
 export interface ParsedCrewSettings {
   setup: CrewSetupState
   baseSettings: Record<string, unknown>
   parseError: string | null
 }
 
+export const organizerCrewSetupFieldKeys = [
+  "volunteerTarget",
+  "staffingLead",
+  "assumptions",
+] as const satisfies readonly (keyof CrewOrganizerSetupState)[]
+
+export const adminOnlyCrewSetupFieldKeys = [
+  "desiredGoLiveDate",
+  "sourceContactName",
+  "sourceContactEmail",
+  "internalNotes",
+] as const satisfies readonly (keyof CrewSetupState)[]
+
 export const crewSetupChecklistItems: Array<{
   key: CrewSetupChecklistKey
   label: string
 }> = [
-  { key: "eventBasicsConfirmed", label: "Event basics confirmed" },
-  { key: "sourceAccessConfirmed", label: "Source access confirmed" },
-  { key: "volunteerNeedsDrafted", label: "Volunteer needs drafted" },
-  { key: "staffingPlanDrafted", label: "Staffing plan drafted" },
-  { key: "operatorHandoffReady", label: "Operator handoff ready" },
+  {
+    key: "eventBasicsConfirmed",
+    label: "Event name, dates, and timezone confirmed",
+  },
+  { key: "sourceAccessConfirmed", label: "Volunteer signup link added" },
+  {
+    key: "volunteerNeedsDrafted",
+    label: "Volunteer roles and targets drafted",
+  },
+  {
+    key: "staffingPlanDrafted",
+    label: "Floors, lanes, and staffing assumptions ready",
+  },
+  {
+    key: "operatorHandoffReady",
+    label: "Ready to import volunteers and heat schedule",
+  },
 ]
 
 const defaultChecklist = {} as Record<CrewSetupChecklistKey, boolean>
@@ -48,6 +80,37 @@ export function createDefaultCrewSetupState(): CrewSetupState {
     checklist: { ...defaultChecklist },
     internalNotes: "",
     assumptions: "",
+  }
+}
+
+export function createDefaultCrewOrganizerSetupState(): CrewOrganizerSetupState {
+  return toOrganizerCrewSetupState(createDefaultCrewSetupState())
+}
+
+export function toOrganizerCrewSetupState(
+  setup: CrewSetupState,
+): CrewOrganizerSetupState {
+  return {
+    volunteerTarget: setup.volunteerTarget,
+    staffingLead: setup.staffingLead,
+    assumptions: setup.assumptions,
+    checklist: { ...setup.checklist },
+  }
+}
+
+export function mergeOrganizerCrewSetupState(
+  current: CrewSetupState,
+  organizer: CrewOrganizerSetupState,
+): CrewSetupState {
+  return {
+    ...current,
+    volunteerTarget: organizer.volunteerTarget,
+    staffingLead: organizer.staffingLead,
+    assumptions: organizer.assumptions,
+    checklist: {
+      ...current.checklist,
+      ...organizer.checklist,
+    },
   }
 }
 

--- a/apps/crew/src/routes/events/$eventId/setup.tsx
+++ b/apps/crew/src/routes/events/$eventId/setup.tsx
@@ -1,112 +1,47 @@
-import type { FormEvent, ReactNode } from "react"
-import { useEffect, useState } from "react"
 import { createFileRoute, getRouteApi, useRouter } from "@tanstack/react-router"
 import { Save } from "lucide-react"
+import type { FormEvent, ReactNode } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
-import type { VolunteerRoleType } from "@/db/schemas/volunteers"
-import { CrewCopyPriorEventPanel } from "@/components/crew-copy-event/crew-copy-prior-event-panel"
-import { CrewDepartmentLeadsPanel } from "@/components/crew-department-leads/crew-department-leads-panel"
-import { GuidedSetupShell } from "@/components/crew-guided-setup/guided-setup-shell"
-import { CrewTemplatePanel } from "@/components/crew-templates/crew-template-panel"
-import type {
-  CrewGuidedSetupOperatorStatus,
-  CrewGuidedSetupStepKey,
-} from "@/lib/crew/guided-setup"
-import type { CrewRoleShiftTemplateRef } from "@/lib/crew/templates"
 import {
+  type CrewOrganizerSetupState,
+  type CrewSetupChecklistKey,
   crewSetupChecklistItems,
+  mergeOrganizerCrewSetupState,
   parseCrewSettings,
   serializeCrewSettings,
-  type CrewSetupChecklistKey,
+  toOrganizerCrewSetupState,
 } from "@/lib/crew-event-setup"
 import { updateCrewEventSettingsFn } from "@/server-fns/crew-event-settings-fns"
-import {
-  getCrewGuidedSetupPageFn,
-  updateCrewGuidedSetupStepFn,
-} from "@/server-fns/crew-guided-setup-fns"
-import {
-  applyCrewTemplateFn,
-  getCrewTemplatePageFn,
-  saveCrewTemplatePresetFn,
-} from "@/server-fns/crew-template-fns"
-import {
-  applyCrewCopyPriorEventFn,
-  getCrewCopyPriorEventPageFn,
-} from "@/server-fns/crew-copy-event-fns"
-import {
-  createCrewDepartmentLeadFn,
-  getCrewDepartmentLeadsPageFn,
-  revokeCrewDepartmentLeadFn,
-  updateCrewDepartmentLeadFn,
-} from "@/server-fns/crew-department-lead-fns"
 
 export const Route = createFileRoute("/events/$eventId/setup")({
-  loader: async ({ params }) => {
-    const [
-      guidedSetupPage,
-      templatePage,
-      copyPriorEventPage,
-      departmentLeadsPage,
-    ] = await Promise.all([
-      getCrewGuidedSetupPageFn({ data: { eventId: params.eventId } }),
-      getCrewTemplatePageFn({ data: { eventId: params.eventId } }),
-      getCrewCopyPriorEventPageFn({ data: { eventId: params.eventId } }),
-      getCrewDepartmentLeadsPageFn({ data: { eventId: params.eventId } }),
-    ])
-
-    return {
-      ...guidedSetupPage,
-      templatePage,
-      copyPriorEventPage,
-      departmentLeadsPage,
-    }
-  },
   component: EventSetupPage,
 })
 
 const parentRoute = getRouteApi("/events/$eventId")
 
 // @lat: [[crew#Event Setup Dashboard]]
-// @lat: [[crew#Guided Setup State]]
-// @lat: [[crew#Copy Prior Event Setup]]
 function EventSetupPage() {
   const router = useRouter()
   const { event } = parentRoute.useLoaderData()
-  const { guidedSetup, templatePage, copyPriorEventPage, departmentLeadsPage } =
-    Route.useLoaderData()
   const parsedSettings = parseCrewSettings(event.settings.settings)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [crewOnly, setCrewOnly] = useState(event.settings.crewOnly)
   const [sourcePlatform, setSourcePlatform] = useState(
     event.settings.sourcePlatform ?? "",
-  )
-  const [sourceEventUrl, setSourceEventUrl] = useState(
-    event.settings.sourceEventUrl ?? "",
   )
   const [externalRegistrationUrl, setExternalRegistrationUrl] = useState(
     event.settings.externalRegistrationUrl ?? "",
   )
-  const [lifecycle, setLifecycle] = useState(event.settings.lifecycle)
-  const [conciergeStatus, setConciergeStatus] = useState(
-    event.settings.conciergeStatus,
+  const [setup, setSetup] = useState<CrewOrganizerSetupState>(
+    toOrganizerCrewSetupState(parsedSettings.setup),
   )
-  const [crewPlan, setCrewPlan] = useState(event.settings.crewPlan)
-  const [acquisitionSource, setAcquisitionSource] = useState(
-    event.settings.acquisitionSource ?? "",
-  )
-  const [setup, setSetup] = useState(parsedSettings.setup)
+  const checklistProgress = calculateOrganizerChecklistProgress(setup)
 
   useEffect(() => {
     const nextSettings = parseCrewSettings(event.settings.settings)
-    setCrewOnly(event.settings.crewOnly)
     setSourcePlatform(event.settings.sourcePlatform ?? "")
-    setSourceEventUrl(event.settings.sourceEventUrl ?? "")
     setExternalRegistrationUrl(event.settings.externalRegistrationUrl ?? "")
-    setLifecycle(event.settings.lifecycle)
-    setConciergeStatus(event.settings.conciergeStatus)
-    setCrewPlan(event.settings.crewPlan)
-    setAcquisitionSource(event.settings.acquisitionSource ?? "")
-    setSetup(nextSettings.setup)
+    setSetup(toOrganizerCrewSetupState(nextSettings.setup))
   }, [event])
 
   async function handleSubmit(submitEvent: FormEvent<HTMLFormElement>) {
@@ -114,18 +49,17 @@ function EventSetupPage() {
     setIsSubmitting(true)
 
     try {
+      const currentSettings = parseCrewSettings(event.settings.settings)
+
       await updateCrewEventSettingsFn({
         data: {
           competitionId: event.competition.id,
-          crewOnly,
           sourcePlatform,
-          sourceEventUrl,
           externalRegistrationUrl,
-          lifecycle,
-          conciergeStatus,
-          crewPlan,
-          acquisitionSource,
-          settings: serializeCrewSettings(event.settings.settings, setup),
+          settings: serializeCrewSettings(
+            event.settings.settings,
+            mergeOrganizerCrewSetupState(currentSettings.setup, setup),
+          ),
         },
       })
 
@@ -150,492 +84,183 @@ function EventSetupPage() {
     }))
   }
 
-  async function handleGuidedSetupUpdate(data: {
-    eventId: string
-    stepKey: CrewGuidedSetupStepKey
-    status: CrewGuidedSetupOperatorStatus | null
-    note: string
-  }) {
-    try {
-      await updateCrewGuidedSetupStepFn({ data })
-      toast.success("Guided setup step saved")
-      await router.invalidate()
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to save setup step",
-      )
-    }
-  }
-
-  async function handleApplyTemplate(data: {
-    templateRef: CrewRoleShiftTemplateRef
-    fillEmptyAssumptions: boolean
-  }) {
-    try {
-      const result = await applyCrewTemplateFn({
-        data: {
-          eventId: event.competition.id,
-          templateRef: data.templateRef,
-          mode: "append_missing",
-          fillEmptyAssumptions: data.fillEmptyAssumptions,
-        },
-      })
-      toast.success(
-        `Template applied: ${result.createdShiftCount} shifts added${result.assumptionsUpdated ? ", assumptions filled" : ""}`,
-      )
-      await router.invalidate()
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to apply template",
-      )
-    }
-  }
-
-  async function handleSaveTemplatePreset(data: {
-    templateRef: CrewRoleShiftTemplateRef
-    name: string
-  }) {
-    try {
-      await saveCrewTemplatePresetFn({
-        data: {
-          eventId: event.competition.id,
-          templateRef: data.templateRef,
-          name: data.name,
-        },
-      })
-      toast.success("Template preset saved")
-      await router.invalidate()
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to save preset",
-      )
-    }
-  }
-
-  async function handleCopyPriorEvent(data: { sourceEventId: string }) {
-    try {
-      const result = await applyCrewCopyPriorEventFn({
-        data: {
-          eventId: event.competition.id,
-          sourceEventId: data.sourceEventId,
-          mode: "empty_target_only",
-        },
-      })
-      toast.success(
-        `Prior event setup copied: ${result.created.venues} venues, ${result.created.trackWorkouts} events, ${result.created.heats} heats, ${result.created.shifts} shifts`,
-      )
-      await router.invalidate()
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to copy prior event setup",
-      )
-    }
-  }
-
-  async function handleCreateDepartmentLead(data: {
-    eventId: string
-    email: string | null
-    name: string | null
-    membershipId: string | null
-    roleType: VolunteerRoleType
-    floor: string | null
-    startsAt: string | null
-    endsAt: string | null
-    status: "invited" | "active" | "revoked"
-    notes: string | null
-  }) {
-    try {
-      await createCrewDepartmentLeadFn({ data })
-      toast.success("Department lead added")
-      await router.invalidate()
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to add lead")
-    }
-  }
-
-  async function handleUpdateDepartmentLead(data: {
-    leadId: string
-    eventId: string
-    email: string | null
-    name: string | null
-    membershipId: string | null
-    roleType: VolunteerRoleType
-    floor: string | null
-    startsAt: string | null
-    endsAt: string | null
-    status: "invited" | "active" | "revoked"
-    notes: string | null
-  }) {
-    try {
-      await updateCrewDepartmentLeadFn({ data })
-      toast.success("Department lead saved")
-      await router.invalidate()
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to save lead",
-      )
-    }
-  }
-
-  async function handleRevokeDepartmentLead(leadId: string) {
-    try {
-      await revokeCrewDepartmentLeadFn({
-        data: { eventId: event.competition.id, leadId },
-      })
-      toast.success("Department lead revoked")
-      await router.invalidate()
-    } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to revoke lead",
-      )
-    }
-  }
-
   return (
-    <section className="space-y-6">
-      <GuidedSetupShell
-        eventId={event.competition.id}
-        guidedSetup={guidedSetup}
-        onUpdate={(data) =>
-          handleGuidedSetupUpdate({
-            eventId: event.competition.id,
-            ...data,
-          })
-        }
-      />
-
-      <CrewTemplatePanel
-        templatePage={templatePage}
-        onApply={handleApplyTemplate}
-        onSavePreset={handleSaveTemplatePreset}
-      />
-
-      <CrewCopyPriorEventPanel
-        eventId={event.competition.id}
-        pageData={copyPriorEventPage}
-        onApply={handleCopyPriorEvent}
-      />
-
-      <CrewDepartmentLeadsPanel
-        pageData={departmentLeadsPage}
-        onCreate={handleCreateDepartmentLead}
-        onUpdate={handleUpdateDepartmentLead}
-        onRevoke={handleRevokeDepartmentLead}
-      />
-
-      <form
-        onSubmit={handleSubmit}
-        className="grid gap-6 lg:grid-cols-[1fr_20rem]"
-      >
-        <section className="space-y-6">
-          <section className="rounded-md border bg-card p-5 shadow-sm">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h2 className="text-xl font-semibold">Setup</h2>
-                <p className="text-sm text-muted-foreground">
-                  Manage lifecycle, concierge status, source details, and
-                  operator assumptions.
-                </p>
-              </div>
-              <label className="flex items-center gap-2 text-sm">
-                <input
-                  type="checkbox"
-                  checked={crewOnly}
-                  onChange={(changeEvent) =>
-                    setCrewOnly(changeEvent.target.checked)
-                  }
-                  className="size-4"
-                />
-                Crew-only
-              </label>
-            </div>
-
-            <div className="mt-5 grid gap-4 sm:grid-cols-2">
-              <Field label="Lifecycle" htmlFor="crew-settings-lifecycle">
-                <select
-                  id="crew-settings-lifecycle"
-                  value={lifecycle}
-                  onChange={(changeEvent) =>
-                    setLifecycle(
-                      changeEvent.target.value as
-                        | "draft"
-                        | "setup"
-                        | "importing"
-                        | "ready"
-                        | "archived",
-                    )
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                >
-                  <option value="draft">Draft</option>
-                  <option value="setup">Setup</option>
-                  <option value="importing">Importing</option>
-                  <option value="ready">Ready</option>
-                  <option value="archived">Archived</option>
-                </select>
-              </Field>
-              <Field
-                label="Concierge status"
-                htmlFor="crew-settings-concierge-status"
-              >
-                <select
-                  id="crew-settings-concierge-status"
-                  value={conciergeStatus}
-                  onChange={(changeEvent) =>
-                    setConciergeStatus(
-                      changeEvent.target.value as
-                        | "not_started"
-                        | "in_progress"
-                        | "ready"
-                        | "blocked",
-                    )
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                >
-                  <option value="not_started">Not started</option>
-                  <option value="in_progress">In progress</option>
-                  <option value="ready">Ready</option>
-                  <option value="blocked">Blocked</option>
-                </select>
-              </Field>
-              <Field label="Crew plan" htmlFor="crew-settings-plan">
-                <select
-                  id="crew-settings-plan"
-                  value={crewPlan}
-                  onChange={(changeEvent) =>
-                    setCrewPlan(
-                      changeEvent.target.value as
-                        | "self_serve"
-                        | "concierge"
-                        | "full_platform",
-                    )
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                >
-                  <option value="self_serve">Self serve</option>
-                  <option value="concierge">Concierge</option>
-                  <option value="full_platform">Full platform</option>
-                </select>
-              </Field>
-            </div>
-          </section>
-
-          <section className="rounded-md border bg-card p-5 shadow-sm">
-            <h2 className="text-xl font-semibold">Source</h2>
-            <div className="mt-5 grid gap-4 sm:grid-cols-2">
-              <Field
-                label="Source platform"
-                htmlFor="crew-settings-source-platform"
-              >
-                <input
-                  id="crew-settings-source-platform"
-                  value={sourcePlatform}
-                  onChange={(changeEvent) =>
-                    setSourcePlatform(changeEvent.target.value)
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-              <Field
-                label="Acquisition source"
-                htmlFor="crew-settings-acquisition-source"
-              >
-                <input
-                  id="crew-settings-acquisition-source"
-                  value={acquisitionSource}
-                  onChange={(changeEvent) =>
-                    setAcquisitionSource(changeEvent.target.value)
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-              <Field
-                label="Source event URL"
-                htmlFor="crew-settings-source-event-url"
-                wide
-              >
-                <input
-                  id="crew-settings-source-event-url"
-                  value={sourceEventUrl}
-                  onChange={(changeEvent) =>
-                    setSourceEventUrl(changeEvent.target.value)
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-              <Field
-                label="External registration URL"
-                htmlFor="crew-settings-external-registration-url"
-                wide
-              >
-                <input
-                  id="crew-settings-external-registration-url"
-                  value={externalRegistrationUrl}
-                  onChange={(changeEvent) =>
-                    setExternalRegistrationUrl(changeEvent.target.value)
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-            </div>
-          </section>
-
-          <section className="rounded-md border bg-card p-5 shadow-sm">
-            <h2 className="text-xl font-semibold">Concierge notes</h2>
-            <div className="mt-5 grid gap-4 sm:grid-cols-2">
-              <Field
-                label="Desired go-live date"
-                htmlFor="crew-setup-go-live-date"
-              >
-                <input
-                  id="crew-setup-go-live-date"
-                  type="date"
-                  value={setup.desiredGoLiveDate}
-                  onChange={(changeEvent) =>
-                    setSetup((current) => ({
-                      ...current,
-                      desiredGoLiveDate: changeEvent.target.value,
-                    }))
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-              <Field
-                label="Volunteer target"
-                htmlFor="crew-setup-volunteer-target"
-              >
-                <input
-                  id="crew-setup-volunteer-target"
-                  value={setup.volunteerTarget}
-                  onChange={(changeEvent) =>
-                    setSetup((current) => ({
-                      ...current,
-                      volunteerTarget: changeEvent.target.value,
-                    }))
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-              <Field label="Staffing lead" htmlFor="crew-setup-staffing-lead">
-                <input
-                  id="crew-setup-staffing-lead"
-                  value={setup.staffingLead}
-                  onChange={(changeEvent) =>
-                    setSetup((current) => ({
-                      ...current,
-                      staffingLead: changeEvent.target.value,
-                    }))
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-              <Field
-                label="Source contact name"
-                htmlFor="crew-setup-source-contact-name"
-              >
-                <input
-                  id="crew-setup-source-contact-name"
-                  value={setup.sourceContactName}
-                  onChange={(changeEvent) =>
-                    setSetup((current) => ({
-                      ...current,
-                      sourceContactName: changeEvent.target.value,
-                    }))
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-              <Field
-                label="Source contact email"
-                htmlFor="crew-setup-source-contact-email"
-                wide
-              >
-                <input
-                  id="crew-setup-source-contact-email"
-                  type="email"
-                  value={setup.sourceContactEmail}
-                  onChange={(changeEvent) =>
-                    setSetup((current) => ({
-                      ...current,
-                      sourceContactEmail: changeEvent.target.value,
-                    }))
-                  }
-                  className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-                />
-              </Field>
-              <Field label="Assumptions" htmlFor="crew-setup-assumptions" wide>
-                <textarea
-                  id="crew-setup-assumptions"
-                  value={setup.assumptions}
-                  onChange={(changeEvent) =>
-                    setSetup((current) => ({
-                      ...current,
-                      assumptions: changeEvent.target.value,
-                    }))
-                  }
-                  className="min-h-28 w-full rounded-md border bg-background px-3 py-2 text-sm"
-                />
-              </Field>
-              <Field label="Internal notes" htmlFor="crew-setup-notes" wide>
-                <textarea
-                  id="crew-setup-notes"
-                  value={setup.internalNotes}
-                  onChange={(changeEvent) =>
-                    setSetup((current) => ({
-                      ...current,
-                      internalNotes: changeEvent.target.value,
-                    }))
-                  }
-                  className="min-h-32 w-full rounded-md border bg-background px-3 py-2 text-sm"
-                />
-              </Field>
-            </div>
-          </section>
-        </section>
-
-        <aside className="h-fit rounded-md border bg-card p-5 shadow-sm">
-          <h2 className="text-sm font-semibold uppercase text-muted-foreground">
-            Setup checklist
-          </h2>
-          <div className="mt-4 space-y-3">
-            {crewSetupChecklistItems.map((item) => (
-              <label
-                key={item.key}
-                className="flex items-start gap-3 rounded-md border bg-background px-3 py-2 text-sm"
-              >
-                <input
-                  type="checkbox"
-                  checked={setup.checklist[item.key]}
-                  onChange={(changeEvent) =>
-                    updateChecklist(item.key, changeEvent.target.checked)
-                  }
-                  className="mt-0.5 size-4"
-                />
-                <span>{item.label}</span>
-              </label>
-            ))}
+    <form
+      onSubmit={handleSubmit}
+      className="grid gap-6 lg:grid-cols-[1fr_20rem]"
+    >
+      <section className="space-y-6">
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <div>
+            <h2 className="text-xl font-semibold">Event basics</h2>
+            <p className="text-sm text-muted-foreground">
+              Confirm the details volunteers and staff will use for planning.
+            </p>
           </div>
 
-          {parsedSettings.parseError ? (
-            <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
-              Existing settings JSON is invalid. Saving will preserve the raw
-              text as legacySettingsText.
-            </p>
-          ) : null}
+          <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2">
+            <Fact label="Event name" value={event.competition.name} />
+            <Fact
+              label="Dates"
+              value={`${event.competition.startDate} to ${event.competition.endDate}`}
+            />
+            <Fact
+              label="Timezone"
+              value={event.competition.timezone ?? "Not set"}
+            />
+          </dl>
+        </section>
 
-          <button
-            type="submit"
-            disabled={isSubmitting}
-            className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
-          >
-            <Save className="size-4" aria-hidden="true" />
-            {isSubmitting ? "Saving..." : "Save setup"}
-          </button>
-        </aside>
-      </form>
-    </section>
+        <section className="rounded-md border bg-card p-5 shadow-sm">
+          <h2 className="text-xl font-semibold">Volunteer setup</h2>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <Field
+              label="Registration platform"
+              htmlFor="crew-settings-source-platform"
+            >
+              <input
+                id="crew-settings-source-platform"
+                value={sourcePlatform}
+                onChange={(changeEvent) =>
+                  setSourcePlatform(changeEvent.target.value)
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="Public volunteer signup link"
+              htmlFor="crew-settings-external-registration-url"
+            >
+              <input
+                id="crew-settings-external-registration-url"
+                value={externalRegistrationUrl}
+                onChange={(changeEvent) =>
+                  setExternalRegistrationUrl(changeEvent.target.value)
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="Expected volunteer target"
+              htmlFor="crew-setup-volunteer-target"
+            >
+              <input
+                id="crew-setup-volunteer-target"
+                value={setup.volunteerTarget}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    volunteerTarget: changeEvent.target.value,
+                  }))
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field label="Staffing lead" htmlFor="crew-setup-staffing-lead">
+              <input
+                id="crew-setup-staffing-lead"
+                value={setup.staffingLead}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    staffingLead: changeEvent.target.value,
+                  }))
+                }
+                className="h-10 w-full rounded-md border bg-background px-3 text-sm"
+              />
+            </Field>
+            <Field
+              label="Role assumptions"
+              htmlFor="crew-setup-assumptions"
+              wide
+            >
+              <textarea
+                id="crew-setup-assumptions"
+                value={setup.assumptions}
+                onChange={(changeEvent) =>
+                  setSetup((current) => ({
+                    ...current,
+                    assumptions: changeEvent.target.value,
+                  }))
+                }
+                className="min-h-28 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              />
+            </Field>
+          </div>
+        </section>
+      </section>
+
+      <aside className="h-fit rounded-md border bg-card p-5 shadow-sm">
+        <h2 className="text-sm font-semibold uppercase text-muted-foreground">
+          Setup checklist
+        </h2>
+        <p className="mt-2 text-2xl font-semibold">
+          {checklistProgress.completed}/{checklistProgress.total}
+        </p>
+        <div className="mt-4 h-2 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all"
+            style={{ width: `${checklistProgress.percent}%` }}
+          />
+        </div>
+
+        <div className="mt-5 space-y-3">
+          {crewSetupChecklistItems.map((item) => (
+            <label
+              key={item.key}
+              className="flex items-start gap-3 rounded-md border bg-background px-3 py-2 text-sm"
+            >
+              <input
+                type="checkbox"
+                checked={setup.checklist[item.key]}
+                onChange={(changeEvent) =>
+                  updateChecklist(item.key, changeEvent.target.checked)
+                }
+                className="mt-0.5 size-4"
+              />
+              <span>{item.label}</span>
+            </label>
+          ))}
+        </div>
+
+        {parsedSettings.parseError ? (
+          <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            Existing setup data needs review before it can be saved.
+          </p>
+        ) : null}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+        >
+          <Save className="size-4" aria-hidden="true" />
+          {isSubmitting ? "Saving..." : "Save setup"}
+        </button>
+      </aside>
+    </form>
+  )
+}
+
+function calculateOrganizerChecklistProgress(setup: CrewOrganizerSetupState) {
+  const completed = crewSetupChecklistItems.filter(
+    (item) => setup.checklist[item.key],
+  ).length
+  const total = crewSetupChecklistItems.length
+
+  return {
+    completed,
+    total,
+    percent: total === 0 ? 0 : Math.round((completed / total) * 100),
+  }
+}
+
+function Fact({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div>
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="mt-1 break-words font-medium">{value}</dd>
+    </div>
   )
 }
 

--- a/apps/crew/src/routes/events/$eventId/setup.tsx
+++ b/apps/crew/src/routes/events/$eventId/setup.tsx
@@ -231,7 +231,7 @@ function EventSetupPage() {
 
         <button
           type="submit"
-          disabled={isSubmitting}
+          disabled={isSubmitting || parsedSettings.parseError !== null}
           className="mt-5 inline-flex w-full items-center justify-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
         >
           <Save className="size-4" aria-hidden="true" />


### PR DESCRIPTION
## Scope

Implements Crew cleanup PR 4: client-safe setup checklist.

- Splits setup settings into explicit organizer-safe and admin-only fields in the setup helper.
- Reworks `/events/$eventId/setup` into an organizer-facing checklist for event basics, volunteer setup, signup link, target, staffing lead, and role assumptions.
- Removes organizer setup rendering/loading for guided operator setup, templates, prior-event copy, department leads, concierge status, crew plan, acquisition source, desired go-live date, source contact, internal notes, source event URL, and other operator/admin setup language.
- Preserves existing admin-only setup values when organizer-safe setup fields are saved.

## Acceptance

- Organizer setup now presents a client-safe checklist of event basics/readiness tasks.
- Clients can complete event basics and volunteer setup without seeing concierge/operator fields.
- Admin-only setup values remain hidden from the organizer setup surface and are preserved in existing settings JSON instead of being moved into `/events/*` routes.
- Admin/operator diagnostics, billing/conversion context, raw/internal IDs, source/debug language, and internal notes remain outside the organizer setup screen.

## Validation

- `pnpm --filter crew exec biome check src/lib/crew-event-setup.ts src/lib/crew-event-setup.test.ts 'src/routes/events/$eventId/setup.tsx'` passed.
- `pnpm --filter crew test -- src/lib/crew-event-setup.test.ts` passed.
- `pnpm --filter crew type-check` passed.
- `git diff --check` passed.
- `pnpm --filter crew lint` completed with existing warnings elsewhere in the app; no touched-file lint failures.
- `pnpm --filter crew build` is blocked locally because `apps/crew/.alchemy/local/wrangler.jsonc` is missing: Vite fails while loading config with `The Wrangler config path ... could not be found. Please run alchemy dev or alchemy deploy to create it.` Relying on CI for build.

## Out of scope / PR 5+

- Imports polish and upload flow copy.
- Assignment, messages, confirmation, volunteer public flow, and day-of persistence changes.
- Billing, Stripe, checkout, conversion assistant, or public pricing changes.
- Schema/migration changes.
- Admin diagnostics redesign beyond preserving the existing admin-only split.
- Route/nav expansion or route generation changes beyond this setup surface.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Crew event setup page client-safe by showing only organizer-safe fields with a simple checklist and volunteer setup form. Admin-only settings are preserved on save.

- **New Features**
  - Organizer checklist with progress (count and bar) and client-safe labels.
  - Event basics panel (name, dates, timezone) plus inputs for `registration platform`, `public signup link`, `volunteer target`, `staffing lead`, and `role assumptions`.

- **Refactors**
  - Added `CrewOrganizerSetupState`, `toOrganizerCrewSetupState`, `mergeOrganizerCrewSetupState`, `organizerCrewSetupFieldKeys`, and `adminOnlyCrewSetupFieldKeys`.
  - Simplified `/events/$eventId/setup` by removing guided setup, templates, prior-event copy, department lead panels, and internal-only fields (lifecycle, concierge status, crew plan, acquisition source, source event URL, go-live date, source contacts, internal notes).
  - Preserve admin-only values by merging on save; added tests for key split, label safety, and value preservation.

<sup>Written for commit 579dadbe3510c2aca33225557a250e11a71fef1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Organizer-focused crew event setup with dedicated checklist sidebar showing progress and checkpoint toggles for key setup items.

* **Refactor**
  * Streamlined setup page focusing on volunteer registration, staffing lead assignment, and role assumptions; removed guided setup, template management, and copy-from-prior-event workflows.

* **Tests**
  * Added comprehensive test coverage for crew event setup logic and organizer-admin field separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->