### PR TITLE
[codex] crew demo data e2e

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -112,6 +112,8 @@ jobs:
   crew-demo-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     services:
       mysql:
         image: mysql:8.0
@@ -126,10 +128,12 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: oven-sh/setup-bun@v2
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
           cache: pnpm
@@ -193,10 +197,10 @@ jobs:
         env:
           CI: true
           DATABASE_URL: mysql://root:testpassword@127.0.0.1:3306/wodsmith_crew_e2e
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         if: always()
         with:
-          name: crew-demo-blob-report
+          name: blob-report-crew-demo
           path: apps/crew/blob-report/
           retention-days: 1
 
@@ -230,7 +234,18 @@ jobs:
             echo "has_reports=false" >> $GITHUB_OUTPUT
             echo "No blob reports found; skipping merge."
           fi
-      - run: pnpm --filter wodsmith-start exec playwright merge-reports --reporter html ./all-blob-reports
+      - name: Configure merged Playwright report root
+        if: steps.check-reports.outputs.has_reports == 'true'
+        working-directory: apps/wodsmith-start
+        run: |
+          cat > playwright-merge.config.ts << 'EOF'
+          import { defineConfig } from "@playwright/test"
+
+          export default defineConfig({
+            testDir: "../..",
+          })
+          EOF
+      - run: pnpm --filter wodsmith-start exec playwright merge-reports -c playwright-merge.config.ts --reporter html ./all-blob-reports
         if: steps.check-reports.outputs.has_reports == 'true'
       - uses: actions/upload-artifact@v4
         if: steps.check-reports.outputs.has_reports == 'true'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -109,8 +109,97 @@ jobs:
           path: apps/wodsmith-start/blob-report/
           retention-days: 1
 
+  crew-demo-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: testpassword
+          MYSQL_DATABASE: wodsmith_crew_e2e
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: oven-sh/setup-bun@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Setup Crew Alchemy local config
+        working-directory: apps/crew
+        run: |
+          mkdir -p .alchemy/local
+          cat > .alchemy/local/wrangler.jsonc << 'EOF'
+          {
+            "name": "wodsmith-crew-e2e",
+            "main": "@tanstack/react-start/server-entry",
+            "compatibility_date": "2025-12-17",
+            "compatibility_flags": ["nodejs_compat", "nodejs_compat_populate_process_env"],
+            "assets": {
+              "directory": "../../dist/client",
+              "binding": "ASSETS",
+              "not_found_handling": "none",
+              "html_handling": "auto-trailing-slash",
+              "run_worker_first": false
+            },
+            "vars": {
+              "DATABASE_URL": "mysql://root:testpassword@127.0.0.1:3306/wodsmith_crew_e2e"
+            },
+            "kv_namespaces": [
+              {
+                "binding": "KV_SESSION",
+                "id": "e2e-kv-session",
+                "preview_id": "e2e-kv-session"
+              }
+            ],
+            "r2_buckets": [
+              {
+                "binding": "R2_BUCKET",
+                "bucket_name": "e2e-uploads",
+                "preview_bucket_name": "e2e-uploads"
+              }
+            ]
+          }
+          EOF
+
+      - name: Configure Crew environment
+        working-directory: apps/crew
+        run: echo 'DATABASE_URL=mysql://root:testpassword@127.0.0.1:3306/wodsmith_crew_e2e' >> .dev.vars
+
+      - name: Setup Crew E2E database
+        working-directory: apps/crew
+        env:
+          DATABASE_URL: mysql://root:testpassword@127.0.0.1:3306/wodsmith_crew_e2e
+        run: |
+          pnpm db:push
+          pnpm db:seed
+          pnpm db:seed:e2e
+
+      - run: pnpm --filter crew exec playwright install chromium --with-deps
+        timeout-minutes: 10
+      - run: pnpm --filter crew exec playwright test e2e/crew-organizer-flow.spec.ts e2e/crew-volunteer-flow.spec.ts
+        env:
+          CI: true
+          DATABASE_URL: mysql://root:testpassword@127.0.0.1:3306/wodsmith_crew_e2e
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: crew-demo-blob-report
+          path: apps/crew/blob-report/
+          retention-days: 1
+
   merge-reports:
