### PR TITLE
[codex] Add Crew confirmations dashboard

### DIFF
--- a/apps/crew/src/lib/crew/navigation.ts
+++ b/apps/crew/src/lib/crew/navigation.ts
@@ -12,6 +12,7 @@ export type CrewEventNavRoute =
   | "/events/$eventId/setup"
   | "/events/$eventId/imports"
   | "/events/$eventId/assignments"
+  | "/events/$eventId/messages"
   | "/events/$eventId/day-of"
   | "/events/$eventId/exports"
 
@@ -76,10 +77,8 @@ export const CREW_EVENT_NAV_ITEMS = [
   {
     key: "confirmations",
     label: "Confirmations",
-    to: "/events/$eventId/assignments",
+    to: "/events/$eventId/messages",
     persona: ["wodsmith_operator", "organizer_admin", "department_lead"],
-    requires: ["has_assignments"],
-    hiddenWhenEmpty: true,
   },
   {
     key: "event-day",

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as EventsEventIdDayOfRouteImport } from './routes/events/$eventId
 import { Route as EventsEventIdConvertRouteImport } from './routes/events/$eventId/convert'
 import { Route as EventsEventIdBillingRouteImport } from './routes/events/$eventId/billing'
 import { Route as EventsEventIdAssignmentsRouteImport } from './routes/events/$eventId/assignments'
+import { Route as EventsEventIdMessagesRouteImport } from './routes/events/$eventId/messages'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
@@ -149,6 +150,11 @@ const EventsEventIdAssignmentsRoute =
     path: '/assignments',
     getParentRoute: () => EventsEventIdRoute,
   } as any)
