### PR TITLE
Simplify crew new event form

### DIFF
--- a/apps/crew/src/routes/events/new.tsx
+++ b/apps/crew/src/routes/events/new.tsx
@@ -21,23 +21,13 @@ function getLocalDateInputValue() {
 function NewEventPage() {
   const navigate = useNavigate()
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [name, setName] = useState("Pilot Weekend")
-  const [slug, setSlug] = useState("pilot-weekend")
-  const [organizingTeamId, setOrganizingTeamId] = useState("")
+  const [name, setName] = useState("")
+  const [slug, setSlug] = useState("")
   const [startDate, setStartDate] = useState(getLocalDateInputValue)
   const [endDate, setEndDate] = useState(getLocalDateInputValue)
   const [description, setDescription] = useState("")
-  const [sourcePlatform, setSourcePlatform] = useState("")
   const [sourceEventUrl, setSourceEventUrl] = useState("")
   const [externalRegistrationUrl, setExternalRegistrationUrl] = useState("")
-  const [acquisitionSource, setAcquisitionSource] = useState("")
-  const [crewPlan, setCrewPlan] = useState<
-    "self_serve" | "concierge" | "full_platform"
-  >("self_serve")
-  // @lat: [[crew#Event Setup Dashboard]]
-  const [settings, setSettings] = useState(
-    '{\n  "setup": {\n    "assumptions": ""\n  }\n}',
-  )
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -46,18 +36,13 @@ function NewEventPage() {
     try {
       const result = await createCrewEventFn({
         data: {
-          organizingTeamId,
           name,
           slug,
           startDate,
           endDate,
           description,
-          sourcePlatform,
           sourceEventUrl,
           externalRegistrationUrl,
-          acquisitionSource,
-          crewPlan,
-          settings,
         },
       })
 
@@ -112,35 +97,6 @@ function NewEventPage() {
               className="h-10 w-full rounded-md border bg-background px-3 text-sm"
             />
           </Field>
-          <Field label="Organizing team ID" htmlFor="crew-organizing-team-id">
-            <input
-              id="crew-organizing-team-id"
-              value={organizingTeamId}
-              onChange={(event) => setOrganizingTeamId(event.target.value)}
-              required
-              placeholder="team_..."
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            />
-          </Field>
-          <Field label="Crew plan" htmlFor="crew-event-plan">
-            <select
-              id="crew-event-plan"
-              value={crewPlan}
-              onChange={(event) =>
-                setCrewPlan(
-                  event.target.value as
-                    | "self_serve"
-                    | "concierge"
-                    | "full_platform",
-                )
-              }
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            >
-              <option value="self_serve">Self serve</option>
-              <option value="concierge">Concierge</option>
-              <option value="full_platform">Full platform</option>
-            </select>
-          </Field>
           <Field label="Start date" htmlFor="crew-event-start-date">
             <input
               id="crew-event-start-date"
@@ -158,24 +114,6 @@ function NewEventPage() {
               value={endDate}
               onChange={(event) => setEndDate(event.target.value)}
               required
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            />
-          </Field>
-          <Field label="Source platform" htmlFor="crew-source-platform">
-            <input
-              id="crew-source-platform"
-              value={sourcePlatform}
-              onChange={(event) => setSourcePlatform(event.target.value)}
-              placeholder="Competition Corner"
-              className="h-10 w-full rounded-md border bg-background px-3 text-sm"
-            />
-          </Field>
-          <Field label="Acquisition source" htmlFor="crew-acquisition-source">
-            <input
-              id="crew-acquisition-source"
-              value={acquisitionSource}
-              onChange={(event) => setAcquisitionSource(event.target.value)}
-              placeholder="Concierge import"
               className="h-10 w-full rounded-md border bg-background px-3 text-sm"
             />
           </Field>
@@ -201,21 +139,13 @@ function NewEventPage() {
               className="h-10 w-full rounded-md border bg-background px-3 text-sm"
             />
           </Field>
+          {/* @lat: [[crew#Event Setup Dashboard]] */}
           <Field label="Description" htmlFor="crew-event-description" wide>
             <textarea
               id="crew-event-description"
               value={description}
               onChange={(event) => setDescription(event.target.value)}
               className="min-h-24 w-full rounded-md border bg-background px-3 py-2 text-sm"
-            />
-          </Field>
-          {/* @lat: [[crew#Event Setup Dashboard]] */}
-          <Field label="Initial setup JSON" htmlFor="crew-assumptions" wide>
-            <textarea
-              id="crew-assumptions"
-              value={settings}
-              onChange={(event) => setSettings(event.target.value)}
-              className="min-h-32 w-full rounded-md border bg-background px-3 py-2 font-mono text-sm"
             />
           </Field>
         </div>

--- a/apps/crew/src/server-fns/crew-event-settings-fns.ts
+++ b/apps/crew/src/server-fns/crew-event-settings-fns.ts
@@ -37,7 +37,9 @@ const getCrewEventInputSchema = z.object({
 })
 
 const createCrewEventInputSchema = z.object({
-  organizingTeamId: z.string().min(1, "Organizing team ID is required"),
+  // Optional: when omitted the event is organized under the creator's personal
+  // team, resolved server-side. The new event form does not surface a team.
+  organizingTeamId: z.string().min(1).optional(),
   name: z.string().min(1, "Event name is required"),
   slug: z.string().min(1, "Slug is required"),
   startDate: dateStringSchema,

--- a/apps/crew/src/server/crew-auth.server.ts
+++ b/apps/crew/src/server/crew-auth.server.ts
@@ -83,6 +83,25 @@ export function canManageCrewEvent(
   )
 }
 
+/**
+ * Resolve the signed-in user's personal team id.
+ *
+ * Crew events are always organized under the creator's personal team — the
+ * product intentionally does not surface a team concept on the new event form,
+ * so the organizing team is resolved server-side rather than chosen by the user.
+ */
+// @lat: [[crew#Event Setup Dashboard]]
+export async function requireCrewPersonalTeamId(): Promise<string> {
+  const session = await requireCrewSignedIn("Crew event creation")
+  const personalTeam = session.teams?.find((team) => team.isPersonalTeam)
+
+  if (!personalTeam) {
+    throw new Error("NOT_AUTHORIZED: A personal team is required")
+  }
+
+  return personalTeam.id
+}
+
 // @lat: [[crew#Event Setup Dashboard]]
 export function getCrewManageCompetitionTeamIds(session: CrewAuthSession) {
   return new Set(

--- a/apps/crew/src/server/crew-event-settings.server.ts
+++ b/apps/crew/src/server/crew-event-settings.server.ts
@@ -27,6 +27,7 @@ import {
   getCrewAuthState,
   getCrewManageCompetitionTeamIds,
   requireCrewEventManagerAccess,
+  requireCrewPersonalTeamId,
 } from "../server/crew-auth.server"
 import { generateSlug } from "../utils/slugify"
 import { requireCrewDepartmentLeadFullAccess } from "./crew-department-lead.server"
@@ -65,7 +66,7 @@ interface GetCrewEventInput {
 }
 
 interface CreateCrewEventInput {
-  organizingTeamId: string
+  organizingTeamId?: string
   name: string
   slug: string
   startDate: string
@@ -315,9 +316,14 @@ export async function createCrewEvent(
     )
   }
 
-  await requireOrganizingTeam(data.organizingTeamId)
+  // The new event form does not surface a team; default to the creator's
+  // personal team when no organizing team is explicitly provided.
+  const organizingTeamId =
+    data.organizingTeamId ?? (await requireCrewPersonalTeamId())
+
+  await requireOrganizingTeam(organizingTeamId)
   await requireCrewEventManagerAccess(
-    { organizingTeamId: data.organizingTeamId },
+    { organizingTeamId },
     "Crew event creation",
   )
 
@@ -353,14 +359,14 @@ export async function createCrewEvent(
       name: `${data.name} (Event)`,
       slug: teamSlug,
       type: "competition_event",
-      parentOrganizationId: data.organizingTeamId,
+      parentOrganizationId: organizingTeamId,
       description: `Competition event team for ${data.name}`,
       creditBalance: 0,
     })
 
     await tx.insert(competitionsTable).values({
       id: competitionId,
-      organizingTeamId: data.organizingTeamId,
+      organizingTeamId,
       competitionTeamId,
       name: data.name,
       slug: data.slug,

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -110,6 +110,8 @@ Crew event setup pages let an operator create and review a normal competition wi
 
 Additional setup dashboard state is stored in the existing `crew_event_settings.settings` JSON text field until a later slice proves that dedicated typed columns or tables are needed.
 
+The new event form ([[apps/crew/src/routes/events/new.tsx]]) does not surface a team concept. The organizing team is resolved server-side in [[apps/crew/src/server/crew-event-settings.server.ts#createCrewEvent]]: when no `organizingTeamId` is supplied it defaults to the creator's personal team via [[apps/crew/src/server/crew-auth.server.ts#requireCrewPersonalTeamId]]. The personal-team owner holds all team permissions (including `MANAGE_COMPETITIONS`), so the existing event-manager access check still passes.
+
 ## Pilot Readiness Checklist
 
 Crew pilot readiness is a read-only operator surface for deciding whether a founding organizer event is ready for handoff.


### PR DESCRIPTION
## What

Streamlines the Crew **New event** form (`apps/crew/src/routes/events/new.tsx`) and removes the team concept from it.

### Form changes
- **Removed fields:** Organizing team, Crew plan, Source platform, Acquisition source, and Initial setup JSON.
- **Event name** no longer defaults to "Pilot Weekend" (name and slug start empty).
- Remaining fields: Event name, Slug, Start/End date, Source event URL, External registration URL, Description.

### Organizing team handling
The organizing team is no longer surfaced in the UI. `organizingTeamId` is now optional on the create input, and `createCrewEvent` defaults it to the creator's **personal team** (resolved server-side via the new `requireCrewPersonalTeamId`) when none is provided. The personal-team owner holds all team permissions (including `MANAGE_COMPETITIONS`), so the existing `requireCrewEventManagerAccess` check still passes. Server defaults continue to apply for the removed optional fields (`crewPlan` → `self_serve`).

## Testing
- `pnpm type-check` — clean
- Biome — clean
- `pnpm test src/lib/crew/self-serve-event-flow.test.ts` — passing
- `lat check` — no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the Crew New event form by removing team selection and other non-essential fields, and stops defaulting the name to "Pilot Weekend." The server now defaults the organizing team to the creator’s personal team, keeping existing permission checks intact.

- **Refactors**
  - Form: removed Organizing team, Crew plan, Source platform, Acquisition source, and Initial setup JSON; name and slug start empty. Kept Event name, Slug, Start/End date, Source event URL, External registration URL, Description.
  - Server: `createCrewEvent` accepts optional `organizingTeamId`; when omitted, uses `requireCrewPersonalTeamId`; `requireCrewEventManagerAccess` unchanged. Input schema updated accordingly.
  - Docs: added notes in `lat.md/crew.md` about personal-team default behavior.

<sup>Written for commit 002df82ec52d1377c5156dfcbaffdb60bc6494a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified the “New Crew event” flow with fewer fields, making event creation faster and easier.
  * Event organizers can now create events without selecting an organizing team up front; it’s handled automatically in the background.

* **Bug Fixes**
  * Improved event creation defaults so new events are tied to the creator’s personal team when no team is chosen.
  * Kept access checks intact while supporting the streamlined setup.

* **Documentation**
  * Updated guidance to reflect the simplified event creation experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->