-    needs: e2e
+    needs: [e2e, crew-demo-e2e]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -153,7 +153,9 @@ jobs:
               "run_worker_first": false
             },
             "vars": {
-              "DATABASE_URL": "mysql://root:testpassword@127.0.0.1:3306/wodsmith_crew_e2e"
+              "DATABASE_URL": "mysql://root:testpassword@127.0.0.1:3306/wodsmith_crew_e2e",
+              "STAGE": "test",
+              "APP_URL": "http://localhost:3002"
             },
             "kv_namespaces": [
               {

--- a/apps/crew/e2e/crew-organizer-flow.spec.ts
+++ b/apps/crew/e2e/crew-organizer-flow.spec.ts
@@ -48,7 +48,7 @@ test.describe("Crew organizer demo flow", () => {
 		await expect(
 			page.locator("section").filter({
 				has: page.getByRole("heading", { name: "Assignment actions" }),
-			}),
+			}).last(),
 		).toContainText(demo.shiftAssignmentName)
 		await expect(
 			page.getByRole("heading", { name: "No-shows and replacements" }),

--- a/apps/crew/e2e/crew-organizer-flow.spec.ts
+++ b/apps/crew/e2e/crew-organizer-flow.spec.ts
@@ -21,7 +21,7 @@ test.describe("Crew organizer demo flow", () => {
 		await expect(
 			page.getByText(`${demo.shiftAssignments} assignments,`),
 		).toBeVisible()
-		await expectPanelWithNonZeroValue(page, "Pending")
+		await expectPanelWithNonZeroValue(page, "Sent")
 		await expectPanelWithNonZeroValue(page, "Confirmed")
 		await expectPanelWithNonZeroValue(page, "Declined")
 		await expectPanelWithNonZeroValue(page, "No response")

--- a/apps/crew/e2e/crew-organizer-flow.spec.ts
+++ b/apps/crew/e2e/crew-organizer-flow.spec.ts
@@ -54,7 +54,7 @@ test.describe("Crew organizer demo flow", () => {
 
 async function expectPanelWithNonZeroValue(page: Page, label: string) {
 	await expect(
-		page.locator("section").filter({
+		page.getByRole("main").filter({
 			hasText: new RegExp(`${escapeRegExp(label)}\\s+[1-9]\\d*`),
 		}).first(),
 	).toBeVisible()

--- a/apps/crew/e2e/crew-organizer-flow.spec.ts
+++ b/apps/crew/e2e/crew-organizer-flow.spec.ts
@@ -1,3 +1,5 @@
+// @lat: [[crew#Assignment Confirmations]]
+// @lat: [[crew#Day Of Operations Board]]
 import { expect, test, type Page } from "@playwright/test"
 import { loginAsTestUser, waitForHydration } from "./fixtures/auth"
 import { TEST_DATA } from "./fixtures/test-data"

--- a/apps/crew/e2e/crew-organizer-flow.spec.ts
+++ b/apps/crew/e2e/crew-organizer-flow.spec.ts
@@ -45,7 +45,11 @@ test.describe("Crew organizer demo flow", () => {
 		await expect(
 			page.getByRole("heading", { name: "Assignment actions" }),
 		).toBeVisible()
-		await expect(page.getByText(demo.shiftAssignmentName)).toBeVisible()
+		await expect(
+			page.locator("section").filter({
+				has: page.getByRole("heading", { name: "Assignment actions" }),
+			}),
+		).toContainText(demo.shiftAssignmentName)
 		await expect(
 			page.getByRole("heading", { name: "No-shows and replacements" }),
 		).toBeVisible()

--- a/apps/crew/e2e/crew-organizer-flow.spec.ts
+++ b/apps/crew/e2e/crew-organizer-flow.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test, type Page } from "@playwright/test"
+import { loginAsTestUser, waitForHydration } from "./fixtures/auth"
+import { TEST_DATA } from "./fixtures/test-data"
+
+const demo = TEST_DATA.crewDemo
+
+test.describe("Crew organizer demo flow", () => {
+	test.beforeEach(async ({ page }) => {
+		await loginAsTestUser(page)
+	})
+
+	test("shows seeded confirmation and day-of workflow data", async ({
+		page,
+	}) => {
+		await page.goto(`/events/${demo.eventId}/messages`)
+		await waitForHydration(page)
+
+		await expect(
+			page.getByRole("heading", { name: "Confirmations" }),
+		).toBeVisible({ timeout: 15000 })
+		await expect(
+			page.getByText(`${demo.shiftAssignments} assignments,`),
+		).toBeVisible()
+		await expectPanelWithNonZeroValue(page, "Pending")
+		await expectPanelWithNonZeroValue(page, "Confirmed")
+		await expectPanelWithNonZeroValue(page, "Declined")
+		await expectPanelWithNonZeroValue(page, "No response")
+		await expect(
+			page.getByRole("heading", { name: "Event-day outcomes" }),
+		).toBeVisible()
+		await expect(page.getByText(demo.noShowShiftName)).toBeVisible()
+
+		await page.goto(`/events/${demo.eventId}/day-of`)
+		await waitForHydration(page)
+
+		await expect(
+			page.getByRole("heading", { name: "Day-of operations" }),
+		).toBeVisible({ timeout: 15000 })
+		await expectPanelWithNonZeroValue(page, "Open roles")
+		await expectPanelWithNonZeroValue(page, "No-show / replaced")
+		await expectPanelWithNonZeroValue(page, "Judge lanes open")
+		await expectLabeledValue(page, "No-shows", "1")
+		await expectLabeledValue(page, "Active judge versions", "3")
+		await expectLabeledValue(page, "Shift assignments", String(demo.shiftAssignments))
+		await expect(
+			page.getByRole("heading", { name: "Assignment actions" }),
+		).toBeVisible()
+		await expect(page.getByText(demo.shiftAssignmentName)).toBeVisible()
+		await expect(
+			page.getByRole("heading", { name: "No-shows and replacements" }),
+		).toBeVisible()
+	})
+})
+
+async function expectPanelWithNonZeroValue(page: Page, label: string) {
+	await expect(
+		page.locator("section").filter({
+			hasText: new RegExp(`${escapeRegExp(label)}\\s+[1-9]\\d*`),
+		}).first(),
+	).toBeVisible()
+}
+
+async function expectLabeledValue(page: Page, label: string, value: string) {
+	await expect(
+		page.locator("div").filter({
+			hasText: new RegExp(`${escapeRegExp(label)}\\s+${escapeRegExp(value)}`),
+		}).first(),
+	).toBeVisible()
+}
+
+function escapeRegExp(value: string) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}

--- a/apps/crew/e2e/crew-organizer-flow.spec.ts
+++ b/apps/crew/e2e/crew-organizer-flow.spec.ts
@@ -55,7 +55,7 @@ test.describe("Crew organizer demo flow", () => {
 async function expectPanelWithNonZeroValue(page: Page, label: string) {
 	await expect(
 		page.getByRole("main").filter({
-			hasText: new RegExp(`${escapeRegExp(label)}\\s+[1-9]\\d*`),
+			hasText: new RegExp(`${escapeRegExp(label)}\\s*[1-9]\\d*`),
 		}).first(),
 	).toBeVisible()
 }
@@ -63,7 +63,7 @@ async function expectPanelWithNonZeroValue(page: Page, label: string) {
 async function expectLabeledValue(page: Page, label: string, value: string) {
 	await expect(
 		page.locator("div").filter({
-			hasText: new RegExp(`${escapeRegExp(label)}\\s+${escapeRegExp(value)}`),
+			hasText: new RegExp(`${escapeRegExp(label)}\\s*${escapeRegExp(value)}`),
 		}).first(),
 	).toBeVisible()
 }

--- a/apps/crew/e2e/crew-volunteer-flow.spec.ts
+++ b/apps/crew/e2e/crew-volunteer-flow.spec.ts
@@ -15,7 +15,7 @@ test.describe("Crew volunteer demo flow", () => {
 			page.getByRole("heading", { name: TEST_DATA.competition.name }),
 		).toBeVisible({ timeout: 15000 })
 		await expect(page.getByText(demo.volunteerName, { exact: true })).toBeVisible()
-		await expect(page.getByText(demo.volunteerEmail)).toBeVisible()
+		await expect(page.getByText(demo.volunteerEmail, { exact: true })).toBeVisible()
 		await expect(page.getByText("Preferred roles")).toBeVisible()
 		await expect(page.getByText("Judge").first()).toBeVisible()
 

--- a/apps/crew/e2e/crew-volunteer-flow.spec.ts
+++ b/apps/crew/e2e/crew-volunteer-flow.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test"
+import { waitForHydration } from "./fixtures/auth"
+import { TEST_DATA } from "./fixtures/test-data"
+
+const demo = TEST_DATA.crewDemo
+
+test.describe("Crew volunteer demo flow", () => {
+	test("shows a public schedule token and records a response", async ({
+		page,
+	}) => {
+		await page.goto(`/e/${demo.slug}/schedule/${demo.volunteerToken}`)
+		await waitForHydration(page)
+
+		await expect(
+			page.getByRole("heading", { name: TEST_DATA.competition.name }),
+		).toBeVisible({ timeout: 15000 })
+		await expect(page.getByText(demo.volunteerName)).toBeVisible()
+		await expect(page.getByText(demo.volunteerEmail)).toBeVisible()
+		await expect(page.getByText("Preferred roles")).toBeVisible()
+		await expect(page.getByText("Judge").first()).toBeVisible()
+
+		const assignment = page
+			.locator("article")
+			.filter({ hasText: demo.volunteerShiftName })
+			.first()
+		await expect(assignment).toBeVisible()
+		await expect(assignment.getByText("Pending")).toBeVisible()
+
+		await assignment.getByRole("button", { name: "Confirm" }).click()
+
+		await expect(
+			assignment.getByText("Confirmed. We'll remind you before your shift."),
+		).toBeVisible({ timeout: 15000 })
+	})
+})

--- a/apps/crew/e2e/crew-volunteer-flow.spec.ts
+++ b/apps/crew/e2e/crew-volunteer-flow.spec.ts
@@ -1,3 +1,5 @@
+// @lat: [[crew#Volunteer Self Service]]
+// @lat: [[crew#Assignment Confirmation Responses]]
 import { expect, test } from "@playwright/test"
 import { waitForHydration } from "./fixtures/auth"
 import { TEST_DATA } from "./fixtures/test-data"

--- a/apps/crew/e2e/crew-volunteer-flow.spec.ts
+++ b/apps/crew/e2e/crew-volunteer-flow.spec.ts
@@ -14,7 +14,7 @@ test.describe("Crew volunteer demo flow", () => {
 		await expect(
 			page.getByRole("heading", { name: TEST_DATA.competition.name }),
 		).toBeVisible({ timeout: 15000 })
-		await expect(page.getByText(demo.volunteerName)).toBeVisible()
+		await expect(page.getByText(demo.volunteerName, { exact: true })).toBeVisible()
 		await expect(page.getByText(demo.volunteerEmail)).toBeVisible()
 		await expect(page.getByText("Preferred roles")).toBeVisible()
 		await expect(page.getByText("Judge").first()).toBeVisible()

--- a/apps/crew/e2e/fixtures/auth.ts
+++ b/apps/crew/e2e/fixtures/auth.ts
@@ -17,45 +17,24 @@ export const ADMIN_USER = TEST_DATA.users.adminUser
 /**
  * Login with specified credentials
  *
- * Waits for React hydration before interacting with the form.
- * Without hydration, the form submits as native HTML GET (no method attr)
- * instead of being handled by React Hook Form's onSubmit handler.
+ * Crew does not expose the full WODsmith Start sign-in screen yet. For E2E,
+ * ask the app's guarded test endpoint to mint the same session cookie the auth
+ * server function creates after password sign-in.
  */
 export async function login(
 	page: Page,
 	credentials: { email: string; password: string },
 ): Promise<void> {
-	// Use default 'load' to ensure JS bundles are loaded (not just HTML parsed)
-	await page.goto("/sign-in")
-
-	if (!page.url().includes('/sign-in')) {
-		return
-	}
-
-	const signInButton = page.getByRole("button", { name: "Sign in" })
-	await signInButton.waitFor({ state: 'visible', timeout: 30000 })
-
-	// Wait for React hydration — the form's submit button must have React's
-	// internal fiber attached, otherwise clicking triggers native form GET
-	await page.waitForFunction(
-		() => {
-			const btn = document.querySelector('button[type="submit"]')
-			return btn && Object.keys(btn).some(k => k.startsWith('__reactFiber'))
-		},
-		{ timeout: 30000 },
-	)
-
-	await page.getByPlaceholder("name@example.com").fill(credentials.email)
-	await page.getByPlaceholder("Enter your password").fill(credentials.password)
-
-	await signInButton.click()
-
-	// After login, app redirects to "/" (REDIRECT_AFTER_SIGN_IN)
-	await page.waitForURL(/^https?:\/\/[^/]+(\/)?$/, {
-		timeout: 30000,
+	const userId = getUserIdForCredentials(credentials)
+	const response = await page.request.post("/api/e2e/session", {
+		data: { userId },
 	})
 
-	await page.waitForLoadState('domcontentloaded')
+	if (!response.ok()) {
+		throw new Error(
+			`E2E session bootstrap failed with ${response.status()}: ${await response.text()}`,
+		)
+	}
 
 	// Wait for session cookie to be set
 	let attempts = 0
@@ -63,11 +42,13 @@ export async function login(
 	while (attempts < maxAttempts) {
 		const cookies = await page.context().cookies()
 		if (cookies.some(c => c.name === 'session')) {
-			break
+			return
 		}
 		await page.waitForTimeout(100)
 		attempts++
 	}
+
+	throw new Error("E2E session bootstrap did not set a session cookie")
 }
 
 /**
@@ -109,6 +90,27 @@ export async function loginAsAdmin(page: Page): Promise<void> {
 			throw new Error('Admin login failed - still on sign-in page')
 		}
 	}
+}
+
+function getUserIdForCredentials(credentials: {
+	email: string
+	password: string
+}) {
+	if (
+		credentials.email === TEST_USER.email &&
+		credentials.password === TEST_USER.password
+	) {
+		return TEST_USER.id
+	}
+
+	if (
+		credentials.email === ADMIN_USER.email &&
+		credentials.password === ADMIN_USER.password
+	) {
+		return ADMIN_USER.id
+	}
+
+	throw new Error(`No seeded E2E user matches ${credentials.email}`)
 }
 
 /**

--- a/apps/crew/e2e/fixtures/auth.ts
+++ b/apps/crew/e2e/fixtures/auth.ts
@@ -1,3 +1,5 @@
+// @lat: [[auth#Sessions]]
+// @lat: [[crew#Server Function Runtime Boundary]]
 /**
  * Authentication fixtures for E2E tests
  *
@@ -6,6 +8,7 @@
  */
 
 import type { Page } from "@playwright/test"
+import { SESSION_COOKIE_NAME } from "../../src/constants"
 import { TEST_DATA } from "./test-data"
 
 /**
@@ -41,7 +44,7 @@ export async function login(
 	const maxAttempts = 30
 	while (attempts < maxAttempts) {
 		const cookies = await page.context().cookies()
-		if (cookies.some(c => c.name === 'session')) {
+		if (cookies.some((c) => c.name === SESSION_COOKIE_NAME)) {
 			return
 		}
 		await page.waitForTimeout(100)
@@ -75,19 +78,19 @@ export async function loginAsAdmin(page: Page): Promise<void> {
 
 	// Extra verification for admin login - wait for session to be fully established
 	// The admin needs the session to be properly set before accessing /admin routes
-	await page.waitForLoadState('domcontentloaded')
+	await page.waitForLoadState("domcontentloaded")
 
 	// Verify the session cookie exists before proceeding
 	// This is critical for admin routes which redirect to sign-in if no session
 	const cookies = await page.context().cookies()
-	const sessionCookie = cookies.find(c => c.name === 'session')
+	const sessionCookie = cookies.find((c) => c.name === SESSION_COOKIE_NAME)
 
 	if (!sessionCookie) {
 		// If no session cookie, the login may have failed silently
 		// Try to verify by checking if we're on an authenticated page
 		const url = page.url()
-		if (url.includes('/sign-in')) {
-			throw new Error('Admin login failed - still on sign-in page')
+		if (url.includes("/sign-in")) {
+			throw new Error("Admin login failed - still on sign-in page")
 		}
 	}
 }
@@ -119,7 +122,7 @@ function getUserIdForCredentials(credentials: {
  * LogoutButton has aria-label="Log out". After logout, app redirects to /sign-in.
  */
 export async function logout(page: Page): Promise<void> {
-	const logoutButton = page.getByRole('button', { name: 'Log out' })
+	const logoutButton = page.getByRole("button", { name: "Log out" })
 	await logoutButton.click()
 	await page.waitForURL(/\/sign-in/, { timeout: 10000 })
 }
@@ -134,8 +137,8 @@ export async function logout(page: Page): Promise<void> {
 export async function waitForHydration(page: Page): Promise<void> {
 	await page.waitForFunction(
 		() => {
-			const el = document.querySelector('button, [role="combobox"], input, a')
-			return el && Object.keys(el).some(k => k.startsWith('__reactFiber'))
+			const el = document.querySelector("button, [role=\"combobox\"], input, a")
+			return el && Object.keys(el).some((k) => k.startsWith("__reactFiber"))
 		},
 		{ timeout: 15000 },
 	)

--- a/apps/crew/e2e/fixtures/test-data.ts
+++ b/apps/crew/e2e/fixtures/test-data.ts
@@ -55,9 +55,21 @@ export const TEST_DATA = {
 	},
 	competition: {
 		id: "e2e_competition",
-		name: "E2E Test Throwdown",
+		name: "E2E Crew Demo Throwdown",
 		slug: "e2e-throwdown",
 		teamId: "e2e_test_team",
+	},
+	crewDemo: {
+		eventId: "e2e_competition",
+		slug: "e2e-throwdown",
+		volunteerToken: "e2e-crew-demo-volunteer-schedule",
+		volunteerName: "Grace Martinez",
+		volunteerEmail: "grace.crew.demo@test.com",
+		volunteerShiftName: "North Lane 2 Judge",
+		shiftAssignmentName: "North Floor Crew",
+		noShowShiftName: "Medical Station",
+		volunteerCount: 18,
+		shiftAssignments: 12,
 	},
 	divisions: {
 		rx: { id: "e2e_div_rx", label: "RX", teamSize: 1 },

--- a/apps/crew/e2e/fixtures/test-data.ts
+++ b/apps/crew/e2e/fixtures/test-data.ts
@@ -69,7 +69,7 @@ export const TEST_DATA = {
 		shiftAssignmentName: "North Floor Crew",
 		noShowShiftName: "Medical Station",
 		volunteerCount: 18,
-		shiftAssignments: 12,
+		shiftAssignments: 11,
 	},
 	divisions: {
 		rx: { id: "e2e_div_rx", label: "RX", teamSize: 1 },

--- a/apps/crew/e2e/fixtures/test-data.ts
+++ b/apps/crew/e2e/fixtures/test-data.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Page } from "@playwright/test"
+import { CREW_DEMO_EVENT } from "../../scripts/seed/crew-demo-event"
 
 /**
  * Seeded test data - matches seed-e2e.sql exactly
@@ -60,16 +61,16 @@ export const TEST_DATA = {
 		teamId: "e2e_test_team",
 	},
 	crewDemo: {
-		eventId: "e2e_competition",
-		slug: "e2e-throwdown",
-		volunteerToken: "e2e-crew-demo-volunteer-schedule",
-		volunteerName: "Grace Martinez",
-		volunteerEmail: "grace.crew.demo@test.com",
-		volunteerShiftName: "North Lane 2 Judge",
-		shiftAssignmentName: "North Floor Crew",
-		noShowShiftName: "Medical Station",
-		volunteerCount: 18,
-		shiftAssignments: 11,
+		eventId: CREW_DEMO_EVENT.eventId,
+		slug: CREW_DEMO_EVENT.slug,
+		volunteerToken: CREW_DEMO_EVENT.volunteerToken,
+		volunteerName: CREW_DEMO_EVENT.volunteerName,
+		volunteerEmail: CREW_DEMO_EVENT.volunteerEmail,
+		volunteerShiftName: CREW_DEMO_EVENT.volunteerShiftName,
+		shiftAssignmentName: CREW_DEMO_EVENT.shiftAssignmentName,
+		noShowShiftName: CREW_DEMO_EVENT.noShowShiftName,
+		volunteerCount: CREW_DEMO_EVENT.organizerTotals.volunteers,
+		shiftAssignments: CREW_DEMO_EVENT.organizerTotals.assignments,
 	},
 	divisions: {
 		rx: { id: "e2e_div_rx", label: "RX", teamSize: 1 },

--- a/apps/crew/scripts/seed-e2e.ts
+++ b/apps/crew/scripts/seed-e2e.ts
@@ -11,6 +11,7 @@
  */
 
 import mysql from "mysql2/promise"
+import { seedCrewDemoEvent } from "./seed/crew-demo-event"
 
 function currentTimestamp(): string {
 	return new Date().toISOString().slice(0, 19).replace("T", " ")
@@ -670,6 +671,8 @@ async function main(): Promise<void> {
 		}
 
 		console.log(`  volunteers: ${volunteerUsers.length} users + ${volunteerAnswers.length} answers inserted`)
+
+		await seedCrewDemoEvent(connection, ts, passwordHash)
 
 		console.log("\nE2E seed complete!")
 	} finally {

--- a/apps/crew/scripts/seed/crew-demo-event.ts
+++ b/apps/crew/scripts/seed/crew-demo-event.ts
@@ -145,7 +145,10 @@ export const CREW_DEMO_EVENT = {
 	slug: SLUG,
 	volunteerToken: VOLUNTEER_TOKEN,
 	volunteerName: "Grace Martinez",
+	volunteerEmail: "grace.crew.demo@test.com",
 	volunteerShiftName: "North Lane 2 Judge",
+	shiftAssignmentName: "North Floor Crew",
+	noShowShiftName: "Medical Station",
 	organizerTotals: {
 		volunteers: DEMO_VOLUNTEERS.length,
 		assignments: 11,

--- a/apps/crew/scripts/seed/crew-demo-event.ts
+++ b/apps/crew/scripts/seed/crew-demo-event.ts
@@ -1,0 +1,669 @@
+import { createHash } from "node:crypto"
+import type { Connection } from "mysql2/promise"
+
+const EVENT_ID = "e2e_competition"
+const ORGANIZER_TEAM_ID = "e2e_test_team"
+const COMPETITION_TEAM_ID = "e2e_comp_team"
+const SLUG = "e2e-throwdown"
+const VOLUNTEER_TOKEN = "e2e-crew-demo-volunteer-schedule"
+
+const DEMO_VOLUNTEERS = [
+	["01", "Frank", "Garcia", "frank.crew.demo@test.com", ["judge", "medical"]],
+	["02", "Grace", "Martinez", "grace.crew.demo@test.com", ["judge"]],
+	["03", "Hank", "Brown", "hank.crew.demo@test.com", ["scorekeeper"]],
+	["04", "Ivy", "Chen", "ivy.crew.demo@test.com", ["check_in"]],
+	["05", "Jules", "Patel", "jules.crew.demo@test.com", ["floor_manager"]],
+	["06", "Kai", "Robinson", "kai.crew.demo@test.com", ["equipment"]],
+	["07", "Lena", "Nguyen", "lena.crew.demo@test.com", ["judge"]],
+	["08", "Miles", "Olsen", "miles.crew.demo@test.com", ["judge"]],
+	["09", "Nora", "Diaz", "nora.crew.demo@test.com", ["judge"]],
+	["10", "Owen", "Reed", "owen.crew.demo@test.com", ["judge"]],
+	["11", "Priya", "Shah", "priya.crew.demo@test.com", ["judge"]],
+	["12", "Quinn", "Stone", "quinn.crew.demo@test.com", ["judge"]],
+	["13", "Rosa", "King", "rosa.crew.demo@test.com", ["athlete_control"]],
+	["14", "Sam", "Lee", "sam.crew.demo@test.com", ["equipment_team"]],
+	["15", "Tara", "Brooks", "tara.crew.demo@test.com", ["staff"]],
+	["16", "Uma", "Miller", "uma.crew.demo@test.com", ["emcee"]],
+	["17", "Vince", "Adams", "vince.crew.demo@test.com", ["media"]],
+	["18", "Wren", "Clark", "wren.crew.demo@test.com", ["head_judge", "judge"]],
+] as const
+
+const DEMO_ATHLETES = [
+	["01", "Riley", "Cross", "riley.athlete.demo@test.com", "e2e_div_rx"],
+	["02", "Jordan", "Lake", "jordan.athlete.demo@test.com", "e2e_div_rx"],
+	["03", "Casey", "Moss", "casey.athlete.demo@test.com", "e2e_div_scaled"],
+	["04", "Morgan", "Vale", "morgan.athlete.demo@test.com", "e2e_div_scaled"],
+	["05", "Taylor", "Pike", "taylor.athlete.demo@test.com", "e2e_div_rx"],
+	["06", "Avery", "Fields", "avery.athlete.demo@test.com", "e2e_div_rx"],
+	["07", "Drew", "Hayes", "drew.athlete.demo@test.com", "e2e_div_scaled"],
+	["08", "Skyler", "Wells", "skyler.athlete.demo@test.com", "e2e_div_scaled"],
+] as const
+
+const DEMO_WORKOUTS = [
+	{
+		trackWorkoutId: "e2e_crew_trwk_1",
+		competitionEventId: "e2e_crew_cevt_1",
+		workoutId: "e2e_workout_fran",
+		name: "Opening Ladder",
+	},
+	{
+		trackWorkoutId: "e2e_crew_trwk_2",
+		competitionEventId: "e2e_crew_cevt_2",
+		workoutId: "e2e_workout_murph",
+		name: "Barbell Sprint",
+	},
+	{
+		trackWorkoutId: "e2e_crew_trwk_3",
+		competitionEventId: "e2e_crew_cevt_3",
+		workoutId: "e2e_workout_cindy",
+		name: "Final Chipper",
+	},
+] as const
+
+const SHIFT_SPECS = [
+	{
+		id: "e2e_crew_shift_checkin",
+		name: "Athlete Check-In",
+		roleType: "check_in",
+		location: "Lobby",
+		capacity: 2,
+		startOffsetMinutes: -60,
+		durationMinutes: 120,
+		volunteers: ["04", "15"],
+		statuses: ["confirmed", "pending"],
+	},
+	{
+		id: "e2e_crew_shift_floor_a",
+		name: "North Floor Crew",
+		roleType: "floor_manager",
+		location: "North Floor",
+		capacity: 2,
+		startOffsetMinutes: -20,
+		durationMinutes: 120,
+		volunteers: ["05", "13"],
+		statuses: ["checked_in", "confirmed"],
+	},
+	{
+		id: "e2e_crew_shift_lane2_judge",
+		name: "North Lane 2 Judge",
+		roleType: "judge",
+		location: "North Floor / Lane 2",
+		capacity: 1,
+		startOffsetMinutes: 20,
+		durationMinutes: 70,
+		volunteers: ["02"],
+		statuses: ["pending"],
+	},
+	{
+		id: "e2e_crew_shift_score",
+		name: "Score Table",
+		roleType: "scorekeeper",
+		location: "Scoring Desk",
+		capacity: 2,
+		startOffsetMinutes: -10,
+		durationMinutes: 150,
+		volunteers: ["03", "16"],
+		statuses: ["declined", "confirmed"],
+	},
+	{
+		id: "e2e_crew_shift_equipment",
+		name: "Equipment Reset",
+		roleType: "equipment",
+		location: "Equipment Staging",
+		capacity: 3,
+		startOffsetMinutes: 45,
+		durationMinutes: 135,
+		volunteers: ["06", "14"],
+		statuses: ["pending", "confirmed"],
+	},
+	{
+		id: "e2e_crew_shift_medical",
+		name: "Medical Station",
+		roleType: "medical",
+		location: "Medical Tent",
+		capacity: 1,
+		startOffsetMinutes: -15,
+		durationMinutes: 210,
+		volunteers: ["01"],
+		statuses: ["no_show"],
+	},
+	{
+		id: "e2e_crew_shift_media",
+		name: "Media Runner",
+		roleType: "media",
+		location: "Awards Backdrop",
+		capacity: 1,
+		startOffsetMinutes: 120,
+		durationMinutes: 90,
+		volunteers: ["17"],
+		statuses: ["confirmed"],
+	},
+] as const
+
+export const CREW_DEMO_EVENT = {
+	eventId: EVENT_ID,
+	slug: SLUG,
+	volunteerToken: VOLUNTEER_TOKEN,
+	volunteerName: "Grace Martinez",
+	volunteerShiftName: "North Lane 2 Judge",
+	organizerTotals: {
+		volunteers: DEMO_VOLUNTEERS.length,
+		assignments: 12,
+	},
+} as const
+
+export async function seedCrewDemoEvent(
+	connection: Connection,
+	ts: string,
+	passwordHash: string,
+): Promise<void> {
+	console.log("Seeding E2E Crew demo event...")
+	await cleanupCrewDemoEvent(connection)
+
+	const now = new Date()
+	const startDate = dateStringFrom(now)
+	const endDate = dateStringFrom(addMinutes(now, 24 * 60))
+	const expiresAt = sqlDatetime(addMinutes(now, 14 * 24 * 60))
+
+	await connection.execute(
+		`UPDATE \`competitions\`
+		 SET name = ?, description = ?, start_date = ?, end_date = ?, timezone = ?, visibility = ?, status = ?, competition_type = ?, updated_at = ?
+		 WHERE id = ?`,
+		[
+			"E2E Crew Demo Throwdown",
+			"A seeded Crew demo with staffed floors, published heats, confirmations, and day-of state.",
+			startDate,
+			endDate,
+			"America/Denver",
+			"public",
+			"published",
+			"in-person",
+			ts,
+			EVENT_ID,
+		],
+	)
+
+	await connection.execute(
+		`INSERT IGNORE INTO \`crew_event_settings\` (id, competition_id, crew_only, source_platform, lifecycle, concierge_status, crew_plan, crew_billing_state, crew_billing_source, crew_billing_amount_cents, crew_billing_currency, settings, created_at, updated_at, update_counter)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		[
+			"e2e_crew_event_settings",
+			EVENT_ID,
+			1,
+			"e2e_demo",
+			"ready",
+			"ready",
+			"self_serve",
+			"comped",
+			"comp",
+			0,
+			"usd",
+			JSON.stringify({
+				demo: true,
+				floors: 2,
+				lanes: 8,
+				workouts: DEMO_WORKOUTS.map((workout) => workout.name),
+			}),
+			ts,
+			ts,
+			0,
+		],
+	)
+
+	await seedAthleteRegistrations(connection, ts, passwordHash)
+	await seedVolunteers(connection, ts, passwordHash, expiresAt)
+	await seedWorkoutsAndHeats(connection, ts, now)
+	await seedShiftAssignments(connection, ts, now, expiresAt)
+	await seedJudgeAssignments(connection, ts, now, expiresAt)
+
+	console.log(
+		`  crew demo: ${DEMO_VOLUNTEERS.length} volunteers, 2 floors, 8 lanes, 3 workouts inserted`,
+	)
+}
+
+async function cleanupCrewDemoEvent(connection: Connection): Promise<void> {
+	const tables = [
+		"crew_volunteer_history_events",
+		"crew_assignment_confirmations",
+		"judge_heat_assignments",
+		"judge_assignment_versions",
+		"competition_heat_assignments",
+		"competition_heats",
+		"competition_events",
+		"competition_venues",
+		"volunteer_shift_assignments",
+		"volunteer_shifts",
+		"track_workouts",
+		"programming_tracks",
+		"crew_event_settings",
+		"volunteer_registration_answers",
+		"team_invitations",
+		"competition_registrations",
+		"team_memberships",
+		"users",
+	]
+
+	for (const table of tables) {
+		await connection.execute(`DELETE FROM \`${table}\` WHERE id LIKE 'e2e_crew_%'`)
+	}
+	await connection.execute(
+		"DELETE FROM `users` WHERE email LIKE '%.crew.demo@test.com' OR email LIKE '%.athlete.demo@test.com'",
+	)
+}
+
+async function seedAthleteRegistrations(
+	connection: Connection,
+	ts: string,
+	passwordHash: string,
+): Promise<void> {
+	for (const [suffix, firstName, lastName, email, divisionId] of DEMO_ATHLETES) {
+		const userId = `e2e_crew_athlete_${suffix}`
+		const membershipId = `e2e_crew_comp_member_${suffix}`
+		const registrationId = `e2e_crew_reg_${suffix}`
+
+		await connection.execute(
+			`INSERT IGNORE INTO \`users\` (id, first_name, last_name, email, password_hash, role, email_verified, current_credits, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[userId, firstName, lastName, email, passwordHash, "user", ts, 0, ts, ts, 0],
+		)
+		await connection.execute(
+			`INSERT IGNORE INTO \`team_memberships\` (id, team_id, user_id, role_id, is_system_role, is_active, joined_at, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[membershipId, COMPETITION_TEAM_ID, userId, "athlete", 1, 1, ts, ts, ts, 0],
+		)
+		await connection.execute(
+			`INSERT IGNORE INTO \`competition_registrations\` (id, event_id, user_id, team_member_id, division_id, status, registered_at, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[registrationId, EVENT_ID, userId, membershipId, divisionId, "active", ts, ts, ts, 0],
+		)
+	}
+}
+
+async function seedVolunteers(
+	connection: Connection,
+	ts: string,
+	passwordHash: string,
+	expiresAt: string,
+): Promise<void> {
+	for (const [suffix, firstName, lastName, email, roleTypes] of DEMO_VOLUNTEERS) {
+		const userId = `e2e_crew_vol_user_${suffix}`
+		const invitationId = `e2e_crew_vol_inv_${suffix}`
+		const membershipId = membershipIdFor(suffix)
+		const isScheduleTokenVolunteer = suffix === "02"
+		const metadata = JSON.stringify({
+			volunteerRoleTypes: roleTypes,
+			availability: suffix === "02" ? "all_day" : "morning",
+			credentials: roleTypes.includes("medical")
+				? "EMT certified"
+				: roleTypes.includes("judge")
+					? "L1 judge course complete"
+					: null,
+			signupName: `${firstName} ${lastName}`,
+			signupEmail: email,
+			signupPhone: `555-20${suffix}`,
+			availabilityNotes: isScheduleTokenVolunteer
+				? "Available all day on both competition floors."
+				: null,
+		})
+
+		await connection.execute(
+			`INSERT IGNORE INTO \`users\` (id, first_name, last_name, email, password_hash, role, email_verified, current_credits, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[userId, firstName, lastName, email, passwordHash, "user", ts, 0, ts, ts, 0],
+		)
+		await connection.execute(
+			`INSERT IGNORE INTO \`team_invitations\` (id, team_id, email, role_id, is_system_role, token, invited_by, expires_at, accepted_at, accepted_by, status, metadata, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				invitationId,
+				COMPETITION_TEAM_ID,
+				email,
+				"volunteer",
+				1,
+				isScheduleTokenVolunteer
+					? VOLUNTEER_TOKEN
+					: `e2e-crew-demo-volunteer-${suffix}`,
+				"e2e_test_user",
+				expiresAt,
+				ts,
+				userId,
+				"accepted",
+				metadata,
+				ts,
+				ts,
+				0,
+			],
+		)
+		await connection.execute(
+			`INSERT IGNORE INTO \`team_memberships\` (id, team_id, user_id, role_id, is_system_role, is_active, invited_by, invited_at, joined_at, metadata, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				membershipId,
+				COMPETITION_TEAM_ID,
+				userId,
+				"volunteer",
+				1,
+				1,
+				"e2e_test_user",
+				ts,
+				ts,
+				metadata,
+				ts,
+				ts,
+				0,
+			],
+		)
+	}
+}
+
+async function seedWorkoutsAndHeats(
+	connection: Connection,
+	ts: string,
+	now: Date,
+): Promise<void> {
+	await connection.execute(
+		`INSERT IGNORE INTO \`programming_tracks\` (id, name, description, type, owner_team_id, scaling_group_id, is_public, competition_id, created_at, updated_at, update_counter)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		[
+			"e2e_crew_programming_track",
+			"Crew Demo Competition Track",
+			"Three-workout demo track for Crew E2E flows",
+			"self_programmed",
+			ORGANIZER_TEAM_ID,
+			"e2e_scaling_group",
+			1,
+			EVENT_ID,
+			ts,
+			ts,
+			0,
+		],
+	)
+
+	for (let index = 0; index < DEMO_WORKOUTS.length; index++) {
+		const workout = DEMO_WORKOUTS[index]
+		await connection.execute(
+			`INSERT IGNORE INTO \`track_workouts\` (id, track_id, workout_id, track_order, notes, heat_status, event_status, default_heats_count, default_lane_shift_pattern, min_heat_buffer, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				workout.trackWorkoutId,
+				"e2e_crew_programming_track",
+				workout.workoutId,
+				index + 1,
+				workout.name,
+				"published",
+				"published",
+				2,
+				"stay",
+				1,
+				ts,
+				ts,
+				0,
+			],
+		)
+		await connection.execute(
+			`INSERT IGNORE INTO \`competition_events\` (id, competition_id, track_workout_id, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			[workout.competitionEventId, EVENT_ID, workout.trackWorkoutId, ts, ts, 0],
+		)
+	}
+
+	const venues = [
+		["e2e_crew_venue_north", "North Floor", 4, 0],
+		["e2e_crew_venue_south", "South Floor", 4, 1],
+	] as const
+	for (const [id, name, laneCount, sortOrder] of venues) {
+		await connection.execute(
+			`INSERT IGNORE INTO \`competition_venues\` (id, competition_id, name, lane_count, transition_minutes, sort_order, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[id, EVENT_ID, name, laneCount, 5, sortOrder, ts, ts, 0],
+		)
+	}
+
+	for (let workoutIndex = 0; workoutIndex < DEMO_WORKOUTS.length; workoutIndex++) {
+		const workout = DEMO_WORKOUTS[workoutIndex]
+		for (let floorIndex = 0; floorIndex < venues.length; floorIndex++) {
+			const heatId = `e2e_crew_heat_${workoutIndex + 1}_${floorIndex + 1}`
+			const scheduledTime = sqlDatetime(
+				addMinutes(now, -15 + workoutIndex * 55 + floorIndex * 8),
+			)
+			const venueId = venues[floorIndex][0]
+			await connection.execute(
+				`INSERT IGNORE INTO \`competition_heats\` (id, competition_id, track_workout_id, venue_id, heat_number, scheduled_time, duration_minutes, schedule_published_at, created_at, updated_at, update_counter)
+				 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				[
+					heatId,
+					EVENT_ID,
+					workout.trackWorkoutId,
+					venueId,
+					floorIndex + 1,
+					scheduledTime,
+					18,
+					ts,
+					ts,
+					ts,
+					0,
+				],
+			)
+			for (let lane = 1; lane <= 4; lane++) {
+				const athleteIndex = floorIndex * 4 + lane
+				await connection.execute(
+					`INSERT IGNORE INTO \`competition_heat_assignments\` (id, heat_id, registration_id, lane_number, created_at, updated_at, update_counter)
+					 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+					[
+						`e2e_crew_heat_asg_${workoutIndex + 1}_${floorIndex + 1}_${lane}`,
+						heatId,
+						`e2e_crew_reg_${String(athleteIndex).padStart(2, "0")}`,
+						lane,
+						ts,
+						ts,
+						0,
+					],
+				)
+			}
+		}
+	}
+}
+
+async function seedShiftAssignments(
+	connection: Connection,
+	ts: string,
+	now: Date,
+	expiresAt: string,
+): Promise<void> {
+	for (const shift of SHIFT_SPECS) {
+		await connection.execute(
+			`INSERT IGNORE INTO \`volunteer_shifts\` (id, competition_id, name, role_type, start_time, end_time, location, capacity, notes, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				shift.id,
+				EVENT_ID,
+				shift.name,
+				shift.roleType,
+				sqlDatetime(addMinutes(now, shift.startOffsetMinutes)),
+				sqlDatetime(addMinutes(now, shift.startOffsetMinutes + shift.durationMinutes)),
+				shift.location,
+				shift.capacity,
+				"Seeded for the Crew client demo flow.",
+				ts,
+				ts,
+				0,
+			],
+		)
+
+		for (let index = 0; index < shift.volunteers.length; index++) {
+			const suffix = shift.volunteers[index]
+			const assignmentId = `e2e_crew_vsha_${shift.id.replace("e2e_crew_shift_", "")}_${index + 1}`
+			const status = shift.statuses[index] ?? "pending"
+			await connection.execute(
+				`INSERT IGNORE INTO \`volunteer_shift_assignments\` (id, shift_id, membership_id, notes, created_at, updated_at, update_counter)
+				 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+				[
+					assignmentId,
+					shift.id,
+					membershipIdFor(suffix),
+					index === 0 ? "Primary owner for this block." : "Support assignment.",
+					ts,
+					ts,
+					0,
+				],
+			)
+			await insertConfirmation(connection, {
+				id: `e2e_crew_conf_${assignmentId}`,
+				assignmentType: "volunteer_shift",
+				assignmentId,
+				membershipId: membershipIdFor(suffix),
+				invitationId: `e2e_crew_vol_inv_${suffix}`,
+				email: emailForVolunteer(suffix),
+				token: `e2e-crew-demo-confirm-${assignmentId}`,
+				status,
+				ts,
+				expiresAt,
+			})
+		}
+	}
+}
+
+async function seedJudgeAssignments(
+	connection: Connection,
+	ts: string,
+	now: Date,
+	expiresAt: string,
+): Promise<void> {
+	const judgeSuffixes = ["02", "07", "08", "09", "10", "11", "12", "18"]
+
+	for (let workoutIndex = 0; workoutIndex < DEMO_WORKOUTS.length; workoutIndex++) {
+		const workout = DEMO_WORKOUTS[workoutIndex]
+		const versionId = `e2e_crew_jver_${workoutIndex + 1}`
+		await connection.execute(
+			`INSERT IGNORE INTO \`judge_assignment_versions\` (id, track_workout_id, version, published_at, published_by, notes, is_active, created_at, updated_at, update_counter)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			[
+				versionId,
+				workout.trackWorkoutId,
+				1,
+				sqlDatetime(addMinutes(now, -90)),
+				"e2e_test_user",
+				"Seeded Crew demo judge version",
+				1,
+				ts,
+				ts,
+				0,
+			],
+		)
+
+		for (let floorIndex = 0; floorIndex < 2; floorIndex++) {
+			const heatId = `e2e_crew_heat_${workoutIndex + 1}_${floorIndex + 1}`
+			for (let lane = 1; lane <= 4; lane++) {
+				if (workoutIndex === 2 && floorIndex === 1 && lane === 4) continue
+				const judgeIndex = (workoutIndex * 2 + floorIndex + lane - 1) % judgeSuffixes.length
+				const suffix = judgeSuffixes[judgeIndex]
+				const assignmentId = `e2e_crew_jha_${workoutIndex + 1}_${floorIndex + 1}_${lane}`
+				await connection.execute(
+					`INSERT IGNORE INTO \`judge_heat_assignments\` (id, heat_id, membership_id, version_id, lane_number, position, instructions, is_manual_override, created_at, updated_at, update_counter)
+					 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+					[
+						assignmentId,
+						heatId,
+						membershipIdFor(suffix),
+						versionId,
+						lane,
+						"judge",
+						`Judge lane ${lane} on ${floorIndex === 0 ? "North" : "South"} Floor.`,
+						0,
+						ts,
+						ts,
+						0,
+					],
+				)
+				await insertConfirmation(connection, {
+					id: `e2e_crew_conf_${assignmentId}`,
+					assignmentType: "judge_heat",
+					assignmentId,
+					membershipId: membershipIdFor(suffix),
+					invitationId: `e2e_crew_vol_inv_${suffix}`,
+					email: emailForVolunteer(suffix),
+					token: `e2e-crew-demo-confirm-${assignmentId}`,
+					status: lane === 1 && workoutIndex === 0 ? "confirmed" : "pending",
+					ts,
+					expiresAt,
+				})
+			}
+		}
+	}
+}
+
+async function insertConfirmation(
+	connection: Connection,
+	data: {
+		id: string
+		assignmentType: "volunteer_shift" | "judge_heat"
+		assignmentId: string
+		membershipId: string
+		invitationId: string
+		email: string
+		token: string
+		status: string
+		ts: string
+		expiresAt: string
+	},
+): Promise<void> {
+	const respondedAt = ["confirmed", "checked_in", "declined", "change_requested", "no_show"].includes(data.status)
+		? data.ts
+		: null
+	const responseNote =
+		data.status === "declined"
+			? "Seeded decline so organizers can demo response triage."
+			: data.status === "no_show"
+				? "Seeded no-show for event-day replacement visibility."
+				: null
+
+	await connection.execute(
+		`INSERT IGNORE INTO \`crew_assignment_confirmations\` (id, competition_id, assignment_type, assignment_id, membership_id, invitation_id, email, token_hash, status, sent_at, responded_at, expires_at, response_note, reminder_count, created_at, updated_at, update_counter)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		[
+			data.id,
+			EVENT_ID,
+			data.assignmentType,
+			data.assignmentId,
+			data.membershipId,
+			data.invitationId,
+			data.email,
+			hashToken(data.token),
+			data.status,
+			data.ts,
+			respondedAt,
+			data.expiresAt,
+			responseNote,
+			data.status === "pending" ? 1 : 0,
+			data.ts,
+			data.ts,
+			0,
+		],
+	)
+}
+
+function membershipIdFor(suffix: string): string {
+	return `e2e_crew_vol_membership_${suffix}`
+}
+
+function emailForVolunteer(suffix: string): string {
+	const row = DEMO_VOLUNTEERS.find((volunteer) => volunteer[0] === suffix)
+	if (!row) throw new Error(`Missing demo volunteer ${suffix}`)
+	return row[3]
+}
+
+function hashToken(token: string): string {
+	return `sha256:${createHash("sha256").update(token).digest("hex")}`
+}
+
+function addMinutes(date: Date, minutes: number): Date {
+	return new Date(date.getTime() + minutes * 60_000)
+}
+
+function sqlDatetime(date: Date): string {
+	return date.toISOString().slice(0, 19).replace("T", " ")
+}
+
+function dateStringFrom(date: Date): string {
+	return date.toISOString().slice(0, 10)
+}

--- a/apps/crew/scripts/seed/crew-demo-event.ts
+++ b/apps/crew/scripts/seed/crew-demo-event.ts
@@ -148,7 +148,7 @@ export const CREW_DEMO_EVENT = {
 	volunteerShiftName: "North Lane 2 Judge",
 	organizerTotals: {
 		volunteers: DEMO_VOLUNTEERS.length,
-		assignments: 12,
+		assignments: 11,
 	},
 } as const
 

--- a/apps/crew/src/routeTree.gen.ts
+++ b/apps/crew/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as EventsEventIdShiftsRouteImport } from './routes/events/$eventI
 import { Route as EventsEventIdSetupRouteImport } from './routes/events/$eventId/setup'
 import { Route as EventsEventIdScheduleRouteImport } from './routes/events/$eventId/schedule'
 import { Route as EventsEventIdReadinessRouteImport } from './routes/events/$eventId/readiness'
+import { Route as EventsEventIdMessagesRouteImport } from './routes/events/$eventId/messages'
 import { Route as EventsEventIdJudgesRouteImport } from './routes/events/$eventId/judges'
 import { Route as EventsEventIdImportsRouteImport } from './routes/events/$eventId/imports'
 import { Route as EventsEventIdExportsRouteImport } from './routes/events/$eventId/exports'
@@ -30,9 +31,9 @@ import { Route as EventsEventIdDayOfRouteImport } from './routes/events/$eventId
 import { Route as EventsEventIdConvertRouteImport } from './routes/events/$eventId/convert'
 import { Route as EventsEventIdBillingRouteImport } from './routes/events/$eventId/billing'
 import { Route as EventsEventIdAssignmentsRouteImport } from './routes/events/$eventId/assignments'
-import { Route as EventsEventIdMessagesRouteImport } from './routes/events/$eventId/messages'
 import { Route as ESlugVolunteerRouteImport } from './routes/e/$slug/volunteer'
 import { Route as ApiWebhooksStripeRouteImport } from './routes/api/webhooks/stripe'
+import { Route as ApiE2eSessionRouteImport } from './routes/api/e2e/session'
 import { Route as ApiCrewImportRouteImport } from './routes/api/crew/import'
 import { Route as AdminCrewEventsRouteImport } from './routes/admin/crew/events'
 import { Route as EventsEventIdDiscoveryJudgesRouteImport } from './routes/events/$eventId/discovery/judges'
@@ -114,6 +115,11 @@ const EventsEventIdReadinessRoute = EventsEventIdReadinessRouteImport.update({
   path: '/readiness',
   getParentRoute: () => EventsEventIdRoute,
 } as any)
+const EventsEventIdMessagesRoute = EventsEventIdMessagesRouteImport.update({
+  id: '/messages',
+  path: '/messages',
+  getParentRoute: () => EventsEventIdRoute,
+} as any)
 const EventsEventIdJudgesRoute = EventsEventIdJudgesRouteImport.update({
   id: '/judges',
   path: '/judges',
@@ -150,11 +156,6 @@ const EventsEventIdAssignmentsRoute =
     path: '/assignments',
     getParentRoute: () => EventsEventIdRoute,
   } as any)
-const EventsEventIdMessagesRoute = EventsEventIdMessagesRouteImport.update({
-  id: '/messages',
-  path: '/messages',
-  getParentRoute: () => EventsEventIdRoute,
-} as any)
 const ESlugVolunteerRoute = ESlugVolunteerRouteImport.update({
   id: '/e/$slug/volunteer',
   path: '/e/$slug/volunteer',
@@ -163,6 +164,11 @@ const ESlugVolunteerRoute = ESlugVolunteerRouteImport.update({
 const ApiWebhooksStripeRoute = ApiWebhooksStripeRouteImport.update({
   id: '/api/webhooks/stripe',
   path: '/api/webhooks/stripe',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiE2eSessionRoute = ApiE2eSessionRouteImport.update({
+  id: '/api/e2e/session',
+  path: '/api/e2e/session',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiCrewImportRoute = ApiCrewImportRouteImport.update({
@@ -229,6 +235,7 @@ export interface FileRoutesByFullPath {
   '/events/new': typeof EventsNewRoute
   '/admin/crew/events': typeof AdminCrewEventsRouteWithChildren
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/api/e2e/session': typeof ApiE2eSessionRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/assignments': typeof EventsEventIdAssignmentsRoute
@@ -264,6 +271,7 @@ export interface FileRoutesByTo {
   '/events/new': typeof EventsNewRoute
   '/admin/crew/events': typeof AdminCrewEventsRouteWithChildren
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/api/e2e/session': typeof ApiE2eSessionRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/assignments': typeof EventsEventIdAssignmentsRoute
@@ -301,6 +309,7 @@ export interface FileRoutesById {
   '/events/new': typeof EventsNewRoute
   '/admin/crew/events': typeof AdminCrewEventsRouteWithChildren
   '/api/crew/import': typeof ApiCrewImportRoute
+  '/api/e2e/session': typeof ApiE2eSessionRoute
   '/api/webhooks/stripe': typeof ApiWebhooksStripeRoute
   '/e/$slug/volunteer': typeof ESlugVolunteerRoute
   '/events/$eventId/assignments': typeof EventsEventIdAssignmentsRoute
@@ -339,6 +348,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/admin/crew/events'
     | '/api/crew/import'
+    | '/api/e2e/session'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/assignments'
@@ -374,6 +384,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/admin/crew/events'
     | '/api/crew/import'
+    | '/api/e2e/session'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/assignments'
@@ -410,6 +421,7 @@ export interface FileRouteTypes {
     | '/events/new'
     | '/admin/crew/events'
     | '/api/crew/import'
+    | '/api/e2e/session'
     | '/api/webhooks/stripe'
     | '/e/$slug/volunteer'
     | '/events/$eventId/assignments'
@@ -444,6 +456,7 @@ export interface RootRouteChildren {
   EventsRoute: typeof EventsRouteWithChildren
   AdminCrewRoute: typeof AdminCrewRouteWithChildren
   ApiCrewImportRoute: typeof ApiCrewImportRoute
+  ApiE2eSessionRoute: typeof ApiE2eSessionRoute
   ApiWebhooksStripeRoute: typeof ApiWebhooksStripeRoute
   ESlugVolunteerRoute: typeof ESlugVolunteerRoute
   SeriesGroupIdCrewRoute: typeof SeriesGroupIdCrewRoute
@@ -552,6 +565,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdReadinessRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
+    '/events/$eventId/messages': {
+      id: '/events/$eventId/messages'
+      path: '/messages'
+      fullPath: '/events/$eventId/messages'
+      preLoaderRoute: typeof EventsEventIdMessagesRouteImport
+      parentRoute: typeof EventsEventIdRoute
+    }
     '/events/$eventId/judges': {
       id: '/events/$eventId/judges'
       path: '/judges'
@@ -601,13 +621,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof EventsEventIdAssignmentsRouteImport
       parentRoute: typeof EventsEventIdRoute
     }
-    '/events/$eventId/messages': {
-      id: '/events/$eventId/messages'
-      path: '/messages'
-      fullPath: '/events/$eventId/messages'
-      preLoaderRoute: typeof EventsEventIdMessagesRouteImport
-      parentRoute: typeof EventsEventIdRoute
-    }
     '/e/$slug/volunteer': {
       id: '/e/$slug/volunteer'
       path: '/e/$slug/volunteer'
@@ -620,6 +633,13 @@ declare module '@tanstack/react-router' {
       path: '/api/webhooks/stripe'
       fullPath: '/api/webhooks/stripe'
       preLoaderRoute: typeof ApiWebhooksStripeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/e2e/session': {
+      id: '/api/e2e/session'
+      path: '/api/e2e/session'
+      fullPath: '/api/e2e/session'
+      preLoaderRoute: typeof ApiE2eSessionRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/crew/import': {
@@ -798,6 +818,7 @@ const rootRouteChildren: RootRouteChildren = {
   EventsRoute: EventsRouteWithChildren,
   AdminCrewRoute: AdminCrewRouteWithChildren,
   ApiCrewImportRoute: ApiCrewImportRoute,
+  ApiE2eSessionRoute: ApiE2eSessionRoute,
   ApiWebhooksStripeRoute: ApiWebhooksStripeRoute,
   ESlugVolunteerRoute: ESlugVolunteerRoute,
   SeriesGroupIdCrewRoute: SeriesGroupIdCrewRoute,

--- a/apps/crew/src/routes/api/e2e/session.ts
+++ b/apps/crew/src/routes/api/e2e/session.ts
@@ -1,0 +1,31 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { json } from "@tanstack/react-start"
+import { z } from "zod"
+import { createAndStoreSession } from "@/utils/auth"
+
+const e2eSessionSchema = z.object({
+  userId: z.string().min(1).default("e2e_test_user"),
+})
+
+export const Route = createFileRoute("/api/e2e/session")({
+  server: {
+    handlers: {
+      POST: async ({ request }) => {
+        if (!isE2EEnabled()) {
+          return json({ error: "Not found" }, { status: 404 })
+        }
+
+        const rawBody = await request.json().catch(() => ({}))
+        const { userId } = e2eSessionSchema.parse(rawBody)
+
+        await createAndStoreSession(userId, "password")
+
+        return json({ ok: true })
+      },
+    },
+  },
+})
+
+function isE2EEnabled() {
+  return import.meta.env.VITE_E2E === "true" || process.env.VITE_E2E === "true"
+}

--- a/apps/crew/src/routes/api/e2e/session.ts
+++ b/apps/crew/src/routes/api/e2e/session.ts
@@ -1,11 +1,23 @@
+// @lat: [[auth#Sessions]]
+// @lat: [[crew#Server Function Runtime Boundary]]
+
+import { env } from "cloudflare:workers"
 import { createFileRoute } from "@tanstack/react-router"
 import { json } from "@tanstack/react-start"
 import { z } from "zod"
 import { createAndStoreSession } from "@/utils/auth"
 
 const e2eSessionSchema = z.object({
-  userId: z.string().min(1).default("e2e_test_user"),
+  userId: z.string().min(1),
 })
+
+const SESSION_BOOTSTRAP_LIMIT = 20
+const SESSION_BOOTSTRAP_WINDOW_MS = 60_000
+
+const sessionBootstrapAttempts = new Map<
+  string,
+  { count: number; resetAt: number }
+>()
 
 export const Route = createFileRoute("/api/e2e/session")({
   server: {
@@ -15,10 +27,17 @@ export const Route = createFileRoute("/api/e2e/session")({
           return json({ error: "Not found" }, { status: 404 })
         }
 
-        const rawBody = await request.json().catch(() => ({}))
-        const { userId } = e2eSessionSchema.parse(rawBody)
+        if (!allowSessionBootstrap(request)) {
+          return json({ error: "Too many requests" }, { status: 429 })
+        }
 
-        await createAndStoreSession(userId, "password")
+        const rawBody = await request.json().catch(() => null)
+        const result = e2eSessionSchema.safeParse(rawBody)
+        if (!result.success) {
+          return json({ error: "Invalid E2E session payload" }, { status: 400 })
+        }
+
+        await createAndStoreSession(result.data.userId, "password")
 
         return json({ ok: true })
       },
@@ -27,5 +46,40 @@ export const Route = createFileRoute("/api/e2e/session")({
 })
 
 function isE2EEnabled() {
-  return import.meta.env.VITE_E2E === "true" || process.env.VITE_E2E === "true"
+  return (
+    import.meta.env.VITE_E2E === "true" || getEnvValue("VITE_E2E") === "true"
+  )
+}
+
+function getEnvValue(key: string) {
+	return (env as unknown as Record<string, string | undefined>)[key]
+}
+
+function allowSessionBootstrap(request: Request) {
+  const now = Date.now()
+  const key = getRateLimitKey(request)
+  const current = sessionBootstrapAttempts.get(key)
+
+  if (!current || current.resetAt <= now) {
+    sessionBootstrapAttempts.set(key, {
+      count: 1,
+      resetAt: now + SESSION_BOOTSTRAP_WINDOW_MS,
+    })
+    return true
+  }
+
+  if (current.count >= SESSION_BOOTSTRAP_LIMIT) {
+    return false
+  }
+
+  current.count += 1
+  return true
+}
+
+function getRateLimitKey(request: Request) {
+  return (
+    request.headers.get("cf-connecting-ip") ??
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    "local"
+  )
 }


### PR DESCRIPTION
## Summary

- Adds a deterministic Crew demo event fixture to the E2E seed with 18 volunteers, 2 four-lane floors, 3 workouts, published heats, shift assignments, judge assignments, confirmation statuses, checked-in state, and a no-show.
- Wires the fixture into `scripts/seed-e2e.ts` and exposes stable Playwright constants for the demo token and event IDs.
- Adds organizer and public volunteer Playwright coverage for confirmation buckets, day-of workflow visibility, public schedule token loading, and volunteer response submission.

## Validation

- `pnpm --filter crew type-check` passed.
- `pnpm --filter crew lint` passed with the existing warning baseline.
- `pnpm check:schema-ownership` passed.
- `git diff --check` passed.
- `pnpm --filter crew exec tsx -e "import('./scripts/seed/crew-demo-event.ts').then(() => undefined)"` passed.

## Local blockers

- Focused Playwright run `pnpm --filter crew exec playwright test e2e/crew-organizer-flow.spec.ts e2e/crew-volunteer-flow.spec.ts` is blocked locally because Playwright global setup requires `DATABASE_URL`.
- Local build `CLOUDFLARE_VITE_REMOTE_BINDINGS=false pnpm --filter crew build` is blocked because `apps/crew/.alchemy/local/wrangler.jsonc` is missing; `pnpm --filter crew alchemy:configure` also blocks in this worktree because the Alchemy config receives an undefined URL from the missing environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds a deterministic Crew demo event for E2E and adds organizer/volunteer flows to verify confirmations, judge/shift assignments, and day‑of stats. CI provisions MySQL, seeds the demo, runs the flows, and merges blob reports in GitHub Actions.

- **New Features**
  - Seeded demo via `seedCrewDemoEvent` wired into `apps/crew/scripts/seed-e2e.ts`.
  - Dataset: 18 volunteers; 2 floors (4 lanes each); 3 workouts; published heats; judge and shift assignments; mixed confirmations incl. checked‑in and one no‑show.
  - Stable test constants in `apps/crew/e2e/fixtures/test-data.ts` sourced from `CREW_DEMO_EVENT` (event name "E2E Crew Demo Throwdown", slug `e2e-throwdown`, volunteer token, key labels, counts).
  - Playwright: organizer validates confirmation buckets and day‑of metrics; volunteer loads a public schedule and confirms a shift.
  - GA job `crew-demo-e2e` provisions MySQL, writes local Alchemy `wrangler.jsonc` and `.dev.vars`, runs `db:push`, `db:seed`, `db:seed:e2e`, executes both specs, uploads a blob report, and the merge step uses a custom Playwright merge config to combine reports.

- **Bug Fixes**
  - Added guarded, rate‑limited test endpoint `/api/e2e/session` and updated Playwright auth to mint a session cookie using seeded user IDs (via `SESSION_COOKIE_NAME`), avoiding UI sign‑in and stabilizing local/CI runs (gated by `VITE_E2E`).
  - Hardened organizer assertions with regex/non‑zero checks and scoped panel matching; verified labeled values (No‑shows=1, Active judge versions=3, Shift assignments=11).

<sup>Written for commit dcce8c7222cdb822b406bf83b106c7e83795da87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests validating Crew organizer workflows including event operations, volunteer scheduling, and shift management
  * Added tests for Crew volunteer workflows covering volunteer scheduling, role selection, and shift confirmations
  * Enhanced CI/CD testing infrastructure with crew-specific database seeding and automated reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->