### PR TITLE
[codex] complete volunteer schedule token responses

### DIFF
--- a/apps/crew/src/components/crew/volunteer-public-response-controls.tsx
+++ b/apps/crew/src/components/crew/volunteer-public-response-controls.tsx
@@ -1,0 +1,211 @@
+"use client"
+
+import { standardSchemaResolver } from "@hookform/resolvers/standard-schema"
+import { Loader2 } from "lucide-react"
+import { useMemo } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+import { getCrewAssignmentConfirmationStatusLabel } from "../../lib/crew/assignment-confirmation-display"
+
+export type CrewVolunteerPublicResponseAction =
+  | "confirm"
+  | "decline"
+  | "request_change"
+
+type CrewVolunteerPublicNoteAction = Exclude<
+  CrewVolunteerPublicResponseAction,
+  "confirm"
+>
+
+export interface CrewVolunteerPublicResponseAssignment {
+  id: string
+  confirmation?: {
+    status?: string | null
+    responseNote?: string | null
+  } | null
+}
+
+interface CrewVolunteerPublicResponseControlsProps {
+  assignment: CrewVolunteerPublicResponseAssignment
+  pendingAction: string | null
+  className?: string
+  onConfirm: () => void
+  onNoteSubmit: (
+    action: CrewVolunteerPublicNoteAction,
+    note: string,
+  ) => Promise<void> | void
+}
+
+interface CrewVolunteerResponseNoteFormProps {
+  action: CrewVolunteerPublicNoteAction
+  disabled: boolean
+  isPending: boolean
+  rows: number
+  onSubmit: (
+    action: CrewVolunteerPublicNoteAction,
+    note: string,
+  ) => Promise<void> | void
+}
+
+interface ResponseNoteFormValues {
+  note: string
+}
+
+export function CrewVolunteerPublicResponseControls({
+  assignment,
+  pendingAction,
+  className = "",
+  onConfirm,
+  onNoteSubmit,
+}: CrewVolunteerPublicResponseControlsProps) {
+  const status = assignment.confirmation?.status ?? "pending"
+  const canRespond = status === "pending"
+
+  if (!canRespond) {
+    return (
+      <div
+        className={`mt-5 rounded-md border bg-background p-3 text-sm ${className}`}
+      >
+        <p className="font-medium">
+          {getCrewVolunteerRecordedResponseMessage(status)}
+        </p>
+        {assignment.confirmation?.responseNote ? (
+          <p className="mt-2 whitespace-pre-wrap text-muted-foreground">
+            {assignment.confirmation.responseNote}
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+
+  const disabled = pendingAction !== null
+  const confirmKey = getCrewVolunteerResponseActionKey(assignment.id, "confirm")
+  const declineKey = getCrewVolunteerResponseActionKey(assignment.id, "decline")
+  const changeKey = getCrewVolunteerResponseActionKey(
+    assignment.id,
+    "request_change",
+  )
+
+  return (
+    <div
+      className={`mt-5 space-y-4 rounded-md border bg-background p-4 ${className}`}
+    >
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onConfirm}
+        className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
+      >
+        {pendingAction === confirmKey ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : null}
+        Confirm
+      </button>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <CrewVolunteerResponseNoteForm
+          action="request_change"
+          disabled={disabled}
+          isPending={pendingAction === changeKey}
+          rows={3}
+          onSubmit={onNoteSubmit}
+        />
+        <CrewVolunteerResponseNoteForm
+          action="decline"
+          disabled={disabled}
+          isPending={pendingAction === declineKey}
+          rows={3}
+          onSubmit={onNoteSubmit}
+        />
+      </div>
+    </div>
+  )
+}
+
+export function getCrewVolunteerResponseActionKey(
+  assignmentId: string,
+  action: CrewVolunteerPublicResponseAction,
+) {
+  return `${assignmentId}:${action}`
+}
+
+export function getCrewVolunteerRecordedResponseMessage(status: string) {
+  if (status === "confirmed") {
+    return "Confirmed. We'll remind you before your shift."
+  }
+  if (status === "declined") {
+    return "Declined. The organizer will see your note."
+  }
+  if (status === "change_requested") {
+    return "Change request sent. The organizer will see your note."
+  }
+  return `Response recorded: ${getCrewAssignmentConfirmationStatusLabel(status)}.`
+}
+
+function CrewVolunteerResponseNoteForm({
+  action,
+  disabled,
+  isPending,
+  rows,
+  onSubmit,
+}: CrewVolunteerResponseNoteFormProps) {
+  const formSchema = useMemo(
+    () =>
+      z.object({
+        note: z
+          .string()
+          .trim()
+          .min(1, getMissingNoteMessage(action))
+          .max(1000, "Keep your note under 1000 characters."),
+      }),
+    [action],
+  )
+  const form = useForm<ResponseNoteFormValues>({
+    resolver: standardSchemaResolver(formSchema),
+    defaultValues: { note: "" },
+  })
+  const label = action === "request_change" ? "Request change" : "Decline"
+  const placeholder =
+    action === "request_change"
+      ? "What needs to change?"
+      : "Let the organizer know why"
+  const buttonLabel = action === "request_change" ? "Send request" : "Decline"
+
+  async function handleValidSubmit(values: ResponseNoteFormValues) {
+    await onSubmit(action, values.note.trim())
+  }
+
+  return (
+    <form onSubmit={form.handleSubmit(handleValidSubmit)} className="space-y-2">
+      <label className="grid gap-2 text-sm">
+        <span className="font-medium">{label}</span>
+        <textarea
+          {...form.register("note")}
+          rows={rows}
+          disabled={disabled}
+          className="rounded-md border bg-card px-3 py-2 disabled:cursor-not-allowed disabled:opacity-60"
+          placeholder={placeholder}
+        />
+      </label>
+      {form.formState.errors.note?.message ? (
+        <p className="text-xs text-destructive">
+          {form.formState.errors.note.message}
+        </p>
+      ) : null}
+      <button
+        type="submit"
+        disabled={disabled}
+        className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isPending ? <Loader2 className="size-4 animate-spin" /> : null}
+        {buttonLabel}
+      </button>
+    </form>
+  )
+}
+
+function getMissingNoteMessage(action: CrewVolunteerPublicNoteAction) {
+  return action === "decline"
+    ? "Add a note before declining."
+    : "Add a note before requesting a change."
+}

--- a/apps/crew/src/lib/crew/assignment-confirmations.test.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.test.ts
@@ -3,14 +3,14 @@ import { describe, expect, it } from "vitest"
 import { CREW_ASSIGNMENT_CONFIRMATION_STATUS } from "../../db/schemas/crew-imports"
 import {
   buildCrewAssignmentConfirmationEmailPlan,
-  buildCrewAssignmentEmailIdempotencyKey,
   buildCrewAssignmentConfirmationUrls,
+  buildCrewAssignmentEmailIdempotencyKey,
   generateCrewAssignmentConfirmationToken,
   getCrewAssignmentConfirmationOperationalState,
   getCrewAssignmentConfirmationTokenState,
   hashCrewAssignmentConfirmationToken,
-  resolveCrewAssignmentConfirmationResponse,
   resolveCrewAssignmentConfirmationOrganizerStateUpdate,
+  resolveCrewAssignmentConfirmationResponse,
   summarizeCrewAssignmentConfirmationOperationalStates,
   summarizeCrewAssignmentConfirmations,
 } from "./assignment-confirmations"
@@ -81,11 +81,17 @@ describe("Crew assignment response state transitions", () => {
       respondedAt: now,
     })
     expect(
-      resolveCrewAssignmentConfirmationResponse(base, "decline", null, now),
+      resolveCrewAssignmentConfirmationResponse(
+        base,
+        "decline",
+        "I cannot make it.",
+        now,
+      ),
     ).toMatchObject({
       ok: true,
       outcome: "updated",
       status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED,
+      responseNote: "I cannot make it.",
       respondedAt: now,
     })
     expect(
@@ -101,6 +107,38 @@ describe("Crew assignment response state transitions", () => {
       status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED,
       responseNote: "I can do the afternoon.",
       respondedAt: now,
+    })
+  })
+
+  it("requires notes for decline and change requests", () => {
+    const base = {
+      status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+      expiresAt: "2026-06-20T12:00:00.000Z",
+    }
+
+    expect(
+      resolveCrewAssignmentConfirmationResponse(
+        base,
+        "decline",
+        "  ",
+        new Date("2026-06-19T12:00:00.000Z"),
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: "missing_note",
+      message: "Add a note before declining this assignment.",
+    })
+    expect(
+      resolveCrewAssignmentConfirmationResponse(
+        base,
+        "request_change",
+        "",
+        new Date("2026-06-19T12:00:00.000Z"),
+      ),
+    ).toMatchObject({
+      ok: false,
+      reason: "missing_note",
+      message: "Add a note before requesting a change.",
     })
   })
 
@@ -127,7 +165,7 @@ describe("Crew assignment response state transitions", () => {
       resolveCrewAssignmentConfirmationResponse(
         confirmed,
         "decline",
-        null,
+        "Schedule conflict",
         now,
       ),
     ).toMatchObject({

--- a/apps/crew/src/lib/crew/assignment-confirmations.ts
+++ b/apps/crew/src/lib/crew/assignment-confirmations.ts
@@ -216,7 +216,7 @@ export type CrewAssignmentConfirmationResponseResolution =
     }
   | {
       ok: false
-      reason: "expired" | "cancelled" | "already_responded"
+      reason: "expired" | "cancelled" | "already_responded" | "missing_note"
       status: CrewAssignmentConfirmationStatus
       message: string
     }
@@ -255,13 +255,26 @@ export function resolveCrewAssignmentConfirmationResponse(
   }
 
   const nextStatus = statusForCrewAssignmentResponseAction(action)
-  const responseNote =
+  const actionRequiresNote =
+    nextStatus === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED ||
     nextStatus === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
-      ? normalizeResponseNote(note)
-      : null
+  const responseNote = actionRequiresNote ? normalizeResponseNote(note) : null
+
+  if (actionRequiresNote && !responseNote) {
+    return {
+      ok: false,
+      reason: "missing_note",
+      status: record.status,
+      message:
+        nextStatus === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED
+          ? "Add a note before declining this assignment."
+          : "Add a note before requesting a change.",
+    }
+  }
 
   if (record.status === nextStatus) {
     const existingNote =
+      nextStatus === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED ||
       nextStatus === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
         ? normalizeResponseNote(record.responseNote)
         : null

--- a/apps/crew/src/routes/e/$slug/confirm/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/confirm/$token.tsx
@@ -1,8 +1,9 @@
 // @lat: [[crew#Assignment Confirmation Responses]]
-import type { FormEvent } from "react"
+
 import { createFileRoute, notFound, useRouter } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import { Loader2 } from "lucide-react"
+import type { FormEvent } from "react"
 import { useState } from "react"
 import { toast } from "sonner"
 import {
@@ -10,26 +11,48 @@ import {
   getCrewAssignmentConfirmationStatusLabel,
 } from "@/lib/crew/assignment-confirmation-display"
 import {
+  type CrewAssignmentConfirmationTokenData,
   getCrewAssignmentConfirmationTokenFn,
   respondCrewAssignmentConfirmationTokenFn,
 } from "@/server-fns/crew-confirmation-fns"
+import {
+  type CrewVolunteerScheduleTokenData,
+  type CrewVolunteerVisibleAssignment,
+  getCrewVolunteerScheduleTokenFn,
+  respondCrewVolunteerScheduleTokenFn,
+} from "@/server-fns/crew-volunteer-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
 export const Route = createFileRoute("/e/$slug/confirm/$token")({
   loader: async ({ params }) => {
-    const result = await getCrewAssignmentConfirmationTokenFn({
+    const assignmentResult = await getCrewAssignmentConfirmationTokenFn({
       data: { slug: params.slug, token: params.token },
     })
 
-    if (result.status === "missing") {
+    if (assignmentResult.status !== "missing") {
+      return { mode: "assignment" as const, assignmentResult }
+    }
+
+    const volunteerResult = await getCrewVolunteerScheduleTokenFn({
+      data: { slug: params.slug, token: params.token },
+    })
+
+    if (
+      volunteerResult.status !== "valid" ||
+      !volunteerResult.event ||
+      !volunteerResult.volunteer
+    ) {
       throw notFound()
     }
 
-    return result
+    return { mode: "volunteer" as const, volunteerResult }
   },
   component: CrewAssignmentConfirmationPage,
   head: ({ loaderData }) => {
-    const event = loaderData?.event
+    const event =
+      loaderData?.mode === "assignment"
+        ? loaderData.assignmentResult.event
+        : loaderData?.volunteerResult.event
     return {
       meta: [
         {
@@ -43,7 +66,22 @@ export const Route = createFileRoute("/e/$slug/confirm/$token")({
 })
 
 function CrewAssignmentConfirmationPage() {
-  const data = Route.useLoaderData()
+  const loaderData = Route.useLoaderData()
+
+  if (loaderData.mode === "assignment") {
+    return (
+      <CrewAssignmentTokenConfirmation data={loaderData.assignmentResult} />
+    )
+  }
+
+  return <CrewVolunteerTokenConfirmation data={loaderData.volunteerResult} />
+}
+
+function CrewAssignmentTokenConfirmation({
+  data,
+}: {
+  data: CrewAssignmentConfirmationTokenData
+}) {
   const { slug, token } = Route.useParams()
   const router = useRouter()
   const respond = useServerFn(respondCrewAssignmentConfirmationTokenFn)
@@ -102,6 +140,13 @@ function CrewAssignmentConfirmationPage() {
     const formData = new FormData(event.currentTarget)
     const responseNote = getFormString(formData, "responseNote")
     await submitResponse("request_change", responseNote)
+  }
+
+  async function handleDecline(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    const responseNote = getFormString(formData, "responseNote")
+    await submitResponse("decline", responseNote)
   }
 
   return (
@@ -172,52 +217,65 @@ function CrewAssignmentConfirmationPage() {
 
       {canRespond ? (
         <section className="space-y-4 rounded-md border bg-card p-6 shadow-sm">
-          <div className="flex flex-wrap gap-3">
-            <button
-              type="button"
-              disabled={pendingAction !== null}
-              onClick={() => submitResponse("confirm")}
-              className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {pendingAction === "confirm" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : null}
-              Confirm
-            </button>
-            <button
-              type="button"
-              disabled={pendingAction !== null}
-              onClick={() => submitResponse("decline")}
-              className="inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {pendingAction === "decline" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : null}
-              Decline
-            </button>
-          </div>
+          <button
+            type="button"
+            disabled={pendingAction !== null}
+            onClick={() => submitResponse("confirm")}
+            className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
+          >
+            {pendingAction === "confirm" ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : null}
+            Confirm
+          </button>
 
-          <form onSubmit={handleChangeRequest} className="space-y-3">
-            <label className="grid gap-2 text-sm">
-              <span className="font-medium">Request a change</span>
-              <textarea
-                name="responseNote"
-                rows={4}
-                className="rounded-md border bg-background px-3 py-2"
-                placeholder="Share what needs to change"
-              />
-            </label>
-            <button
-              type="submit"
-              disabled={pendingAction !== null}
-              className="inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {pendingAction === "request_change" ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : null}
-              Send request
-            </button>
-          </form>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <form onSubmit={handleChangeRequest} className="space-y-3">
+              <label className="grid gap-2 text-sm">
+                <span className="font-medium">Request a change</span>
+                <textarea
+                  name="responseNote"
+                  required
+                  rows={4}
+                  className="rounded-md border bg-background px-3 py-2"
+                  placeholder="Share what needs to change"
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={pendingAction !== null}
+                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {pendingAction === "request_change" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                Send request
+              </button>
+            </form>
+
+            <form onSubmit={handleDecline} className="space-y-3">
+              <label className="grid gap-2 text-sm">
+                <span className="font-medium">Decline</span>
+                <textarea
+                  name="responseNote"
+                  required
+                  rows={4}
+                  className="rounded-md border bg-background px-3 py-2"
+                  placeholder="Let the organizer know why"
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={pendingAction !== null}
+                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {pendingAction === "decline" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                Decline
+              </button>
+            </form>
+          </div>
         </section>
       ) : (
         <section className="rounded-md border bg-card p-6 shadow-sm">
@@ -234,6 +292,258 @@ function CrewAssignmentConfirmationPage() {
         </section>
       )}
     </main>
+  )
+}
+
+function CrewVolunteerTokenConfirmation({
+  data,
+}: {
+  data: CrewVolunteerScheduleTokenData
+}) {
+  const { slug, token } = Route.useParams()
+  const router = useRouter()
+  const respond = useServerFn(respondCrewVolunteerScheduleTokenFn)
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+
+  if (data.status !== "valid" || !data.event || !data.volunteer) {
+    return (
+      <main className="mx-auto max-w-2xl px-4 py-10 sm:px-6">
+        <section className="rounded-md border bg-card p-6 shadow-sm">
+          <p className="text-sm font-medium text-muted-foreground">
+            Assignment confirmation
+          </p>
+          <h1 className="mt-2 text-2xl font-semibold">
+            This link is no longer valid
+          </h1>
+          <p className="mt-3 text-muted-foreground">
+            Please contact the event organizer for a fresh assignment link.
+          </p>
+        </section>
+      </main>
+    )
+  }
+
+  const timezone = data.event.timezone ?? "America/Denver"
+
+  async function submitResponse(
+    assignment: CrewVolunteerVisibleAssignment,
+    action: "confirm" | "decline" | "request_change",
+    responseNote?: string,
+  ) {
+    const actionKey = `${assignment.id}:${action}`
+    setPendingAction(actionKey)
+    try {
+      const result = await respond({
+        data: {
+          slug,
+          token,
+          assignmentId: assignment.id,
+          action,
+          responseNote: responseNote?.trim() || undefined,
+        },
+      })
+      if (result.success) {
+        toast.success(result.message)
+      } else {
+        toast.error(result.message)
+      }
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Assignment response failed",
+      )
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  function handleNoteResponse(
+    assignment: CrewVolunteerVisibleAssignment,
+    action: "decline" | "request_change",
+    event: FormEvent<HTMLFormElement>,
+  ) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    void submitResponse(assignment, action, getFormString(formData, "note"))
+  }
+
+  return (
+    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <p className="text-sm font-medium text-muted-foreground">
+          Assignment confirmation
+        </p>
+        <h1 className="mt-2 text-3xl font-semibold">{data.event.name}</h1>
+        <p className="mt-2 text-muted-foreground">
+          {data.volunteer.name ?? "Volunteer"} · {data.volunteer.email}
+        </p>
+      </section>
+
+      {data.assignments.length === 0 ? (
+        <section className="rounded-md border bg-card p-6 shadow-sm">
+          <h2 className="text-xl font-semibold">No assignments yet</h2>
+          <p className="mt-2 text-muted-foreground">
+            No volunteer assignments are published for this link yet.
+          </p>
+        </section>
+      ) : (
+        <section className="space-y-4">
+          {data.assignments.map((assignment) => (
+            <VolunteerAssignmentResponseCard
+              key={assignment.id}
+              assignment={assignment}
+              timezone={timezone}
+              pendingAction={pendingAction}
+              onConfirm={() => void submitResponse(assignment, "confirm")}
+              onNoteSubmit={handleNoteResponse}
+            />
+          ))}
+        </section>
+      )}
+    </main>
+  )
+}
+
+function VolunteerAssignmentResponseCard({
+  assignment,
+  timezone,
+  pendingAction,
+  onConfirm,
+  onNoteSubmit,
+}: {
+  assignment: CrewVolunteerVisibleAssignment
+  timezone: string
+  pendingAction: string | null
+  onConfirm: () => void
+  onNoteSubmit: (
+    assignment: CrewVolunteerVisibleAssignment,
+    action: "decline" | "request_change",
+    event: FormEvent<HTMLFormElement>,
+  ) => void
+}) {
+  const status = assignment.confirmation?.status ?? "pending"
+  const canRespond = status === "pending"
+  const disabled = pendingAction !== null
+  const declineKey = `${assignment.id}:decline`
+  const changeKey = `${assignment.id}:request_change`
+
+  return (
+    <article className="rounded-md border bg-card p-6 shadow-sm">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">{assignment.name}</h2>
+          <p className="mt-2 text-muted-foreground">{assignment.roleLabel}</p>
+        </div>
+        <StatusBadge status={status} />
+      </div>
+
+      <dl className="mt-6 grid gap-4 text-sm sm:grid-cols-2">
+        <Fact
+          label="Start"
+          value={formatDateTimeInTimezone(
+            assignment.startTime,
+            timezone,
+            "EEE, MMM d h:mm a",
+          )}
+        />
+        <Fact
+          label="End"
+          value={formatDateTimeInTimezone(
+            assignment.endTime,
+            timezone,
+            "EEE, MMM d h:mm a",
+          )}
+        />
+        <Fact label="Location" value={assignment.location ?? "Not set"} />
+      </dl>
+
+      {assignment.notes ? (
+        <p className="mt-5 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
+          {assignment.notes}
+        </p>
+      ) : null}
+
+      {canRespond ? (
+        <div className="mt-5 space-y-4 rounded-md border bg-background p-4">
+          <button
+            type="button"
+            disabled={disabled}
+            onClick={onConfirm}
+            className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
+          >
+            {pendingAction === `${assignment.id}:confirm` ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : null}
+            Confirm
+          </button>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <form
+              onSubmit={(event) =>
+                onNoteSubmit(assignment, "request_change", event)
+              }
+              className="space-y-3"
+            >
+              <label className="grid gap-2 text-sm">
+                <span className="font-medium">Request a change</span>
+                <textarea
+                  name="note"
+                  required
+                  rows={4}
+                  className="rounded-md border bg-card px-3 py-2"
+                  placeholder="Share what needs to change"
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={disabled}
+                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {pendingAction === changeKey ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                Send request
+              </button>
+            </form>
+
+            <form
+              onSubmit={(event) => onNoteSubmit(assignment, "decline", event)}
+              className="space-y-3"
+            >
+              <label className="grid gap-2 text-sm">
+                <span className="font-medium">Decline</span>
+                <textarea
+                  name="note"
+                  required
+                  rows={4}
+                  className="rounded-md border bg-card px-3 py-2"
+                  placeholder="Let the organizer know why"
+                />
+              </label>
+              <button
+                type="submit"
+                disabled={disabled}
+                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {pendingAction === declineKey ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : null}
+                Decline
+              </button>
+            </form>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-5 rounded-md border bg-background p-3 text-sm">
+          <p className="font-medium">{getRecordedResponseMessage(status)}</p>
+          {assignment.confirmation?.responseNote ? (
+            <p className="mt-2 whitespace-pre-wrap text-muted-foreground">
+              {assignment.confirmation.responseNote}
+            </p>
+          ) : null}
+        </div>
+      )}
+    </article>
   )
 }
 
@@ -256,6 +566,19 @@ function StatusBadge({ status }: { status: string }) {
       {getCrewAssignmentConfirmationStatusLabel(status)}
     </span>
   )
+}
+
+function getRecordedResponseMessage(status: string) {
+  if (status === "confirmed") {
+    return "Confirmed. We'll remind you before your shift."
+  }
+  if (status === "declined") {
+    return "Declined. The organizer will see your note."
+  }
+  if (status === "change_requested") {
+    return "Change request sent. The organizer will see your note."
+  }
+  return `Response recorded: ${getCrewAssignmentConfirmationStatusLabel(status)}.`
 }
 
 function getFormString(formData: FormData, name: string) {

--- a/apps/crew/src/routes/e/$slug/confirm/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/confirm/$token.tsx
@@ -2,10 +2,12 @@
 
 import { createFileRoute, notFound, useRouter } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
-import { Loader2 } from "lucide-react"
-import type { FormEvent } from "react"
 import { useState } from "react"
 import { toast } from "sonner"
+import {
+  CrewVolunteerPublicResponseControls,
+  getCrewVolunteerResponseActionKey,
+} from "@/components/crew/volunteer-public-response-controls"
 import {
   getCrewAssignmentConfirmationStatusBadgeClassName,
   getCrewAssignmentConfirmationStatusLabel,
@@ -108,17 +110,22 @@ function CrewAssignmentTokenConfirmation({
   }
 
   const timezone = data.event.timezone ?? "America/Denver"
+  const assignment = data.assignment
   const confirmationStatus = data.confirmation?.status ?? "pending"
-  const canRespond = confirmationStatus === "pending"
 
   async function submitResponse(
     action: "confirm" | "decline" | "request_change",
     responseNote?: string,
   ) {
-    setPendingAction(action)
+    setPendingAction(getCrewVolunteerResponseActionKey(assignment.id, action))
     try {
       const result = await respond({
-        data: { slug, token, action, responseNote },
+        data: {
+          slug,
+          token,
+          action,
+          responseNote: responseNote?.trim() || undefined,
+        },
       })
       if (result.success) {
         toast.success(result.message)
@@ -133,20 +140,6 @@ function CrewAssignmentTokenConfirmation({
     } finally {
       setPendingAction(null)
     }
-  }
-
-  async function handleChangeRequest(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const responseNote = getFormString(formData, "responseNote")
-    await submitResponse("request_change", responseNote)
-  }
-
-  async function handleDecline(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const responseNote = getFormString(formData, "responseNote")
-    await submitResponse("decline", responseNote)
   }
 
   return (
@@ -165,10 +158,8 @@ function CrewAssignmentTokenConfirmation({
       <section className="rounded-md border bg-card p-6 shadow-sm">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
-            <h2 className="text-xl font-semibold">{data.assignment.name}</h2>
-            <p className="mt-2 text-muted-foreground">
-              {data.assignment.roleLabel}
-            </p>
+            <h2 className="text-xl font-semibold">{assignment.name}</h2>
+            <p className="mt-2 text-muted-foreground">{assignment.roleLabel}</p>
           </div>
           <StatusBadge status={confirmationStatus} />
         </div>
@@ -177,7 +168,7 @@ function CrewAssignmentTokenConfirmation({
           <Fact
             label="Start"
             value={formatDateTimeInTimezone(
-              data.assignment.startTime,
+              assignment.startTime,
               timezone,
               "EEE, MMM d h:mm a",
             )}
@@ -185,15 +176,12 @@ function CrewAssignmentTokenConfirmation({
           <Fact
             label="End"
             value={formatDateTimeInTimezone(
-              data.assignment.endTime,
+              assignment.endTime,
               timezone,
               "EEE, MMM d h:mm a",
             )}
           />
-          <Fact
-            label="Location"
-            value={data.assignment.location ?? "Not set"}
-          />
+          <Fact label="Location" value={assignment.location ?? "Not set"} />
           <Fact
             label="Respond by"
             value={
@@ -208,89 +196,24 @@ function CrewAssignmentTokenConfirmation({
           />
         </dl>
 
-        {data.assignment.notes ? (
+        {assignment.notes ? (
           <p className="mt-5 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
-            {data.assignment.notes}
+            {assignment.notes}
           </p>
         ) : null}
       </section>
 
-      {canRespond ? (
-        <section className="space-y-4 rounded-md border bg-card p-6 shadow-sm">
-          <button
-            type="button"
-            disabled={pendingAction !== null}
-            onClick={() => submitResponse("confirm")}
-            className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
-          >
-            {pendingAction === "confirm" ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : null}
-            Confirm
-          </button>
-
-          <div className="grid gap-4 sm:grid-cols-2">
-            <form onSubmit={handleChangeRequest} className="space-y-3">
-              <label className="grid gap-2 text-sm">
-                <span className="font-medium">Request a change</span>
-                <textarea
-                  name="responseNote"
-                  required
-                  rows={4}
-                  className="rounded-md border bg-background px-3 py-2"
-                  placeholder="Share what needs to change"
-                />
-              </label>
-              <button
-                type="submit"
-                disabled={pendingAction !== null}
-                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {pendingAction === "request_change" ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : null}
-                Send request
-              </button>
-            </form>
-
-            <form onSubmit={handleDecline} className="space-y-3">
-              <label className="grid gap-2 text-sm">
-                <span className="font-medium">Decline</span>
-                <textarea
-                  name="responseNote"
-                  required
-                  rows={4}
-                  className="rounded-md border bg-background px-3 py-2"
-                  placeholder="Let the organizer know why"
-                />
-              </label>
-              <button
-                type="submit"
-                disabled={pendingAction !== null}
-                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {pendingAction === "decline" ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : null}
-                Decline
-              </button>
-            </form>
-          </div>
-        </section>
-      ) : (
-        <section className="rounded-md border bg-card p-6 shadow-sm">
-          <h2 className="text-xl font-semibold">Response recorded</h2>
-          <p className="mt-2 text-muted-foreground">
-            Your current response is{" "}
-            {getCrewAssignmentConfirmationStatusLabel(confirmationStatus)}.
-          </p>
-          {data.confirmation?.responseNote ? (
-            <p className="mt-4 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm">
-              {data.confirmation.responseNote}
-            </p>
-          ) : null}
-        </section>
-      )}
+      <section className="rounded-md border bg-card p-6 shadow-sm">
+        <CrewVolunteerPublicResponseControls
+          assignment={{
+            id: assignment.id,
+            confirmation: data.confirmation,
+          }}
+          pendingAction={pendingAction}
+          onConfirm={() => void submitResponse("confirm")}
+          onNoteSubmit={(action, note) => submitResponse(action, note)}
+        />
+      </section>
     </main>
   )
 }
@@ -330,8 +253,7 @@ function CrewVolunteerTokenConfirmation({
     action: "confirm" | "decline" | "request_change",
     responseNote?: string,
   ) {
-    const actionKey = `${assignment.id}:${action}`
-    setPendingAction(actionKey)
+    setPendingAction(getCrewVolunteerResponseActionKey(assignment.id, action))
     try {
       const result = await respond({
         data: {
@@ -355,16 +277,6 @@ function CrewVolunteerTokenConfirmation({
     } finally {
       setPendingAction(null)
     }
-  }
-
-  function handleNoteResponse(
-    assignment: CrewVolunteerVisibleAssignment,
-    action: "decline" | "request_change",
-    event: FormEvent<HTMLFormElement>,
-  ) {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    void submitResponse(assignment, action, getFormString(formData, "note"))
   }
 
   return (
@@ -395,7 +307,9 @@ function CrewVolunteerTokenConfirmation({
               timezone={timezone}
               pendingAction={pendingAction}
               onConfirm={() => void submitResponse(assignment, "confirm")}
-              onNoteSubmit={handleNoteResponse}
+              onNoteSubmit={(action, note) =>
+                submitResponse(assignment, action, note)
+              }
             />
           ))}
         </section>
@@ -416,16 +330,11 @@ function VolunteerAssignmentResponseCard({
   pendingAction: string | null
   onConfirm: () => void
   onNoteSubmit: (
-    assignment: CrewVolunteerVisibleAssignment,
     action: "decline" | "request_change",
-    event: FormEvent<HTMLFormElement>,
-  ) => void
+    note: string,
+  ) => Promise<void> | void
 }) {
   const status = assignment.confirmation?.status ?? "pending"
-  const canRespond = status === "pending"
-  const disabled = pendingAction !== null
-  const declineKey = `${assignment.id}:decline`
-  const changeKey = `${assignment.id}:request_change`
 
   return (
     <article className="rounded-md border bg-card p-6 shadow-sm">
@@ -463,86 +372,12 @@ function VolunteerAssignmentResponseCard({
         </p>
       ) : null}
 
-      {canRespond ? (
-        <div className="mt-5 space-y-4 rounded-md border bg-background p-4">
-          <button
-            type="button"
-            disabled={disabled}
-            onClick={onConfirm}
-            className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
-          >
-            {pendingAction === `${assignment.id}:confirm` ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : null}
-            Confirm
-          </button>
-
-          <div className="grid gap-4 sm:grid-cols-2">
-            <form
-              onSubmit={(event) =>
-                onNoteSubmit(assignment, "request_change", event)
-              }
-              className="space-y-3"
-            >
-              <label className="grid gap-2 text-sm">
-                <span className="font-medium">Request a change</span>
-                <textarea
-                  name="note"
-                  required
-                  rows={4}
-                  className="rounded-md border bg-card px-3 py-2"
-                  placeholder="Share what needs to change"
-                />
-              </label>
-              <button
-                type="submit"
-                disabled={disabled}
-                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {pendingAction === changeKey ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : null}
-                Send request
-              </button>
-            </form>
-
-            <form
-              onSubmit={(event) => onNoteSubmit(assignment, "decline", event)}
-              className="space-y-3"
-            >
-              <label className="grid gap-2 text-sm">
-                <span className="font-medium">Decline</span>
-                <textarea
-                  name="note"
-                  required
-                  rows={4}
-                  className="rounded-md border bg-card px-3 py-2"
-                  placeholder="Let the organizer know why"
-                />
-              </label>
-              <button
-                type="submit"
-                disabled={disabled}
-                className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {pendingAction === declineKey ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : null}
-                Decline
-              </button>
-            </form>
-          </div>
-        </div>
-      ) : (
-        <div className="mt-5 rounded-md border bg-background p-3 text-sm">
-          <p className="font-medium">{getRecordedResponseMessage(status)}</p>
-          {assignment.confirmation?.responseNote ? (
-            <p className="mt-2 whitespace-pre-wrap text-muted-foreground">
-              {assignment.confirmation.responseNote}
-            </p>
-          ) : null}
-        </div>
-      )}
+      <CrewVolunteerPublicResponseControls
+        assignment={assignment}
+        pendingAction={pendingAction}
+        onConfirm={onConfirm}
+        onNoteSubmit={onNoteSubmit}
+      />
     </article>
   )
 }
@@ -566,22 +401,4 @@ function StatusBadge({ status }: { status: string }) {
       {getCrewAssignmentConfirmationStatusLabel(status)}
     </span>
   )
-}
-
-function getRecordedResponseMessage(status: string) {
-  if (status === "confirmed") {
-    return "Confirmed. We'll remind you before your shift."
-  }
-  if (status === "declined") {
-    return "Declined. The organizer will see your note."
-  }
-  if (status === "change_requested") {
-    return "Change request sent. The organizer will see your note."
-  }
-  return `Response recorded: ${getCrewAssignmentConfirmationStatusLabel(status)}.`
-}
-
-function getFormString(formData: FormData, name: string) {
-  const value = formData.get(name)
-  return typeof value === "string" ? value.trim() : ""
 }

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -12,7 +12,7 @@ import {
   Printer,
   ShieldCheck,
 } from "lucide-react"
-import { useMemo } from "react"
+import { type FormEvent, type ReactNode, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
 import { z } from "zod"
@@ -27,16 +27,21 @@ import {
   getCrewAssignmentConfirmationStatusLabel,
 } from "@/lib/crew/assignment-confirmation-display"
 import {
-  getCrewAssignmentConfirmationTokenFn,
-  type CrewAssignmentConfirmationTokenData,
-  updateCrewAssignmentConfirmationContactTokenFn,
-} from "@/server-fns/crew-confirmation-fns"
-import {
   buildCrewVolunteerSelfServiceGoogleCalendarUrl,
   buildCrewVolunteerSelfServiceIcs,
   buildCrewVolunteerSelfServiceIcsFilename,
 } from "@/lib/crew/volunteer-self-service"
-import { getCrewVolunteerScheduleTokenFn } from "@/server-fns/crew-volunteer-fns"
+import {
+  type CrewAssignmentConfirmationTokenData,
+  getCrewAssignmentConfirmationTokenFn,
+  updateCrewAssignmentConfirmationContactTokenFn,
+} from "@/server-fns/crew-confirmation-fns"
+import {
+  type CrewVolunteerScheduleTokenData,
+  type CrewVolunteerVisibleAssignment,
+  getCrewVolunteerScheduleTokenFn,
+  respondCrewVolunteerScheduleTokenFn,
+} from "@/server-fns/crew-volunteer-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
 const optionalContactString = (maxLength: number) =>
@@ -108,70 +113,238 @@ function CrewVolunteerScheduleTokenPage() {
     return <CrewAssignmentSchedule data={loaderData.assignmentResult} />
   }
 
-  const { event, volunteer } = loaderData.volunteerResult
+  return (
+    <CrewVolunteerTokenSchedule
+      data={loaderData.volunteerResult}
+      consentHref={consentHref}
+    />
+  )
+}
 
-  if (!event || !volunteer) {
+function CrewVolunteerTokenSchedule({
+  data,
+  consentHref,
+}: {
+  data: CrewVolunteerScheduleTokenData
+  consentHref: string
+}) {
+  const { slug, token } = Route.useParams()
+  const router = useRouter()
+  const respond = useServerFn(respondCrewVolunteerScheduleTokenFn)
+  const [pendingAction, setPendingAction] = useState<string | null>(null)
+  const [noteErrors, setNoteErrors] = useState<Record<string, string>>({})
+
+  if (data.status !== "valid" || !data.event || !data.volunteer) {
     return null
   }
 
+  const timezone = data.event.timezone ?? "America/Denver"
+  const eventDates = `${data.event.startDate} to ${data.event.endDate}`
+  const icsText = buildCrewVolunteerSelfServiceIcs({
+    eventName: data.event.name,
+    assignments: data.assignments,
+  })
+  const icsHref = `data:text/calendar;charset=utf-8,${encodeURIComponent(
+    icsText,
+  )}`
+  const firstAssignment = data.assignments[0] ?? null
+  const googleCalendarUrl = firstAssignment
+    ? buildCrewVolunteerSelfServiceGoogleCalendarUrl({
+        eventName: data.event.name,
+        assignment: firstAssignment,
+      })
+    : null
+  const confirmHref = `/e/${encodeURIComponent(slug)}/confirm/${encodeURIComponent(
+    token,
+  )}`
+
+  async function submitResponse(
+    assignment: CrewVolunteerVisibleAssignment,
+    action: "confirm" | "decline" | "request_change",
+    responseNote?: string,
+  ) {
+    const note = responseNote?.trim() ?? ""
+    const noteErrorKey = `${assignment.id}:${action}`
+    if ((action === "decline" || action === "request_change") && !note) {
+      setNoteErrors((current) => ({
+        ...current,
+        [noteErrorKey]:
+          action === "decline"
+            ? "Add a note before declining."
+            : "Add a note before requesting a change.",
+      }))
+      return
+    }
+
+    setPendingAction(noteErrorKey)
+    setNoteErrors((current) => ({ ...current, [noteErrorKey]: "" }))
+    try {
+      const result = await respond({
+        data: {
+          slug,
+          token,
+          assignmentId: assignment.id,
+          action,
+          responseNote: note || undefined,
+        },
+      })
+      if (result.success) {
+        toast.success(result.message)
+      } else {
+        toast.error(result.message)
+      }
+      await router.invalidate()
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Assignment response failed",
+      )
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  function handleNoteResponse(
+    assignment: CrewVolunteerVisibleAssignment,
+    action: "decline" | "request_change",
+    event: FormEvent<HTMLFormElement>,
+  ) {
+    event.preventDefault()
+    const formData = new FormData(event.currentTarget)
+    void submitResponse(assignment, action, getFormString(formData, "note"))
+  }
+
   return (
-    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6">
-      <section className="rounded-md border bg-card p-6 shadow-sm">
+    <main className="mx-auto max-w-3xl space-y-6 px-4 py-8 sm:px-6 print:max-w-none print:px-0">
+      <section className="rounded-md border bg-card p-6 shadow-sm print:border-0 print:shadow-none">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <p className="text-sm font-medium text-muted-foreground">
               Volunteer schedule
             </p>
-            <h1 className="mt-2 text-3xl font-semibold">{event.name}</h1>
+            <h1 className="mt-2 text-3xl font-semibold">{data.event.name}</h1>
             <p className="mt-2 text-muted-foreground">
-              {event.startDate} to {event.endDate}
+              {data.volunteer.name ?? "Volunteer"} · {data.volunteer.email}
             </p>
           </div>
-          <a
-            href={consentHref}
-            className="inline-flex h-10 w-fit items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
-          >
-            <ShieldCheck className="size-4" />
-            Consent
-          </a>
+          <div className="flex flex-wrap gap-2 print:hidden">
+            {data.assignments.length > 0 ? (
+              <>
+                <a
+                  href={icsHref}
+                  download={buildCrewVolunteerSelfServiceIcsFilename(
+                    data.event.name,
+                  )}
+                  className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+                >
+                  <CalendarPlus className="size-4" />
+                  iCal
+                </a>
+                {googleCalendarUrl ? (
+                  <a
+                    href={googleCalendarUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+                  >
+                    <ExternalLink className="size-4" />
+                    Google
+                  </a>
+                ) : null}
+                <button
+                  type="button"
+                  onClick={() => window.print()}
+                  className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+                >
+                  <Printer className="size-4" />
+                  Print
+                </button>
+              </>
+            ) : null}
+            <a
+              href={consentHref}
+              className="inline-flex h-10 w-fit items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted"
+            >
+              <ShieldCheck className="size-4" />
+              Consent
+            </a>
+          </div>
         </div>
       </section>
 
-      <section className="grid gap-4 sm:grid-cols-2">
-        <InfoBlock label="Volunteer" value={volunteer.name ?? "Not provided"} />
-        <InfoBlock label="Email" value={volunteer.email} />
+      <section className="grid gap-4 sm:grid-cols-2 print:hidden">
+        <InfoBlock
+          label="Volunteer"
+          value={data.volunteer.name ?? "Not provided"}
+        />
+        <InfoBlock label="Email" value={data.volunteer.email} />
         <InfoBlock
           label="Availability"
-          value={formatAvailability(volunteer.availability)}
+          value={formatAvailability(data.volunteer.availability)}
         />
         <InfoBlock
           label="Preferred roles"
-          value={formatRoleTypes(volunteer.roleTypes)}
+          value={formatRoleTypes(data.volunteer.roleTypes)}
         />
       </section>
 
-      {(volunteer.phone ||
-        volunteer.credentials ||
-        volunteer.availabilityNotes) && (
-        <section className="space-y-4 rounded-md border bg-card p-6 shadow-sm">
-          {volunteer.phone && <InfoRow label="Phone" value={volunteer.phone} />}
-          {volunteer.credentials && (
-            <InfoRow label="Credentials" value={volunteer.credentials} />
+      {(data.volunteer.phone ||
+        data.volunteer.credentials ||
+        data.volunteer.availabilityNotes) && (
+        <section className="space-y-4 rounded-md border bg-card p-6 shadow-sm print:hidden">
+          {data.volunteer.phone && (
+            <InfoRow label="Phone" value={data.volunteer.phone} />
           )}
-          {volunteer.availabilityNotes && (
+          {data.volunteer.credentials && (
+            <InfoRow label="Credentials" value={data.volunteer.credentials} />
+          )}
+          {data.volunteer.availabilityNotes && (
             <InfoRow
               label="Availability notes"
-              value={volunteer.availabilityNotes}
+              value={data.volunteer.availabilityNotes}
             />
           )}
         </section>
       )}
 
-      <section className="rounded-md border bg-card p-6 shadow-sm">
-        <h2 className="text-xl font-semibold">Assignments</h2>
-        <p className="mt-2 text-muted-foreground">
-          No volunteer assignments are published for this link yet.
-        </p>
+      <section className="space-y-3">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <h2 className="text-xl font-semibold">Assignments</h2>
+          {data.assignments.length > 0 ? (
+            <a
+              href={confirmHref}
+              className="inline-flex h-10 w-fit items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted print:hidden"
+            >
+              <ExternalLink className="size-4" />
+              Response page
+            </a>
+          ) : null}
+        </div>
+
+        {data.assignments.length === 0 ? (
+          <div className="rounded-md border bg-card p-6 shadow-sm">
+            <p className="text-muted-foreground">
+              No volunteer assignments are published for this link yet.
+            </p>
+          </div>
+        ) : (
+          data.assignments.map((assignment) => (
+            <ScheduleAssignmentCard
+              key={assignment.id}
+              assignment={assignment}
+              timezone={timezone}
+              eventDates={eventDates}
+              responseControls={
+                <VolunteerResponseControls
+                  assignment={assignment}
+                  pendingAction={pendingAction}
+                  noteErrors={noteErrors}
+                  onConfirm={() => void submitResponse(assignment, "confirm")}
+                  onNoteSubmit={handleNoteResponse}
+                />
+              }
+            />
+          ))
+        )}
       </section>
     </main>
   )
@@ -357,62 +530,24 @@ function CrewAssignmentSchedule({
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">Assignments</h2>
         {schedule.map((assignment) => (
-          <article
+          <ScheduleAssignmentCard
             key={assignment.id}
-            className={`rounded-md border bg-card p-5 shadow-sm print:break-inside-avoid print:shadow-none ${
-              assignment.isTokenAssignment ? "border-primary/50" : ""
-            }`}
-          >
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div>
-                <h3 className="text-lg font-semibold">{assignment.name}</h3>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {assignment.roleLabel}
-                </p>
-              </div>
-              <StatusBadge status={assignment.confirmation?.status} />
-            </div>
-
-            <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2">
-              <InfoRow
-                label="Start"
-                value={formatDateTimeInTimezone(
-                  assignment.startTime,
-                  timezone,
-                  "EEE, MMM d h:mm a",
-                )}
-              />
-              <InfoRow
-                label="End"
-                value={formatDateTimeInTimezone(
-                  assignment.endTime,
-                  timezone,
-                  "EEE, MMM d h:mm a",
-                )}
-              />
-              <InfoRow
-                label="Location"
-                value={assignment.location ?? "Not set"}
-              />
-              <InfoRow label="Event dates" value={eventDates} />
-            </dl>
-
-            {assignment.notes ? (
-              <p className="mt-5 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
-                {assignment.notes}
-              </p>
-            ) : null}
-
-            {assignment.isTokenAssignment ? (
-              <a
-                href={confirmHref}
-                className="mt-5 inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted print:hidden"
-              >
-                <ExternalLink className="size-4" />
-                Update response
-              </a>
-            ) : null}
-          </article>
+            assignment={assignment}
+            timezone={timezone}
+            eventDates={eventDates}
+            highlighted={assignment.isTokenAssignment}
+            responseControls={
+              assignment.isTokenAssignment ? (
+                <a
+                  href={confirmHref}
+                  className="mt-5 inline-flex h-10 items-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted print:hidden"
+                >
+                  <ExternalLink className="size-4" />
+                  Update response
+                </a>
+              ) : null
+            }
+          />
         ))}
       </section>
 
@@ -534,6 +669,194 @@ function CrewAssignmentSchedule({
   )
 }
 
+interface ScheduleAssignmentCardData {
+  id: string
+  name: string
+  roleLabel: string
+  startTime: Date
+  endTime: Date
+  location: string | null
+  notes: string | null
+  confirmation?: { status?: string | null; responseNote?: string | null } | null
+}
+
+function ScheduleAssignmentCard({
+  assignment,
+  timezone,
+  eventDates,
+  highlighted = false,
+  responseControls = null,
+}: {
+  assignment: ScheduleAssignmentCardData
+  timezone: string
+  eventDates: string
+  highlighted?: boolean
+  responseControls?: ReactNode
+}) {
+  return (
+    <article
+      className={`rounded-md border bg-card p-5 shadow-sm print:break-inside-avoid print:shadow-none ${
+        highlighted ? "border-primary/50" : ""
+      }`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">{assignment.name}</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {assignment.roleLabel}
+          </p>
+        </div>
+        <StatusBadge status={assignment.confirmation?.status} />
+      </div>
+
+      <dl className="mt-5 grid gap-4 text-sm sm:grid-cols-2">
+        <InfoRow
+          label="Start"
+          value={formatDateTimeInTimezone(
+            assignment.startTime,
+            timezone,
+            "EEE, MMM d h:mm a",
+          )}
+        />
+        <InfoRow
+          label="End"
+          value={formatDateTimeInTimezone(
+            assignment.endTime,
+            timezone,
+            "EEE, MMM d h:mm a",
+          )}
+        />
+        <InfoRow label="Location" value={assignment.location ?? "Not set"} />
+        <InfoRow label="Event dates" value={eventDates} />
+      </dl>
+
+      {assignment.notes ? (
+        <p className="mt-5 whitespace-pre-wrap rounded-md border bg-background p-3 text-sm text-muted-foreground">
+          {assignment.notes}
+        </p>
+      ) : null}
+
+      {responseControls}
+    </article>
+  )
+}
+
+function VolunteerResponseControls({
+  assignment,
+  pendingAction,
+  noteErrors,
+  onConfirm,
+  onNoteSubmit,
+}: {
+  assignment: CrewVolunteerVisibleAssignment
+  pendingAction: string | null
+  noteErrors: Record<string, string>
+  onConfirm: () => void
+  onNoteSubmit: (
+    assignment: CrewVolunteerVisibleAssignment,
+    action: "decline" | "request_change",
+    event: FormEvent<HTMLFormElement>,
+  ) => void
+}) {
+  const status = assignment.confirmation?.status ?? "pending"
+  const canRespond = status === "pending"
+
+  if (!canRespond) {
+    return (
+      <div className="mt-5 rounded-md border bg-background p-3 text-sm print:hidden">
+        <p className="font-medium">{getRecordedResponseMessage(status)}</p>
+        {assignment.confirmation?.responseNote ? (
+          <p className="mt-2 whitespace-pre-wrap text-muted-foreground">
+            {assignment.confirmation.responseNote}
+          </p>
+        ) : null}
+      </div>
+    )
+  }
+
+  const declineKey = `${assignment.id}:decline`
+  const changeKey = `${assignment.id}:request_change`
+  const disabled = pendingAction !== null
+
+  return (
+    <div className="mt-5 space-y-4 rounded-md border bg-background p-4 print:hidden">
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={onConfirm}
+        className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
+      >
+        {pendingAction === `${assignment.id}:confirm` ? (
+          <Loader2 className="size-4 animate-spin" />
+        ) : null}
+        Confirm
+      </button>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <form
+          onSubmit={(event) =>
+            onNoteSubmit(assignment, "request_change", event)
+          }
+          className="space-y-2"
+        >
+          <label className="grid gap-2 text-sm">
+            <span className="font-medium">Request change</span>
+            <textarea
+              name="note"
+              required
+              rows={3}
+              className="rounded-md border bg-card px-3 py-2"
+              placeholder="What needs to change?"
+            />
+          </label>
+          {noteErrors[changeKey] ? (
+            <p className="text-xs text-destructive">{noteErrors[changeKey]}</p>
+          ) : null}
+          <button
+            type="submit"
+            disabled={disabled}
+            className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {pendingAction === changeKey ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : null}
+            Send request
+          </button>
+        </form>
+
+        <form
+          onSubmit={(event) => onNoteSubmit(assignment, "decline", event)}
+          className="space-y-2"
+        >
+          <label className="grid gap-2 text-sm">
+            <span className="font-medium">Decline</span>
+            <textarea
+              name="note"
+              required
+              rows={3}
+              className="rounded-md border bg-card px-3 py-2"
+              placeholder="Let the organizer know why"
+            />
+          </label>
+          {noteErrors[declineKey] ? (
+            <p className="text-xs text-destructive">{noteErrors[declineKey]}</p>
+          ) : null}
+          <button
+            type="submit"
+            disabled={disabled}
+            className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {pendingAction === declineKey ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : null}
+            Decline
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
 function InfoBlock({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border bg-card p-5 shadow-sm">
@@ -600,4 +923,22 @@ function emptyToUndefined(value: string | undefined) {
 
 function buildConsentCenterHref(slug: string, token: string) {
   return `/e/${encodeURIComponent(slug)}/consent/${encodeURIComponent(token)}`
+}
+
+function getRecordedResponseMessage(status: string) {
+  if (status === "confirmed") {
+    return "Confirmed. We'll remind you before your shift."
+  }
+  if (status === "declined") {
+    return "Declined. The organizer will see your note."
+  }
+  if (status === "change_requested") {
+    return "Change request sent. The organizer will see your note."
+  }
+  return `Response recorded: ${getCrewAssignmentConfirmationStatusLabel(status)}.`
+}
+
+function getFormString(formData: FormData, name: string) {
+  const value = formData.get(name)
+  return typeof value === "string" ? value.trim() : ""
 }

--- a/apps/crew/src/routes/e/$slug/schedule/$token.tsx
+++ b/apps/crew/src/routes/e/$slug/schedule/$token.tsx
@@ -12,10 +12,14 @@ import {
   Printer,
   ShieldCheck,
 } from "lucide-react"
-import { type FormEvent, type ReactNode, useMemo, useState } from "react"
+import { type ReactNode, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
 import { z } from "zod"
+import {
+  CrewVolunteerPublicResponseControls,
+  getCrewVolunteerResponseActionKey,
+} from "@/components/crew/volunteer-public-response-controls"
 import {
   VOLUNTEER_AVAILABILITY,
   VOLUNTEER_ROLE_LABELS,
@@ -132,7 +136,6 @@ function CrewVolunteerTokenSchedule({
   const router = useRouter()
   const respond = useServerFn(respondCrewVolunteerScheduleTokenFn)
   const [pendingAction, setPendingAction] = useState<string | null>(null)
-  const [noteErrors, setNoteErrors] = useState<Record<string, string>>({})
 
   if (data.status !== "valid" || !data.event || !data.volunteer) {
     return null
@@ -164,20 +167,7 @@ function CrewVolunteerTokenSchedule({
     responseNote?: string,
   ) {
     const note = responseNote?.trim() ?? ""
-    const noteErrorKey = `${assignment.id}:${action}`
-    if ((action === "decline" || action === "request_change") && !note) {
-      setNoteErrors((current) => ({
-        ...current,
-        [noteErrorKey]:
-          action === "decline"
-            ? "Add a note before declining."
-            : "Add a note before requesting a change.",
-      }))
-      return
-    }
-
-    setPendingAction(noteErrorKey)
-    setNoteErrors((current) => ({ ...current, [noteErrorKey]: "" }))
+    setPendingAction(getCrewVolunteerResponseActionKey(assignment.id, action))
     try {
       const result = await respond({
         data: {
@@ -201,16 +191,6 @@ function CrewVolunteerTokenSchedule({
     } finally {
       setPendingAction(null)
     }
-  }
-
-  function handleNoteResponse(
-    assignment: CrewVolunteerVisibleAssignment,
-    action: "decline" | "request_change",
-    event: FormEvent<HTMLFormElement>,
-  ) {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    void submitResponse(assignment, action, getFormString(formData, "note"))
   }
 
   return (
@@ -334,12 +314,14 @@ function CrewVolunteerTokenSchedule({
               timezone={timezone}
               eventDates={eventDates}
               responseControls={
-                <VolunteerResponseControls
+                <CrewVolunteerPublicResponseControls
                   assignment={assignment}
                   pendingAction={pendingAction}
-                  noteErrors={noteErrors}
+                  className="print:hidden"
                   onConfirm={() => void submitResponse(assignment, "confirm")}
-                  onNoteSubmit={handleNoteResponse}
+                  onNoteSubmit={(action, note) =>
+                    submitResponse(assignment, action, note)
+                  }
                 />
               }
             />
@@ -741,122 +723,6 @@ function ScheduleAssignmentCard({
   )
 }
 
-function VolunteerResponseControls({
-  assignment,
-  pendingAction,
-  noteErrors,
-  onConfirm,
-  onNoteSubmit,
-}: {
-  assignment: CrewVolunteerVisibleAssignment
-  pendingAction: string | null
-  noteErrors: Record<string, string>
-  onConfirm: () => void
-  onNoteSubmit: (
-    assignment: CrewVolunteerVisibleAssignment,
-    action: "decline" | "request_change",
-    event: FormEvent<HTMLFormElement>,
-  ) => void
-}) {
-  const status = assignment.confirmation?.status ?? "pending"
-  const canRespond = status === "pending"
-
-  if (!canRespond) {
-    return (
-      <div className="mt-5 rounded-md border bg-background p-3 text-sm print:hidden">
-        <p className="font-medium">{getRecordedResponseMessage(status)}</p>
-        {assignment.confirmation?.responseNote ? (
-          <p className="mt-2 whitespace-pre-wrap text-muted-foreground">
-            {assignment.confirmation.responseNote}
-          </p>
-        ) : null}
-      </div>
-    )
-  }
-
-  const declineKey = `${assignment.id}:decline`
-  const changeKey = `${assignment.id}:request_change`
-  const disabled = pendingAction !== null
-
-  return (
-    <div className="mt-5 space-y-4 rounded-md border bg-background p-4 print:hidden">
-      <button
-        type="button"
-        disabled={disabled}
-        onClick={onConfirm}
-        className="inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-60 sm:w-fit"
-      >
-        {pendingAction === `${assignment.id}:confirm` ? (
-          <Loader2 className="size-4 animate-spin" />
-        ) : null}
-        Confirm
-      </button>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <form
-          onSubmit={(event) =>
-            onNoteSubmit(assignment, "request_change", event)
-          }
-          className="space-y-2"
-        >
-          <label className="grid gap-2 text-sm">
-            <span className="font-medium">Request change</span>
-            <textarea
-              name="note"
-              required
-              rows={3}
-              className="rounded-md border bg-card px-3 py-2"
-              placeholder="What needs to change?"
-            />
-          </label>
-          {noteErrors[changeKey] ? (
-            <p className="text-xs text-destructive">{noteErrors[changeKey]}</p>
-          ) : null}
-          <button
-            type="submit"
-            disabled={disabled}
-            className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {pendingAction === changeKey ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : null}
-            Send request
-          </button>
-        </form>
-
-        <form
-          onSubmit={(event) => onNoteSubmit(assignment, "decline", event)}
-          className="space-y-2"
-        >
-          <label className="grid gap-2 text-sm">
-            <span className="font-medium">Decline</span>
-            <textarea
-              name="note"
-              required
-              rows={3}
-              className="rounded-md border bg-card px-3 py-2"
-              placeholder="Let the organizer know why"
-            />
-          </label>
-          {noteErrors[declineKey] ? (
-            <p className="text-xs text-destructive">{noteErrors[declineKey]}</p>
-          ) : null}
-          <button
-            type="submit"
-            disabled={disabled}
-            className="inline-flex h-10 w-full items-center justify-center gap-2 rounded-md border px-4 text-sm font-medium hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {pendingAction === declineKey ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : null}
-            Decline
-          </button>
-        </form>
-      </div>
-    </div>
-  )
-}
-
 function InfoBlock({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-md border bg-card p-5 shadow-sm">
@@ -923,22 +789,4 @@ function emptyToUndefined(value: string | undefined) {
 
 function buildConsentCenterHref(slug: string, token: string) {
   return `/e/${encodeURIComponent(slug)}/consent/${encodeURIComponent(token)}`
-}
-
-function getRecordedResponseMessage(status: string) {
-  if (status === "confirmed") {
-    return "Confirmed. We'll remind you before your shift."
-  }
-  if (status === "declined") {
-    return "Declined. The organizer will see your note."
-  }
-  if (status === "change_requested") {
-    return "Change request sent. The organizer will see your note."
-  }
-  return `Response recorded: ${getCrewAssignmentConfirmationStatusLabel(status)}.`
-}
-
-function getFormString(formData: FormData, name: string) {
-  const value = formData.get(name)
-  return typeof value === "string" ? value.trim() : ""
 }

--- a/apps/crew/src/server-fns/crew-volunteer-fns.ts
+++ b/apps/crew/src/server-fns/crew-volunteer-fns.ts
@@ -5,9 +5,13 @@ import { z } from "zod"
 import { crewVolunteerSignupInputSchema } from "../lib/crew/volunteer-signup"
 
 export type {
+  CrewVolunteerScheduleResponseResult,
   CrewVolunteerScheduleTokenData,
   CrewVolunteerSignupPageData,
+  CrewVolunteerVisibleAssignment,
+  CrewVolunteerVisibleConfirmation,
   PublicCrewVolunteerEvent,
+  PublicCrewVolunteerProfile,
   PublicCrewVolunteerQuestion,
   PublicCrewVolunteerWaiver,
 } from "../server/crew-volunteer.server"
@@ -20,6 +24,13 @@ const getCrewVolunteerScheduleTokenInputSchema = z.object({
   slug: z.string().trim().min(1, "Event slug is required").max(255),
   token: z.string().trim().min(1, "Token is required").max(255),
 })
+
+const respondCrewVolunteerScheduleTokenInputSchema =
+  getCrewVolunteerScheduleTokenInputSchema.extend({
+    assignmentId: z.string().trim().min(1, "Assignment is required").max(255),
+    action: z.enum(["confirm", "decline", "request_change"]),
+    responseNote: z.string().trim().max(1000).optional(),
+  })
 
 export const getCrewVolunteerSignupPageFn = createServerFn({ method: "GET" })
   .inputValidator((data: unknown) =>
@@ -52,4 +63,17 @@ export const getCrewVolunteerScheduleTokenFn = createServerFn({
       "../server/crew-volunteer.server"
     )
     return getCrewVolunteerScheduleToken(data)
+  })
+
+export const respondCrewVolunteerScheduleTokenFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator((data: unknown) =>
+    respondCrewVolunteerScheduleTokenInputSchema.parse(data),
+  )
+  .handler(async ({ data }) => {
+    const { respondCrewVolunteerScheduleToken } = await import(
+      "../server/crew-volunteer.server"
+    )
+    return respondCrewVolunteerScheduleToken(data)
   })

--- a/apps/crew/src/server/crew-confirmation.server.ts
+++ b/apps/crew/src/server/crew-confirmation.server.ts
@@ -149,6 +149,7 @@ export interface CrewAssignmentConfirmationResponseResult
     | "expired"
     | "cancelled"
     | "already_responded"
+    | "missing_note"
     | "missing"
     | "bad"
   message: string

--- a/apps/crew/src/server/crew-volunteer.server.ts
+++ b/apps/crew/src/server/crew-volunteer.server.ts
@@ -1,21 +1,32 @@
 // @lat: [[crew#Import Apply#Confirmed Mutation]]
 import { createId } from "@paralleldrive/cuid2"
-import { and, asc, eq, ne, notInArray, sql } from "drizzle-orm"
+import { and, asc, desc, eq, ne, notInArray, or, sql } from "drizzle-orm"
 import { z } from "zod"
 import { getDb } from "../db"
+import {
+  createCrewAssignmentConfirmationId,
+  createTeamInvitationId,
+} from "../db/schemas/common"
 import {
   competitionRegistrationQuestionsTable,
   competitionsTable,
   volunteerRegistrationAnswersTable,
 } from "../db/schemas/competitions"
-import { createTeamInvitationId } from "../db/schemas/common"
 import {
   CREW_EVENT_LIFECYCLE,
   crewEventSettingsTable,
 } from "../db/schemas/crew-event-settings"
 import {
+  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
+  CREW_ASSIGNMENT_CONFIRMATION_TYPE,
+  type CrewAssignmentConfirmationStatus,
+  crewAssignmentConfirmationsTable,
+} from "../db/schemas/crew-imports"
+import {
+  CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE,
   CREW_VOLUNTEER_HISTORY_EVENT_TYPE,
   CREW_VOLUNTEER_IDENTITY_SOURCE,
+  type CrewVolunteerHistoryEventType,
 } from "../db/schemas/crew-volunteer-intelligence"
 import {
   INVITATION_STATUS,
@@ -24,18 +35,39 @@ import {
   teamMembershipTable,
 } from "../db/schemas/teams"
 import { userTable } from "../db/schemas/users"
+import {
+  type VolunteerAvailability,
+  type VolunteerRoleType,
+  volunteerShiftAssignmentsTable,
+  volunteerShiftsTable,
+} from "../db/schemas/volunteers"
 import { waiversTable } from "../db/schemas/waivers"
-import type { VolunteerAvailability } from "../db/schemas/volunteers"
+import {
+  type CrewAssignmentResponseAction,
+  generateCrewAssignmentConfirmationToken,
+  hashCrewAssignmentConfirmationToken,
+  resolveCrewAssignmentConfirmationResponse,
+} from "../lib/crew/assignment-confirmations"
+import {
+  formatVolunteerRole,
+  getCrewRosterRoleTypes,
+  parseCrewRosterMetadata,
+} from "../lib/crew/roster-shifts"
+import {
+  buildCrewVolunteerSelfServiceSchedule,
+  type CrewVolunteerSelfServiceAssignmentRecord,
+  type CrewVolunteerSelfServiceConfirmation,
+  type CrewVolunteerSelfServiceScheduleItem,
+} from "../lib/crew/volunteer-self-service"
 import {
   buildCrewVolunteerSignupMetadata,
+  type crewVolunteerSignupInputSchema,
   getCrewVolunteerTokenState,
   isCrewVolunteerSignupSpam,
   mergeCrewVolunteerSignupMetadata,
   normalizeVolunteerSignupEmail,
   planCrewVolunteerSignup,
   validateCrewVolunteerSignupRequirements,
-  type crewVolunteerSignupInputSchema,
-  type CrewVolunteerSignupMetadata,
 } from "../lib/crew/volunteer-signup"
 import { getFirstExecuteValue } from "../server-fns/db-execute"
 import type { QuestionType } from "../server-fns/registration-questions-fns"
@@ -83,16 +115,42 @@ export interface CrewVolunteerSignupPageData {
 export interface CrewVolunteerScheduleTokenData {
   status: "valid" | "missing" | "expired" | "bad"
   event: PublicCrewVolunteerEvent | null
-  volunteer: {
-    email: string
-    name: string | null
-    phone: string | null
-    availability: VolunteerAvailability | null
-    availabilityNotes: string | null
-    credentials: string | null
-    roleTypes: CrewVolunteerSignupMetadata["volunteerRoleTypes"]
-    invitationStatus: string
-  } | null
+  volunteer: PublicCrewVolunteerProfile | null
+  assignments: CrewVolunteerVisibleAssignment[]
+  confirmations: CrewVolunteerVisibleConfirmation[]
+}
+
+export interface PublicCrewVolunteerProfile {
+  email: string
+  name: string | null
+  phone: string | null
+  availability: VolunteerAvailability | null
+  availabilityNotes: string | null
+  credentials: string | null
+  roleTypes: VolunteerRoleType[]
+  invitationStatus: string
+}
+
+export interface CrewVolunteerVisibleConfirmation
+  extends CrewVolunteerSelfServiceConfirmation {
+  assignmentId: string
+}
+
+export interface CrewVolunteerVisibleAssignment
+  extends CrewVolunteerSelfServiceScheduleItem {}
+export interface CrewVolunteerScheduleResponseResult
+  extends CrewVolunteerScheduleTokenData {
+  success: boolean
+  outcome:
+    | "updated"
+    | "idempotent"
+    | "expired"
+    | "cancelled"
+    | "already_responded"
+    | "missing_note"
+    | "missing"
+    | "bad"
+  message: string
 }
 
 const getCrewVolunteerSignupPageInputSchema = z.object({
@@ -103,6 +161,13 @@ const getCrewVolunteerScheduleTokenInputSchema = z.object({
   slug: z.string().trim().min(1, "Event slug is required").max(255),
   token: z.string().trim().min(1, "Token is required").max(255),
 })
+
+const respondCrewVolunteerScheduleTokenInputSchema =
+  getCrewVolunteerScheduleTokenInputSchema.extend({
+    assignmentId: z.string().trim().min(1, "Assignment is required").max(255),
+    action: z.enum(["confirm", "decline", "request_change"]),
+    responseNote: z.string().trim().max(1000).optional(),
+  })
 
 export async function getCrewVolunteerSignupPage(
   data: z.infer<typeof getCrewVolunteerSignupPageInputSchema>,
@@ -268,63 +333,177 @@ export async function getCrewVolunteerScheduleToken(
   data: z.infer<typeof getCrewVolunteerScheduleTokenInputSchema>,
 ): Promise<CrewVolunteerScheduleTokenData> {
   const db = getDb()
-  const [row] = await db
-    .select({
-      event: publicCrewEventSelect,
-      invitation: {
-        id: teamInvitationTable.id,
-        email: teamInvitationTable.email,
-        token: teamInvitationTable.token,
-        status: teamInvitationTable.status,
-        expiresAt: teamInvitationTable.expiresAt,
-        metadata: teamInvitationTable.metadata,
-      },
-    })
-    .from(teamInvitationTable)
-    .innerJoin(
-      competitionsTable,
-      eq(teamInvitationTable.teamId, competitionsTable.competitionTeamId),
-    )
-    .innerJoin(
-      crewEventSettingsTable,
-      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
-    )
-    .where(
-      and(
-        eq(competitionsTable.slug, data.slug),
-        eq(teamInvitationTable.token, data.token),
-        eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
-        eq(teamInvitationTable.isSystemRole, true),
-        eq(crewEventSettingsTable.crewOnly, true),
-        ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
-      ),
-    )
-    .limit(1)
+  const row = await getCrewVolunteerTokenContext(db, data)
 
   if (!row) {
-    return { status: "missing", event: null, volunteer: null }
+    return emptyScheduleTokenData("missing")
   }
 
   const status = getCrewVolunteerTokenState(row.invitation)
   if (status !== "valid") {
-    return { status, event: null, volunteer: null }
+    return emptyScheduleTokenData(status)
   }
 
-  const metadata = parseVolunteerMetadata(row.invitation.metadata)
+  const membership = await findVolunteerTokenMembership(db, {
+    competitionTeamId: row.event.competitionTeamId,
+    invitation: row.invitation,
+  })
+  const volunteer = toPublicVolunteerProfile(row.invitation, membership)
+  const assignments = await loadCrewVolunteerVisibleAssignments(db, {
+    competitionId: row.event.id,
+    invitationId: row.invitation.id,
+    email: volunteer.email,
+    membershipId: membership?.id ?? null,
+  })
 
   return {
     status,
     event: toPublicCrewVolunteerEvent(row.event),
-    volunteer: {
-      email: row.invitation.email,
-      name: metadata?.signupName ?? null,
-      phone: metadata?.signupPhone ?? null,
-      availability: metadata?.availability ?? null,
-      availabilityNotes: metadata?.availabilityNotes ?? null,
-      credentials: metadata?.credentials ?? null,
-      roleTypes: metadata?.volunteerRoleTypes ?? [],
-      invitationStatus: row.invitation.status,
-    },
+    volunteer,
+    assignments,
+    confirmations: listVisibleConfirmations(assignments),
+  }
+}
+
+export async function respondCrewVolunteerScheduleToken(
+  data: z.infer<typeof respondCrewVolunteerScheduleTokenInputSchema>,
+): Promise<CrewVolunteerScheduleResponseResult> {
+  const db = getDb()
+  const responseState: {
+    outcome: CrewVolunteerScheduleResponseResult["outcome"]
+    message: string
+  } = {
+    outcome: "missing",
+    message: "Volunteer schedule link was not found.",
+  }
+
+  await db.transaction(async (tx) => {
+    const client = tx as unknown as DbClient
+    const context = await getCrewVolunteerTokenContext(client, data)
+
+    if (!context) {
+      responseState.outcome = "missing"
+      return
+    }
+
+    const tokenState = getCrewVolunteerTokenState(context.invitation)
+    if (tokenState !== "valid") {
+      responseState.outcome = tokenState === "expired" ? "expired" : "bad"
+      responseState.message =
+        tokenState === "expired"
+          ? "This volunteer schedule link has expired."
+          : "This volunteer schedule link is no longer valid."
+      return
+    }
+
+    const membership = await findVolunteerTokenMembership(client, {
+      competitionTeamId: context.event.competitionTeamId,
+      invitation: context.invitation,
+    })
+    const volunteer = toPublicVolunteerProfile(context.invitation, membership)
+    const assignmentContext = await getVisibleVolunteerAssignmentForResponse(
+      client,
+      {
+        competitionId: context.event.id,
+        assignmentId: data.assignmentId,
+        invitationId: context.invitation.id,
+        email: volunteer.email,
+        membershipId: membership?.id ?? null,
+      },
+    )
+
+    if (!assignmentContext) {
+      responseState.outcome = "bad"
+      responseState.message = "This assignment is not available from this link."
+      return
+    }
+
+    const confirmation =
+      toResponseConfirmation(assignmentContext.confirmation) ??
+      (await createCrewVolunteerScheduleConfirmation(client, {
+        competitionId: context.event.id,
+        assignmentId: assignmentContext.assignment.id,
+        membershipId: assignmentContext.assignment.membershipId,
+        invitationId: context.invitation.id,
+        email: volunteer.email,
+      }))
+
+    const resolution = resolveCrewAssignmentConfirmationResponse(
+      confirmation,
+      data.action,
+      data.responseNote,
+    )
+
+    if (!resolution.ok) {
+      responseState.outcome = resolution.reason
+      responseState.message = resolution.message
+      return
+    }
+
+    responseState.outcome = resolution.outcome
+    responseState.message =
+      resolution.outcome === "idempotent"
+        ? "Your assignment response was already recorded."
+        : getVolunteerScheduleResponseSuccessMessage(data.action)
+
+    if (resolution.outcome === "updated") {
+      await client
+        .update(crewAssignmentConfirmationsTable)
+        .set({
+          status: resolution.status,
+          responseNote: resolution.responseNote,
+          respondedAt: resolution.respondedAt,
+          updatedAt: resolution.respondedAt,
+        })
+        .where(eq(crewAssignmentConfirmationsTable.id, confirmation.id))
+
+      const historyEventType = historyEventTypeForVolunteerResponse(
+        resolution.status,
+      )
+      if (historyEventType) {
+        const membershipMetadata = parseCrewRosterMetadata(
+          assignmentContext.membership?.metadata,
+        )
+        await recordCrewVolunteerHistoryEvent({
+          db: client,
+          teamId: context.event.organizingTeamId,
+          competitionId: context.event.id,
+          groupId: context.event.groupId,
+          eventType: historyEventType,
+          identity: {
+            userId: assignmentContext.membership?.userId,
+            email:
+              membershipMetadata.signupEmail ??
+              confirmation.email ??
+              volunteer.email,
+            phone: membershipMetadata.signupPhone ?? volunteer.phone,
+            sourceMembershipId: assignmentContext.assignment.membershipId,
+            sourceInvitationId: context.invitation.id,
+            identitySource: membership
+              ? CREW_VOLUNTEER_IDENTITY_SOURCE.MEMBERSHIP
+              : CREW_VOLUNTEER_IDENTITY_SOURCE.SELF_SERVICE,
+          },
+          assignmentType:
+            CREW_VOLUNTEER_HISTORY_ASSIGNMENT_TYPE.VOLUNTEER_SHIFT,
+          assignmentId: assignmentContext.assignment.id,
+          roleType: assignmentContext.shift.roleType,
+          occurredAt: resolution.respondedAt,
+          sourceType: "crew_volunteer_schedule_token",
+          sourceId: confirmation.id,
+        })
+      }
+    }
+  })
+
+  const freshData = await getCrewVolunteerScheduleToken(data)
+
+  return {
+    ...freshData,
+    success:
+      responseState.outcome === "updated" ||
+      responseState.outcome === "idempotent",
+    outcome: responseState.outcome,
+    message: responseState.message,
   }
 }
 
@@ -379,6 +558,508 @@ function toPublicCrewVolunteerEvent(
     timezone: event.timezone,
     competitionTeamId: event.competitionTeamId,
   }
+}
+
+async function getCrewVolunteerTokenContext(
+  db: DbClient,
+  data: { slug: string; token: string },
+) {
+  const [row] = await db
+    .select({
+      event: publicCrewEventSelect,
+      invitation: {
+        id: teamInvitationTable.id,
+        email: teamInvitationTable.email,
+        token: teamInvitationTable.token,
+        status: teamInvitationTable.status,
+        acceptedAt: teamInvitationTable.acceptedAt,
+        acceptedBy: teamInvitationTable.acceptedBy,
+        expiresAt: teamInvitationTable.expiresAt,
+        metadata: teamInvitationTable.metadata,
+      },
+    })
+    .from(teamInvitationTable)
+    .innerJoin(
+      competitionsTable,
+      eq(teamInvitationTable.teamId, competitionsTable.competitionTeamId),
+    )
+    .innerJoin(
+      crewEventSettingsTable,
+      eq(crewEventSettingsTable.competitionId, competitionsTable.id),
+    )
+    .where(
+      and(
+        eq(competitionsTable.slug, data.slug),
+        eq(teamInvitationTable.token, data.token),
+        eq(teamInvitationTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamInvitationTable.isSystemRole, true),
+        eq(crewEventSettingsTable.crewOnly, true),
+        ne(crewEventSettingsTable.lifecycle, CREW_EVENT_LIFECYCLE.ARCHIVED),
+      ),
+    )
+    .limit(1)
+
+  return row ?? null
+}
+
+type CrewVolunteerTokenContext = NonNullable<
+  Awaited<ReturnType<typeof getCrewVolunteerTokenContext>>
+>
+
+type CrewVolunteerTokenInvitation = CrewVolunteerTokenContext["invitation"]
+
+interface CrewVolunteerTokenMembership {
+  id: string
+  userId: string
+  metadata: string | null
+  email: string | null
+  firstName: string | null
+  lastName: string | null
+}
+
+async function findVolunteerTokenMembership(
+  db: DbClient,
+  params: {
+    competitionTeamId: string
+    invitation: CrewVolunteerTokenInvitation
+  },
+): Promise<CrewVolunteerTokenMembership | null> {
+  const acceptedInvitation =
+    params.invitation.acceptedAt ||
+    params.invitation.acceptedBy ||
+    params.invitation.status === INVITATION_STATUS.ACCEPTED
+  if (!acceptedInvitation) {
+    return null
+  }
+
+  const rows = await db
+    .select({
+      id: teamMembershipTable.id,
+      userId: teamMembershipTable.userId,
+      metadata: teamMembershipTable.metadata,
+      email: userTable.email,
+      firstName: userTable.firstName,
+      lastName: userTable.lastName,
+    })
+    .from(teamMembershipTable)
+    .leftJoin(userTable, eq(teamMembershipTable.userId, userTable.id))
+    .where(
+      and(
+        eq(teamMembershipTable.teamId, params.competitionTeamId),
+        eq(teamMembershipTable.roleId, SYSTEM_ROLES_ENUM.VOLUNTEER),
+        eq(teamMembershipTable.isSystemRole, true),
+        eq(teamMembershipTable.isActive, true),
+      ),
+    )
+
+  const acceptedMembership = params.invitation.acceptedBy
+    ? rows.find((row) => row.userId === params.invitation.acceptedBy)
+    : null
+  if (acceptedMembership) return acceptedMembership
+
+  const invitationMetadata = parseCrewRosterMetadata(params.invitation.metadata)
+  const email = normalizeVolunteerSignupEmail(
+    invitationMetadata.signupEmail ?? params.invitation.email,
+  )
+
+  return (
+    rows.find((row) => {
+      const membershipMetadata = parseCrewRosterMetadata(row.metadata)
+      return (
+        normalizeVolunteerSignupEmail(membershipMetadata.signupEmail ?? "") ===
+          email || normalizeVolunteerSignupEmail(row.email ?? "") === email
+      )
+    }) ?? null
+  )
+}
+
+function toPublicVolunteerProfile(
+  invitation: CrewVolunteerTokenInvitation,
+  membership: CrewVolunteerTokenMembership | null,
+): PublicCrewVolunteerProfile {
+  const metadata = parseCrewRosterMetadata(
+    membership?.metadata ?? invitation.metadata,
+  )
+  const name =
+    metadata.signupName ??
+    [membership?.firstName, membership?.lastName].filter(Boolean).join(" ") ??
+    null
+  const email =
+    metadata.signupEmail ?? membership?.email ?? invitation.email ?? ""
+
+  return {
+    email,
+    name: name || null,
+    phone: metadata.signupPhone ?? null,
+    availability: metadata.availability ?? null,
+    availabilityNotes: metadata.availabilityNotes ?? null,
+    credentials: metadata.credentials ?? null,
+    roleTypes: getCrewRosterRoleTypes(metadata.volunteerRoleTypes),
+    invitationStatus: invitation.status,
+  }
+}
+
+async function loadCrewVolunteerVisibleAssignments(
+  db: DbClient,
+  params: {
+    competitionId: string
+    invitationId: string
+    email: string
+    membershipId: string | null
+  },
+): Promise<CrewVolunteerVisibleAssignment[]> {
+  const rows = params.membershipId
+    ? await loadCrewVolunteerAssignmentRows(db, {
+        competitionId: params.competitionId,
+        assignmentId: null,
+        membershipId: params.membershipId,
+        invitationId: null,
+        email: null,
+        includeAssignmentsWithoutConfirmations: true,
+        lockRows: false,
+      })
+    : await loadCrewVolunteerAssignmentRows(db, {
+        competitionId: params.competitionId,
+        assignmentId: null,
+        membershipId: null,
+        invitationId: params.invitationId,
+        email: params.email,
+        includeAssignmentsWithoutConfirmations: false,
+        lockRows: false,
+      })
+
+  if (params.membershipId) {
+    return buildCrewVolunteerSelfServiceSchedule({
+      membershipId: params.membershipId,
+      tokenAssignmentId: "",
+      assignments: toSelfServiceAssignmentRecords(rows),
+    })
+  }
+
+  return buildCrewVolunteerVisibleSchedule(toSelfServiceAssignmentRecords(rows))
+}
+
+async function getVisibleVolunteerAssignmentForResponse(
+  db: DbClient,
+  params: {
+    competitionId: string
+    assignmentId: string
+    invitationId: string
+    email: string
+    membershipId: string | null
+  },
+) {
+  const rows = params.membershipId
+    ? await loadCrewVolunteerAssignmentRows(db, {
+        competitionId: params.competitionId,
+        assignmentId: params.assignmentId,
+        membershipId: params.membershipId,
+        invitationId: null,
+        email: null,
+        includeAssignmentsWithoutConfirmations: true,
+        lockRows: true,
+      })
+    : await loadCrewVolunteerAssignmentRows(db, {
+        competitionId: params.competitionId,
+        assignmentId: params.assignmentId,
+        membershipId: null,
+        invitationId: params.invitationId,
+        email: params.email,
+        includeAssignmentsWithoutConfirmations: false,
+        lockRows: true,
+      })
+
+  return rows[0] ?? null
+}
+
+async function loadCrewVolunteerAssignmentRows(
+  db: DbClient,
+  params: {
+    competitionId: string
+    assignmentId: string | null
+    membershipId: string | null
+    invitationId: string | null
+    email: string | null
+    includeAssignmentsWithoutConfirmations: boolean
+    lockRows: boolean
+  },
+) {
+  const confirmationConditions = [
+    params.invitationId
+      ? eq(crewAssignmentConfirmationsTable.invitationId, params.invitationId)
+      : null,
+    params.email
+      ? sql`lower(${crewAssignmentConfirmationsTable.email}) = ${normalizeVolunteerSignupEmail(
+          params.email,
+        )}`
+      : null,
+  ].filter((condition): condition is NonNullable<typeof condition> =>
+    Boolean(condition),
+  )
+  const visibilityCondition =
+    params.membershipId !== null
+      ? eq(volunteerShiftAssignmentsTable.membershipId, params.membershipId)
+      : confirmationConditions.length === 1
+        ? confirmationConditions[0]
+        : confirmationConditions.length > 1
+          ? or(...confirmationConditions)
+          : sql`false`
+  const confirmationStatusCondition =
+    params.includeAssignmentsWithoutConfirmations
+      ? null
+      : ne(
+          crewAssignmentConfirmationsTable.status,
+          CREW_ASSIGNMENT_CONFIRMATION_STATUS.CANCELLED,
+        )
+  const rowsQuery = db
+    .select({
+      assignment: {
+        id: volunteerShiftAssignmentsTable.id,
+        membershipId: volunteerShiftAssignmentsTable.membershipId,
+        notes: volunteerShiftAssignmentsTable.notes,
+      },
+      shift: {
+        id: volunteerShiftsTable.id,
+        name: volunteerShiftsTable.name,
+        roleType: volunteerShiftsTable.roleType,
+        startTime: volunteerShiftsTable.startTime,
+        endTime: volunteerShiftsTable.endTime,
+        location: volunteerShiftsTable.location,
+        notes: volunteerShiftsTable.notes,
+      },
+      membership: {
+        id: teamMembershipTable.id,
+        userId: teamMembershipTable.userId,
+        metadata: teamMembershipTable.metadata,
+      },
+      confirmation: {
+        id: crewAssignmentConfirmationsTable.id,
+        status: crewAssignmentConfirmationsTable.status,
+        sentAt: crewAssignmentConfirmationsTable.sentAt,
+        respondedAt: crewAssignmentConfirmationsTable.respondedAt,
+        expiresAt: crewAssignmentConfirmationsTable.expiresAt,
+        responseNote: crewAssignmentConfirmationsTable.responseNote,
+        email: crewAssignmentConfirmationsTable.email,
+        updatedAt: crewAssignmentConfirmationsTable.updatedAt,
+      },
+    })
+    .from(volunteerShiftAssignmentsTable)
+    .innerJoin(
+      volunteerShiftsTable,
+      eq(volunteerShiftAssignmentsTable.shiftId, volunteerShiftsTable.id),
+    )
+    .leftJoin(
+      teamMembershipTable,
+      eq(volunteerShiftAssignmentsTable.membershipId, teamMembershipTable.id),
+    )
+    .leftJoin(
+      crewAssignmentConfirmationsTable,
+      and(
+        eq(
+          crewAssignmentConfirmationsTable.assignmentType,
+          CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+        ),
+        eq(
+          crewAssignmentConfirmationsTable.assignmentId,
+          volunteerShiftAssignmentsTable.id,
+        ),
+      ),
+    )
+    .where(
+      and(
+        eq(volunteerShiftsTable.competitionId, params.competitionId),
+        params.assignmentId
+          ? eq(volunteerShiftAssignmentsTable.id, params.assignmentId)
+          : undefined,
+        visibilityCondition,
+        confirmationStatusCondition ?? undefined,
+      ),
+    )
+    .orderBy(
+      asc(volunteerShiftsTable.startTime),
+      asc(volunteerShiftsTable.name),
+      desc(crewAssignmentConfirmationsTable.updatedAt),
+    )
+
+  return params.lockRows ? await rowsQuery.for("update") : await rowsQuery
+}
+
+type CrewVolunteerAssignmentRow = Awaited<
+  ReturnType<typeof loadCrewVolunteerAssignmentRows>
+>[number]
+
+function toSelfServiceAssignmentRecords(
+  rows: CrewVolunteerAssignmentRow[],
+): CrewVolunteerSelfServiceAssignmentRecord[] {
+  return rows.map((row) => ({
+    id: row.assignment.id,
+    membershipId: row.assignment.membershipId,
+    shiftId: row.shift.id,
+    name: row.shift.name,
+    roleType: row.shift.roleType,
+    roleLabel: formatVolunteerRole(row.shift.roleType),
+    startTime: row.shift.startTime,
+    endTime: row.shift.endTime,
+    location: row.shift.location,
+    notes: row.assignment.notes ?? row.shift.notes,
+    confirmation:
+      row.confirmation?.id && row.confirmation.status
+        ? {
+            id: row.confirmation.id,
+            status: row.confirmation.status,
+            sentAt: row.confirmation.sentAt,
+            respondedAt: row.confirmation.respondedAt,
+            expiresAt: row.confirmation.expiresAt,
+            responseNote: row.confirmation.responseNote,
+          }
+        : null,
+  }))
+}
+
+function buildCrewVolunteerVisibleSchedule(
+  assignments: CrewVolunteerSelfServiceAssignmentRecord[],
+): CrewVolunteerVisibleAssignment[] {
+  const byAssignmentId = new Map<string, CrewVolunteerVisibleAssignment>()
+
+  for (const assignment of assignments) {
+    if (byAssignmentId.has(assignment.id)) continue
+
+    const startTime = toValidDate(assignment.startTime)
+    const endTime = toValidDate(assignment.endTime)
+    if (!startTime || !endTime) continue
+
+    byAssignmentId.set(assignment.id, {
+      id: assignment.id,
+      shiftId: assignment.shiftId,
+      name: assignment.name,
+      roleType: assignment.roleType,
+      roleLabel: assignment.roleLabel,
+      startTime,
+      endTime,
+      location: assignment.location,
+      notes: assignment.notes,
+      confirmation: assignment.confirmation,
+      isTokenAssignment: false,
+    })
+  }
+
+  return [...byAssignmentId.values()].sort((left, right) => {
+    const timeDiff = left.startTime.getTime() - right.startTime.getTime()
+    if (timeDiff !== 0) return timeDiff
+    return left.name.localeCompare(right.name)
+  })
+}
+
+function listVisibleConfirmations(
+  assignments: CrewVolunteerVisibleAssignment[],
+): CrewVolunteerVisibleConfirmation[] {
+  return assignments.flatMap((assignment) =>
+    assignment.confirmation
+      ? [{ ...assignment.confirmation, assignmentId: assignment.id }]
+      : [],
+  )
+}
+
+function toResponseConfirmation(
+  confirmation: CrewVolunteerAssignmentRow["confirmation"],
+) {
+  if (!confirmation?.id || !confirmation.status) return null
+  return {
+    id: confirmation.id,
+    status: confirmation.status,
+    expiresAt: confirmation.expiresAt,
+    responseNote: confirmation.responseNote,
+    email: confirmation.email,
+  }
+}
+
+async function createCrewVolunteerScheduleConfirmation(
+  db: DbClient,
+  params: {
+    competitionId: string
+    assignmentId: string
+    membershipId: string
+    invitationId: string
+    email: string
+  },
+) {
+  const now = new Date()
+  const expiresAt = new Date(now)
+  expiresAt.setDate(expiresAt.getDate() + 14)
+  const token = generateCrewAssignmentConfirmationToken()
+  const tokenHash = await hashCrewAssignmentConfirmationToken(token)
+  const confirmation = {
+    id: createCrewAssignmentConfirmationId(),
+    competitionId: params.competitionId,
+    assignmentType: CREW_ASSIGNMENT_CONFIRMATION_TYPE.VOLUNTEER_SHIFT,
+    assignmentId: params.assignmentId,
+    membershipId: params.membershipId,
+    invitationId: params.invitationId,
+    email: normalizeVolunteerSignupEmail(params.email),
+    tokenHash,
+    status: CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING,
+    sentAt: null,
+    respondedAt: null,
+    expiresAt,
+    responseNote: null,
+    createdAt: now,
+    updatedAt: now,
+  } satisfies typeof crewAssignmentConfirmationsTable.$inferInsert
+
+  await db.insert(crewAssignmentConfirmationsTable).values(confirmation)
+
+  return {
+    id: confirmation.id,
+    status: confirmation.status,
+    expiresAt: confirmation.expiresAt,
+    responseNote: confirmation.responseNote,
+    email: confirmation.email,
+  }
+}
+
+function getVolunteerScheduleResponseSuccessMessage(
+  action: CrewAssignmentResponseAction,
+) {
+  if (action === "confirm") {
+    return "Confirmed. We'll remind you before your shift."
+  }
+  if (action === "decline") {
+    return "Declined. The organizer will see your note."
+  }
+  return "Change request sent. The organizer will see your note."
+}
+
+function historyEventTypeForVolunteerResponse(
+  status: CrewAssignmentConfirmationStatus,
+): CrewVolunteerHistoryEventType | null {
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CONFIRMED) {
+    return CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CONFIRMED
+  }
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED) {
+    return CREW_VOLUNTEER_HISTORY_EVENT_TYPE.DECLINED
+  }
+  if (status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED) {
+    return CREW_VOLUNTEER_HISTORY_EVENT_TYPE.CHANGE_REQUESTED
+  }
+  return null
+}
+
+function emptyScheduleTokenData(
+  status: CrewVolunteerScheduleTokenData["status"],
+): CrewVolunteerScheduleTokenData {
+  return {
+    status,
+    event: null,
+    volunteer: null,
+    assignments: [],
+    confirmations: [],
+  }
+}
+
+function toValidDate(value: Date | string | null | undefined) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date
 }
 
 async function listVolunteerQuestions(
@@ -611,17 +1292,6 @@ function parseQuestionOptions(options: string | null): string[] | null {
   try {
     const parsed = JSON.parse(options)
     return Array.isArray(parsed) ? parsed.filter(isString) : null
-  } catch {
-    return null
-  }
-}
-
-function parseVolunteerMetadata(
-  metadata: string | null,
-): CrewVolunteerSignupMetadata | null {
-  if (!metadata) return null
-  try {
-    return JSON.parse(metadata) as CrewVolunteerSignupMetadata
   } catch {
     return null
   }


### PR DESCRIPTION
## Scope

- Completes the public Crew volunteer schedule token fallback so volunteer-token links return visible assignments and confirmation rows, not only volunteer profile metadata.
- Adds a volunteer-token response action for confirm, decline, and request change, authorized by the volunteer token plus visible assignment ID.
- Keeps assignment-token schedule behavior compatible while sharing the assignment card rendering path with volunteer-token schedules.
- Updates `/e/$slug/confirm/$token` to resolve assignment tokens first, then volunteer schedule tokens, so volunteers can respond without signing in.
- Requires notes for decline and request-change responses in both UI and shared server response resolution.

## Acceptance

- Volunteer schedule links work without a session.
- Volunteer-token schedules can show real assignments matched by accepted membership ID, or for pending invitations by invitation ID / normalized email confirmation rows.
- Public schedule and confirmation pages show assignment name, role, location, times, and report instructions/notes when available.
- Volunteers can confirm, decline, or request a change from mobile-sized controls.
- Decline and request-change actions require notes on the client and server path.
- Public copy stays volunteer-facing; no admin, billing, import, readiness, source-platform, raw-ID, or operator-only language was added.

## Validation

- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew exec vitest run src/lib/crew/assignment-confirmations.test.ts`
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew type-check`
- `PATH=/Users/ianjones/.nvm/versions/node/v24.14.1/bin:$PATH pnpm --filter crew exec biome check src/server/crew-volunteer.server.ts src/server-fns/crew-volunteer-fns.ts 'src/routes/e/$slug/schedule/$token.tsx' 'src/routes/e/$slug/confirm/$token.tsx' src/lib/crew/assignment-confirmations.ts src/lib/crew/assignment-confirmations.test.ts`
- `git diff --check`

## Out Of Scope

- Organizer confirmations dashboard changes.
- Organizer assignment/import/setup/sidebar/home redesign.
- Schema changes or new persistence for no-show, replaced, or event-day state.
- Billing, Stripe, Crew plan, conversion, email-template, or WODsmith volunteer-management integration work.

## Notes

- Dependency install in this fresh worktree linked packages, but `better-sqlite3` emitted a native rebuild failure under local Python 3.7; the focused Crew checks above still ran successfully under Node 24.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the volunteer schedule token response flow with shared response controls so volunteers can view shifts and confirm, decline, or request changes from either the schedule or confirm links without signing in. Adds client-side note validation and clearer recorded-response messages.

- **New Features**
  - Added `CrewVolunteerPublicResponseControls` and used it on both `/e/$slug/schedule/$token` and `/e/$slug/confirm/$token`; shows pending state, enforces notes for decline/change, and displays recorded responses.
  - Schedule token page now renders per-assignment response cards and provides iCal, Google Calendar, and Print actions when assignments exist.

- **Refactors**
  - Split confirm route into dedicated components for assignment-token and volunteer-token flows; both use the shared response controls and the same assignment card UI.

<sup>Written for commit e9f895ed55146f2384468f9b3f2b82eead3df901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Volunteers can now respond to individual assignments via schedule token links.
  * Decline and change-request responses now require explanatory notes.
  * Added per-assignment response cards with confirm/decline/request-change options.

* **Bug Fixes**
  * Improved validation to ensure required notes are provided for decline and change-request actions.
  * Enhanced error messaging for missing required information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->