+const EventsEventIdMessagesRoute = EventsEventIdMessagesRouteImport.update({
+  id: '/messages',
+  path: '/messages',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const ESlugVolunteerRoute = ESlugVolunteerRouteImport.update({
   id: '/e/$slug/volunteer',
   path: '/e/$slug/volunteer',
@@ -232,6 +238,7 @@ export interface FileRoutesByFullPath {
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
+  '/events/$eventId/messages': typeof EventsEventIdMessagesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
@@ -266,6 +273,7 @@ export interface FileRoutesByTo {
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
+  '/events/$eventId/messages': typeof EventsEventIdMessagesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
@@ -302,6 +310,7 @@ export interface FileRoutesById {
   '/events/$eventId/exports': typeof EventsEventIdExportsRoute
   '/events/$eventId/imports': typeof EventsEventIdImportsRoute
   '/events/$eventId/judges': typeof EventsEventIdJudgesRoute
+  '/events/$eventId/messages': typeof EventsEventIdMessagesRoute
   '/events/$eventId/readiness': typeof EventsEventIdReadinessRoute
   '/events/$eventId/schedule': typeof EventsEventIdScheduleRoute
   '/events/$eventId/setup': typeof EventsEventIdSetupRoute
@@ -339,6 +348,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
+    | '/events/$eventId/messages'
     | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
@@ -373,6 +383,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
+    | '/events/$eventId/messages'
     | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
@@ -408,6 +419,7 @@ export interface FileRouteTypes {
     | '/events/$eventId/exports'
     | '/events/$eventId/imports'
     | '/events/$eventId/judges'
+    | '/events/$eventId/messages'
     | '/events/$eventId/readiness'
     | '/events/$eventId/schedule'
     | '/events/$eventId/setup'
@@ -589,6 +601,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdAssignmentsRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/messages': {
+      id: '/events/$eventId/messages'
+      path: '/messages'
+      fullPath: '/events/$eventId/messages'
+      preLoaderRoute: typeof EventsEventIdMessagesRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/e/$slug/volunteer': {
       id: '/e/$slug/volunteer'
       path: '/e/$slug/volunteer'
@@ -684,6 +703,7 @@ interface EventsEventIdRouteChildren {
   EventsEventIdExportsRoute: typeof EventsEventIdExportsRoute
   EventsEventIdImportsRoute: typeof EventsEventIdImportsRoute
   EventsEventIdJudgesRoute: typeof EventsEventIdJudgesRoute
+  EventsEventIdMessagesRoute: typeof EventsEventIdMessagesRoute
   EventsEventIdReadinessRoute: typeof EventsEventIdReadinessRoute
   EventsEventIdScheduleRoute: typeof EventsEventIdScheduleRoute
   EventsEventIdSetupRoute: typeof EventsEventIdSetupRoute
@@ -702,6 +722,7 @@ const EventsEventIdRouteChildren: EventsEventIdRouteChildren = {
   EventsEventIdExportsRoute: EventsEventIdExportsRoute,
   EventsEventIdImportsRoute: EventsEventIdImportsRoute,
   EventsEventIdJudgesRoute: EventsEventIdJudgesRoute,
+  EventsEventIdMessagesRoute: EventsEventIdMessagesRoute,
   EventsEventIdReadinessRoute: EventsEventIdReadinessRoute,
   EventsEventIdScheduleRoute: EventsEventIdScheduleRoute,
   EventsEventIdSetupRoute: EventsEventIdSetupRoute,

--- a/apps/crew/src/routes/events/$eventId/index.tsx
+++ b/apps/crew/src/routes/events/$eventId/index.tsx
@@ -128,8 +128,9 @@ function toEventRoute(ctaTo: CrewOrganizerHomeView["nextAction"]["ctaTo"]) {
     case "/staffing":
       return "/events/$eventId/staffing"
     case "/assignments":
-    case "/messages":
       return "/events/$eventId/assignments"
+    case "/messages":
+      return "/events/$eventId/messages"
     case "/day-of":
       return "/events/$eventId/day-of"
     case "/exports":

--- a/apps/crew/src/routes/events/$eventId/messages.tsx
+++ b/apps/crew/src/routes/events/$eventId/messages.tsx
@@ -1,0 +1,573 @@
+// @lat: [[crew#Assignment Confirmations]]
+// @lat: [[crew#Confirmation Emails And Reminders]]
+import {
+  createFileRoute,
+  getRouteApi,
+  Link,
+  useRouter,
+} from "@tanstack/react-router"
+import { useServerFn } from "@tanstack/react-start"
+import {
+  BellRing,
+  Download,
+  Loader2,
+  Mail,
+  MessageSquareWarning,
+  UserCheck,
+} from "lucide-react"
+import { useMemo, useState } from "react"
+import { toast } from "sonner"
+import {
+  getCrewAssignmentConfirmationStatusBadgeClassName,
+  getCrewAssignmentConfirmationStatusLabel,
+} from "@/lib/crew/assignment-confirmation-display"
+import type {
+  CrewAssignmentCommunicationDashboard,
+  CrewAssignmentCommunicationRow,
+  CrewAssignmentCommunicationState,
+  CrewAssignmentEmailSendPreview,
+  QueueCrewAssignmentConfirmationEmailsResult,
+} from "@/server-fns/crew-confirmation-fns"
+import {
+  getCrewAssignmentCommunicationDashboardFn,
+  queueCrewAssignmentConfirmationEmailsFn,
+} from "@/server-fns/crew-confirmation-fns"
+import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
+
+export const Route = createFileRoute("/events/$eventId/messages")({
+  loader: async ({ params }) =>
+    await getCrewAssignmentCommunicationDashboardFn({
+      data: { eventId: params.eventId },
+    }),
+  component: CrewMessagesPage,
+})
+
+const parentRoute = getRouteApi("/events/$eventId")
+
+type QueueMode = "confirmations" | "reminders"
+
+const RESPONSE_BUCKETS = [
+  {
+    key: "no_response",
+    title: "No response",
+    states: ["not_ready", "pending", "sent"],
+  },
+  { key: "declined", title: "Declined", states: ["declined"] },
+  {
+    key: "change_requested",
+    title: "Change requested",
+    states: ["change_requested"],
+  },
+  { key: "confirmed", title: "Confirmed", states: ["confirmed"] },
+  {
+    key: "event_day_outcomes",
+    title: "Event-day outcomes",
+    states: ["no_show", "replaced"],
+  },
+] as const satisfies readonly {
+  key: string
+  title: string
+  states: readonly CrewAssignmentCommunicationState[]
+}[]
+
+function CrewMessagesPage() {
+  const { eventId } = parentRoute.useParams()
+  const dashboard = Route.useLoaderData()
+  const router = useRouter()
+  const queueAssignmentEmails = useServerFn(
+    queueCrewAssignmentConfirmationEmailsFn,
+  )
+  const [queueingMode, setQueueingMode] = useState<QueueMode | null>(null)
+  const rowsByBucket = useMemo(() => bucketRows(dashboard.rows), [dashboard])
+  const noResponseRows = rowsByBucket.get("no_response") ?? []
+  const declineRows = rowsByBucket.get("declined") ?? []
+  const changeRows = rowsByBucket.get("change_requested") ?? []
+
+  async function handleQueue(mode: QueueMode) {
+    setQueueingMode(mode)
+    try {
+      const result = await queueAssignmentEmails({
+        data: { eventId, mode },
+      })
+      toast.success(formatQueueResult(result))
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Assignment emails failed",
+      )
+    } finally {
+      setQueueingMode(null)
+    }
+  }
+
+  function handleExportNoResponses() {
+    if (noResponseRows.length === 0) return
+    downloadNoResponseCsv(dashboard.event.name, noResponseRows, timezone)
+  }
+
+  const timezone = dashboard.event.timezone ?? "America/Denver"
+
+  return (
+    <section className="space-y-6">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="max-w-3xl">
+          <h2 className="text-xl font-semibold">Confirmations</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {dashboard.summary.totalAssignments} assignments,{" "}
+            {dashboard.summary.noResponse} awaiting a volunteer response
+          </p>
+        </div>
+        <Link
+          to="/events/$eventId/assignments"
+          params={{ eventId }}
+          className="inline-flex h-10 w-fit items-center rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          Assignments
+        </Link>
+      </div>
+
+      <section className="grid gap-3 md:grid-cols-3 xl:grid-cols-6">
+        <StatusPanel label="Pending" value={dashboard.summary.pending} />
+        <StatusPanel label="Sent" value={dashboard.summary.sent} />
+        <StatusPanel label="Confirmed" value={dashboard.summary.confirmed} />
+        <StatusPanel label="Declined" value={dashboard.summary.declined} />
+        <StatusPanel
+          label="Change requested"
+          value={dashboard.summary.changeRequested}
+        />
+        <StatusPanel label="No response" value={dashboard.summary.noResponse} />
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <EmailPreviewPanel
+          title="Send assignment emails"
+          description={`${dashboard.previews.assignmentEmails.eligible} assignment email${plural(dashboard.previews.assignmentEmails.eligible)} ready to send`}
+          icon="mail"
+          preview={dashboard.previews.assignmentEmails}
+          isBusy={queueingMode === "confirmations"}
+          disabled={queueingMode !== null}
+          onSend={() => void handleQueue("confirmations")}
+        />
+        <EmailPreviewPanel
+          title="Send reminder emails"
+          description={`${dashboard.previews.reminderEmails.eligible} reminder email${plural(dashboard.previews.reminderEmails.eligible)} ready to send`}
+          icon="bell"
+          preview={dashboard.previews.reminderEmails}
+          isBusy={queueingMode === "reminders"}
+          disabled={queueingMode !== null}
+          onSend={() => void handleQueue("reminders")}
+        />
+      </section>
+
+      <section className="grid gap-3 md:grid-cols-4">
+        <ActionCard
+          title="Send all unsent"
+          detail={`${dashboard.previews.assignmentEmails.eligible} ready`}
+          enabled={
+            dashboard.previews.assignmentEmails.eligible > 0 &&
+            queueingMode === null
+          }
+          onClick={() => void handleQueue("confirmations")}
+        />
+        <ActionCard
+          title="Remind no responses"
+          detail={`${dashboard.previews.reminderEmails.eligible} due now`}
+          enabled={
+            dashboard.previews.reminderEmails.eligible > 0 &&
+            queueingMode === null
+          }
+          onClick={() => void handleQueue("reminders")}
+        />
+        <ActionLink
+          title="Review declines"
+          detail={`${declineRows.length} assignment${plural(declineRows.length)}`}
+          href="#declined"
+          enabled={declineRows.length > 0}
+        />
+        <ActionLink
+          title="Review change requests"
+          detail={`${changeRows.length} assignment${plural(changeRows.length)}`}
+          href="#change_requested"
+          enabled={changeRows.length > 0}
+        />
+      </section>
+
+      <section className="rounded-md border bg-card p-4 shadow-sm">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h3 className="font-semibold">No-response list</h3>
+            <p className="text-sm text-muted-foreground">
+              {noResponseRows.length} assignment{plural(noResponseRows.length)}
+            </p>
+          </div>
+          <button
+            type="button"
+            disabled={noResponseRows.length === 0}
+            onClick={handleExportNoResponses}
+            className="inline-flex h-10 w-fit items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <Download className="size-4" />
+            Export no-response list
+          </button>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        {RESPONSE_BUCKETS.map((bucket) => {
+          const rows = rowsByBucket.get(bucket.key) ?? []
+          if (bucket.key === "event_day_outcomes" && rows.length === 0) {
+            return null
+          }
+          return (
+            <AssignmentBucket
+              key={bucket.key}
+              id={bucket.key}
+              title={bucket.title}
+              rows={rows}
+              timezone={timezone}
+            />
+          )
+        })}
+      </section>
+    </section>
+  )
+}
+
+function EmailPreviewPanel({
+  title,
+  description,
+  icon,
+  preview,
+  isBusy,
+  disabled,
+  onSend,
+}: {
+  title: string
+  description: string
+  icon: "mail" | "bell"
+  preview: CrewAssignmentEmailSendPreview
+  isBusy: boolean
+  disabled: boolean
+  onSend: () => void
+}) {
+  const Icon = icon === "mail" ? Mail : BellRing
+  const canSend = preview.eligible > 0 && !disabled
+
+  return (
+    <section className="rounded-md border bg-card p-5 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-semibold">{title}</h3>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        </div>
+        <span className="rounded-md border bg-background p-2 text-muted-foreground">
+          <Icon className="size-4" />
+        </span>
+      </div>
+      <dl className="mt-5 grid gap-3 sm:grid-cols-3">
+        <PreviewStat label="Will send" value={preview.eligible} />
+        <PreviewStat label="Already sent" value={preview.skipped.alreadySent} />
+        <PreviewStat label="No email" value={preview.skipped.missingEmail} />
+      </dl>
+      <dl className="mt-3 grid gap-3 sm:grid-cols-3">
+        <PreviewStat
+          label="Already answered"
+          value={preview.skipped.responded}
+        />
+        <PreviewStat label="Not due" value={preview.skipped.notDue} />
+        <PreviewStat label="Past shift" value={preview.skipped.pastShift} />
+      </dl>
+      <button
+        type="button"
+        disabled={!canSend}
+        onClick={onSend}
+        className="mt-5 inline-flex h-10 w-fit items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isBusy ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : (
+          <Icon className="size-4" />
+        )}
+        {title}
+      </button>
+    </section>
+  )
+}
+
+function AssignmentBucket({
+  id,
+  title,
+  rows,
+  timezone,
+}: {
+  id: string
+  title: string
+  rows: CrewAssignmentCommunicationRow[]
+  timezone: string
+}) {
+  return (
+    <section
+      id={id}
+      className="overflow-hidden rounded-md border bg-card shadow-sm"
+    >
+      <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
+        <h3 className="font-semibold">{title}</h3>
+        <span className="rounded-md border bg-background px-2 py-1 text-xs font-medium text-muted-foreground">
+          {rows.length}
+        </span>
+      </div>
+      {rows.length > 0 ? (
+        <div className="divide-y">
+          {rows.map((row, index) => (
+            <AssignmentResponseRow
+              key={`${row.volunteerName}:${row.shiftName}:${row.startsAt.toString()}:${index}`}
+              row={row}
+              timezone={timezone}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="p-4 text-sm text-muted-foreground">No assignments</p>
+      )}
+    </section>
+  )
+}
+
+function AssignmentResponseRow({
+  row,
+  timezone,
+}: {
+  row: CrewAssignmentCommunicationRow
+  timezone: string
+}) {
+  return (
+    <article className="grid gap-3 p-4 lg:grid-cols-[1fr_15rem]">
+      <div>
+        <div className="flex flex-wrap items-center gap-2">
+          <p className="font-medium">{row.volunteerName}</p>
+          <StatusBadge state={row.state} />
+        </div>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {row.shiftName} · {row.roleLabel} ·{" "}
+          {formatDateTimeInTimezone(
+            row.startsAt,
+            timezone,
+            "EEE, MMM d h:mm a",
+          )}
+          {" - "}
+          {formatDateTimeInTimezone(row.endsAt, timezone, "h:mm a")}
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {row.volunteerEmail ?? "No email on file"}
+          {row.location ? ` · ${row.location}` : ""}
+        </p>
+        {row.responseNote ? (
+          <p className="mt-2 max-w-2xl whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
+            {row.responseNote}
+          </p>
+        ) : null}
+      </div>
+      <div className="text-sm text-muted-foreground lg:text-right">
+        <TimestampDetail row={row} timezone={timezone} />
+      </div>
+    </article>
+  )
+}
+
+function TimestampDetail({
+  row,
+  timezone,
+}: {
+  row: CrewAssignmentCommunicationRow
+  timezone: string
+}) {
+  if (row.state === "pending") return "Not sent"
+  if (row.state === "not_ready") return "Not ready"
+  if (row.respondedAt) {
+    return (
+      <>
+        Responded{" "}
+        {formatDateTimeInTimezone(row.respondedAt, timezone, "MMM d h:mm a")}
+      </>
+    )
+  }
+  if (row.lastReminderAt) {
+    return (
+      <>
+        Reminder {row.reminderCount}{" "}
+        {formatDateTimeInTimezone(row.lastReminderAt, timezone, "MMM d h:mm a")}
+      </>
+    )
+  }
+  if (row.sentAt) {
+    return (
+      <>Sent {formatDateTimeInTimezone(row.sentAt, timezone, "MMM d h:mm a")}</>
+    )
+  }
+  return "Awaiting response"
+}
+
+function StatusPanel({ label, value }: { label: string; value: number }) {
+  return (
+    <section className="rounded-md border bg-card p-4 shadow-sm">
+      <p className="text-sm text-muted-foreground">{label}</p>
+      <p className="mt-2 text-lg font-semibold">{value}</p>
+    </section>
+  )
+}
+
+function PreviewStat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-md border bg-background p-3">
+      <dt className="text-xs text-muted-foreground">{label}</dt>
+      <dd className="mt-1 text-lg font-semibold">{value}</dd>
+    </div>
+  )
+}
+
+function ActionCard({
+  title,
+  detail,
+  enabled,
+  onClick,
+}: {
+  title: string
+  detail: string
+  enabled: boolean
+  onClick: () => void
+}) {
+  return (
+    <button
+      type="button"
+      disabled={!enabled}
+      onClick={onClick}
+      className="rounded-md border bg-card p-4 text-left shadow-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      <Mail className="size-4 text-muted-foreground" />
+      <span className="mt-3 block font-medium">{title}</span>
+      <span className="mt-1 block text-sm text-muted-foreground">{detail}</span>
+    </button>
+  )
+}
+
+function ActionLink({
+  title,
+  detail,
+  href,
+  enabled,
+}: {
+  title: string
+  detail: string
+  href: string
+  enabled: boolean
+}) {
+  const content = (
+    <>
+      {title === "Review declines" ? (
+        <MessageSquareWarning className="size-4 text-muted-foreground" />
+      ) : (
+        <UserCheck className="size-4 text-muted-foreground" />
+      )}
+      <span className="mt-3 block font-medium">{title}</span>
+      <span className="mt-1 block text-sm text-muted-foreground">{detail}</span>
+    </>
+  )
+
+  if (!enabled) {
+    return (
+      <span className="rounded-md border bg-card p-4 opacity-60">
+        {content}
+      </span>
+    )
+  }
+
+  return (
+    <a
+      href={href}
+      className="rounded-md border bg-card p-4 shadow-sm hover:bg-muted"
+    >
+      {content}
+    </a>
+  )
+}
+
+function StatusBadge({ state }: { state: CrewAssignmentCommunicationState }) {
+  const status = state === "not_ready" ? "missing" : state
+  return (
+    <span
+      className={`inline-flex rounded-md border px-2 py-1 text-xs font-medium ${getCrewAssignmentConfirmationStatusBadgeClassName(status)}`}
+    >
+      {state === "not_ready"
+        ? "Not ready"
+        : getCrewAssignmentConfirmationStatusLabel(status)}
+    </span>
+  )
+}
+
+function bucketRows(rows: CrewAssignmentCommunicationDashboard["rows"]) {
+  const buckets = new Map<string, CrewAssignmentCommunicationRow[]>()
+  for (const bucket of RESPONSE_BUCKETS) {
+    const states = new Set<CrewAssignmentCommunicationState>(bucket.states)
+    buckets.set(
+      bucket.key,
+      rows.filter((row) => states.has(row.state)),
+    )
+  }
+  return buckets
+}
+
+function formatQueueResult(
+  result: QueueCrewAssignmentConfirmationEmailsResult,
+) {
+  const label =
+    result.mode === "confirmations" ? "assignment emails" : "reminder emails"
+  if (result.queueAvailable) {
+    return `${result.queued}/${result.eligible} ${label} queued${result.failed ? `, ${result.failed} failed` : ""}`
+  }
+  return `${result.previewed}/${result.eligible} ${label} previewed; delivery is unavailable`
+}
+
+function downloadNoResponseCsv(
+  eventName: string,
+  rows: CrewAssignmentCommunicationRow[],
+  timezone: string,
+) {
+  const header = ["Volunteer", "Email", "Shift", "Role", "Starts", "Status"]
+  const csvRows = rows.map((row) => [
+    row.volunteerName,
+    row.volunteerEmail ?? "",
+    row.shiftName,
+    row.roleLabel,
+    formatDateTimeInTimezone(row.startsAt, timezone, "yyyy-MM-dd h:mm a"),
+    row.state === "not_ready"
+      ? "Not ready"
+      : getCrewAssignmentConfirmationStatusLabel(row.state),
+  ])
+  const csv = [header, ...csvRows]
+    .map((line) => line.map(escapeCsvValue).join(","))
+    .join("\n")
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = `${slugifyFileName(eventName)}-no-response.csv`
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+function escapeCsvValue(value: string) {
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+function slugifyFileName(value: string) {
+  const slug = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return slug || "crew-confirmations"
+}
+
+function plural(count: number) {
+  return count === 1 ? "" : "s"
+}

--- a/apps/crew/src/routes/events/$eventId/messages.tsx
+++ b/apps/crew/src/routes/events/$eventId/messages.tsx
@@ -556,7 +556,8 @@ function downloadNoResponseCsv(
 }
 
 function escapeCsvValue(value: string) {
-  return `"${value.replaceAll('"', '""')}"`
+  const neutralized = /^[=+\-@]/.test(value) ? `'${value}` : value
+  return `"${neutralized.replaceAll('"', '""')}"`
 }
 
 function slugifyFileName(value: string) {

--- a/apps/crew/src/server-fns/crew-confirmation-fns.ts
+++ b/apps/crew/src/server-fns/crew-confirmation-fns.ts
@@ -8,6 +8,7 @@ import { z } from "zod"
 import { VOLUNTEER_AVAILABILITY } from "../db/schemas/volunteers"
 import { CREW_ASSIGNMENT_CONFIRMATION_ORGANIZER_STATES } from "../lib/crew/assignment-confirmations"
 import type {
+  CrewAssignmentCommunicationDashboard,
   QueueCrewAssignmentConfirmationEmailsInput,
   QueueCrewAssignmentConfirmationEmailsResult,
   UpdateCrewAssignmentConfirmationContactTokenInput,
@@ -15,15 +16,19 @@ import type {
 } from "../server/crew-confirmation.server"
 
 export type {
-  CrewAssignmentEmailQueueMessage,
+  CrewAssignmentCommunicationDashboard,
+  CrewAssignmentCommunicationRow,
+  CrewAssignmentCommunicationState,
   CrewAssignmentConfirmationContactUpdateResult,
   CrewAssignmentConfirmationResponseResult,
   CrewAssignmentConfirmationTokenData,
-  UpdateCrewAssignmentConfirmationContactTokenInput,
+  CrewAssignmentEmailQueueMessage,
+  CrewAssignmentEmailSendPreview,
   CrewShiftAssignmentConfirmationStatus,
   EnsureCrewShiftAssignmentConfirmationResult,
   QueueCrewAssignmentConfirmationEmailsInput,
   QueueCrewAssignmentConfirmationEmailsResult,
+  UpdateCrewAssignmentConfirmationContactTokenInput,
   UpdateCrewShiftAssignmentConfirmationStateInput,
 } from "../server/crew-confirmation.server"
 
@@ -62,6 +67,10 @@ const queueCrewAssignmentConfirmationEmailsInputSchema = z.object({
   eventId: z.string().min(1, "Event ID is required"),
   mode: z.enum(["confirmations", "reminders"]),
 }) satisfies z.ZodType<QueueCrewAssignmentConfirmationEmailsInput>
+
+const crewAssignmentCommunicationDashboardInputSchema = z.object({
+  eventId: z.string().min(1, "Event ID is required"),
+})
 
 export const getCrewAssignmentConfirmationTokenFn = createServerFn({
   method: "GET",
@@ -123,3 +132,16 @@ export const queueCrewAssignmentConfirmationEmailsFn = createServerFn({
       return queueCrewAssignmentConfirmationEmails(data)
     },
   )
+
+export const getCrewAssignmentCommunicationDashboardFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator((data: unknown) =>
+    crewAssignmentCommunicationDashboardInputSchema.parse(data),
+  )
+  .handler(async ({ data }): Promise<CrewAssignmentCommunicationDashboard> => {
+    const { getCrewAssignmentCommunicationDashboard } = await import(
+      "../server/crew-confirmation.server"
+    )
+    return getCrewAssignmentCommunicationDashboard(data)
+  })

--- a/apps/crew/src/server/crew-confirmation.server.ts
+++ b/apps/crew/src/server/crew-confirmation.server.ts
@@ -1,9 +1,9 @@
-import { render } from "@react-email/render"
 // @lat: [[crew#Assignment Confirmation Responses]]
 // @lat: [[crew#Assignment Confirmations]]
 // @lat: [[crew#Confirmation Emails And Reminders]]
 // @lat: [[crew#Volunteer Self Service]]
 import { env } from "cloudflare:workers"
+import { render } from "@react-email/render"
 import {
   and,
   asc,
@@ -17,18 +17,18 @@ import {
   sql,
 } from "drizzle-orm"
 import { getDb } from "../db"
-import { competitionsTable, type Competition } from "../db/schemas/competitions"
 import { createCrewAssignmentConfirmationId } from "../db/schemas/common"
-import {
-  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
-  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
-  crewAssignmentConfirmationsTable,
-  type CrewAssignmentConfirmationStatus,
-} from "../db/schemas/crew-imports"
+import { type Competition, competitionsTable } from "../db/schemas/competitions"
 import {
   CREW_EVENT_LIFECYCLE,
   crewEventSettingsTable,
 } from "../db/schemas/crew-event-settings"
+import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+  type CrewAssignmentConfirmationStatus,
+  crewAssignmentConfirmationsTable,
+} from "../db/schemas/crew-imports"
 import {
   CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE,
   CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
@@ -38,36 +38,37 @@ import {
 import { SYSTEM_ROLES_ENUM, teamMembershipTable } from "../db/schemas/teams"
 import { userTable } from "../db/schemas/users"
 import {
-  volunteerShiftAssignmentsTable,
-  volunteerShiftsTable,
   type VolunteerAvailability,
   type VolunteerRoleType,
+  volunteerShiftAssignmentsTable,
+  volunteerShiftsTable,
 } from "../db/schemas/volunteers"
 import {
-  buildCrewAssignmentConfirmationUrls,
   buildCrewAssignmentConfirmationEmailPlan,
+  buildCrewAssignmentConfirmationUrls,
   buildCrewAssignmentEmailIdempotencyKey,
-  generateCrewAssignmentConfirmationToken,
-  getCrewAssignmentConfirmationTokenState,
-  hashCrewAssignmentConfirmationToken,
-  normalizeConfirmationEmailForSend,
-  resolveCrewAssignmentConfirmationResponse,
-  resolveCrewAssignmentConfirmationOrganizerStateUpdate,
-  statusForCrewAssignmentResponseAction,
-  summarizeCrewAssignmentConfirmations,
-  type CrewAssignmentConfirmationEmailOperation,
   type CrewAssignmentConfirmationEmailCandidate,
+  type CrewAssignmentConfirmationEmailOperation,
   type CrewAssignmentConfirmationEmailOperationMode,
   type CrewAssignmentConfirmationOrganizerState,
   type CrewAssignmentConfirmationStatusSummary,
   type CrewAssignmentEmailQueueMessage,
   type CrewAssignmentResponseAction,
   type CrewAssignmentTokenState,
+  generateCrewAssignmentConfirmationToken,
+  getCrewAssignmentConfirmationOperationalState,
+  getCrewAssignmentConfirmationTokenState,
+  hashCrewAssignmentConfirmationToken,
+  normalizeConfirmationEmailForSend,
+  resolveCrewAssignmentConfirmationOrganizerStateUpdate,
+  resolveCrewAssignmentConfirmationResponse,
+  statusForCrewAssignmentResponseAction,
+  summarizeCrewAssignmentConfirmations,
 } from "../lib/crew/assignment-confirmations"
 import {
   assertCrewDepartmentLeadCanManageShift,
-  filterCrewDepartmentLeadShifts,
   type CrewDepartmentLeadAccess,
+  filterCrewDepartmentLeadShifts,
 } from "../lib/crew/department-leads"
 import {
   formatVolunteerRole,
@@ -76,18 +77,18 @@ import {
 } from "../lib/crew/roster-shifts"
 import {
   buildCrewVolunteerSelfServiceSchedule,
-  resolveCrewVolunteerSelfServiceContactUpdate,
   type CrewVolunteerSelfServiceScheduleItem,
+  resolveCrewVolunteerSelfServiceContactUpdate,
 } from "../lib/crew/volunteer-self-service"
 import { getAppUrl } from "../lib/env"
 import { CrewAssignmentConfirmationEmail } from "../react-email/crew/assignment-confirmation"
 import { CrewAssignmentReminder24HourEmail } from "../react-email/crew/reminder-24-hour"
 import { CrewAssignmentReminder48HourEmail } from "../react-email/crew/reminder-48-hour"
+import { getFirstExecuteValue } from "../server-fns/db-execute"
 import {
   DEFAULT_TIMEZONE,
   formatDateTimeInTimezone,
 } from "../utils/timezone-utils"
-import { getFirstExecuteValue } from "../server-fns/db-execute"
 import {
   requireCrewDepartmentLeadEvent,
   resolveCrewDepartmentLeadAccess,
@@ -199,6 +200,65 @@ export interface QueueCrewAssignmentConfirmationEmailsResult {
   skipped: ReturnType<
     typeof buildCrewAssignmentConfirmationEmailPlan
   >["skipped"]
+}
+
+export interface CrewAssignmentEmailSendPreview {
+  mode: CrewAssignmentConfirmationEmailOperationMode
+  eligible: number
+  skipped: ReturnType<
+    typeof buildCrewAssignmentConfirmationEmailPlan
+  >["skipped"]
+}
+
+export type CrewAssignmentCommunicationState =
+  | "not_ready"
+  | "pending"
+  | "sent"
+  | "confirmed"
+  | "declined"
+  | "change_requested"
+  | "no_show"
+  | "replaced"
+
+export interface CrewAssignmentCommunicationRow {
+  volunteerName: string
+  volunteerEmail: string | null
+  shiftName: string
+  roleLabel: string
+  startsAt: Date
+  endsAt: Date
+  location: string | null
+  state: CrewAssignmentCommunicationState
+  sentAt: Date | null
+  respondedAt: Date | null
+  lastReminderAt: Date | null
+  reminderCount: number
+  responseNote: string | null
+}
+
+export interface CrewAssignmentCommunicationDashboard {
+  event: {
+    id: string
+    name: string
+    timezone: string | null
+  }
+  summary: {
+    totalAssignments: number
+    notReady: number
+    pending: number
+    sent: number
+    confirmed: number
+    declined: number
+    changeRequested: number
+    noResponse: number
+    noShow: number
+    replaced: number
+  }
+  previews: {
+    assignmentEmails: CrewAssignmentEmailSendPreview
+    reminderEmails: CrewAssignmentEmailSendPreview
+  }
+  rows: CrewAssignmentCommunicationRow[]
 }
 
 export type EnsureCrewShiftAssignmentConfirmationResult =
@@ -997,6 +1057,55 @@ export async function queueCrewAssignmentConfirmationEmails(
   }
 }
 
+export async function getCrewAssignmentCommunicationDashboard(data: {
+  eventId: string
+}): Promise<CrewAssignmentCommunicationDashboard> {
+  const event = await requireCrewDepartmentLeadEvent(data.eventId)
+  const access = await resolveCrewDepartmentLeadAccess(event)
+  const [eventDetail] = await getDb()
+    .select({ name: competitionsTable.name })
+    .from(competitionsTable)
+    .where(eq(competitionsTable.id, data.eventId))
+    .limit(1)
+  const [assignments, candidates] = await Promise.all([
+    loadCrewAssignmentCommunicationRows(data.eventId, access),
+    loadCrewAssignmentEmailCandidates(data.eventId).then((rows) =>
+      filterCrewAssignmentEmailCandidates(rows, access),
+    ),
+  ])
+  const now = new Date()
+  const assignmentEmails = buildCrewAssignmentConfirmationEmailPlan({
+    mode: "confirmations",
+    candidates,
+    now,
+  })
+  const reminderEmails = buildCrewAssignmentConfirmationEmailPlan({
+    mode: "reminders",
+    candidates,
+    now,
+  })
+
+  return {
+    event: {
+      id: event.id,
+      name: eventDetail?.name ?? "Crew confirmations",
+      timezone: event.timezone,
+    },
+    summary: summarizeCrewAssignmentCommunicationRows(assignments),
+    previews: {
+      assignmentEmails: toCrewAssignmentEmailSendPreview(
+        "confirmations",
+        assignmentEmails,
+      ),
+      reminderEmails: toCrewAssignmentEmailSendPreview(
+        "reminders",
+        reminderEmails,
+      ),
+    },
+    rows: assignments,
+  }
+}
+
 export function summarizeCrewShiftAssignmentConfirmations(
   confirmations: Array<CrewShiftAssignmentConfirmationStatus | null>,
 ): CrewAssignmentConfirmationStatusSummary {
@@ -1037,6 +1146,145 @@ export async function buildCrewAssignmentConfirmationEmailMessage(params: {
     token: params.token,
     queuedAt: new Date(),
   })
+}
+
+async function loadCrewAssignmentCommunicationRows(
+  eventId: string,
+  access: CrewDepartmentLeadAccess,
+): Promise<CrewAssignmentCommunicationRow[]> {
+  const db = getDb()
+  const assignmentRows = await db
+    .select({
+      assignment: {
+        id: volunteerShiftAssignmentsTable.id,
+        membershipId: volunteerShiftAssignmentsTable.membershipId,
+      },
+      shift: {
+        id: volunteerShiftsTable.id,
+        name: volunteerShiftsTable.name,
+        roleType: volunteerShiftsTable.roleType,
+        startTime: volunteerShiftsTable.startTime,
+        endTime: volunteerShiftsTable.endTime,
+        location: volunteerShiftsTable.location,
+      },
+      membership: {
+        metadata: teamMembershipTable.metadata,
+      },
+      user: {
+        firstName: userTable.firstName,
+        lastName: userTable.lastName,
+        email: userTable.email,
+      },
+    })
+    .from(volunteerShiftAssignmentsTable)
+    .innerJoin(
+      volunteerShiftsTable,
+      eq(volunteerShiftAssignmentsTable.shiftId, volunteerShiftsTable.id),
+    )
+    .leftJoin(
+      teamMembershipTable,
+      eq(volunteerShiftAssignmentsTable.membershipId, teamMembershipTable.id),
+    )
+    .leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(eq(volunteerShiftsTable.competitionId, eventId))
+    .orderBy(
+      asc(volunteerShiftsTable.startTime),
+      asc(volunteerShiftsTable.name),
+    )
+
+  const visibleAssignments =
+    access.kind === "full"
+      ? assignmentRows
+      : filterCrewDepartmentLeadShifts(
+          assignmentRows.map((row) => ({
+            ...row,
+            roleType: row.shift.roleType,
+            startTime: row.shift.startTime,
+            endTime: row.shift.endTime,
+            location: row.shift.location,
+          })),
+          access,
+        )
+  const confirmationMap = await loadCrewShiftAssignmentConfirmationMap(
+    db,
+    visibleAssignments.map((row) => row.assignment.id),
+  )
+
+  return visibleAssignments.map((row) => {
+    const metadata = parseCrewRosterMetadata(row.membership?.metadata)
+    const email =
+      normalizeConfirmationEmailForSend(metadata.signupEmail) ??
+      normalizeConfirmationEmailForSend(row.user?.email)
+    const volunteerName =
+      metadata.signupName ||
+      [row.user?.firstName, row.user?.lastName].filter(Boolean).join(" ") ||
+      email ||
+      "Volunteer"
+    const confirmation = confirmationMap.get(row.assignment.id) ?? null
+    const operationalState =
+      getCrewAssignmentConfirmationOperationalState(confirmation)
+
+    return {
+      volunteerName,
+      volunteerEmail: email,
+      shiftName: row.shift.name,
+      roleLabel: formatVolunteerRole(row.shift.roleType),
+      startsAt: row.shift.startTime,
+      endsAt: row.shift.endTime,
+      location: row.shift.location,
+      state:
+        operationalState === "missing"
+          ? "not_ready"
+          : (operationalState as CrewAssignmentCommunicationState),
+      sentAt: confirmation?.sentAt ?? null,
+      respondedAt: confirmation?.respondedAt ?? null,
+      lastReminderAt: confirmation?.lastReminderAt ?? null,
+      reminderCount: confirmation?.reminderCount ?? 0,
+      responseNote: confirmation?.responseNote ?? null,
+    }
+  })
+}
+
+function summarizeCrewAssignmentCommunicationRows(
+  rows: CrewAssignmentCommunicationRow[],
+): CrewAssignmentCommunicationDashboard["summary"] {
+  const summary = {
+    totalAssignments: rows.length,
+    notReady: 0,
+    pending: 0,
+    sent: 0,
+    confirmed: 0,
+    declined: 0,
+    changeRequested: 0,
+    noResponse: 0,
+    noShow: 0,
+    replaced: 0,
+  }
+
+  for (const row of rows) {
+    if (row.state === "not_ready") summary.notReady += 1
+    else if (row.state === "pending") summary.pending += 1
+    else if (row.state === "sent") summary.sent += 1
+    else if (row.state === "confirmed") summary.confirmed += 1
+    else if (row.state === "declined") summary.declined += 1
+    else if (row.state === "change_requested") summary.changeRequested += 1
+    else if (row.state === "no_show") summary.noShow += 1
+    else summary.replaced += 1
+  }
+
+  summary.noResponse = summary.notReady + summary.pending + summary.sent
+  return summary
+}
+
+function toCrewAssignmentEmailSendPreview(
+  mode: CrewAssignmentConfirmationEmailOperationMode,
+  plan: ReturnType<typeof buildCrewAssignmentConfirmationEmailPlan>,
+): CrewAssignmentEmailSendPreview {
+  return {
+    mode,
+    eligible: plan.operations.length,
+    skipped: plan.skipped,
+  }
 }
 
 async function buildCrewAssignmentEmailQueueMessage(params: {


### PR DESCRIPTION
## Scope

- Adds a dedicated organizer confirmations dashboard at `/events/$eventId/messages`.
- Adds a client-safe dashboard loader for assignment communication state and send previews.
- Retargets the existing Confirmations nav and organizer next-action route to `/messages`.
- Reuses existing Crew assignment confirmation rows and existing assignment/reminder queue mechanics.

## Acceptance

- Organizers can manage assignment communication from the Confirmations page without working from the shift board.
- The page shows pre-send counts for assignment emails/reminders before mutation, including ready-to-send, already sent, missing email, answered, not due, and past-shift skips.
- The page groups assignment responses into organizer-facing buckets: pending, sent, confirmed, declined, change requested, no response, and client-safe event-day outcomes when present.
- Core actions are present for send all unsent, remind no responses, review declines, review change requests, and export no-response list.
- Existing shift-board send/reminder actions remain compatible and unchanged.

## Validation

- `pnpm --filter crew type-check`
- `pnpm --filter crew exec vitest run src/lib/crew/assignment-confirmations.test.ts`
- `pnpm --filter crew exec biome check --write src/server/crew-confirmation.server.ts src/server-fns/crew-confirmation-fns.ts src/routes/events/$eventId/messages.tsx src/routes/events/$eventId/index.tsx src/lib/crew/navigation.ts`
- `git diff --check`

Build caveat: `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` is blocked locally before Vite runs because `apps/crew/.alchemy/local/wrangler.jsonc` is missing; Alchemy reports to run `alchemy dev` or `alchemy deploy` to create it.

## Out of scope

- No schema changes.
- No public volunteer confirmation-flow changes.
- No assignments, imports, setup, event-day persistence, billing/Stripe, admin diagnostics, or organizer shell redesign.
- No new export surfaces beyond the no-response CSV from the dashboard.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an organizer-facing confirmations dashboard at `/events/$eventId/messages` to manage crew assignment emails and reminders with live previews and bulk actions. Protects the no‑response CSV export by neutralizing spreadsheet formulas.

- **New Features**
  - Dashboard groups responses (no response, declined, change requested, confirmed, plus event‑day outcomes) with per-bucket lists and timestamps.
  - Pre-send previews for assignment and reminder emails showing eligible counts and skips (already sent, missing email, responded, not due, past shift).
  - Quick actions: send all unsent, remind no responses, review declines, review change requests, and export a no‑response CSV.
  - Confirmations nav now routes to `/events/$eventId/messages`; organizer next‑action mapping supports `/messages`. Client-safe loader `getCrewAssignmentCommunicationDashboardFn` aggregates summary, previews, and rows; sending reuses `queueCrewAssignmentConfirmationEmailsFn`. Shift‑board actions remain unchanged.

- **Bug Fixes**
  - CSV export escapes values that start with `=`, `+`, `-`, or `@` to prevent spreadsheet formula injection.

<sup>Written for commit 4249461154ba838ace0f47de459361c4afcab769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Confirmations view to event navigation displaying assignment communication status with grouped responses (confirmations, declines, change requests, no-response).
  * Added email controls to send assignment and reminder emails with success/error notifications.
  * Added CSV export functionality for no-response assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->