### PR TITLE
[codex] Consolidate Crew assignments routes

### DIFF
--- a/apps/crew/src/lib/crew/navigation.test.ts
+++ b/apps/crew/src/lib/crew/navigation.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest"
+import { getCrewEventNavItems } from "./navigation"
+
+describe("getCrewEventNavItems", () => {
+  it("centers organizer assignment navigation on the consolidated route", () => {
+    const navItems = getCrewEventNavItems({ viewerRole: "organizer_admin" })
+    const assignments = navItems.find((item) => item.key === "assignments")
+
+    expect(assignments?.label).toBe("Assignments")
+    expect(assignments?.to).toBe("/events/$eventId/assignments")
+  })
+})

--- a/apps/crew/src/lib/crew/navigation.ts
+++ b/apps/crew/src/lib/crew/navigation.ts
@@ -11,7 +11,7 @@ export type CrewEventNavRoute =
   | "/events/$eventId/staffing"
   | "/events/$eventId/setup"
   | "/events/$eventId/imports"
-  | "/events/$eventId/shifts"
+  | "/events/$eventId/assignments"
   | "/events/$eventId/day-of"
   | "/events/$eventId/exports"
 
@@ -70,13 +70,13 @@ export const CREW_EVENT_NAV_ITEMS = [
   {
     key: "assignments",
     label: "Assignments",
-    to: "/events/$eventId/shifts",
+    to: "/events/$eventId/assignments",
     persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
   },
   {
     key: "confirmations",
     label: "Confirmations",
-    to: "/events/$eventId/shifts",
+    to: "/events/$eventId/assignments",
     persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
     requires: ["has_assignments"],
     hiddenWhenEmpty: true,

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -29,6 +29,7 @@ import { Route as EventsEventIdExportsRouteImport } from './routes/events/$event
 import { Route as EventsEventIdDayOfRouteImport } from './routes/events/$eventId/day-of'
 import { Route as EventsEventIdConvertRouteImport } from './routes/events/$eventId/convert'
 import { Route as EventsEventIdBillingRouteImport } from './routes/events/$eventId/billing'
+import { Route as EventsEventIdAssignmentsRouteImport } from './routes/events/$eventId/assignments'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
@@ -142,6 +143,12 @@ const EventsEventIdBillingRoute = EventsEventIdBillingRouteImport.update({
   path: '/billing',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdAssignmentsRoute =
+  EventsEventIdAssignmentsRouteImport.update({
+    id: '/assignments',
+    path: '/assignments',
+    getParentRoute: () => EventsEventIdRoute,
+  } as any)
 const ESlugVolunteerRoute = ESlugVolunteerRouteImport.update({
   id: '/e/$slug/volunteer',
   path: '/e/$slug/volunteer',
@@ -218,6 +225,7 @@ export interface FileRoutesByFullPath {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/assignments': typeof EventsEventIdAssignmentsRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/convert': typeof EventsEventIdConvertRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
@@ -251,6 +259,7 @@ export interface FileRoutesByTo {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/assignments': typeof EventsEventIdAssignmentsRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/convert': typeof EventsEventIdConvertRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
@@ -286,6 +295,7 @@ export interface FileRoutesById {
   '/api/crew/import': typeof ApiCrewImportRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
+  '/events/$eventId/assignments': typeof EventsEventIdAssignmentsRoute
   '/events/$eventId/billing': typeof EventsEventIdBillingRoute
   '/events/$eventId/convert': typeof EventsEventIdConvertRoute
   '/events/$eventId/day-of': typeof EventsEventIdDayOfRoute
@@ -322,6 +332,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/assignments'
     | '/events/$eventId/billing'
     | '/events/$eventId/convert'
     | '/events/$eventId/day-of'
@@ -355,6 +366,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/assignments'
     | '/events/$eventId/billing'
     | '/events/$eventId/convert'
     | '/events/$eventId/day-of'
@@ -389,6 +401,7 @@ export interface FileRouteTypes {
     | '/api/crew/import'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
+    | '/events/$eventId/assignments'
     | '/events/$eventId/billing'
     | '/events/$eventId/convert'
     | '/events/$eventId/day-of'
@@ -569,6 +582,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdBillingRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/assignments': {
+      id: '/events/$eventId/assignments'
+      path: '/assignments'
+      fullPath: '/events/$eventId/assignments'
+      preLoaderRoute: typeof EventsEventIdAssignmentsRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/e/$slug/volunteer': {
       id: '/e/$slug/volunteer'
       path: '/e/$slug/volunteer'
@@ -657,6 +677,7 @@ declare module '@tanstack/react-router' {
 }
 
 interface EventsEventIdRouteChildren {
+  EventsEventIdAssignmentsRoute: typeof EventsEventIdAssignmentsRoute
   EventsEventIdBillingRoute: typeof EventsEventIdBillingRoute
   EventsEventIdConvertRoute: typeof EventsEventIdConvertRoute
   EventsEventIdDayOfRoute: typeof EventsEventIdDayOfRoute
@@ -674,6 +695,7 @@ interface EventsEventIdRouteChildren {
 }
 
 const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
+  EventsEventIdAssignmentsRoute: EventsEventIdAssignmentsRoute,
   EventsEventIdBillingRoute: EventsEventIdBillingRoute,
   EventsEventIdConvertRoute: EventsEventIdConvertRoute,
   EventsEventIdDayOfRoute: EventsEventIdDayOfRoute,

--- a/apps/crew/src/routes/events/$eventId/assignments.tsx
+++ b/apps/crew/src/routes/events/$eventId/assignments.tsx
@@ -1,0 +1,252 @@
+// @lat: [[crew#Roster Shifts Assignments]]
+// @lat: [[crew#Shift Board Pilot Ops]]
+// @lat: [[crew#Judge Rotations]]
+import {
+  createFileRoute,
+  getRouteApi,
+  Link,
+  useNavigate,
+  useSearch,
+} from "@tanstack/react-router"
+import { ClipboardList, UserCheck } from "lucide-react"
+import {
+  type CrewJudgeRotationsPageData,
+  getCrewJudgeRotationsPageFn,
+} from "@/server-fns/crew-judge-rotations-fns"
+import { getCrewShiftBoardFn } from "@/server-fns/crew-roster-shift-fns"
+import { CrewJudgeAssignmentsTab } from "./judges"
+import { CrewShiftBoardAssignmentsTab } from "./shifts"
+
+type CrewAssignmentsTab = "shifts" | "judges"
+
+export const Route = createFileRoute("/events/$eventId/assignments")({
+  loader: async ({ params }) => {
+    const shiftBoard = await getCrewShiftBoardFn({
+      data: { eventId: params.eventId },
+    })
+    const judgeAssignments = await getCrewJudgeAssignmentsRouteData(
+      params.eventId,
+    )
+
+    return { shiftBoard, judgeAssignments }
+  },
+  component: EventAssignmentsPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+function EventAssignmentsPage() {
+  const { eventId } = parentRoute.useParams()
+  const { shiftBoard, judgeAssignments } = Route.useLoaderData()
+  const search = useSearch({ strict: false }) as { tab?: unknown }
+  const navigate = useNavigate()
+  const selectedTab = normalizeCrewAssignmentsTab(search.tab)
+  const judgeAvailability = getCrewJudgeAssignmentsAvailability(
+    judgeAssignments?.page ?? null,
+  )
+
+  function selectTab(tab: CrewAssignmentsTab) {
+    void navigate({
+      to: ".",
+      search: (previous: Record<string, unknown>) => ({
+        ...previous,
+        tab,
+      }),
+      replace: true,
+    })
+  }
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <h2 className="text-xl font-semibold">Assignments</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Build the volunteer shift board and publish judge schedules from one
+            organizer workspace.
+          </p>
+        </div>
+        <Link
+          to="/events/$eventId/volunteers"
+          params={{ eventId }}
+          className="inline-flex h-10 w-fit items-center rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          Volunteer roster
+        </Link>
+      </div>
+
+      <div
+        role="tablist"
+        aria-label="Assignment views"
+        className="flex flex-wrap gap-2 border-b"
+      >
+        <AssignmentTabButton
+          tab="shifts"
+          label="Shifts"
+          selected={selectedTab === "shifts"}
+          onSelect={selectTab}
+        />
+        <AssignmentTabButton
+          tab="judges"
+          label="Judges"
+          selected={selectedTab === "judges"}
+          disabled={!judgeAvailability.available}
+          disabledLabel={judgeAvailability.badgeLabel}
+          onSelect={selectTab}
+        />
+      </div>
+
+      {selectedTab === "judges" ? (
+        judgeAvailability.available && judgeAssignments ? (
+          <CrewJudgeAssignmentsTab data={judgeAssignments} />
+        ) : (
+          <JudgeAssignmentsUnavailable
+            eventId={eventId}
+            availability={judgeAvailability}
+          />
+        )
+      ) : (
+        <CrewShiftBoardAssignmentsTab data={shiftBoard} />
+      )}
+    </section>
+  )
+}
+
+function AssignmentTabButton({
+  tab,
+  label,
+  selected,
+  disabled = false,
+  disabledLabel,
+  onSelect,
+}: {
+  tab: CrewAssignmentsTab
+  label: string
+  selected: boolean
+  disabled?: boolean
+  disabledLabel?: string
+  onSelect: (tab: CrewAssignmentsTab) => void
+}) {
+  const Icon = tab === "shifts" ? ClipboardList : UserCheck
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={selected}
+      aria-disabled={disabled || undefined}
+      disabled={disabled && !selected}
+      onClick={() => onSelect(tab)}
+      className={
+        selected
+          ? "inline-flex h-11 items-center gap-2 border-b-2 border-primary px-3 text-sm font-semibold text-foreground"
+          : "inline-flex h-11 items-center gap-2 border-b-2 border-transparent px-3 text-sm font-medium text-muted-foreground hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+      }
+    >
+      <Icon className="size-4" />
+      <span>{label}</span>
+      {disabledLabel ? (
+        <span className="rounded-md border bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+          {disabledLabel}
+        </span>
+      ) : null}
+    </button>
+  )
+}
+
+function JudgeAssignmentsUnavailable({
+  eventId,
+  availability,
+}: {
+  eventId: string
+  availability: CrewJudgeAssignmentsAvailability
+}) {
+  return (
+    <section className="rounded-md border bg-card p-8 shadow-sm">
+      <div className="max-w-2xl">
+        <h3 className="text-lg font-semibold">{availability.title}</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {availability.description}
+        </p>
+        <div className="mt-5 flex flex-wrap gap-2">
+          <Link
+            to="/events/$eventId/imports"
+            params={{ eventId }}
+            search={{ tab: "heat_schedule" }}
+            className="inline-flex h-10 w-fit items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+          >
+            Import heat schedule
+          </Link>
+          <Link
+            to="/events/$eventId/setup"
+            params={{ eventId }}
+            className="inline-flex h-10 w-fit items-center rounded-md border px-4 text-sm font-medium text-foreground hover:bg-muted"
+          >
+            Review setup
+          </Link>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export interface CrewJudgeAssignmentsAvailability {
+  available: boolean
+  title: string
+  description: string
+  badgeLabel?: string
+}
+
+export function getCrewJudgeAssignmentsAvailability(
+  page: CrewJudgeRotationsPageData | null,
+): CrewJudgeAssignmentsAvailability {
+  if (!page) {
+    return {
+      available: false,
+      title: "Judge assignments are not available yet",
+      description:
+        "Judge scheduling will appear here once the event is ready for judge assignments.",
+      badgeLabel: "Unavailable",
+    }
+  }
+
+  const hasWorkouts = page.workouts.length > 0
+  const hasHeats = page.heats.length > 0
+  if (hasWorkouts && hasHeats) {
+    return {
+      available: true,
+      title: "Judge assignments are ready",
+      description: "Workouts and heats are available for judge scheduling.",
+    }
+  }
+
+  return {
+    available: false,
+    title: "Judge assignments are not ready yet",
+    description:
+      "Import or create the event workouts and heat schedule before assigning judges.",
+    badgeLabel: "Needs heat schedule",
+  }
+}
+
+function normalizeCrewAssignmentsTab(tab: unknown): CrewAssignmentsTab {
+  return tab === "judges" ? "judges" : "shifts"
+}
+
+async function getCrewJudgeAssignmentsRouteData(eventId: string) {
+  try {
+    return await getCrewJudgeRotationsPageFn({ data: { eventId } })
+  } catch (error) {
+    if (isCrewJudgeAssignmentsAccessError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+function isCrewJudgeAssignmentsAccessError(error: unknown) {
+  return (
+    error instanceof Error &&
+    error.message.includes("Crew judge rotations access is local-operator only")
+  )
+}

--- a/apps/crew/src/routes/events/$eventId/assignments.tsx
+++ b/apps/crew/src/routes/events/$eventId/assignments.tsx
@@ -18,6 +18,7 @@ import { CrewJudgeAssignmentsTab } from "./judges"
 import { CrewShiftBoardAssignmentsTab } from "./shifts"
 
 type CrewAssignmentsTab = "shifts" | "judges"
+const CREW_LOCAL_ACCESS_ERROR_NAME = "CrewLocalAccessError"
 
 export const Route = createFileRoute("/events/$eventId/assignments")({
   loader: async ({ params }) => {
@@ -245,8 +246,15 @@ async function getCrewJudgeAssignmentsRouteData(eventId: string) {
 }
 
 function isCrewJudgeAssignmentsAccessError(error: unknown) {
-  return (
-    error instanceof Error &&
-    error.message.includes("Crew judge rotations access is local-operator only")
-  )
+  return getErrorName(error) === CREW_LOCAL_ACCESS_ERROR_NAME
+}
+
+function getErrorName(error: unknown) {
+  if (error instanceof Error) return error.name
+  if (typeof error !== "object" || error === null || !("name" in error)) {
+    return null
+  }
+
+  const name = error.name
+  return typeof name === "string" ? name : null
 }

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -129,7 +129,7 @@ function toEventRoute(ctaTo: CrewOrganizerHomeView["nextAction"]["ctaTo"]) {
       return "/events/$eventId/staffing"
     case "/assignments":
     case "/messages":
-      return "/events/$eventId/shifts"
+      return "/events/$eventId/assignments"
     case "/day-of":
       return "/events/$eventId/day-of"
     case "/exports":

--- a/apps/crew/src/routes/events/$eventId/judges.tsx
+++ b/apps/crew/src/routes/events/$eventId/judges.tsx
@@ -1,14 +1,16 @@
 // @lat: [[crew#Judge Rotations]]
-import type { FormEvent } from "react"
+
 import {
   createFileRoute,
   getRouteApi,
+  redirect,
   useNavigate,
   useRouter,
   useSearch,
 } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import { Plus, RotateCcw, Save, Send, Trash2 } from "lucide-react"
+import type { FormEvent } from "react"
 import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import { Badge } from "@/components/ui/badge"
@@ -28,26 +30,27 @@ import {
   type LaneShiftPattern,
 } from "@/db/schemas/volunteers"
 import {
+  type CrewJudgeRotationDraft,
+  type CrewJudgeRotationHeat,
   expandCrewJudgeRotationDrafts,
   summarizeCrewJudgeCoverage,
   validateCrewJudgeRotationDrafts,
-  type CrewJudgeRotationDraft,
-  type CrewJudgeRotationHeat,
 } from "@/lib/crew/judge-rotations"
 import {
-  getCrewJudgeRotationsPageFn,
-  publishCrewJudgeRotationsFn,
-  saveCrewJudgeRotationsForVolunteerFn,
   type CrewJudgeRotationsPageData,
   type CrewJudgeVolunteer,
+  publishCrewJudgeRotationsFn,
+  saveCrewJudgeRotationsForVolunteerFn,
 } from "@/server-fns/crew-judge-rotations-fns"
 
 export const Route = createFileRoute("/events/$eventId/judges")({
-  loader: async ({ params }) =>
-    await getCrewJudgeRotationsPageFn({
-      data: { eventId: params.eventId },
-    }),
-  component: EventJudgeRotationsPage,
+  beforeLoad: ({ params, search }) => {
+    throw redirect({
+      to: "/events/$eventId/assignments",
+      params,
+      search: toLegacyAssignmentsRedirectSearch(search, "judges"),
+    })
+  },
 })
 
 const parentRoute = getRouteApi("/events/$eventId")
@@ -60,9 +63,13 @@ interface RotationFormRow {
   notes: string
 }
 
-function EventJudgeRotationsPage() {
+export function CrewJudgeAssignmentsTab({
+  data,
+}: {
+  data: { page: CrewJudgeRotationsPageData }
+}) {
   const { eventId } = parentRoute.useParams()
-  const { page } = Route.useLoaderData()
+  const { page } = data
   const search = useSearch({ strict: false }) as {
     workout?: string
     judge?: string
@@ -113,9 +120,10 @@ function EventJudgeRotationsPage() {
     <section className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="text-xl font-semibold">Judge rotations</h2>
+          <h2 className="text-xl font-semibold">Judge assignments</h2>
           <p className="text-sm text-muted-foreground">
-            {page.judges.length} judges, {page.rotations.length} rotations
+            {page.judges.length} judges, {page.rotations.length} planned
+            assignments
           </p>
         </div>
         {selectedWorkoutId ? (
@@ -123,7 +131,7 @@ function EventJudgeRotationsPage() {
             eventId={eventId}
             trackWorkoutId={selectedWorkoutId}
             activeVersionLabel={
-              activeVersion ? `Version ${activeVersion.version}` : "No version"
+              activeVersion ? "Published schedule" : "Not published"
             }
           />
         ) : null}
@@ -134,8 +142,8 @@ function EventJudgeRotationsPage() {
         <StatusPanel label="Heats" value={workoutHeats.length} />
         <StatusPanel label="Coverage" value={`${coverage.coveragePercent}%`} />
         <StatusPanel
-          label="Published"
-          value={activeVersion ? `v${activeVersion.version}` : "Draft"}
+          label="Schedule"
+          value={activeVersion ? "Published" : "Draft"}
         />
       </div>
 
@@ -186,12 +194,12 @@ function EventJudgeRotationsPage() {
 
         <section className="rounded-md border bg-card p-4 shadow-sm">
           <h3 className="text-sm font-semibold uppercase text-muted-foreground">
-            Active version
+            Published schedule
           </h3>
           <div className="mt-3 space-y-2 text-sm">
             <Fact
-              label="Version"
-              value={activeVersion ? `v${activeVersion.version}` : "None"}
+              label="Status"
+              value={activeVersion ? "Published" : "Not published"}
             />
             <Fact
               label="Published"
@@ -212,7 +220,7 @@ function EventJudgeRotationsPage() {
       ) : page.judges.length === 0 ? (
         <EmptyState
           title="No judges"
-          body="Add volunteers with judge roles before creating rotations."
+          body="Add volunteers with judge roles before creating judge assignments."
         />
       ) : selectedWorkout && selectedJudge ? (
         <div className="grid gap-6 xl:grid-cols-[22rem_minmax(0,1fr)]">
@@ -246,7 +254,7 @@ function EventJudgeRotationsPage() {
                   assignment.trackWorkoutId === selectedWorkout.id,
               )}
             />
-            <VersionHistory
+            <PublishedSchedules
               versions={page.versionHistoryByWorkout[selectedWorkout.id] ?? []}
             />
           </div>
@@ -254,6 +262,20 @@ function EventJudgeRotationsPage() {
       ) : null}
     </section>
   )
+}
+
+function toLegacyAssignmentsRedirectSearch(
+  search: unknown,
+  tab: "shifts" | "judges",
+) {
+  return {
+    ...(isSearchRecord(search) ? search : {}),
+    tab,
+  }
+}
+
+function isSearchRecord(search: unknown): search is Record<string, unknown> {
+  return typeof search === "object" && search !== null && !Array.isArray(search)
 }
 
 function PublishRotationsPanel({
@@ -273,19 +295,21 @@ function PublishRotationsPanel({
   async function handlePublish() {
     setIsPublishing(true)
     try {
-      const result = await publishRotations({
+      await publishRotations({
         data: {
           eventId,
           trackWorkoutId,
           notes,
         },
       })
-      toast.success(`Published judge schedule v${result.version.version}`)
+      toast.success("Published judge schedule")
       setNotes("")
       await router.invalidate()
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to publish rotations",
+        error instanceof Error
+          ? error.message
+          : "Failed to publish judge schedule",
       )
     } finally {
       setIsPublishing(false)
@@ -304,7 +328,7 @@ function PublishRotationsPanel({
       <Textarea
         value={notes}
         onChange={(event) => setNotes(event.target.value)}
-        placeholder="Version notes"
+        placeholder="Schedule notes"
         className="min-h-16"
       />
     </div>
@@ -352,7 +376,7 @@ function JudgeList({
                 <Badge variant={count > 0 ? "default" : "outline"}>
                   {count}
                 </Badge>
-                rotations
+                assignments
               </span>
             </button>
           )
@@ -467,11 +491,13 @@ function RotationEditor({
           })),
         },
       })
-      toast.success("Judge rotations saved")
+      toast.success("Judge assignments saved")
       await router.invalidate()
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : "Failed to save rotations",
+        error instanceof Error
+          ? error.message
+          : "Failed to save judge assignments",
       )
     } finally {
       setIsSaving(false)
@@ -489,7 +515,7 @@ function RotationEditor({
             {getJudgeName(selectedJudge)}
           </h3>
           <p className="text-sm text-muted-foreground">
-            {rows.length} rotations
+            {rows.length} assignments
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -635,7 +661,7 @@ function RotationEditor({
         </table>
         {rows.length === 0 ? (
           <div className="p-6 text-center text-sm text-muted-foreground">
-            No rotations for this judge.
+            No judge assignments for this judge.
           </div>
         ) : null}
       </div>
@@ -792,14 +818,14 @@ function PublishedAssignments({
   )
 }
 
-function VersionHistory({
+function PublishedSchedules({
   versions,
 }: {
   versions: CrewJudgeRotationsPageData["versionHistoryByWorkout"][string]
 }) {
   return (
     <section className="space-y-3 rounded-md border bg-card p-4 shadow-sm">
-      <h3 className="text-lg font-semibold">Version history</h3>
+      <h3 className="text-lg font-semibold">Published schedules</h3>
       {versions.length > 0 ? (
         <div className="divide-y rounded-md border">
           {versions.map((version) => (
@@ -807,7 +833,7 @@ function VersionHistory({
               key={version.id}
               className="grid gap-2 px-3 py-3 text-sm sm:grid-cols-[6rem_1fr_10rem]"
             >
-              <div className="font-medium">v{version.version}</div>
+              <div className="font-medium">Schedule {version.version}</div>
               <div className="text-muted-foreground">
                 {version.notes || "No notes"}
               </div>

--- a/apps/crew/src/routes/events/$eventId/schedule.tsx
+++ b/apps/crew/src/routes/events/$eventId/schedule.tsx
@@ -3,8 +3,9 @@ import { createFileRoute, redirect } from "@tanstack/react-router"
 export const Route = createFileRoute("/events/$eventId/schedule")({
   beforeLoad: ({ params }) => {
     throw redirect({
-      to: "/events/$eventId/shifts",
+      to: "/events/$eventId/assignments",
       params,
+      search: { tab: "shifts" },
     })
   },
 })

--- a/apps/crew/src/routes/events/$eventId/shifts.tsx
+++ b/apps/crew/src/routes/events/$eventId/shifts.tsx
@@ -1,11 +1,12 @@
 // @lat: [[crew#Shift Board Pilot Ops]]
 // @lat: [[crew#Assignment Confirmations]]
 // @lat: [[crew#Confirmation Emails And Reminders]]
-import type { FormEvent } from "react"
+
 import {
   createFileRoute,
   getRouteApi,
   Link,
+  redirect,
   useNavigate,
   useRouter,
   useSearch,
@@ -23,52 +24,57 @@ import {
   Trash2,
   UploadCloud,
 } from "lucide-react"
+import type { FormEvent } from "react"
 import { useMemo, useState } from "react"
 import { toast } from "sonner"
+import {
+  VOLUNTEER_ROLE_OPTIONS,
+  type VolunteerRoleType,
+} from "@/db/schemas/volunteers"
 import {
   getCrewAssignmentConfirmationStatusBadgeClassName,
   getCrewAssignmentConfirmationStatusLabel,
 } from "@/lib/crew/assignment-confirmation-display"
 import {
   CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES,
-  getCrewAssignmentConfirmationOperationalState,
   type CrewAssignmentConfirmationOrganizerState,
+  getCrewAssignmentConfirmationOperationalState,
 } from "@/lib/crew/assignment-confirmations"
-import { formatCrewValue } from "@/lib/crew-event-display"
 import {
-  filterCrewShiftBoardPilotShifts,
-  getRoleFilterOptions,
-  type CrewShiftBoardPilotFilters,
-  type CrewShiftPilotShiftState,
-} from "@/lib/crew/shift-board-pilot-ops"
-import {
+  type CrewRosterVolunteer,
   formatVolunteerAvailability,
   isVolunteerCompatibleWithShift,
-  type CrewRosterVolunteer,
 } from "@/lib/crew/roster-shifts"
 import {
-  assignCrewVolunteerToShiftFn,
-  createCrewShiftFn,
-  deleteCrewShiftFn,
-  getCrewShiftBoardFn,
-  removeCrewVolunteerShiftAssignmentFn,
-  updateCrewShiftFn,
-  type CrewShiftBoardItem,
-} from "@/server-fns/crew-roster-shift-fns"
+  type CrewShiftBoardPilotFilters,
+  type CrewShiftPilotShiftState,
+  filterCrewShiftBoardPilotShifts,
+  getRoleFilterOptions,
+} from "@/lib/crew/shift-board-pilot-ops"
+import { formatCrewValue } from "@/lib/crew-event-display"
 import {
   queueCrewAssignmentConfirmationEmailsFn,
   updateCrewShiftAssignmentConfirmationStateFn,
 } from "@/server-fns/crew-confirmation-fns"
-import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 import {
-  VOLUNTEER_ROLE_OPTIONS,
-  type VolunteerRoleType,
-} from "@/db/schemas/volunteers"
+  assignCrewVolunteerToShiftFn,
+  type CrewShiftBoardData,
+  type CrewShiftBoardItem,
+  createCrewShiftFn,
+  deleteCrewShiftFn,
+  removeCrewVolunteerShiftAssignmentFn,
+  updateCrewShiftFn,
+} from "@/server-fns/crew-roster-shift-fns"
+import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
 export const Route = createFileRoute("/events/$eventId/shifts")({
-  loader: async ({ params }) =>
-    await getCrewShiftBoardFn({ data: { eventId: params.eventId } }),
-  component: EventShiftsPage,
+  beforeLoad: ({ params, search }) => {
+    throw redirect({
+      to: "/events/$eventId/assignments",
+      params,
+      search: toLegacyAssignmentsRedirectSearch(search, "shifts"),
+    })
+  },
 })
 
 const parentRoute = getRouteApi("/events/$eventId")
@@ -88,10 +94,13 @@ const SHIFT_BOARD_SOURCE_FILTERS = new Set<
   CrewShiftBoardPilotFilters["source"]
 >(["all", "imported_assignments", "direct_assignments"])
 
-function EventShiftsPage() {
+export function CrewShiftBoardAssignmentsTab({
+  data,
+}: {
+  data: CrewShiftBoardData
+}) {
   const { eventId } = parentRoute.useParams()
-  const { event, roster, rosterSummary, shifts, shiftSummary, pilotOps } =
-    Route.useLoaderData()
+  const { event, roster, rosterSummary, shifts, shiftSummary, pilotOps } = data
   const timezone = event.timezone ?? "America/Denver"
   const router = useRouter()
   const navigate = useNavigate()
@@ -159,7 +168,7 @@ function EventShiftsPage() {
     <section className="space-y-6">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h2 className="text-xl font-semibold">Shift board</h2>
+          <h2 className="text-xl font-semibold">Shift assignments</h2>
           <p className="text-sm text-muted-foreground">
             {pilotOps.summary.readyShifts} ready,{" "}
             {pilotOps.summary.openShiftCount} with open slots,{" "}
@@ -178,7 +187,7 @@ function EventShiftsPage() {
             ) : (
               <Mail className="size-4" />
             )}
-            Send confirmations
+            Send assignment emails
           </button>
           <button
             type="button"
@@ -191,7 +200,7 @@ function EventShiftsPage() {
             ) : (
               <BellRing className="size-4" />
             )}
-            Send reminders
+            Send reminder emails
           </button>
           <Link
             to="/events/$eventId/staffing"
@@ -293,6 +302,20 @@ function EventShiftsPage() {
       </div>
     </section>
   )
+}
+
+function toLegacyAssignmentsRedirectSearch(
+  search: unknown,
+  tab: "shifts" | "judges",
+) {
+  return {
+    ...(isSearchRecord(search) ? search : {}),
+    tab,
+  }
+}
+
+function isSearchRecord(search: unknown): search is Record<string, unknown> {
+  return typeof search === "object" && search !== null && !Array.isArray(search)
 }
 
 function getShiftBoardFiltersFromSearch(


### PR DESCRIPTION
## Scope

- Add organizer `/events/$eventId/assignments` as the center for assignment work.
- Reuse the existing Crew shift board as the `Shifts` assignments tab.
- Reuse the existing judge scheduling surface as the `Judges` tab, with a client-safe unavailable state until workouts/heats are ready or judge scheduling is otherwise available.
- Redirect legacy organizer `/events/$eventId/shifts`, `/events/$eventId/judges`, and placeholder `/events/$eventId/schedule` URLs into the consolidated assignments route with explicit tab search state.
- Update organizer nav and home next-action routing so assignment flows land on `/assignments`.

## Acceptance

- Organizer navigation now centers on `Assignments` instead of linking assignment work to the legacy shifts route.
- Existing shift-board functionality remains available under `Assignments -> Shifts` with URL-backed filters preserved during legacy redirects.
- The `Judges` tab is disabled/unavailable until judge assignment data is ready, avoiding an empty or confusing page.
- Old organizer URLs redirect safely to the new assignments route and preserve relevant query state.
- Visible copy was adjusted away from raw route/rotation/version wording where the consolidated organizer page surfaces it.

## Validation

- `pnpm --filter crew exec vitest run src/lib/crew/navigation.test.ts`
- `pnpm --filter crew exec biome check 'src/routes/events/$eventId/assignments.tsx' 'src/routes/events/$eventId/shifts.tsx' 'src/routes/events/$eventId/judges.tsx' 'src/routes/events/$eventId/index.tsx' 'src/routes/events/$eventId/schedule.tsx' src/lib/crew/navigation.ts src/lib/crew/navigation.test.ts`
- `pnpm --filter crew type-check`
- `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build`
- `git diff --check`

## Out of Scope

- No schema, billing, Stripe, public volunteer flow, day-of persistence, exports, imports redesign, setup checklist redesign, organizer home redesign, event sidebar shell redesign, admin diagnostics, or confirmation/message behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidated organizer assignment flows into a single Assignments page at `/events/$eventId/assignments`, with tabs for Shifts and Judges, deep-linkable state, and a safer fallback when judge scheduling isn’t available.

- **New Features**
  - New Assignments route with “Shifts” and “Judges” tabs.
  - Shifts tab reuses the shift board and preserves existing filters.
  - Judges tab reuses scheduling UI, is labeled “Judge assignments,” and shows a disabled state with clear badges (“Unavailable” or “Needs heat schedule”) until workouts/heats are ready or access is restricted; includes quick links to import heat schedules or review setup.
  - Organizer nav and home next-action now point to Assignments (including the Confirmations link); copy updated (e.g., “Published schedule,” “assignment emails”).

- **Migration**
  - Update hardcoded links to `/events/$eventId/assignments` (use `?tab=shifts` or `?tab=judges` as needed).
  - Legacy routes (`/events/$eventId/shifts`, `/events/$eventId/judges`, `/events/$eventId/schedule`) redirect to Assignments and preserve relevant query/search state.

<sup>Written for commit 1bdaac9e29c7b99c0c9561f3ae5947f917f55b47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consolidated Assignments page that combines shift and judge assignment management in a single location with tab-based navigation.

* **Updates**
  * Updated navigation items to direct users to the new Assignments section.
  * Renamed terminology from "rotations" to "assignments" throughout the user interface for consistency.
  * Improved UI messaging and button labels for assignment-related actions, including email communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->