### PR TITLE
feat(crew): retab print packet into schedule, judges & shifts

### DIFF
--- a/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
@@ -66,58 +66,51 @@ describe("Crew pilot exports", () => {
     expect(exports.masterScheduleCsv).toContain("'+Mallory")
   })
 
-  it("groups role sheets with open shift slots and judge assignments", () => {
+  it("builds flat time-ordered shift sheets with open slots and statuses", () => {
     const exports = buildCrewPilotExports(baseInput())
 
-    const equipment = exports.roleSheets.find(
-      (sheet) => sheet.roleType === VOLUNTEER_ROLE_TYPES.EQUIPMENT,
-    )
-    const judges = exports.roleSheets.find(
-      (sheet) => sheet.roleType === VOLUNTEER_ROLE_TYPES.JUDGE,
-    )
-
-    expect(equipment?.rows).toMatchObject([
-      { volunteerName: "Rae Reset", blockLabel: "Floor reset" },
-      { volunteerName: "OPEN", confirmationStatus: "open" },
+    expect(exports.shiftSheets.map((sheet) => sheet.name)).toEqual([
+      "Check-in",
+      "Floor reset",
     ])
-    expect(judges?.rows.map((row) => row.volunteerName)).toEqual([
-      "Jules Judge",
-      "Lane Two",
-    ])
-  })
 
-  it("derives no-response and decline rows from confirmation states", () => {
-    const exports = buildCrewPilotExports(baseInput())
-
+    const checkIn = exports.shiftSheets.find(
+      (sheet) => sheet.name === "Check-in",
+    )
     expect(
-      exports.responseRows.map((row) => [
-        row.volunteerName,
-        row.status,
-        row.reason,
-      ]),
+      checkIn?.rows.map((row) => [row.volunteerName, row.confirmationStatus]),
     ).toEqual([
-      ["Casey Check", "pending", "no_response"],
-      ["Lane Two", "declined", "declined"],
-      ["Rae Reset", "missing", "missing_confirmation"],
+      ["Ari Arrivals", "confirmed"],
+      ["Casey Check", "pending"],
     ])
-    expect(exports.responseCsv).toContain(
-      "heat,jha_lane2,Lane Two,lane2@example.com",
+
+    const floorReset = exports.shiftSheets.find(
+      (sheet) => sheet.name === "Floor reset",
     )
+    expect(floorReset?.open).toBe(1)
+    expect(
+      floorReset?.rows.map((row) => [row.volunteerName, row.isOpen]),
+    ).toEqual([
+      ["Rae Reset", false],
+      ["OPEN", true],
+    ])
   })
 
-  it("generates judge heat lane sheets with open lanes", () => {
+  it("groups judge event sections by workout with open lanes per heat", () => {
     const exports = buildCrewPilotExports(baseInput())
-    const [sheet] = exports.judgeHeatLaneSheets
+    const [section] = exports.judgeEventSections
 
-    expect(sheet?.label).toBe("Event 1 - Heat 1")
-    expect(sheet?.rows.map((row) => [row.laneNumber, row.judgeName])).toEqual([
+    expect(section?.workoutName).toBe("Event 1")
+    const [heat] = section?.heats ?? []
+    expect(heat?.label).toBe("Event 1 - Heat 1")
+    expect(heat?.rows.map((row) => [row.laneNumber, row.judgeName])).toEqual([
       [1, "Jules Judge"],
       [2, "Lane Two"],
       [3, "OPEN"],
     ])
   })
 
-  it("assembles an event-day packet index with day, station, and lane cards", () => {
+  it("orders day sections and judge event sections across multiple events", () => {
     const input = baseInput()
     input.venues?.push({
       id: "venue_annex",
@@ -138,27 +131,9 @@ describe("Crew pilot exports", () => {
       { heatId: "heat_2", laneNumber: 1 },
       { heatId: "heat_2", laneNumber: 2 },
     )
-    input.shifts?.push({
-      id: "shift_annex_briefing",
-      name: "Annex briefing",
-      roleType: VOLUNTEER_ROLE_TYPES.FLOOR_MANAGER,
-      startTime: "2026-07-02T14:30:00.000Z",
-      endTime: "2026-07-02T15:00:00.000Z",
-      capacity: 1,
-      location: "Annex floor",
-      assignments: [],
-    })
 
     const exports = buildCrewPilotExports(input)
 
-    expect(exports.packetIndexItems.map((item) => item.id)).toEqual([
-      "master-schedule",
-      "station-cards",
-      "role-sheets",
-      "judge-cards",
-      "response-list",
-      "floor-lead-sheets",
-    ])
     expect(exports.masterScheduleDaySections.map((section) => section.dayKey))
       .toEqual(["2026-07-01", "2026-07-02"])
     expect(
@@ -167,26 +142,16 @@ describe("Crew pilot exports", () => {
       ),
     ).toEqual([
       ["Check-in", "Event 1 - Heat 1", "Floor reset"],
-      ["Annex briefing", "Event 2 - Heat 1"],
-    ])
-    expect(exports.stationCards.map((card) => card.stationName)).toEqual([
-      "Annex floor",
-      "Competition floor",
-      "Front desk",
+      ["Event 2 - Heat 1"],
     ])
     expect(
-      exports.stationCards.find((card) => card.stationName === "Annex floor"),
-    ).toMatchObject({
-      openBlocks: 2,
-      laneCards: [
-        { laneNumber: 1, rows: [{ workoutName: "Event 2" }] },
-        { laneNumber: 2, rows: [{ judgeName: "OPEN" }] },
-      ],
-    })
+      exports.judgeEventSections.map((section) => section.workoutName),
+    ).toEqual(["Event 1", "Event 2"])
     expect(exports.summary).toMatchObject({
       masterScheduleDaySections: 2,
-      stationCards: 3,
-      laneCards: 5,
+      judgeEventSections: 2,
+      judgeHeatSheets: 2,
+      shiftSheets: 2,
     })
   })
 })

--- a/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.test.ts
@@ -6,8 +6,8 @@ import {
   CREW_ASSIGNMENT_CONFIRMATION_TYPE,
 } from "../../../db/schemas/crew-imports"
 import { VOLUNTEER_ROLE_TYPES } from "../../../db/schemas/volunteers"
-import { buildCrewPilotExports } from "./pilot-exports"
 import type { CrewPilotExportInput } from "./pilot-exports"
+import { buildCrewPilotExports } from "./pilot-exports"
 
 describe("Crew pilot exports", () => {
   it("requires explicit generatedAt input for deterministic output", () => {
@@ -88,6 +88,8 @@ describe("Crew pilot exports", () => {
       (sheet) => sheet.name === "Floor reset",
     )
     expect(floorReset?.open).toBe(1)
+    expect(floorReset?.rows[0]).not.toHaveProperty("email")
+    expect(floorReset?.rows[0]).not.toHaveProperty("responseNote")
     expect(
       floorReset?.rows.map((row) => [row.volunteerName, row.isOpen]),
     ).toEqual([
@@ -134,8 +136,9 @@ describe("Crew pilot exports", () => {
 
     const exports = buildCrewPilotExports(input)
 
-    expect(exports.masterScheduleDaySections.map((section) => section.dayKey))
-      .toEqual(["2026-07-01", "2026-07-02"])
+    expect(
+      exports.masterScheduleDaySections.map((section) => section.dayKey),
+    ).toEqual(["2026-07-01", "2026-07-02"])
     expect(
       exports.masterScheduleDaySections.map((section) =>
         section.rows.map((row) => row.label),

--- a/apps/crew/src/lib/crew/exports/pilot-exports.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.ts
@@ -1,7 +1,6 @@
 // @lat: [[crew#Pilot Exports]]
 // @lat: [[crew#Event Day Export Packet]]
 import {
-  CREW_ASSIGNMENT_CONFIRMATION_STATUS,
   type CrewAssignmentConfirmationStatus,
   type CrewAssignmentConfirmationType,
 } from "../../../db/schemas/crew-imports"
@@ -94,11 +93,6 @@ export interface CrewPilotExportInput {
 }
 
 export type CrewPilotExportBlockType = "shift" | "heat"
-export type CrewPilotExportResponseReason =
-  | "missing_confirmation"
-  | "no_response"
-  | "declined"
-  | "change_requested"
 
 export interface CrewPilotMasterScheduleRow {
   blockType: CrewPilotExportBlockType
@@ -115,25 +109,9 @@ export interface CrewPilotMasterScheduleRow {
   confirmationSummary: string
 }
 
-export interface CrewPilotRoleSheetAssignmentRow {
-  rowKey: string
-  assignmentType: CrewPilotExportBlockType
-  assignmentId: string | null
-  blockId: string
-  volunteerName: string
-  email: string
-  startsAt: string | null
-  endsAt: string | null
-  location: string
-  blockLabel: string
-  confirmationStatus: string
-  responseNote: string
-}
-
-export interface CrewPilotRoleSheet {
-  roleType: VolunteerRoleType
-  roleLabel: string
-  rows: CrewPilotRoleSheetAssignmentRow[]
+export interface CrewPilotMasterScheduleDaySection {
+  dayKey: string
+  rows: CrewPilotMasterScheduleRow[]
 }
 
 export interface CrewPilotJudgeLaneRow {
@@ -154,102 +132,64 @@ export interface CrewPilotJudgeLaneRow {
 export interface CrewPilotJudgeHeatLaneSheet {
   heatId: string
   label: string
+  heatNumber: number
   startsAt: string | null
+  endsAt: string | null
   venueName: string
   rows: CrewPilotJudgeLaneRow[]
 }
 
-export interface CrewPilotResponseRow {
-  assignmentType: CrewPilotExportBlockType
-  assignmentId: string
-  membershipId: string
+export interface CrewPilotJudgeEventSection {
+  workoutId: string
+  workoutName: string
+  heats: CrewPilotJudgeHeatLaneSheet[]
+}
+
+export interface CrewPilotShiftSheetRow {
+  rowKey: string
+  assignmentId: string | null
   volunteerName: string
   email: string
+  confirmationStatus: string
+  responseNote: string
+  isOpen: boolean
+}
+
+export interface CrewPilotShiftSheet {
+  shiftId: string
+  name: string
+  roleType: VolunteerRoleType
+  roleLabel: string
   startsAt: string | null
   endsAt: string | null
   location: string
-  blockLabel: string
-  role: string
-  status: string
-  reason: CrewPilotExportResponseReason
-  responseNote: string
-}
-
-export interface CrewPilotFloorLeadSheet {
-  floorName: string
-  rows: CrewPilotMasterScheduleRow[]
-  judgeRows: CrewPilotJudgeLaneRow[]
-}
-
-export interface CrewPilotPacketIndexItem {
-  id: string
-  title: string
-  description: string
-  count: number
-}
-
-export interface CrewPilotMasterScheduleDaySection {
-  dayKey: string
-  rows: CrewPilotMasterScheduleRow[]
-}
-
-export interface CrewPilotJudgeLaneCardRow {
-  heatId: string
-  workoutName: string
-  heatNumber: number
-  startsAt: string | null
-  endsAt: string | null
-  judgeName: string
-  email: string
-  confirmationStatus: string
-}
-
-export interface CrewPilotJudgeLaneCard {
-  cardKey: string
-  venueName: string
-  laneNumber: number
-  rows: CrewPilotJudgeLaneCardRow[]
-}
-
-export interface CrewPilotStationCard {
-  stationName: string
-  startsAt: string | null
-  endsAt: string | null
-  rows: CrewPilotMasterScheduleRow[]
-  judgeRows: CrewPilotJudgeLaneRow[]
-  laneCards: CrewPilotJudgeLaneCard[]
-  openBlocks: number
+  needed: number
+  assigned: number
+  open: number
+  rows: CrewPilotShiftSheetRow[]
 }
 
 export interface CrewPilotExports {
   generatedAt: string
   summary: {
     masterScheduleRows: number
-    roleSheets: number
-    judgeHeatSheets: number
-    responseRows: number
-    floorLeadSheets: number
-    packetIndexItems: number
     masterScheduleDaySections: number
-    stationCards: number
-    laneCards: number
+    judgeEventSections: number
+    judgeHeatSheets: number
+    shiftSheets: number
   }
-  packetIndexItems: CrewPilotPacketIndexItem[]
   masterScheduleRows: CrewPilotMasterScheduleRow[]
   masterScheduleDaySections: CrewPilotMasterScheduleDaySection[]
   masterScheduleCsv: string
-  roleSheets: CrewPilotRoleSheet[]
-  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
-  judgeLaneCards: CrewPilotJudgeLaneCard[]
-  stationCards: CrewPilotStationCard[]
-  responseRows: CrewPilotResponseRow[]
-  responseCsv: string
-  floorLeadSheets: CrewPilotFloorLeadSheet[]
+  judgeEventSections: CrewPilotJudgeEventSection[]
+  shiftSheets: CrewPilotShiftSheet[]
 }
 
 interface NormalizedHeat {
   input: CrewPilotExportHeatInput
+  workoutId: string
   workoutName: string
+  workoutSortOrder: number | null
   venueName: string
   startsAt: Date | null
   endsAt: Date | null
@@ -287,7 +227,6 @@ export function buildCrewPilotExports(
       heatLaneAssignments,
     }),
   )
-  const heatById = new Map(normalizedHeats.map((heat) => [heat.input.id, heat]))
 
   const masterScheduleRows = [
     ...shifts.map(buildShiftMasterScheduleRow),
@@ -298,57 +237,34 @@ export function buildCrewPilotExports(
       ),
     ),
   ].sort(compareMasterScheduleRow)
-  const roleSheets = buildRoleSheets({ shifts, judgeAssignments, heatById })
+  const masterScheduleDaySections = buildMasterScheduleDaySections(
+    masterScheduleRows,
+    input.event.timezone,
+  )
   const judgeHeatLaneSheets = normalizedHeats.map((heat) =>
     buildJudgeHeatLaneSheet(
       heat,
       judgeAssignmentsByHeatId.get(heat.input.id) ?? [],
     ),
   )
-  const responseRows = buildResponseRows({
-    shifts,
-    judgeAssignments,
-    heatById,
-  })
-  const floorLeadSheets = buildFloorLeadSheets({
-    masterScheduleRows,
-    judgeHeatLaneSheets,
-  })
-  const masterScheduleDaySections = buildMasterScheduleDaySections(
-    masterScheduleRows,
-    input.event.timezone,
+  const sheetByHeatId = new Map(
+    judgeHeatLaneSheets.map((sheet) => [sheet.heatId, sheet]),
   )
-  const judgeLaneCards = buildJudgeLaneCards(judgeHeatLaneSheets)
-  const stationCards = buildStationCards({
-    masterScheduleRows,
-    judgeHeatLaneSheets,
-    judgeLaneCards,
-  })
-  const packetIndexItems = buildPacketIndexItems({
-    masterScheduleRows,
-    masterScheduleDaySections,
-    roleSheets,
-    judgeHeatLaneSheets,
-    judgeLaneCards,
-    stationCards,
-    responseRows,
-    floorLeadSheets,
-  })
+  const judgeEventSections = buildJudgeEventSections(
+    normalizedHeats,
+    sheetByHeatId,
+  )
+  const shiftSheets = buildShiftSheets(shifts)
 
   return {
     generatedAt,
     summary: {
       masterScheduleRows: masterScheduleRows.length,
-      roleSheets: roleSheets.length,
-      judgeHeatSheets: judgeHeatLaneSheets.length,
-      responseRows: responseRows.length,
-      floorLeadSheets: floorLeadSheets.length,
-      packetIndexItems: packetIndexItems.length,
       masterScheduleDaySections: masterScheduleDaySections.length,
-      stationCards: stationCards.length,
-      laneCards: judgeLaneCards.length,
+      judgeEventSections: judgeEventSections.length,
+      judgeHeatSheets: judgeHeatLaneSheets.length,
+      shiftSheets: shiftSheets.length,
     },
-    packetIndexItems,
     masterScheduleRows,
     masterScheduleDaySections,
     masterScheduleCsv: buildCsv(
@@ -379,42 +295,8 @@ export function buildCrewPilotExports(
         row.confirmationSummary,
       ]),
     ),
-    roleSheets,
-    judgeHeatLaneSheets,
-    judgeLaneCards,
-    stationCards,
-    responseRows,
-    responseCsv: buildCsv(
-      [
-        "Type",
-        "Assignment ID",
-        "Volunteer",
-        "Email",
-        "Start",
-        "End",
-        "Location",
-        "Block",
-        "Role",
-        "Status",
-        "Reason",
-        "Note",
-      ],
-      responseRows.map((row) => [
-        row.assignmentType,
-        row.assignmentId,
-        row.volunteerName,
-        row.email,
-        row.startsAt ?? "",
-        row.endsAt ?? "",
-        row.location,
-        row.blockLabel,
-        row.role,
-        row.status,
-        row.reason,
-        row.responseNote,
-      ]),
-    ),
-    floorLeadSheets,
+    judgeEventSections,
+    shiftSheets,
   }
 }
 
@@ -466,89 +348,6 @@ function buildHeatMasterScheduleRow(
   }
 }
 
-function buildRoleSheets(input: {
-  shifts: CrewPilotExportShiftInput[]
-  judgeAssignments: CrewPilotExportJudgeAssignmentInput[]
-  heatById: Map<string, NormalizedHeat>
-}) {
-  const rowsByRoleType = new Map<
-    VolunteerRoleType,
-    CrewPilotRoleSheetAssignmentRow[]
-  >()
-
-  for (const shift of input.shifts) {
-    const roleRows = rowsByRoleType.get(shift.roleType) ?? []
-    for (const assignment of shift.assignments) {
-      roleRows.push({
-        rowKey: assignment.id,
-        assignmentType: "shift",
-        assignmentId: assignment.id,
-        blockId: shift.id,
-        volunteerName: assignment.volunteerName,
-        email: assignment.email ?? "",
-        startsAt: toIsoString(shift.startTime),
-        endsAt: toIsoString(shift.endTime),
-        location: shift.location || "Unassigned",
-        blockLabel: shift.name,
-        confirmationStatus: formatConfirmationStatus(assignment.confirmation),
-        responseNote: assignment.confirmation?.responseNote ?? "",
-      })
-    }
-    for (
-      let index = shift.assignments.length;
-      index < shift.capacity;
-      index++
-    ) {
-      roleRows.push({
-        rowKey: `open:${shift.id}:${index}`,
-        assignmentType: "shift",
-        assignmentId: null,
-        blockId: shift.id,
-        volunteerName: "OPEN",
-        email: "",
-        startsAt: toIsoString(shift.startTime),
-        endsAt: toIsoString(shift.endTime),
-        location: shift.location || "Unassigned",
-        blockLabel: shift.name,
-        confirmationStatus: "open",
-        responseNote: "",
-      })
-    }
-    rowsByRoleType.set(shift.roleType, roleRows)
-  }
-
-  for (const assignment of input.judgeAssignments) {
-    const roleType = getJudgeRoleType(assignment.position)
-    const heat = input.heatById.get(assignment.heatId)
-    const roleRows = rowsByRoleType.get(roleType) ?? []
-    roleRows.push({
-      rowKey: assignment.id,
-      assignmentType: "heat",
-      assignmentId: assignment.id,
-      blockId: assignment.heatId,
-      volunteerName: assignment.volunteerName,
-      email: assignment.email ?? "",
-      startsAt: toIsoString(heat?.startsAt),
-      endsAt: toIsoString(heat?.endsAt),
-      location: heat?.venueName ?? "Unassigned",
-      blockLabel: heat
-        ? `${heat.workoutName} - Heat ${heat.input.heatNumber}`
-        : assignment.heatId,
-      confirmationStatus: formatConfirmationStatus(assignment.confirmation),
-      responseNote: assignment.confirmation?.responseNote ?? "",
-    })
-    rowsByRoleType.set(roleType, roleRows)
-  }
-
-  return [...rowsByRoleType.entries()]
-    .map(([roleType, rows]) => ({
-      roleType,
-      roleLabel: formatRole(roleType),
-      rows: rows.sort(compareRoleSheetRow),
-    }))
-    .sort((left, right) => compareText(left.roleLabel, right.roleLabel))
-}
-
 function buildJudgeHeatLaneSheet(
   heat: NormalizedHeat,
   assignments: CrewPilotExportJudgeAssignmentInput[],
@@ -586,89 +385,85 @@ function buildJudgeHeatLaneSheet(
   return {
     heatId: heat.input.id,
     label: `${heat.workoutName} - Heat ${heat.input.heatNumber}`,
+    heatNumber: heat.input.heatNumber,
     startsAt: toIsoString(heat.startsAt),
+    endsAt: toIsoString(heat.endsAt),
     venueName: heat.venueName,
     rows,
   }
 }
 
-function buildResponseRows(input: {
-  shifts: CrewPilotExportShiftInput[]
-  judgeAssignments: CrewPilotExportJudgeAssignmentInput[]
-  heatById: Map<string, NormalizedHeat>
-}) {
-  const shiftRows = input.shifts.flatMap((shift) =>
-    shift.assignments.flatMap((assignment) => {
-      const reason = getResponseReason(assignment.confirmation)
-      if (!reason) return []
-      return {
-        assignmentType: "shift" as const,
-        assignmentId: assignment.id,
-        membershipId: assignment.membershipId,
-        volunteerName: assignment.volunteerName,
-        email: assignment.email ?? "",
-        startsAt: toIsoString(shift.startTime),
-        endsAt: toIsoString(shift.endTime),
-        location: shift.location || "Unassigned",
-        blockLabel: shift.name,
-        role: formatRole(shift.roleType),
-        status: formatConfirmationStatus(assignment.confirmation),
-        reason,
-        responseNote: assignment.confirmation?.responseNote ?? "",
-      }
-    }),
-  )
-  const judgeRows = input.judgeAssignments.flatMap((assignment) => {
-    const reason = getResponseReason(assignment.confirmation)
-    if (!reason) return []
-    const heat = input.heatById.get(assignment.heatId)
-    return {
-      assignmentType: "heat" as const,
-      assignmentId: assignment.id,
-      membershipId: assignment.membershipId,
-      volunteerName: assignment.volunteerName,
-      email: assignment.email ?? "",
-      startsAt: toIsoString(heat?.startsAt),
-      endsAt: toIsoString(heat?.endsAt),
-      location: heat?.venueName ?? "Unassigned",
-      blockLabel: heat
-        ? `${heat.workoutName} - Heat ${heat.input.heatNumber}`
-        : assignment.heatId,
-      role: formatRole(getJudgeRoleType(assignment.position)),
-      status: formatConfirmationStatus(assignment.confirmation),
-      reason,
-      responseNote: assignment.confirmation?.responseNote ?? "",
-    }
-  })
+function buildJudgeEventSections(
+  normalizedHeats: NormalizedHeat[],
+  sheetByHeatId: Map<string, CrewPilotJudgeHeatLaneSheet>,
+): CrewPilotJudgeEventSection[] {
+  const heatsByWorkoutId = groupBy(normalizedHeats, (heat) => heat.workoutId)
 
-  return [...shiftRows, ...judgeRows].sort(compareResponseRow)
+  return [...heatsByWorkoutId.entries()]
+    .map(([workoutId, heats]) => ({
+      workoutId,
+      workoutName: heats[0]?.workoutName ?? "Workout",
+      sortOrder: heats[0]?.workoutSortOrder ?? null,
+      heats: heats
+        .map((heat) => sheetByHeatId.get(heat.input.id))
+        .filter((sheet): sheet is CrewPilotJudgeHeatLaneSheet =>
+          Boolean(sheet),
+        ),
+    }))
+    .sort(
+      (left, right) =>
+        (left.sortOrder ?? Number.POSITIVE_INFINITY) -
+          (right.sortOrder ?? Number.POSITIVE_INFINITY) ||
+        compareText(left.workoutName, right.workoutName) ||
+        compareText(left.workoutId, right.workoutId),
+    )
+    .map(({ sortOrder: _sortOrder, ...section }) => section)
 }
 
-function buildFloorLeadSheets(input: {
-  masterScheduleRows: CrewPilotMasterScheduleRow[]
-  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
-}) {
-  const scheduleRowsByFloor = groupBy(
-    input.masterScheduleRows,
-    (row) => row.location || "Unassigned",
-  )
-  const judgeRowsByFloor = groupBy(
-    input.judgeHeatLaneSheets.flatMap((sheet) => sheet.rows),
-    (row) => row.venueName || "Unassigned",
-  )
-  const floorNames = [
-    ...new Set([...scheduleRowsByFloor.keys(), ...judgeRowsByFloor.keys()]),
-  ].sort(compareText)
+function buildShiftSheets(
+  shifts: CrewPilotExportShiftInput[],
+): CrewPilotShiftSheet[] {
+  return shifts.map((shift) => {
+    const assigned = shift.assignments.length
+    const rows: CrewPilotShiftSheetRow[] = shift.assignments
+      .map((assignment) => ({
+        rowKey: assignment.id,
+        assignmentId: assignment.id,
+        volunteerName: assignment.volunteerName,
+        email: assignment.email ?? "",
+        confirmationStatus: formatConfirmationStatus(assignment.confirmation),
+        responseNote: assignment.confirmation?.responseNote ?? "",
+        isOpen: false,
+      }))
+      .sort((left, right) =>
+        compareText(left.volunteerName, right.volunteerName),
+      )
+    for (let index = assigned; index < shift.capacity; index++) {
+      rows.push({
+        rowKey: `open:${shift.id}:${index}`,
+        assignmentId: null,
+        volunteerName: "OPEN",
+        email: "",
+        confirmationStatus: "open",
+        responseNote: "",
+        isOpen: true,
+      })
+    }
 
-  return floorNames.map((floorName) => ({
-    floorName,
-    rows: (scheduleRowsByFloor.get(floorName) ?? []).sort(
-      compareMasterScheduleRow,
-    ),
-    judgeRows: (judgeRowsByFloor.get(floorName) ?? []).sort(
-      compareJudgeLaneRow,
-    ),
-  }))
+    return {
+      shiftId: shift.id,
+      name: shift.name,
+      roleType: shift.roleType,
+      roleLabel: formatRole(shift.roleType),
+      startsAt: toIsoString(shift.startTime),
+      endsAt: toIsoString(shift.endTime),
+      location: shift.location || "Unassigned",
+      needed: shift.capacity,
+      assigned,
+      open: Math.max(shift.capacity - assigned, 0),
+      rows,
+    }
+  })
 }
 
 function buildMasterScheduleDaySections(
@@ -684,149 +479,6 @@ function buildMasterScheduleDaySections(
       dayKey,
       rows: dayRows.sort(compareMasterScheduleRow),
     }))
-}
-
-function buildJudgeLaneCards(
-  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[],
-) {
-  const rowsByLane = new Map<string, CrewPilotJudgeLaneCardRow[]>()
-  const cardMeta = new Map<string, { venueName: string; laneNumber: number }>()
-
-  for (const sheet of judgeHeatLaneSheets) {
-    for (const row of sheet.rows) {
-      const cardKey = `${row.venueName}:lane:${row.laneNumber}`
-      cardMeta.set(cardKey, {
-        venueName: row.venueName,
-        laneNumber: row.laneNumber,
-      })
-      const rows = rowsByLane.get(cardKey) ?? []
-      rows.push({
-        heatId: row.heatId,
-        workoutName: row.workoutName,
-        heatNumber: row.heatNumber,
-        startsAt: row.startsAt,
-        endsAt: row.endsAt,
-        judgeName: row.judgeName,
-        email: row.email,
-        confirmationStatus: row.confirmationStatus,
-      })
-      rowsByLane.set(cardKey, rows)
-    }
-  }
-
-  return [...rowsByLane.entries()]
-    .map(([cardKey, rows]) => {
-      const meta = cardMeta.get(cardKey)
-      return {
-        cardKey,
-        venueName: meta?.venueName ?? "Unassigned",
-        laneNumber: meta?.laneNumber ?? 0,
-        rows: rows.sort(compareJudgeLaneCardRow),
-      }
-    })
-    .sort(compareJudgeLaneCard)
-}
-
-function buildStationCards(input: {
-  masterScheduleRows: CrewPilotMasterScheduleRow[]
-  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
-  judgeLaneCards: CrewPilotJudgeLaneCard[]
-}) {
-  const scheduleRowsByStation = groupBy(
-    input.masterScheduleRows,
-    (row) => row.location || "Unassigned",
-  )
-  const judgeRowsByStation = groupBy(
-    input.judgeHeatLaneSheets.flatMap((sheet) => sheet.rows),
-    (row) => row.venueName || "Unassigned",
-  )
-  const laneCardsByStation = groupBy(
-    input.judgeLaneCards,
-    (card) => card.venueName || "Unassigned",
-  )
-  const stationNames = [
-    ...new Set([
-      ...scheduleRowsByStation.keys(),
-      ...judgeRowsByStation.keys(),
-      ...laneCardsByStation.keys(),
-    ]),
-  ].sort(compareText)
-
-  return stationNames.map((stationName) => {
-    const rows = (scheduleRowsByStation.get(stationName) ?? []).sort(
-      compareMasterScheduleRow,
-    )
-    const judgeRows = (judgeRowsByStation.get(stationName) ?? []).sort(
-      compareJudgeLaneRow,
-    )
-    const laneCards = (laneCardsByStation.get(stationName) ?? []).sort(
-      compareJudgeLaneCard,
-    )
-    const allDateStrings = [
-      ...rows.flatMap((row) => [row.startsAt, row.endsAt]),
-      ...judgeRows.flatMap((row) => [row.startsAt, row.endsAt]),
-    ].filter((value): value is string => Boolean(value))
-
-    return {
-      stationName,
-      startsAt: firstDateString(allDateStrings),
-      endsAt: lastDateString(allDateStrings),
-      rows,
-      judgeRows,
-      laneCards,
-      openBlocks: rows.filter((row) => row.open > 0).length,
-    }
-  })
-}
-
-function buildPacketIndexItems(input: {
-  masterScheduleRows: CrewPilotMasterScheduleRow[]
-  masterScheduleDaySections: CrewPilotMasterScheduleDaySection[]
-  roleSheets: CrewPilotRoleSheet[]
-  judgeHeatLaneSheets: CrewPilotJudgeHeatLaneSheet[]
-  judgeLaneCards: CrewPilotJudgeLaneCard[]
-  stationCards: CrewPilotStationCard[]
-  responseRows: CrewPilotResponseRow[]
-  floorLeadSheets: CrewPilotFloorLeadSheet[]
-}) {
-  return [
-    {
-      id: "master-schedule",
-      title: "Master schedule",
-      description: `${input.masterScheduleRows.length} shift and heat rows across ${input.masterScheduleDaySections.length} day sections.`,
-      count: input.masterScheduleRows.length,
-    },
-    {
-      id: "station-cards",
-      title: "Station cards",
-      description: `${input.stationCards.length} floor or station cards with local coverage and lane summaries.`,
-      count: input.stationCards.length,
-    },
-    {
-      id: "role-sheets",
-      title: "Role sheets",
-      description: `${input.roleSheets.length} department-ready role sheets with open slots included.`,
-      count: input.roleSheets.length,
-    },
-    {
-      id: "judge-cards",
-      title: "Judge cards",
-      description: `${input.judgeHeatLaneSheets.length} heat cards and ${input.judgeLaneCards.length} lane cards.`,
-      count: input.judgeHeatLaneSheets.length + input.judgeLaneCards.length,
-    },
-    {
-      id: "response-list",
-      title: "Response list",
-      description: `${input.responseRows.length} missing, pending, declined, or change-requested assignments.`,
-      count: input.responseRows.length,
-    },
-    {
-      id: "floor-lead-sheets",
-      title: "Floor lead sheets",
-      description: `${input.floorLeadSheets.length} floor lead sheets for localized day-of handoff.`,
-      count: input.floorLeadSheets.length,
-    },
-  ]
 }
 
 function normalizeHeat(
@@ -863,30 +515,14 @@ function normalizeHeat(
 
   return {
     input: heat,
+    workoutId: heat.trackWorkoutId,
     workoutName: workout?.name ?? "Workout",
+    workoutSortOrder: workout?.sortOrder ?? null,
     venueName: venue?.name ?? "Unassigned",
     startsAt,
     endsAt,
     laneNumbers,
   }
-}
-
-function getResponseReason(
-  confirmation: CrewPilotExportConfirmationInput | null | undefined,
-): CrewPilotExportResponseReason | null {
-  if (!confirmation) return "missing_confirmation"
-  if (confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.PENDING) {
-    return confirmation.sentAt ? "no_response" : "missing_confirmation"
-  }
-  if (confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.DECLINED) {
-    return "declined"
-  }
-  if (
-    confirmation.status === CREW_ASSIGNMENT_CONFIRMATION_STATUS.CHANGE_REQUESTED
-  ) {
-    return "change_requested"
-  }
-  return null
 }
 
 function formatConfirmationSummary(
@@ -969,69 +605,6 @@ function compareMasterScheduleRow(
     compareText(left.blockType, right.blockType) ||
     compareText(left.label, right.label) ||
     compareText(left.blockId, right.blockId)
-  )
-}
-
-function compareRoleSheetRow(
-  left: CrewPilotRoleSheetAssignmentRow,
-  right: CrewPilotRoleSheetAssignmentRow,
-) {
-  return (
-    compareDateString(left.startsAt, right.startsAt) ||
-    compareText(left.location, right.location) ||
-    compareText(left.blockLabel, right.blockLabel) ||
-    Number(isOpenRoleRow(left)) - Number(isOpenRoleRow(right)) ||
-    compareText(left.volunteerName, right.volunteerName) ||
-    compareText(left.assignmentId ?? "", right.assignmentId ?? "")
-  )
-}
-
-function isOpenRoleRow(row: CrewPilotRoleSheetAssignmentRow) {
-  return row.assignmentId === null
-}
-
-function compareResponseRow(
-  left: CrewPilotResponseRow,
-  right: CrewPilotResponseRow,
-) {
-  return (
-    compareDateString(left.startsAt, right.startsAt) ||
-    compareText(left.reason, right.reason) ||
-    compareText(left.volunteerName, right.volunteerName) ||
-    compareText(left.assignmentId, right.assignmentId)
-  )
-}
-
-function compareJudgeLaneRow(
-  left: CrewPilotJudgeLaneRow,
-  right: CrewPilotJudgeLaneRow,
-) {
-  return (
-    compareDateString(left.startsAt, right.startsAt) ||
-    left.heatNumber - right.heatNumber ||
-    left.laneNumber - right.laneNumber ||
-    compareText(left.assignmentId ?? "", right.assignmentId ?? "")
-  )
-}
-
-function compareJudgeLaneCardRow(
-  left: CrewPilotJudgeLaneCardRow,
-  right: CrewPilotJudgeLaneCardRow,
-) {
-  return (
-    compareDateString(left.startsAt, right.startsAt) ||
-    left.heatNumber - right.heatNumber ||
-    compareText(left.heatId, right.heatId)
-  )
-}
-
-function compareJudgeLaneCard(
-  left: CrewPilotJudgeLaneCard,
-  right: CrewPilotJudgeLaneCard,
-) {
-  return (
-    compareText(left.venueName, right.venueName) ||
-    left.laneNumber - right.laneNumber
   )
 }
 
@@ -1130,14 +703,6 @@ function toDateOrNull(value: Date | string | null | undefined) {
 
 function toIsoString(value: Date | string | null | undefined) {
   return toDateOrNull(value)?.toISOString() ?? null
-}
-
-function firstDateString(values: string[]) {
-  return values.sort(compareDateString)[0] ?? null
-}
-
-function lastDateString(values: string[]) {
-  return values.sort(compareDateString).at(-1) ?? null
 }
 
 function getDayKey(value: string | null, timezone: string | null | undefined) {

--- a/apps/crew/src/lib/crew/exports/pilot-exports.ts
+++ b/apps/crew/src/lib/crew/exports/pilot-exports.ts
@@ -1,8 +1,8 @@
 // @lat: [[crew#Pilot Exports]]
 // @lat: [[crew#Event Day Export Packet]]
-import {
-  type CrewAssignmentConfirmationStatus,
-  type CrewAssignmentConfirmationType,
+import type {
+  CrewAssignmentConfirmationStatus,
+  CrewAssignmentConfirmationType,
 } from "../../../db/schemas/crew-imports"
 import {
   VOLUNTEER_ROLE_LABELS,
@@ -149,9 +149,7 @@ export interface CrewPilotShiftSheetRow {
   rowKey: string
   assignmentId: string | null
   volunteerName: string
-  email: string
   confirmationStatus: string
-  responseNote: string
   isOpen: boolean
 }
 
@@ -430,9 +428,7 @@ function buildShiftSheets(
         rowKey: assignment.id,
         assignmentId: assignment.id,
         volunteerName: assignment.volunteerName,
-        email: assignment.email ?? "",
         confirmationStatus: formatConfirmationStatus(assignment.confirmation),
-        responseNote: assignment.confirmation?.responseNote ?? "",
         isOpen: false,
       }))
       .sort((left, right) =>
@@ -443,9 +439,7 @@ function buildShiftSheets(
         rowKey: `open:${shift.id}:${index}`,
         assignmentId: null,
         volunteerName: "OPEN",
-        email: "",
         confirmationStatus: "open",
-        responseNote: "",
         isOpen: true,
       })
     }

--- a/apps/crew/src/lib/crew/self-serve-event-flow.test.ts
+++ b/apps/crew/src/lib/crew/self-serve-event-flow.test.ts
@@ -425,16 +425,11 @@ describe("Crew self-serve event flow", () => {
 
     expect(exports.summary).toMatchObject({
       masterScheduleRows: 2,
-      roleSheets: 2,
+      judgeEventSections: 1,
       judgeHeatSheets: 1,
-      responseRows: 0,
-      stationCards: 2,
-      laneCards: 2,
+      shiftSheets: 1,
     })
-    expect(exports.packetIndexItems.map((item) => item.id)).toContain(
-      "station-cards",
-    )
-    expect(exports.judgeHeatLaneSheets[0]?.rows).toMatchObject([
+    expect(exports.judgeEventSections[0]?.heats[0]?.rows).toMatchObject([
       {
         laneNumber: 1,
         judgeName: "Jules Judge",

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -1,15 +1,17 @@
 // @lat: [[crew#Pilot Exports]]
 // @lat: [[crew#Event Day Export Packet]]
-import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
-import { Download, FileSpreadsheet, Printer } from "lucide-react"
-import type { ReactNode } from "react"
+import {
+  createFileRoute,
+  getRouteApi,
+  useSearch,
+} from "@tanstack/react-router"
+import { Download, Printer } from "lucide-react"
+import { type ReactNode, useState } from "react"
 import type {
   CrewPilotExports,
-  CrewPilotFloorLeadSheet,
-  CrewPilotJudgeHeatLaneSheet,
-  CrewPilotJudgeLaneCard,
-  CrewPilotRoleSheet,
-  CrewPilotStationCard,
+  CrewPilotJudgeEventSection,
+  CrewPilotMasterScheduleDaySection,
+  CrewPilotShiftSheet,
 } from "@/lib/crew/exports/pilot-exports"
 import { formatCrewValue } from "@/lib/crew-event-display"
 import {
@@ -28,9 +30,23 @@ export const Route = createFileRoute("/events/$eventId/exports")({
 
 const parentRoute = getRouteApi("/events/$eventId")
 
+const PACKET_TABS = [
+  { id: "schedule", label: "Master Schedule" },
+  { id: "judges", label: "Judges" },
+  { id: "shifts", label: "Shifts" },
+] as const
+
+type PacketTabId = (typeof PACKET_TABS)[number]["id"]
+
+function isPacketTabId(value: unknown): value is PacketTabId {
+  return PACKET_TABS.some((tab) => tab.id === value)
+}
+
 function EventPilotExportsPage() {
   const { eventId } = parentRoute.useParams()
   const { event, exports, sources } = Route.useLoaderData()
+  const search = useSearch({ strict: false }) as { tab?: string }
+  const initialTab = isPacketTabId(search.tab) ? search.tab : "schedule"
 
   return (
     <EventPilotExportsView
@@ -38,31 +54,31 @@ function EventPilotExportsPage() {
       event={event}
       exports={exports}
       sources={sources}
+      initialTab={initialTab}
     />
   )
 }
 
 export function EventPilotExportsView({
-  eventId,
   event,
   exports,
   sources,
+  initialTab = "schedule",
 }: EventPilotExportsViewProps) {
   const timezone = event.timezone ?? "America/Denver"
+  const [activeTab, setActiveTab] = useState<PacketTabId>(initialTab)
 
   return (
-    <>
-      <section className="space-y-5 print:hidden">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h2 className="text-xl font-semibold">
-              Event-day export packet
-            </h2>
-            <p className="text-sm text-muted-foreground">
-              {formatExportDate(exports.generatedAt, timezone)} / {timezone}
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-2">
+    <section className="space-y-5">
+      <div className="flex flex-col gap-3 print:hidden sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="text-xl font-semibold">Print packet</h2>
+          <p className="text-sm text-muted-foreground">
+            {formatExportDate(exports.generatedAt, timezone)} / {timezone}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {activeTab === "schedule" ? (
             <button
               type="button"
               className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
@@ -76,248 +92,63 @@ export function EventPilotExportsView({
               <Download className="size-4" />
               Master CSV
             </button>
-            <button
-              type="button"
-              className="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-              onClick={() =>
-                downloadCsv(
-                  `${event.slug || event.id}-responses.csv`,
-                  exports.responseCsv,
-                )
-              }
-            >
-              <FileSpreadsheet className="size-4" />
-              Responses CSV
-            </button>
-            <button
-              type="button"
-              className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
-              onClick={() => window.print()}
-            >
-              <Printer className="size-4" />
-              Print packet
-            </button>
-          </div>
+          ) : null}
+          <button
+            type="button"
+            className="inline-flex h-10 items-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+            onClick={() => window.print()}
+          >
+            <Printer className="size-4" />
+            Print
+          </button>
         </div>
+      </div>
 
-        <section className="grid gap-3 md:grid-cols-4 xl:grid-cols-8">
-          <MetricPanel
-            label="Rows"
-            value={exports.summary.masterScheduleRows}
-          />
-          <MetricPanel
-            label="Days"
-            value={exports.summary.masterScheduleDaySections}
-          />
-          <MetricPanel
-            label="Stations"
-            value={exports.summary.stationCards}
-          />
-          <MetricPanel label="Role sheets" value={exports.summary.roleSheets} />
-          <MetricPanel
-            label="Judge sheets"
-            value={exports.summary.judgeHeatSheets}
-          />
-          <MetricPanel label="Lane cards" value={exports.summary.laneCards} />
-          <MetricPanel label="Responses" value={exports.summary.responseRows} />
-          <MetricPanel label="Versions" value={sources.activeJudgeVersions} />
-        </section>
+      <div
+        className="flex flex-wrap gap-2 border-b print:hidden"
+        role="tablist"
+        aria-label="Print packet sections"
+      >
+        {PACKET_TABS.map((tab) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={activeTab === tab.id}
+            className={`-mb-px border-b-2 px-3 py-2 text-sm font-medium ${
+              activeTab === tab.id
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label} ({getTabCount(tab.id, exports, sources)})
+          </button>
+        ))}
+      </div>
 
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h3 className="font-semibold">Packet index</h3>
-              <p className="text-sm text-muted-foreground">
-                {exports.summary.masterScheduleDaySections} days /{" "}
-                {exports.summary.stationCards} stations /{" "}
-                {exports.summary.laneCards} lane cards
-              </p>
-            </div>
-            <StatusPill>{exports.summary.packetIndexItems} sections</StatusPill>
-          </div>
-          <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-            {exports.packetIndexItems.map((item) => (
-              <div key={item.id} className="rounded-md border p-3 text-sm">
-                <div className="flex items-start justify-between gap-3">
-                  <p className="font-medium">{item.title}</p>
-                  <StatusPill>{item.count}</StatusPill>
-                </div>
-                <p className="mt-2 text-muted-foreground">
-                  {item.description}
-                </p>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        <section className="rounded-md border bg-card p-5 shadow-sm">
-          <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
-            <div>
-              <h3 className="font-semibold">Master schedule</h3>
-              <p className="text-sm text-muted-foreground">
-                {sources.shifts} shifts / {sources.heats} heats
-              </p>
-            </div>
-            <StatusPill>{formatCrewValue(event.slug)}</StatusPill>
-          </div>
-          {exports.masterScheduleRows.length > 0 ? (
-            <div className="mt-4 overflow-x-auto">
-              <table className="w-full min-w-[900px] text-left text-sm">
-                <thead className="border-b text-xs uppercase text-muted-foreground">
-                  <tr>
-                    <th className="py-2 pr-3">Time</th>
-                    <th className="py-2 pr-3">Block</th>
-                    <th className="py-2 pr-3">Location</th>
-                    <th className="py-2 pr-3">Role</th>
-                    <th className="py-2 pr-3">Coverage</th>
-                    <th className="py-2 pr-3">People</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y">
-                  {exports.masterScheduleRows.map((row) => (
-                    <tr key={`${row.blockType}:${row.blockId}`}>
-                      <td className="py-3 pr-3 text-muted-foreground">
-                        {formatRange(row.startsAt, row.endsAt, timezone)}
-                      </td>
-                      <td className="py-3 pr-3 font-medium">{row.label}</td>
-                      <td className="py-3 pr-3">{row.location}</td>
-                      <td className="py-3 pr-3">{row.role}</td>
-                      <td className="py-3 pr-3">
-                        {row.assigned}/{row.needed}
-                        {row.open > 0 ? ` (${row.open} open)` : ""}
-                      </td>
-                      <td className="py-3 pr-3 text-muted-foreground">
-                        {row.people || "Unassigned"}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          ) : (
-            <EmptyState message="No shift or heat rows are ready to export." />
-          )}
-        </section>
-
-        <section className="space-y-4">
-          <h3 className="font-semibold">Station cards</h3>
-          <div className="grid gap-4 lg:grid-cols-2">
-            {exports.stationCards.map((card) => (
-              <StationCardPreview
-                key={card.stationName}
-                card={card}
-                timezone={timezone}
-              />
-            ))}
-          </div>
-        </section>
-
-        <div className="grid gap-5 lg:grid-cols-2">
-          <section className="rounded-md border bg-card p-5 shadow-sm">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h3 className="font-semibold">No-response and declines</h3>
-                <p className="text-sm text-muted-foreground">
-                  {sources.shiftAssignments + sources.judgeAssignments} active
-                  assignments
-                </p>
-              </div>
-              <Link
-                to="/events/$eventId/day-of"
-                params={{ eventId }}
-                className="text-sm font-medium text-primary hover:underline"
-              >
-                Day-of
-              </Link>
-            </div>
-            {exports.responseRows.length > 0 ? (
-              <div className="mt-4 grid gap-3">
-                {exports.responseRows.slice(0, 12).map((row) => (
-                  <div
-                    key={`${row.assignmentType}:${row.assignmentId}`}
-                    className="rounded-md border p-3 text-sm"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <p className="font-medium">{row.volunteerName}</p>
-                        <p className="text-muted-foreground">
-                          {row.blockLabel} / {row.role}
-                        </p>
-                      </div>
-                      <StatusPill>{formatCrewValue(row.reason)}</StatusPill>
-                    </div>
-                    <p className="mt-2 text-muted-foreground">
-                      {formatRange(row.startsAt, row.endsAt, timezone)}
-                    </p>
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <EmptyState message="No missing, pending, declined, or change-requested responses." />
-            )}
-          </section>
-
-          <section className="rounded-md border bg-card p-5 shadow-sm">
-            <div className="flex items-start justify-between gap-4">
-              <div>
-                <h3 className="font-semibold">Judge heat sheets</h3>
-                <p className="text-sm text-muted-foreground">
-                  {sources.judgeAssignments}/{sources.heatLaneAssignments} lanes
-                  assigned
-                </p>
-              </div>
-              <Link
-                to="/events/$eventId/judges"
-                params={{ eventId }}
-                className="text-sm font-medium text-primary hover:underline"
-              >
-                Judges
-              </Link>
-            </div>
-            <div className="mt-4 grid gap-3">
-              {exports.judgeHeatLaneSheets.slice(0, 4).map((sheet) => (
-                <JudgeHeatSheetPreview
-                  key={sheet.heatId}
-                  sheet={sheet}
-                  timezone={timezone}
-                />
-              ))}
-            </div>
-          </section>
-        </div>
-
-        <section className="space-y-4">
-          <h3 className="font-semibold">Role sheets</h3>
-          <div className="grid gap-4 lg:grid-cols-2">
-            {exports.roleSheets.map((sheet) => (
-              <RoleSheetPreview
-                key={sheet.roleType}
-                sheet={sheet}
-                timezone={timezone}
-              />
-            ))}
-          </div>
-        </section>
-
-        <section className="space-y-4">
-          <h3 className="font-semibold">Floor lead sheets</h3>
-          <div className="grid gap-4">
-            {exports.floorLeadSheets.map((sheet) => (
-              <FloorLeadSheetPreview
-                key={sheet.floorName}
-                sheet={sheet}
-                timezone={timezone}
-              />
-            ))}
-          </div>
-        </section>
-      </section>
-      <PrintSheets
+      <PrintHeader
         eventName={event.name}
-        exports={exports}
-        timezone={timezone}
+        subtitle={PACKET_TABS.find((tab) => tab.id === activeTab)?.label ?? ""}
+        generatedAt={formatExportDate(exports.generatedAt, timezone)}
       />
-    </>
+
+      {activeTab === "schedule" ? (
+        <ScheduleTab
+          daySections={exports.masterScheduleDaySections}
+          timezone={timezone}
+        />
+      ) : null}
+      {activeTab === "judges" ? (
+        <JudgesTab
+          eventSections={exports.judgeEventSections}
+          timezone={timezone}
+        />
+      ) : null}
+      {activeTab === "shifts" ? (
+        <ShiftsTab shiftSheets={exports.shiftSheets} timezone={timezone} />
+      ) : null}
+    </section>
   )
 }
 
@@ -326,51 +157,39 @@ interface EventPilotExportsViewProps {
   event: CrewPilotExportsPageData["event"]
   exports: CrewPilotExports
   sources: CrewPilotExportsPageData["sources"]
+  initialTab?: PacketTabId
 }
 
-function PrintSheets({
-  eventName,
-  exports,
+function getTabCount(
+  tabId: PacketTabId,
+  exports: CrewPilotExports,
+  sources: CrewPilotExportsPageData["sources"],
+) {
+  if (tabId === "schedule") return exports.summary.masterScheduleRows
+  if (tabId === "judges") return exports.summary.judgeHeatSheets
+  return sources.shifts
+}
+
+function ScheduleTab({
+  daySections,
   timezone,
 }: {
-  eventName: string
-  exports: CrewPilotExports
+  daySections: CrewPilotMasterScheduleDaySection[]
   timezone: string
 }) {
+  if (daySections.length === 0) {
+    return <EmptyState message="No shift or heat rows are ready to export." />
+  }
+
   return (
-    <section className="hidden space-y-8 bg-white text-black print:block">
-      <header className="border-b pb-4">
-        <h1 className="text-2xl font-semibold">{eventName}</h1>
-        <p className="text-sm">
-          Event-day export packet /{" "}
-          {formatExportDate(exports.generatedAt, timezone)}
-        </p>
-      </header>
-
-      <PrintSection title="Packet index">
-        <PrintTable
-          headers={["Section", "Count", "Contents"]}
-          rows={exports.packetIndexItems.map((item) => ({
-            key: item.id,
-            cells: [item.title, item.count, item.description],
-          }))}
-        />
-      </PrintSection>
-
-      {exports.masterScheduleDaySections.map((section) => (
-        <PrintSection
+    <div className="space-y-8">
+      {daySections.map((section) => (
+        <PacketSection
           key={section.dayKey}
-          title={`Master schedule / ${formatPacketDay(section.dayKey)}`}
+          title={formatPacketDay(section.dayKey)}
         >
-          <PrintTable
-            headers={[
-              "Time",
-              "Block",
-              "Location",
-              "Role",
-              "Coverage",
-              "People",
-            ]}
+          <PacketTable
+            headers={["Time", "Block", "Location", "Role", "Coverage", "People"]}
             rows={section.rows.map((row) => ({
               key: `${row.blockType}:${row.blockId}`,
               cells: [
@@ -383,210 +202,137 @@ function PrintSheets({
               ],
             }))}
           />
-        </PrintSection>
+        </PacketSection>
       ))}
-
-      <PrintSection title="Master schedule / all days">
-        <PrintTable
-          headers={["Time", "Block", "Location", "Role", "Coverage", "People"]}
-          rows={exports.masterScheduleRows.map((row) => ({
-            key: `${row.blockType}:${row.blockId}`,
-            cells: [
-              formatRange(row.startsAt, row.endsAt, timezone),
-              row.label,
-              row.location,
-              row.role,
-              `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
-              row.people || "Unassigned",
-            ],
-          }))}
-        />
-      </PrintSection>
-
-      {exports.stationCards.map((card) => (
-        <PrintSection
-          key={card.stationName}
-          title={`${card.stationName} station card`}
-        >
-          <p className="mb-2 text-sm">
-            {formatRange(card.startsAt, card.endsAt, timezone)} /{" "}
-            {card.openBlocks} open blocks
-          </p>
-          <PrintTable
-            headers={["Time", "Block", "Role", "Coverage", "People"]}
-            rows={card.rows.map((row) => ({
-              key: `${row.blockType}:${row.blockId}`,
-              cells: [
-                formatRange(row.startsAt, row.endsAt, timezone),
-                row.label,
-                row.role,
-                `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
-                row.people || "Unassigned",
-              ],
-            }))}
-            empty="No schedule rows for this station."
-          />
-          <div className="mt-4">
-            <PrintTable
-              headers={["Time", "Heat", "Lane", "Judge", "Status"]}
-              rows={card.judgeRows.map((row) => ({
-                key: `${row.heatId}:lane:${row.laneNumber}`,
-                cells: [
-                  formatRange(row.startsAt, row.endsAt, timezone),
-                  `${row.workoutName} heat ${row.heatNumber}`,
-                  row.laneNumber,
-                  row.judgeName,
-                  formatCrewValue(row.confirmationStatus),
-                ],
-              }))}
-              empty="No judge lanes for this station."
-            />
-          </div>
-        </PrintSection>
-      ))}
-
-      <PrintSection title="No-response and decline list">
-        <PrintTable
-          headers={["Time", "Volunteer", "Block", "Role", "Status", "Note"]}
-          rows={exports.responseRows.map((row) => ({
-            key: `${row.assignmentType}:${row.assignmentId}`,
-            cells: [
-              formatRange(row.startsAt, row.endsAt, timezone),
-              `${row.volunteerName}${row.email ? ` <${row.email}>` : ""}`,
-              row.blockLabel,
-              row.role,
-              formatCrewValue(row.reason),
-              row.responseNote,
-            ],
-          }))}
-          empty="No missing, pending, declined, or change-requested responses."
-        />
-      </PrintSection>
-
-      {exports.roleSheets.map((sheet) => (
-        <PrintSection key={sheet.roleType} title={`${sheet.roleLabel} sheet`}>
-          <PrintTable
-            headers={[
-              "Time",
-              "Volunteer",
-              "Email",
-              "Block",
-              "Location",
-              "Status",
-            ]}
-            rows={sheet.rows.map((row) => ({
-              key: row.rowKey,
-              cells: [
-                formatRange(row.startsAt, row.endsAt, timezone),
-                row.volunteerName,
-                row.email,
-                row.blockLabel,
-                row.location,
-                formatCrewValue(row.confirmationStatus),
-              ],
-            }))}
-          />
-        </PrintSection>
-      ))}
-
-      {exports.judgeHeatLaneSheets.map((sheet) => (
-        <PrintSection key={sheet.heatId} title={`${sheet.label} judge lanes`}>
-          <p className="mb-2 text-sm">
-            {formatExportDate(sheet.startsAt, timezone)} / {sheet.venueName}
-          </p>
-          <PrintTable
-            headers={["Lane", "Judge", "Email", "Position", "Status"]}
-            rows={sheet.rows.map((row) => ({
-              key: `${row.heatId}:lane:${row.laneNumber}`,
-              cells: [
-                row.laneNumber,
-                row.judgeName,
-                row.email,
-                row.position,
-                formatCrewValue(row.confirmationStatus),
-              ],
-            }))}
-          />
-        </PrintSection>
-      ))}
-
-      {exports.judgeLaneCards.map((card) => (
-        <PrintSection
-          key={card.cardKey}
-          title={`${card.venueName} lane ${card.laneNumber} card`}
-        >
-          <PrintTable
-            headers={["Time", "Heat", "Judge", "Email", "Status"]}
-            rows={card.rows.map((row) => ({
-              key: row.heatId,
-              cells: [
-                formatRange(row.startsAt, row.endsAt, timezone),
-                `${row.workoutName} heat ${row.heatNumber}`,
-                row.judgeName,
-                row.email,
-                formatCrewValue(row.confirmationStatus),
-              ],
-            }))}
-          />
-        </PrintSection>
-      ))}
-
-      {exports.floorLeadSheets.map((sheet) => (
-        <PrintSection
-          key={sheet.floorName}
-          title={`${sheet.floorName} floor lead`}
-        >
-          <PrintTable
-            headers={["Time", "Block", "Role", "Coverage", "People"]}
-            rows={sheet.rows.map((row) => ({
-              key: `${row.blockType}:${row.blockId}`,
-              cells: [
-                formatRange(row.startsAt, row.endsAt, timezone),
-                row.label,
-                row.role,
-                `${row.assigned}/${row.needed}${row.open > 0 ? ` (${row.open} open)` : ""}`,
-                row.people || "Unassigned",
-              ],
-            }))}
-          />
-          <div className="mt-4">
-            <PrintTable
-              headers={["Time", "Heat", "Lane", "Judge", "Status"]}
-              rows={sheet.judgeRows.map((row) => ({
-                key: `${row.heatId}:lane:${row.laneNumber}`,
-                cells: [
-                  formatRange(row.startsAt, row.endsAt, timezone),
-                  `${row.workoutName} heat ${row.heatNumber}`,
-                  row.laneNumber,
-                  row.judgeName,
-                  formatCrewValue(row.confirmationStatus),
-                ],
-              }))}
-              empty="No judge lanes for this floor."
-            />
-          </div>
-        </PrintSection>
-      ))}
-    </section>
+    </div>
   )
 }
 
-function PrintSection({
+function JudgesTab({
+  eventSections,
+  timezone,
+}: {
+  eventSections: CrewPilotJudgeEventSection[]
+  timezone: string
+}) {
+  if (eventSections.length === 0) {
+    return <EmptyState message="No heats are ready for judge assignment." />
+  }
+
+  return (
+    <div className="space-y-8">
+      {eventSections.map((section) => (
+        <PacketSection key={section.workoutId} title={section.workoutName}>
+          <div className="space-y-4">
+            {section.heats.map((heat) => (
+              <div key={heat.heatId} className="break-inside-avoid space-y-1">
+                <p className="text-sm font-medium">
+                  Heat {heat.heatNumber} / {heat.venueName} /{" "}
+                  {formatExportDate(heat.startsAt, timezone) || "Unscheduled"}
+                </p>
+                <PacketTable
+                  headers={["Lane", "Judge", "Position", "Status"]}
+                  rows={heat.rows.map((row) => ({
+                    key: `${heat.heatId}:lane:${row.laneNumber}`,
+                    cells: [
+                      row.laneNumber,
+                      row.judgeName,
+                      row.position,
+                      formatCrewValue(row.confirmationStatus),
+                    ],
+                  }))}
+                  empty="No lanes for this heat."
+                />
+              </div>
+            ))}
+          </div>
+        </PacketSection>
+      ))}
+    </div>
+  )
+}
+
+function ShiftsTab({
+  shiftSheets,
+  timezone,
+}: {
+  shiftSheets: CrewPilotShiftSheet[]
+  timezone: string
+}) {
+  if (shiftSheets.length === 0) {
+    return <EmptyState message="No shifts are ready to export." />
+  }
+
+  return (
+    <div className="space-y-8">
+      {shiftSheets.map((sheet) => (
+        <PacketSection
+          key={sheet.shiftId}
+          title={sheet.name}
+          subtitle={`${formatRange(sheet.startsAt, sheet.endsAt, timezone)} / ${sheet.location} / ${sheet.roleLabel} / ${sheet.assigned}/${sheet.needed} filled${sheet.open > 0 ? ` (${sheet.open} open)` : ""}`}
+        >
+          <PacketTable
+            headers={["Volunteer", "Email", "Status"]}
+            rows={sheet.rows.map((row) => ({
+              key: row.rowKey,
+              cells: [
+                row.volunteerName,
+                row.email,
+                formatCrewValue(row.confirmationStatus),
+              ],
+            }))}
+            empty="No volunteers on this shift."
+          />
+        </PacketSection>
+      ))}
+    </div>
+  )
+}
+
+function PrintHeader({
+  eventName,
+  subtitle,
+  generatedAt,
+}: {
+  eventName: string
+  subtitle: string
+  generatedAt: string
+}) {
+  return (
+    <header className="hidden border-b pb-4 print:block">
+      <h1 className="text-2xl font-semibold">{eventName}</h1>
+      <p className="text-sm">
+        {subtitle} / {generatedAt}
+      </p>
+    </header>
+  )
+}
+
+function PacketSection({
   title,
+  subtitle,
   children,
 }: {
   title: string
+  subtitle?: string
   children: ReactNode
 }) {
   return (
-    <section className="break-inside-avoid space-y-3 print:break-before-page first:print:break-before-auto">
-      <h2 className="text-xl font-semibold">{title}</h2>
+    <section className="space-y-3 break-inside-avoid print:break-before-page first:print:break-before-auto">
+      <div>
+        <h3 className="text-lg font-semibold">{title}</h3>
+        {subtitle ? (
+          <p className="text-sm text-muted-foreground print:text-black">
+            {subtitle}
+          </p>
+        ) : null}
+      </div>
       {children}
     </section>
   )
 }
 
-function PrintTable({
+function PacketTable({
   headers,
   rows,
   empty = "No rows.",
@@ -596,214 +342,37 @@ function PrintTable({
   empty?: string
 }) {
   if (rows.length === 0) {
-    return <p className="text-sm">{empty}</p>
+    return <p className="text-sm text-muted-foreground">{empty}</p>
   }
 
   return (
-    <table className="w-full border-collapse text-left text-xs">
-      <thead>
-        <tr>
-          {headers.map((header) => (
-            <th key={header} className="border px-2 py-1 font-semibold">
-              {header}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row) => (
-          <tr key={row.key}>
-            {headers.map((header, cellIndex) => (
-              <td key={header} className="border px-2 py-1 align-top">
-                {row.cells[cellIndex]}
-              </td>
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse text-left text-sm">
+        <thead>
+          <tr>
+            {headers.map((header) => (
+              <th
+                key={header}
+                className="border px-2 py-1 text-xs font-semibold uppercase text-muted-foreground print:text-black"
+              >
+                {header}
+              </th>
             ))}
           </tr>
-        ))}
-      </tbody>
-    </table>
-  )
-}
-
-function StationCardPreview({
-  card,
-  timezone,
-}: {
-  card: CrewPilotStationCard
-  timezone: string
-}) {
-  return (
-    <section className="rounded-md border bg-card p-4 shadow-sm">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <h4 className="font-semibold">{card.stationName}</h4>
-          <p className="text-sm text-muted-foreground">
-            {formatRange(card.startsAt, card.endsAt, timezone)}
-          </p>
-        </div>
-        <StatusPill>
-          {card.rows.length} blocks / {card.laneCards.length} lanes
-        </StatusPill>
-      </div>
-      <div className="mt-3 grid gap-3 lg:grid-cols-2">
-        <div className="space-y-2 text-sm">
-          {card.rows.slice(0, 6).map((row) => (
-            <div key={`${row.blockType}:${row.blockId}`}>
-              <p className="font-medium">{row.label}</p>
-              <p className="text-muted-foreground">
-                {formatRange(row.startsAt, row.endsAt, timezone)} / {row.role}
-              </p>
-            </div>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.key}>
+              {headers.map((header, cellIndex) => (
+                <td key={header} className="border px-2 py-1 align-top">
+                  {row.cells[cellIndex]}
+                </td>
+              ))}
+            </tr>
           ))}
-        </div>
-        <div className="space-y-2 text-sm">
-          {card.laneCards.slice(0, 6).map((laneCard) => (
-            <LaneCardLine key={laneCard.cardKey} card={laneCard} />
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-function LaneCardLine({ card }: { card: CrewPilotJudgeLaneCard }) {
-  return (
-    <div>
-      <p className="font-medium">Lane {card.laneNumber}</p>
-      <p className="text-muted-foreground">
-        {card.rows.length} heats /{" "}
-        {card.rows.filter((row) => row.judgeName === "OPEN").length} open
-      </p>
+        </tbody>
+      </table>
     </div>
-  )
-}
-
-function JudgeHeatSheetPreview({
-  sheet,
-  timezone,
-}: {
-  sheet: CrewPilotJudgeHeatLaneSheet
-  timezone: string
-}) {
-  return (
-    <div className="rounded-md border p-3 text-sm">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="font-medium">{sheet.label}</p>
-          <p className="text-muted-foreground">
-            {formatExportDate(sheet.startsAt, timezone)} / {sheet.venueName}
-          </p>
-        </div>
-        <StatusPill>{sheet.rows.length} lanes</StatusPill>
-      </div>
-      <div className="mt-3 grid gap-2">
-        {sheet.rows.map((row) => (
-          <div
-            key={`${sheet.heatId}:${row.laneNumber}`}
-            className="grid grid-cols-[4rem_1fr_auto] gap-2"
-          >
-            <span className="text-muted-foreground">Lane {row.laneNumber}</span>
-            <span>{row.judgeName}</span>
-            <span className="text-muted-foreground">
-              {formatCrewValue(row.confirmationStatus)}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-function RoleSheetPreview({
-  sheet,
-  timezone,
-}: {
-  sheet: CrewPilotRoleSheet
-  timezone: string
-}) {
-  return (
-    <section className="rounded-md border bg-card p-4 shadow-sm">
-      <div className="flex items-start justify-between gap-3">
-        <h4 className="font-semibold">{sheet.roleLabel}</h4>
-        <StatusPill>{sheet.rows.length} rows</StatusPill>
-      </div>
-      <div className="mt-3 grid gap-2 text-sm">
-        {sheet.rows.slice(0, 8).map((row) => (
-          <div key={row.rowKey} className="grid gap-1 rounded-md border p-3">
-            <div className="flex items-start justify-between gap-3">
-              <p className="font-medium">{row.volunteerName}</p>
-              <span className="text-muted-foreground">
-                {formatCrewValue(row.confirmationStatus)}
-              </span>
-            </div>
-            <p className="text-muted-foreground">
-              {row.blockLabel} / {row.location}
-            </p>
-            <p className="text-muted-foreground">
-              {formatRange(row.startsAt, row.endsAt, timezone)}
-            </p>
-          </div>
-        ))}
-      </div>
-    </section>
-  )
-}
-
-function FloorLeadSheetPreview({
-  sheet,
-  timezone,
-}: {
-  sheet: CrewPilotFloorLeadSheet
-  timezone: string
-}) {
-  return (
-    <section className="rounded-md border bg-card p-4 shadow-sm">
-      <div className="flex items-start justify-between gap-3">
-        <h4 className="font-semibold">{sheet.floorName}</h4>
-        <StatusPill>
-          {sheet.rows.length} blocks / {sheet.judgeRows.length} lanes
-        </StatusPill>
-      </div>
-      <div className="mt-3 grid gap-3 lg:grid-cols-2">
-        <div className="space-y-2 text-sm">
-          {sheet.rows.slice(0, 8).map((row) => (
-            <div key={`${row.blockType}:${row.blockId}`}>
-              <p className="font-medium">{row.label}</p>
-              <p className="text-muted-foreground">
-                {formatRange(row.startsAt, row.endsAt, timezone)} / {row.role}
-              </p>
-            </div>
-          ))}
-        </div>
-        <div className="space-y-2 text-sm">
-          {sheet.judgeRows.slice(0, 8).map((row) => (
-            <div key={`${row.heatId}:${row.laneNumber}`}>
-              <p className="font-medium">
-                {row.workoutName} heat {row.heatNumber}, lane {row.laneNumber}
-              </p>
-              <p className="text-muted-foreground">{row.judgeName}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-function MetricPanel({ label, value }: { label: string; value: ReactNode }) {
-  return (
-    <section className="rounded-md border bg-card p-4 shadow-sm">
-      <p className="text-sm text-muted-foreground">{label}</p>
-      <p className="mt-1 text-2xl font-semibold">{value}</p>
-    </section>
-  )
-}
-
-function StatusPill({ children }: { children: ReactNode }) {
-  return (
-    <span className="rounded-md bg-muted px-2 py-1 text-xs font-medium text-muted-foreground">
-      {children}
-    </span>
   )
 }
 

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -3,10 +3,11 @@
 import {
   createFileRoute,
   getRouteApi,
+  useNavigate,
   useSearch,
 } from "@tanstack/react-router"
 import { Download, Printer } from "lucide-react"
-import { type ReactNode, useState } from "react"
+import type { ReactNode } from "react"
 import type {
   CrewPilotExports,
   CrewPilotJudgeEventSection,
@@ -15,8 +16,8 @@ import type {
 } from "@/lib/crew/exports/pilot-exports"
 import { formatCrewValue } from "@/lib/crew-event-display"
 import {
-  getCrewPilotExportsPageFn,
   type CrewPilotExportsPageData,
+  getCrewPilotExportsPageFn,
 } from "@/server-fns/crew-pilot-export-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
@@ -45,8 +46,20 @@ function isPacketTabId(value: unknown): value is PacketTabId {
 function EventPilotExportsPage() {
   const { eventId } = parentRoute.useParams()
   const { event, exports, sources } = Route.useLoaderData()
+  const navigate = useNavigate()
   const search = useSearch({ strict: false }) as { tab?: string }
-  const initialTab = isPacketTabId(search.tab) ? search.tab : "schedule"
+  const activeTab = isPacketTabId(search.tab) ? search.tab : "schedule"
+
+  function handleTabChange(tabId: PacketTabId) {
+    void navigate({
+      to: ".",
+      search: (previous: Record<string, unknown>) => ({
+        ...previous,
+        tab: tabId,
+      }),
+      replace: true,
+    })
+  }
 
   return (
     <EventPilotExportsView
@@ -54,7 +67,8 @@ function EventPilotExportsPage() {
       event={event}
       exports={exports}
       sources={sources}
-      initialTab={initialTab}
+      activeTab={activeTab}
+      onTabChange={handleTabChange}
     />
   )
 }
@@ -63,10 +77,10 @@ export function EventPilotExportsView({
   event,
   exports,
   sources,
-  initialTab = "schedule",
+  activeTab,
+  onTabChange,
 }: EventPilotExportsViewProps) {
   const timezone = event.timezone ?? "America/Denver"
-  const [activeTab, setActiveTab] = useState<PacketTabId>(initialTab)
 
   return (
     <section className="space-y-5">
@@ -120,7 +134,7 @@ export function EventPilotExportsView({
                 ? "border-primary text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground"
             }`}
-            onClick={() => setActiveTab(tab.id)}
+            onClick={() => onTabChange(tab.id)}
           >
             {tab.label} ({getTabCount(tab.id, exports, sources)})
           </button>
@@ -157,7 +171,8 @@ interface EventPilotExportsViewProps {
   event: CrewPilotExportsPageData["event"]
   exports: CrewPilotExports
   sources: CrewPilotExportsPageData["sources"]
-  initialTab?: PacketTabId
+  activeTab: PacketTabId
+  onTabChange: (tabId: PacketTabId) => void
 }
 
 function getTabCount(
@@ -189,7 +204,14 @@ function ScheduleTab({
           title={formatPacketDay(section.dayKey)}
         >
           <PacketTable
-            headers={["Time", "Block", "Location", "Role", "Coverage", "People"]}
+            headers={[
+              "Time",
+              "Block",
+              "Location",
+              "Role",
+              "Coverage",
+              "People",
+            ]}
             rows={section.rows.map((row) => ({
               key: `${row.blockType}:${row.blockId}`,
               cells: [
@@ -272,12 +294,11 @@ function ShiftsTab({
           subtitle={`${formatRange(sheet.startsAt, sheet.endsAt, timezone)} / ${sheet.location} / ${sheet.roleLabel} / ${sheet.assigned}/${sheet.needed} filled${sheet.open > 0 ? ` (${sheet.open} open)` : ""}`}
         >
           <PacketTable
-            headers={["Volunteer", "Email", "Status"]}
+            headers={["Volunteer", "Status"]}
             rows={sheet.rows.map((row) => ({
               key: row.rowKey,
               cells: [
                 row.volunteerName,
-                row.email,
                 formatCrewValue(row.confirmationStatus),
               ],
             }))}

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -1,11 +1,6 @@
 // @lat: [[crew#Pilot Exports]]
 // @lat: [[crew#Event Day Export Packet]]
-import {
-  createFileRoute,
-  getRouteApi,
-  useNavigate,
-  useSearch,
-} from "@tanstack/react-router"
+import { createFileRoute } from "@tanstack/react-router"
 import { Download, Printer } from "lucide-react"
 import type { ReactNode } from "react"
 import type {
@@ -21,16 +16,6 @@ import {
 } from "@/server-fns/crew-pilot-export-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
-export const Route = createFileRoute("/events/$eventId/exports")({
-  loader: async ({ params }) =>
-    await getCrewPilotExportsPageFn({
-      data: { eventId: params.eventId },
-    }),
-  component: EventPilotExportsPage,
-})
-
-const parentRoute = getRouteApi("/events/$eventId")
-
 const PACKET_TABS = [
   { id: "schedule", label: "Master Schedule" },
   { id: "judges", label: "Judges" },
@@ -43,30 +28,41 @@ function isPacketTabId(value: unknown): value is PacketTabId {
   return PACKET_TABS.some((tab) => tab.id === value)
 }
 
+interface ExportsSearch {
+  tab: PacketTabId
+}
+
+function validateExportsSearch(search: Record<string, unknown>): ExportsSearch {
+  return {
+    tab: isPacketTabId(search.tab) ? search.tab : "schedule",
+  }
+}
+
+export const Route = createFileRoute("/events/$eventId/exports")({
+  validateSearch: validateExportsSearch,
+  loader: async ({ params }) =>
+    await getCrewPilotExportsPageFn({
+      data: { eventId: params.eventId },
+    }),
+  component: EventPilotExportsPage,
+})
+
 function EventPilotExportsPage() {
-  const { eventId } = parentRoute.useParams()
-  const { event, exports, sources } = Route.useLoaderData()
-  const navigate = useNavigate()
-  const search = useSearch({ strict: false }) as { tab?: string }
-  const activeTab = isPacketTabId(search.tab) ? search.tab : "schedule"
+  const { event, exports } = Route.useLoaderData()
+  const navigate = Route.useNavigate()
+  const { tab: activeTab } = Route.useSearch()
 
   function handleTabChange(tabId: PacketTabId) {
     void navigate({
-      to: ".",
-      search: (previous: Record<string, unknown>) => ({
-        ...previous,
-        tab: tabId,
-      }),
+      search: (previous) => ({ ...previous, tab: tabId }),
       replace: true,
     })
   }
 
   return (
     <EventPilotExportsView
-      eventId={eventId}
       event={event}
       exports={exports}
-      sources={sources}
       activeTab={activeTab}
       onTabChange={handleTabChange}
     />
@@ -76,7 +72,6 @@ function EventPilotExportsPage() {
 export function EventPilotExportsView({
   event,
   exports,
-  sources,
   activeTab,
   onTabChange,
 }: EventPilotExportsViewProps) {
@@ -136,7 +131,7 @@ export function EventPilotExportsView({
             }`}
             onClick={() => onTabChange(tab.id)}
           >
-            {tab.label} ({getTabCount(tab.id, exports, sources)})
+            {tab.label} ({getTabCount(tab.id, exports)})
           </button>
         ))}
       </div>
@@ -167,22 +162,16 @@ export function EventPilotExportsView({
 }
 
 interface EventPilotExportsViewProps {
-  eventId: string
   event: CrewPilotExportsPageData["event"]
   exports: CrewPilotExports
-  sources: CrewPilotExportsPageData["sources"]
   activeTab: PacketTabId
   onTabChange: (tabId: PacketTabId) => void
 }
 
-function getTabCount(
-  tabId: PacketTabId,
-  exports: CrewPilotExports,
-  sources: CrewPilotExportsPageData["sources"],
-) {
+function getTabCount(tabId: PacketTabId, exports: CrewPilotExports) {
   if (tabId === "schedule") return exports.summary.masterScheduleRows
   if (tabId === "judges") return exports.summary.judgeHeatSheets
-  return sources.shifts
+  return exports.summary.shiftSheets
 }
 
 function ScheduleTab({

--- a/apps/crew/src/routes/events/$eventId/judges.tsx
+++ b/apps/crew/src/routes/events/$eventId/judges.tsx
@@ -1,19 +1,24 @@
 // @lat: [[crew#Judge Rotations]]
 
-import {
-  createFileRoute,
-  getRouteApi,
-  Link,
-  useNavigate,
-  useSearch,
-} from "@tanstack/react-router"
+import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
 import {
   type CrewJudgeRotationsPageData,
   getCrewJudgeRotationsPageFn,
 } from "@/server-fns/crew-judge-rotations-fns"
 import { JudgeSchedulingContainer } from "./-components/judges/judge-scheduling-container"
 
+interface JudgesSearch {
+  workout?: string
+}
+
+function validateJudgesSearch(search: Record<string, unknown>): JudgesSearch {
+  return {
+    workout: typeof search.workout === "string" ? search.workout : undefined,
+  }
+}
+
 export const Route = createFileRoute("/events/$eventId/judges")({
+  validateSearch: validateJudgesSearch,
   loader: async ({ params }) =>
     await getCrewJudgeRotationsPageFn({ data: { eventId: params.eventId } }),
   component: EventJudgeAssignmentsPage,
@@ -49,8 +54,8 @@ function getJudgeAssignmentsAvailability(
 function EventJudgeAssignmentsPage() {
   const { eventId } = parentRoute.useParams()
   const data = Route.useLoaderData()
-  const navigate = useNavigate()
-  const search = useSearch({ strict: false }) as { workout?: string }
+  const navigate = Route.useNavigate()
+  const search = Route.useSearch()
   const availability = getJudgeAssignmentsAvailability(data.page)
 
   const { page } = data
@@ -62,11 +67,7 @@ function EventJudgeAssignmentsPage() {
 
   function handleWorkoutChange(workoutId: string) {
     void navigate({
-      to: ".",
-      search: (previous: Record<string, unknown>) => ({
-        ...previous,
-        workout: workoutId,
-      }),
+      search: (previous) => ({ ...previous, workout: workoutId }),
       replace: true,
     })
   }

--- a/apps/crew/src/server/crew-pilot-exports.server.ts
+++ b/apps/crew/src/server/crew-pilot-exports.server.ts
@@ -24,9 +24,7 @@ export interface CrewPilotExportsPageData {
     shifts: number
     shiftAssignments: number
     heats: number
-    heatLaneAssignments: number
     judgeAssignments: number
-    activeJudgeVersions: number
   }
 }
 
@@ -35,10 +33,10 @@ export async function getCrewPilotExportsPage(data: {
 }): Promise<CrewPilotExportsPageData> {
   const event = await requireCrewStaffingEvent(data.eventId)
   await requireCrewDepartmentLeadFullAccess(event)
-  const { input, activeJudgeVersions } = await loadCrewStaffingMatrixInput(
-    event,
-    { kind: "full", scopes: [] },
-  )
+  const { input } = await loadCrewStaffingMatrixInput(event, {
+    kind: "full",
+    scopes: [],
+  })
   const pilotExports = buildCrewPilotExports({
     event,
     generatedAt: new Date(),
@@ -61,12 +59,7 @@ export async function getCrewPilotExportsPage(data: {
           0,
         ) ?? 0,
       heats: input.heats?.length ?? 0,
-      heatLaneAssignments: pilotExports.judgeHeatLaneSheets.reduce(
-        (total, sheet) => total + sheet.rows.length,
-        0,
-      ),
       judgeAssignments: input.judgeAssignments?.length ?? 0,
-      activeJudgeVersions,
     },
   }
 }

--- a/apps/crew/test/routes/event-day-export-packet.test.tsx
+++ b/apps/crew/test/routes/event-day-export-packet.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react"
+import { useState } from "react"
 import { describe, expect, it, vi } from "vitest"
 import { VOLUNTEER_ROLE_TYPES } from "@/db/schemas/volunteers"
 import {
@@ -23,30 +24,40 @@ vi.mock("@/server-fns/crew-pilot-export-fns", () => ({
 }))
 
 function renderView() {
-  const exports = buildCrewPilotExports(packetInput())
+  const input = packetInput()
+  const exports = buildCrewPilotExports(input)
 
-  render(
-    <EventPilotExportsView
-      eventId="comp_packet"
-      event={{
-        id: "comp_packet",
-        name: "Packet Classic",
-        slug: "packet-classic",
-        organizingTeamId: "team_org",
-        competitionTeamId: "team_comp",
-        timezone: "Pacific/Kiritimati",
-        startDate: "2026-07-01",
-        endDate: "2026-07-02",
-      }}
-      exports={exports}
-      sources={{
-        shifts: 1,
-        shiftAssignments: 1,
-        heats: 1,
-        judgeAssignments: 1,
-      }}
-    />,
-  )
+  function TestView() {
+    const [activeTab, setActiveTab] = useState<"schedule" | "judges" | "shifts">(
+      "schedule",
+    )
+    return (
+      <EventPilotExportsView
+        eventId="comp_packet"
+        event={{
+          id: "comp_packet",
+          name: "Packet Classic",
+          slug: "packet-classic",
+          organizingTeamId: "team_org",
+          competitionTeamId: "team_comp",
+          timezone: input.event.timezone,
+          startDate: "2026-07-01",
+          endDate: "2026-07-02",
+        }}
+        exports={exports}
+        sources={{
+          shifts: 1,
+          shiftAssignments: 1,
+          heats: 1,
+          judgeAssignments: 1,
+        }}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
+      />
+    )
+  }
+
+  render(<TestView />)
 }
 
 describe("EventPilotExportsView", () => {
@@ -73,10 +84,11 @@ describe("EventPilotExportsView", () => {
       screen.queryByRole("button", { name: "Master CSV" }),
     ).not.toBeInTheDocument()
 
-    // Shifts tab lists each shift as its own section.
+    // Shifts tab lists each shift as its own section without contact details.
     fireEvent.click(screen.getByRole("tab", { name: /Shifts/ }))
     expect(screen.getByText("Floor reset")).toBeInTheDocument()
     expect(screen.getByText("Rae Reset")).toBeInTheDocument()
+    expect(screen.queryByText("reset@example.com")).not.toBeInTheDocument()
   })
 })
 

--- a/apps/crew/test/routes/event-day-export-packet.test.tsx
+++ b/apps/crew/test/routes/event-day-export-packet.test.tsx
@@ -1,5 +1,4 @@
-import { render, screen } from "@testing-library/react"
-import type { ReactNode } from "react"
+import { fireEvent, render, screen } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 import { VOLUNTEER_ROLE_TYPES } from "@/db/schemas/volunteers"
 import {
@@ -16,66 +15,68 @@ vi.mock("@tanstack/react-router", () => ({
   getRouteApi: () => ({
     useParams: () => ({ eventId: "comp_packet" }),
   }),
-  Link: ({ children, to }: { children: ReactNode; to: string }) => (
-    <a href={to}>{children}</a>
-  ),
+  useSearch: () => ({}),
 }))
 
 vi.mock("@/server-fns/crew-pilot-export-fns", () => ({
   getCrewPilotExportsPageFn: vi.fn(),
 }))
 
+function renderView() {
+  const exports = buildCrewPilotExports(packetInput())
+
+  render(
+    <EventPilotExportsView
+      eventId="comp_packet"
+      event={{
+        id: "comp_packet",
+        name: "Packet Classic",
+        slug: "packet-classic",
+        organizingTeamId: "team_org",
+        competitionTeamId: "team_comp",
+        timezone: "Pacific/Kiritimati",
+        startDate: "2026-07-01",
+        endDate: "2026-07-02",
+      }}
+      exports={exports}
+      sources={{
+        shifts: 1,
+        shiftAssignments: 1,
+        heats: 1,
+        judgeAssignments: 1,
+      }}
+    />,
+  )
+}
+
 describe("EventPilotExportsView", () => {
   // @lat: [[crew#Event Day Export Packet]]
-  it("renders packet index, station cards, and print packet sections", () => {
-    const exports = buildCrewPilotExports(packetInput())
-
-    render(
-      <EventPilotExportsView
-        eventId="comp_packet"
-        event={{
-          id: "comp_packet",
-          name: "Packet Classic",
-          slug: "packet-classic",
-          organizingTeamId: "team_org",
-          competitionTeamId: "team_comp",
-          timezone: "Pacific/Kiritimati",
-          startDate: "2026-07-01",
-          endDate: "2026-07-02",
-        }}
-        exports={exports}
-        sources={{
-          shifts: 1,
-          shiftAssignments: 1,
-          heats: 1,
-          heatLaneAssignments: 2,
-          judgeAssignments: 1,
-          activeJudgeVersions: 1,
-        }}
-      />,
-    )
+  it("renders schedule, judges, and shifts tabs and switches between them", () => {
+    renderView()
 
     expect(
-      screen.getByRole("heading", { name: "Event-day export packet" }),
+      screen.getByRole("heading", { name: "Print packet" }),
     ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Print" })).toBeInTheDocument()
+
+    // Master schedule tab is active by default.
+    expect(screen.getByText("Jul 1, 2026")).toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: "Print packet" }),
+      screen.getByRole("button", { name: "Master CSV" }),
     ).toBeInTheDocument()
-    expect(screen.getAllByText("Packet index").length).toBeGreaterThan(0)
-    expect(screen.getAllByText("Station cards").length).toBeGreaterThan(0)
+
+    // Judges tab groups heats by event.
+    fireEvent.click(screen.getByRole("tab", { name: /Judges/ }))
+    expect(screen.getByText("Event 1")).toBeInTheDocument()
+    expect(screen.getByText(/Heat 1 \/ Competition floor/)).toBeInTheDocument()
     expect(
-      screen.getByText("Competition floor station card"),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText("Competition floor lane 1 card"),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByText("Master schedule / Jul 1, 2026"),
-    ).toBeInTheDocument()
-    expect(
-      screen.queryByText("Master schedule / Jul 2, 2026"),
+      screen.queryByRole("button", { name: "Master CSV" }),
     ).not.toBeInTheDocument()
-    expect(screen.getByText("Master schedule / all days")).toBeInTheDocument()
+
+    // Shifts tab lists each shift as its own section.
+    fireEvent.click(screen.getByRole("tab", { name: /Shifts/ }))
+    expect(screen.getByText("Floor reset")).toBeInTheDocument()
+    expect(screen.getByText("Rae Reset")).toBeInTheDocument()
   })
 })
 

--- a/apps/crew/test/routes/event-day-export-packet.test.tsx
+++ b/apps/crew/test/routes/event-day-export-packet.test.tsx
@@ -12,11 +12,9 @@ vi.mock("@tanstack/react-router", () => ({
   createFileRoute: () => (config: Record<string, unknown>) => ({
     ...config,
     useLoaderData: vi.fn(),
+    useNavigate: () => vi.fn(),
+    useSearch: () => ({ tab: "schedule" }),
   }),
-  getRouteApi: () => ({
-    useParams: () => ({ eventId: "comp_packet" }),
-  }),
-  useSearch: () => ({}),
 }))
 
 vi.mock("@/server-fns/crew-pilot-export-fns", () => ({
@@ -33,7 +31,6 @@ function renderView() {
     )
     return (
       <EventPilotExportsView
-        eventId="comp_packet"
         event={{
           id: "comp_packet",
           name: "Packet Classic",
@@ -45,12 +42,6 @@ function renderView() {
           endDate: "2026-07-02",
         }}
         exports={exports}
-        sources={{
-          shifts: 1,
-          shiftAssignments: 1,
-          heats: 1,
-          judgeAssignments: 1,
-        }}
         activeTab={activeTab}
         onTabChange={setActiveTab}
       />

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -492,13 +492,15 @@ Crew pilot exports turn the active event staffing and judge assignment data into
 
 [[apps/crew/src/routes/events/$eventId/exports.tsx]] renders the per-event export surface. [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]] keeps the route import light while [[apps/crew/src/server/crew-pilot-exports.server.ts]] reuses server-only staffing hydration and active judge assignment data.
 
-[[apps/crew/src/lib/crew/exports/pilot-exports.ts]] owns deterministic export derivation for master schedule CSV rows, role sheets, judge heat/lane sheets, no-response and decline lists, and printable floor lead sheets. Exports are read-only and must not send reminders, create queues, alter confirmation tokens, or mutate versioned judge assignment rows.
+[[apps/crew/src/lib/crew/exports/pilot-exports.ts]] owns deterministic export derivation for the three focused packets: master schedule rows (with CSV) grouped into day sections, judge event sections (heats grouped by workout, each with per-lane judge rows), and flat time-ordered shift sheets (each shift with its assigned volunteers and open slots). Exports are read-only and must not send reminders, create queues, alter confirmation tokens, or mutate versioned judge assignment rows.
 
 ## Event Day Export Packet
 
-The event-day packet extends [[crew#Pilot Exports]] with a print-first index, day schedule, station cards, lane cards, role sheets, and judge cards from [[apps/crew/src/lib/crew/exports/pilot-exports.ts]], rendered at [[apps/crew/src/routes/events/$eventId/exports.tsx]].
+The event-day packet renders [[crew#Pilot Exports]] as three printable tabs at [[apps/crew/src/routes/events/$eventId/exports.tsx]], one per operator packet, with the active tab driving `window.print()` so each prints on its own.
 
-The packet is still full local-operator-only through [[apps/crew/src/server/crew-pilot-exports.server.ts]] and [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]]. It does not add PDF runtime infrastructure, schema, queue/email work, public tokens, department-lead subset export access, or assignment/judge-version mutations.
+The tabs are **Master Schedule** (shifts and heats combined, day-sectioned, with a Master CSV download), **Judges** (per event/workout, a clear heat × lane × judge table), and **Shifts** (each shift as its own section listing who is on and when).
+
+The packet is full local-operator-only through [[apps/crew/src/server/crew-pilot-exports.server.ts]] and [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]]. It deliberately omits station/floor cards, role sheets, the response/decline list, the packet index, and metric panels, and does not add PDF runtime infrastructure, schema, queue/email work, public tokens, department-lead subset export access, or assignment/judge-version mutations.
 
 ## Strategic Moat Privacy Model
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -492,11 +492,11 @@ Crew pilot exports turn the active event staffing and judge assignment data into
 
 [[apps/crew/src/routes/events/$eventId/exports.tsx]] renders the per-event export surface. [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]] keeps the route import light while [[apps/crew/src/server/crew-pilot-exports.server.ts]] reuses server-only staffing hydration and active judge assignment data.
 
-[[apps/crew/src/lib/crew/exports/pilot-exports.ts]] owns deterministic export derivation for the three focused packets: master schedule rows (with CSV) grouped into day sections, judge event sections (heats grouped by workout, each with per-lane judge rows), and flat time-ordered shift sheets (each shift with its assigned volunteers and open slots). Exports are read-only and must not send reminders, create queues, alter confirmation tokens, or mutate versioned judge assignment rows.
+[[apps/crew/src/lib/crew/exports/pilot-exports.ts]] owns deterministic export derivation for the three focused packets: master schedule rows (with CSV) grouped into day sections, judge event sections (heats grouped by workout, each with per-lane judge rows), and flat time-ordered shift sheets (each shift with its assigned volunteers and open slots). Default shift sheets omit contact details and response notes; exports are read-only and must not send reminders, create queues, alter confirmation tokens, or mutate versioned judge assignment rows.
 
 ## Event Day Export Packet
 
-The event-day packet renders [[crew#Pilot Exports]] as three printable tabs at [[apps/crew/src/routes/events/$eventId/exports.tsx]], one per operator packet, with the active tab driving `window.print()` so each prints on its own.
+The event-day packet renders [[crew#Pilot Exports]] as three printable tabs at [[apps/crew/src/routes/events/$eventId/exports.tsx]], one per operator packet, with the active `tab` search parameter driving `window.print()` so each prints on its own.
 
 The tabs are **Master Schedule** (shifts and heats combined, day-sectioned, with a Master CSV download), **Judges** (per event/workout, a clear heat × lane × judge table), and **Shifts** (each shift as its own section listing who is on and when).
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -496,7 +496,7 @@ Crew pilot exports turn the active event staffing and judge assignment data into
 
 ## Event Day Export Packet
 
-The event-day packet renders [[crew#Pilot Exports]] as three printable tabs at [[apps/crew/src/routes/events/$eventId/exports.tsx]], one per operator packet, with the active `tab` search parameter driving `window.print()` so each prints on its own.
+The event-day packet renders [[crew#Pilot Exports]] as three printable tabs at [[apps/crew/src/routes/events/$eventId/exports.tsx]], one per operator packet, with the route-validated active `tab` search parameter driving `window.print()` so each prints on its own.
 
 The tabs are **Master Schedule** (shifts and heats combined, day-sectioned, with a Master CSV download), **Judges** (per event/workout, a clear heat × lane × judge table), and **Shifts** (each shift as its own section listing who is on and when).
 


### PR DESCRIPTION
Replace the single long export scroll with three focused, individually printable tabs:
- Master Schedule: shifts + heats combined, day-sectioned, Master CSV
- Judges: per event/workout, a clear heat × lane × judge table
- Shifts: each shift as its own section with assignees and open slots

Trim the builder to the three needed outputs (master schedule day sections, judge event sections, flat shift sheets); drop station/floor cards, role sheets, response/decline list, packet index, metric panels, and the Responses CSV. Collapse the duplicated screen/print component trees into one table-based layout per tab; active tab drives print.


Entire-Checkpoint: c6332be749c2

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retabs the event-day export into three printable tabs—Master Schedule, Judges, and Shifts—for faster scanning and printing. Validates route search params and trims the builder to only what these tabs need, dropping the Responses CSV and unused packet types.

- **New Features**
  - Tabbed print packet: Master Schedule (shifts + heats, day-sectioned, Master CSV), Judges (grouped by workout with a heat × lane × judge table), Shifts (one section per shift with assignees, open slots, and statuses; no contact details).
  - The active validated `tab` search param controls the visible section and printing; the Master CSV button shows only on the Schedule tab.

- **Refactors**
  - Export builder now returns master schedule day sections, judge event sections, and flat time-ordered shift sheets.
  - Removed packet index, station/floor cards, lane cards, role sheets, response/decline list and CSV, floor lead sheets, and metric panels; simplified server counts and consolidated screen/print into one table layout per tab.
  - Validated route search params on exports (`tab`) and judges (`workout`); updated tests and docs.

<sup>Written for commit f18d0c1e0e161bdd50fb251c83d6748a1b149ad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a tabbed print packet view with separate **Master Schedule**, **Judges**, and **Shifts** sections, driven by a validated tab query parameter and including a **Print** button.
  - Expanded the printable **Judges** and **Shifts** content to reflect the new grouped packet structure (including open-slot rows).

- **Bug Fixes**
  - Updated export payloads, page data, and related UI/testing to match the revised packet contents and `exports.summary` shape.

- **Documentation**
  - Updated Pilot Exports documentation to describe the new three-packet print contents and removed materials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->