### PR TITLE
Simplify Crew staffing gap report

### DIFF
--- a/apps/crew/src/routes/events/$eventId/staffing.tsx
+++ b/apps/crew/src/routes/events/$eventId/staffing.tsx
@@ -34,6 +34,7 @@ function EventStaffingPage() {
 
   const roleGaps = report.roleSummaries.filter((role) => role.open > 0)
   const blockGaps = report.underfilledRows
+  const blockGapCount = new Set(blockGaps.map((row) => row.timeBlockId)).size
 
   return (
     <section className="space-y-6">
@@ -50,7 +51,7 @@ function EventStaffingPage() {
         openSlots={openSlots}
         totalFilled={totalFilled}
         totalNeeded={totalNeeded}
-        blockGapCount={blockGaps.length}
+        blockGapCount={blockGapCount}
       />
 
       {openSlots > 0 && (
@@ -156,13 +157,25 @@ function RoleGaps({
   eventId: string
   roleGaps: CrewStaffingRoleSummary[]
 }) {
+  const hasJudgeGaps = roleGaps.some((role) => isJudgeRole(role.roleType))
+  const hasShiftGaps = roleGaps.some((role) => !isJudgeRole(role.roleType))
+
   return (
     <section className="rounded-lg border bg-card p-5 shadow-sm">
       <div className="flex items-center justify-between gap-3">
         <h3 className="font-semibold">Who you need</h3>
-        <PillLink to="/events/$eventId/shifts" eventId={eventId}>
-          Manage shifts
-        </PillLink>
+        <div className="flex flex-wrap justify-end gap-2">
+          {hasShiftGaps && (
+            <PillLink to="/events/$eventId/shifts" eventId={eventId}>
+              Manage shifts
+            </PillLink>
+          )}
+          {hasJudgeGaps && (
+            <PillLink to="/events/$eventId/judges" eventId={eventId}>
+              Assign judges
+            </PillLink>
+          )}
+        </div>
       </div>
       <ul className="mt-4 space-y-2">
         {roleGaps.map((role) => (
@@ -254,7 +267,10 @@ function PillLink({
   eventId,
   children,
 }: {
-  to: "/events/$eventId/shifts" | "/events/$eventId/heats"
+  to:
+    | "/events/$eventId/shifts"
+    | "/events/$eventId/heats"
+    | "/events/$eventId/judges"
   eventId: string
   children: ReactNode
 }) {
@@ -267,6 +283,10 @@ function PillLink({
       {children}
     </Link>
   )
+}
+
+function isJudgeRole(roleType: CrewStaffingRoleSummary["roleType"]) {
+  return roleType === "judge" || roleType === "head_judge"
 }
 
 function formatTimeWindow(

--- a/apps/crew/src/routes/events/$eventId/staffing.tsx
+++ b/apps/crew/src/routes/events/$eventId/staffing.tsx
@@ -1,22 +1,13 @@
 // @lat: [[crew#Staffing Page Gap Report]]
 import { createFileRoute, getRouteApi, Link } from "@tanstack/react-router"
-import { AlertCircle, CheckCircle2, CircleAlert } from "lucide-react"
+import { CalendarClock, CheckCircle2, Users } from "lucide-react"
 import type { ReactNode } from "react"
-import {
-  getCrewAssignmentConfirmationStatusBadgeClassName,
-  getCrewAssignmentConfirmationStatusLabel,
-} from "@/lib/crew/assignment-confirmation-display"
+import { formatVolunteerRole } from "@/lib/crew/roster-shifts"
 import type {
   CrewStaffingCoverageRow,
-  CrewStaffingReportIssueSummary,
-  CrewStaffingReportStatus,
+  CrewStaffingRoleSummary,
   CrewStaffingTimeBlock,
 } from "@/lib/crew/staffing"
-import {
-  formatVolunteerAvailability,
-  formatVolunteerRole,
-} from "@/lib/crew/roster-shifts"
-import { formatCrewValue } from "@/lib/crew-event-display"
 import { getCrewStaffingReportPageFn } from "@/server-fns/crew-staffing-fns"
 import { formatDateTimeInTimezone } from "@/utils/timezone-utils"
 
@@ -30,439 +21,252 @@ const parentRoute = getRouteApi("/events/$eventId")
 
 function EventStaffingPage() {
   const { eventId } = parentRoute.useParams()
-  const { matrix, report, sources, event } = Route.useLoaderData()
+  const { matrix, report, event } = Route.useLoaderData()
   const timezone = event.timezone ?? "America/Denver"
+
   const timeBlockById = new Map(
     matrix.timeBlocks.map((block) => [block.id, block]),
   )
-  const criticalIssueCount = report.issueSummary
-    .filter((issue) => issue.severity === "critical")
-    .reduce((total, issue) => total + issue.count, 0)
-  const responseIssueCount =
-    matrix.summary.confirmationNoResponses +
-    matrix.summary.confirmationDeclines +
-    matrix.summary.confirmationChangeRequests +
-    matrix.summary.confirmationNoShows +
-    matrix.summary.confirmationReplaced
+  const openSlots = matrix.summary.openCapacity
+  const totalNeeded = matrix.summary.totalNeeded
+  const totalFilled = matrix.summary.totalFilled
+  const hasStaffingBlocks = matrix.timeBlocks.length > 0 && totalNeeded > 0
+
+  const roleGaps = report.roleSummaries.filter((role) => role.open > 0)
+  const blockGaps = report.underfilledRows
 
   return (
     <section className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div>
-          <h2 className="text-xl font-semibold">Staffing</h2>
-          <p className="text-sm text-muted-foreground">
-            {report.summaryLabel}. {report.summaryDetail}
-          </p>
-        </div>
-        <StatusBadge status={report.status} />
+      <div>
+        <h2 className="text-xl font-semibold">Staffing gaps</h2>
+        <p className="text-sm text-muted-foreground">
+          The volunteer and judge slots you still need to fill.
+        </p>
       </div>
 
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <div className="grid gap-4 md:grid-cols-4">
-          <StatusPanel
-            label="Filled"
-            value={`${matrix.summary.totalFilled}/${matrix.summary.totalNeeded}`}
+      <Verdict
+        eventId={eventId}
+        hasStaffingBlocks={hasStaffingBlocks}
+        openSlots={openSlots}
+        totalFilled={totalFilled}
+        totalNeeded={totalNeeded}
+        blockGapCount={blockGaps.length}
+      />
+
+      {openSlots > 0 && (
+        <div className="grid gap-6 lg:grid-cols-2">
+          <RoleGaps eventId={eventId} roleGaps={roleGaps} />
+          <BlockGaps
+            blockGaps={blockGaps}
+            timeBlockById={timeBlockById}
+            timezone={timezone}
           />
-          <StatusPanel label="Open" value={matrix.summary.openCapacity} />
-          <StatusPanel label="Critical" value={criticalIssueCount} />
-          <StatusPanel label="Responses" value={responseIssueCount} />
         </div>
-      </section>
-
-      <section className="grid gap-3 md:grid-cols-3">
-        {report.issueSummary.map((issue) => (
-          <IssuePanel key={issue.key} issue={issue} />
-        ))}
-      </section>
-
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div>
-            <h3 className="font-semibold">Coverage by role</h3>
-            <p className="text-sm text-muted-foreground">
-              Filled and needed totals across shifts and heat lanes.
-            </p>
-          </div>
-          <Link
-            to="/events/$eventId/shifts"
-            params={{ eventId }}
-            className="w-fit rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
-          >
-            Manage shifts
-          </Link>
-        </div>
-        {report.roleSummaries.length > 0 ? (
-          <div className="mt-5 grid gap-3 md:grid-cols-2 lg:grid-cols-3">
-            {report.roleSummaries.map((role) => (
-              <article
-                key={role.roleType}
-                className="rounded-md border bg-background p-4"
-              >
-                <div className="flex items-start justify-between gap-3">
-                  <div>
-                    <h4 className="font-medium">{role.roleLabel}</h4>
-                    <p className="text-sm text-muted-foreground">
-                      {role.timeBlocks} block{plural(role.timeBlocks)}
-                    </p>
-                  </div>
-                  <span
-                    className={`rounded-md border px-2 py-1 text-xs font-medium ${
-                      role.open > 0
-                        ? "border-amber-500/30 bg-amber-500/10 text-amber-700"
-                        : "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
-                    }`}
-                  >
-                    {role.open} open
-                  </span>
-                </div>
-                <p className="mt-4 text-2xl font-semibold">
-                  {role.filled}/{role.needed}
-                </p>
-              </article>
-            ))}
-          </div>
-        ) : (
-          <EmptyState message="No staffing role rows yet." />
-        )}
-      </section>
-
-      <section className="rounded-md border bg-card p-5 shadow-sm">
-        <h3 className="font-semibold">Coverage by time block</h3>
-        <CoverageTable
-          rows={matrix.coverageRows}
-          timeBlockById={timeBlockById}
-          timezone={timezone}
-        />
-      </section>
-
-      <div className="grid gap-6 lg:grid-cols-[1fr_20rem]">
-        <section className="space-y-6">
-          <ActionList
-            title="Open capacity"
-            count={report.underfilledRows.length}
-            empty="No open capacity in current coverage rows."
-          >
-            {report.underfilledRows.map((row) => (
-              <GapRow key={row.id}>
-                <span>{getTimeBlockLabel(timeBlockById, row.timeBlockId)}</span>
-                <span className="text-muted-foreground">
-                  {formatVolunteerRole(row.roleType)} needs {row.open} more.
-                </span>
-              </GapRow>
-            ))}
-          </ActionList>
-
-          <ActionList
-            title="Judge lane gaps"
-            count={matrix.judgeLaneGaps.length}
-            empty="No uncovered judge lanes."
-          >
-            {matrix.judgeLaneGaps.map((gap) => (
-              <GapRow key={`${gap.heatId}:${gap.laneNumber}`}>
-                <span>{getTimeBlockLabel(timeBlockById, gap.timeBlockId)}</span>
-                <span className="text-muted-foreground">
-                  Heat {gap.heatNumber}, lane {gap.laneNumber}
-                </span>
-              </GapRow>
-            ))}
-          </ActionList>
-
-          <ActionList
-            title="Volunteer conflicts"
-            count={matrix.doubleBookedVolunteers.length}
-            empty="No double-booked volunteers."
-          >
-            {matrix.doubleBookedVolunteers.map((booking) => (
-              <GapRow
-                key={`${booking.membershipId}:${booking.assignmentIds.join(":")}`}
-              >
-                <span>{booking.volunteerName}</span>
-                <span className="text-muted-foreground">
-                  {booking.timeBlockIds
-                    .map((timeBlockId) =>
-                      getTimeBlockLabel(timeBlockById, timeBlockId),
-                    )
-                    .join(" / ")}
-                </span>
-              </GapRow>
-            ))}
-          </ActionList>
-
-          <ActionList
-            title="Availability warnings"
-            count={matrix.outsideAvailabilityAssignments.length}
-            empty="No outside-availability assignments."
-          >
-            {matrix.outsideAvailabilityAssignments.map((warning) => (
-              <GapRow key={`${warning.assignmentId}:${warning.timeBlockId}`}>
-                <span>{warning.volunteerName}</span>
-                <span className="text-muted-foreground">
-                  {formatVolunteerAvailability(warning.availability)} /{" "}
-                  {getTimeBlockLabel(timeBlockById, warning.timeBlockId)}
-                </span>
-              </GapRow>
-            ))}
-          </ActionList>
-
-          <ActionList
-            title="Role warnings"
-            count={matrix.credentialWarnings.length}
-            empty="No role or credential warnings."
-          >
-            {matrix.credentialWarnings.map((warning) => (
-              <GapRow key={`${warning.assignmentId}:${warning.reason}`}>
-                <span>{warning.volunteerName}</span>
-                <span className="text-muted-foreground">
-                  {formatCrewValue(warning.reason)} / needs{" "}
-                  {formatVolunteerRole(warning.requiredRoleType)}
-                </span>
-              </GapRow>
-            ))}
-          </ActionList>
-
-          <ActionList
-            title="Confirmation gaps"
-            count={matrix.confirmationGaps.length}
-            empty="No assignment confirmation gaps."
-          >
-            {matrix.confirmationGaps.map((gap) => (
-              <GapRow key={`${gap.assignmentId}:${gap.reason}`}>
-                <span>{gap.volunteerName}</span>
-                <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
-                  {formatCrewValue(gap.reason)} /{" "}
-                  {getTimeBlockLabel(timeBlockById, gap.timeBlockId)}
-                  <ConfirmationBadge status={gap.status ?? "missing"} />
-                </span>
-              </GapRow>
-            ))}
-          </ActionList>
-        </section>
-
-        <aside className="rounded-md border bg-card p-5 shadow-sm">
-          <h3 className="text-sm font-semibold uppercase text-muted-foreground">
-            Source counts
-          </h3>
-          <dl className="mt-4 space-y-4 text-sm">
-            <Fact label="Venues" value={sources.venues} />
-            <Fact label="Workouts" value={sources.workouts} />
-            <Fact label="Heats" value={sources.heats} />
-            <Fact
-              label="Lane assignments"
-              value={sources.heatLaneAssignments}
-            />
-            <Fact label="Roster" value={sources.roster} />
-            <Fact label="Assignable" value={sources.assignableRoster} />
-            <Fact label="Shifts" value={sources.shifts} />
-            <Fact label="Shift assignments" value={sources.shiftAssignments} />
-            <Fact
-              label="Active judge versions"
-              value={sources.activeJudgeVersions}
-            />
-            <Fact label="Judge assignments" value={sources.judgeAssignments} />
-          </dl>
-        </aside>
-      </div>
-    </section>
-  )
-}
-
-function CoverageTable({
-  rows,
-  timeBlockById,
-  timezone,
-}: {
-  rows: CrewStaffingCoverageRow[]
-  timeBlockById: Map<string, CrewStaffingTimeBlock>
-  timezone: string
-}) {
-  if (rows.length === 0) {
-    return <EmptyState message="No coverage rows yet." />
-  }
-
-  return (
-    <div className="mt-4 overflow-x-auto rounded-md border">
-      <table className="w-full min-w-[44rem] border-collapse text-sm">
-        <thead className="bg-muted/60 text-left text-muted-foreground">
-          <tr>
-            <th className="px-3 py-2 font-medium">Time block</th>
-            <th className="px-3 py-2 font-medium">Role</th>
-            <th className="px-3 py-2 font-medium">Window</th>
-            <th className="px-3 py-2 text-right font-medium">Filled</th>
-            <th className="px-3 py-2 text-right font-medium">Needed</th>
-            <th className="px-3 py-2 text-right font-medium">Open</th>
-          </tr>
-        </thead>
-        <tbody>
-          {rows.map((row) => {
-            const block = timeBlockById.get(row.timeBlockId)
-            return (
-              <tr key={row.id} className="border-t">
-                <td className="px-3 py-3 font-medium">
-                  {block?.label ?? row.timeBlockId}
-                </td>
-                <td className="px-3 py-3">
-                  {formatVolunteerRole(row.roleType)}
-                </td>
-                <td className="px-3 py-3 text-muted-foreground">
-                  {formatTimeWindow(block, timezone)}
-                </td>
-                <td className="px-3 py-3 text-right">{row.filled}</td>
-                <td className="px-3 py-3 text-right">{row.needed}</td>
-                <td className="px-3 py-3 text-right">
-                  <span
-                    className={
-                      row.open > 0 ? "font-semibold text-amber-700" : ""
-                    }
-                  >
-                    {row.open}
-                  </span>
-                </td>
-              </tr>
-            )
-          })}
-        </tbody>
-      </table>
-    </div>
-  )
-}
-
-function ActionList({
-  title,
-  count,
-  empty,
-  children,
-}: {
-  title: string
-  count: number
-  empty: string
-  children: ReactNode
-}) {
-  return (
-    <section className="rounded-md border bg-card p-5 shadow-sm">
-      <div className="flex items-center justify-between gap-3">
-        <h3 className="font-semibold">{title}</h3>
-        <span className="rounded-md border bg-background px-2 py-1 text-xs font-medium">
-          {count}
-        </span>
-      </div>
-      {count > 0 ? (
-        <div className="mt-4 space-y-2">{children}</div>
-      ) : (
-        <EmptyState message={empty} compact />
       )}
     </section>
   )
 }
 
-function GapRow({ children }: { children: ReactNode }) {
-  return (
-    <div className="flex flex-col gap-1 rounded-md border bg-background p-3 text-sm sm:flex-row sm:items-center sm:justify-between">
-      {children}
-    </div>
-  )
-}
-
-function IssuePanel({ issue }: { issue: CrewStaffingReportIssueSummary }) {
-  return (
-    <article className="rounded-md border bg-card p-4 shadow-sm">
-      <div className="flex items-start justify-between gap-3">
-        <div>
-          <p className="text-sm text-muted-foreground">{issue.label}</p>
-          <p className="mt-2 text-xl font-semibold">{issue.count}</p>
+function Verdict({
+  eventId,
+  hasStaffingBlocks,
+  openSlots,
+  totalFilled,
+  totalNeeded,
+  blockGapCount,
+}: {
+  eventId: string
+  hasStaffingBlocks: boolean
+  openSlots: number
+  totalFilled: number
+  totalNeeded: number
+  blockGapCount: number
+}) {
+  if (!hasStaffingBlocks) {
+    return (
+      <article className="rounded-lg border bg-card p-6 shadow-sm">
+        <div className="flex items-start gap-4">
+          <IconBadge tone="neutral">
+            <CalendarClock className="size-6" />
+          </IconBadge>
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold">Nothing to staff yet</h3>
+            <p className="text-sm text-muted-foreground">
+              Add volunteer shifts or scheduled heats, then come back to see
+              your gaps.
+            </p>
+            <div className="flex flex-wrap gap-2 pt-2">
+              <PillLink to="/events/$eventId/shifts" eventId={eventId}>
+                Add shifts
+              </PillLink>
+              <PillLink to="/events/$eventId/heats" eventId={eventId}>
+                Schedule heats
+              </PillLink>
+            </div>
+          </div>
         </div>
-        <span
-          className={`rounded-md border px-2 py-1 text-xs font-medium ${
-            issue.severity === "critical"
-              ? "border-destructive/30 bg-destructive/10 text-destructive"
-              : "border-amber-500/30 bg-amber-500/10 text-amber-700"
-          }`}
-        >
-          {issue.severity}
-        </span>
+      </article>
+    )
+  }
+
+  if (openSlots === 0) {
+    return (
+      <article className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-6 shadow-sm">
+        <div className="flex items-start gap-4">
+          <IconBadge tone="positive">
+            <CheckCircle2 className="size-6" />
+          </IconBadge>
+          <div className="space-y-1">
+            <h3 className="text-lg font-semibold text-emerald-800">
+              Fully staffed
+            </h3>
+            <p className="text-sm text-emerald-700/90">
+              All {totalNeeded} slots are filled. No volunteer gaps to close.
+            </p>
+          </div>
+        </div>
+      </article>
+    )
+  }
+
+  return (
+    <article className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-6 shadow-sm">
+      <div className="flex items-start gap-4">
+        <IconBadge tone="warning">
+          <Users className="size-6" />
+        </IconBadge>
+        <div className="space-y-1">
+          <h3 className="text-2xl font-semibold text-amber-900">
+            {openSlots} more {openSlots === 1 ? "person" : "people"} needed
+          </h3>
+          <p className="text-sm text-amber-800/90">
+            {totalFilled} of {totalNeeded} slots filled · gaps across{" "}
+            {blockGapCount} time block{blockGapCount === 1 ? "" : "s"}.
+          </p>
+        </div>
       </div>
     </article>
   )
 }
 
-function StatusPanel({
-  label,
-  value,
+function RoleGaps({
+  eventId,
+  roleGaps,
 }: {
-  label: string
-  value: number | string
+  eventId: string
+  roleGaps: CrewStaffingRoleSummary[]
 }) {
   return (
-    <section className="rounded-md border bg-background p-4">
-      <p className="text-sm text-muted-foreground">{label}</p>
-      <p className="mt-2 text-lg font-semibold">{value}</p>
+    <section className="rounded-lg border bg-card p-5 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="font-semibold">Who you need</h3>
+        <PillLink to="/events/$eventId/shifts" eventId={eventId}>
+          Manage shifts
+        </PillLink>
+      </div>
+      <ul className="mt-4 space-y-2">
+        {roleGaps.map((role) => (
+          <li
+            key={role.roleType}
+            className="flex items-center justify-between gap-3 rounded-md border bg-background px-4 py-3"
+          >
+            <div>
+              <p className="font-medium">{role.roleLabel}</p>
+              <p className="text-sm text-muted-foreground">
+                {role.filled}/{role.needed} filled
+              </p>
+            </div>
+            <span className="rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-sm font-semibold text-amber-700">
+              {role.open} open
+            </span>
+          </li>
+        ))}
+      </ul>
     </section>
   )
 }
 
-function StatusBadge({ status }: { status: CrewStaffingReportStatus }) {
-  const Icon =
-    status === "covered"
-      ? CheckCircle2
-      : status === "critical"
-        ? AlertCircle
-        : CircleAlert
-
-  return (
-    <span
-      className={`inline-flex w-fit items-center gap-2 rounded-md border px-2 py-1 text-xs font-medium ${statusBadgeClass(status)}`}
-    >
-      <Icon className="size-3.5" />
-      {status === "covered"
-        ? "Covered"
-        : status === "critical"
-          ? "Critical gaps"
-          : "Needs attention"}
-    </span>
-  )
-}
-
-function ConfirmationBadge({ status }: { status: string }) {
-  return (
-    <span
-      className={`rounded-md border px-2 py-1 text-xs font-medium ${getCrewAssignmentConfirmationStatusBadgeClassName(status)}`}
-    >
-      {getCrewAssignmentConfirmationStatusLabel(status)}
-    </span>
-  )
-}
-
-function Fact({ label, value }: { label: string; value: number | string }) {
-  return (
-    <div>
-      <dt className="text-muted-foreground">{label}</dt>
-      <dd className="mt-1 font-medium">{value}</dd>
-    </div>
-  )
-}
-
-function EmptyState({
-  message,
-  compact = false,
+function BlockGaps({
+  blockGaps,
+  timeBlockById,
+  timezone,
 }: {
-  message: string
-  compact?: boolean
+  blockGaps: CrewStaffingCoverageRow[]
+  timeBlockById: Map<string, CrewStaffingTimeBlock>
+  timezone: string
 }) {
   return (
-    <div
-      className={`rounded-md border bg-background text-center text-sm text-muted-foreground ${
-        compact ? "mt-4 p-3" : "mt-4 p-6"
-      }`}
-    >
-      {message}
-    </div>
+    <section className="rounded-lg border bg-card p-5 shadow-sm">
+      <h3 className="font-semibold">When they're needed</h3>
+      <ul className="mt-4 space-y-2">
+        {blockGaps.map((row) => {
+          const block = timeBlockById.get(row.timeBlockId)
+          return (
+            <li
+              key={row.id}
+              className="flex items-center justify-between gap-3 rounded-md border bg-background px-4 py-3"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-medium">
+                  {block?.label ?? row.timeBlockId}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {formatVolunteerRole(row.roleType)} ·{" "}
+                  {formatTimeWindow(block, timezone)}
+                </p>
+              </div>
+              <span className="shrink-0 rounded-md border border-amber-500/30 bg-amber-500/10 px-2.5 py-1 text-sm font-semibold text-amber-700">
+                {row.open} open
+              </span>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
   )
 }
 
-function getTimeBlockLabel(
-  timeBlockById: Map<string, CrewStaffingTimeBlock>,
-  timeBlockId: string,
-) {
-  return timeBlockById.get(timeBlockId)?.label ?? timeBlockId
+function IconBadge({
+  tone,
+  children,
+}: {
+  tone: "neutral" | "positive" | "warning"
+  children: ReactNode
+}) {
+  const toneClass =
+    tone === "positive"
+      ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
+      : tone === "warning"
+        ? "border-amber-500/30 bg-amber-500/10 text-amber-700"
+        : "border-border bg-muted text-muted-foreground"
+
+  return (
+    <span
+      className={`flex size-12 shrink-0 items-center justify-center rounded-full border ${toneClass}`}
+    >
+      {children}
+    </span>
+  )
+}
+
+function PillLink({
+  to,
+  eventId,
+  children,
+}: {
+  to: "/events/$eventId/shifts" | "/events/$eventId/heats"
+  eventId: string
+  children: ReactNode
+}) {
+  return (
+    <Link
+      to={to}
+      params={{ eventId }}
+      className="w-fit rounded-md border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+    >
+      {children}
+    </Link>
+  )
 }
 
 function formatTimeWindow(
@@ -480,18 +284,4 @@ function formatTimeWindow(
     : ""
 
   return end ? `${start} to ${end}` : start
-}
-
-function statusBadgeClass(status: CrewStaffingReportStatus) {
-  if (status === "covered") {
-    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700"
-  }
-  if (status === "critical") {
-    return "border-destructive/30 bg-destructive/10 text-destructive"
-  }
-  return "border-amber-500/30 bg-amber-500/10 text-amber-700"
-}
-
-function plural(count: number) {
-  return count === 1 ? "" : "s"
 }

--- a/apps/crew/src/routes/events/$eventId/staffing.tsx
+++ b/apps/crew/src/routes/events/$eventId/staffing.tsx
@@ -21,19 +21,18 @@ const parentRoute = getRouteApi("/events/$eventId")
 
 function EventStaffingPage() {
   const { eventId } = parentRoute.useParams()
-  const { matrix, report, event } = Route.useLoaderData()
+  const { timeBlocks, summary, roleSummaries, underfilledRows, event } =
+    Route.useLoaderData()
   const timezone = event.timezone ?? "America/Denver"
 
-  const timeBlockById = new Map(
-    matrix.timeBlocks.map((block) => [block.id, block]),
-  )
-  const openSlots = matrix.summary.openCapacity
-  const totalNeeded = matrix.summary.totalNeeded
-  const totalFilled = matrix.summary.totalFilled
-  const hasStaffingBlocks = matrix.timeBlocks.length > 0 && totalNeeded > 0
+  const timeBlockById = new Map(timeBlocks.map((block) => [block.id, block]))
+  const openSlots = summary.openCapacity
+  const totalNeeded = summary.totalNeeded
+  const totalFilled = summary.totalFilled
+  const hasStaffingBlocks = timeBlocks.length > 0 && totalNeeded > 0
 
-  const roleGaps = report.roleSummaries.filter((role) => role.open > 0)
-  const blockGaps = report.underfilledRows
+  const roleGaps = roleSummaries.filter((role) => role.open > 0)
+  const blockGaps = underfilledRows
   const blockGapCount = new Set(blockGaps.map((row) => row.timeBlockId)).size
 
   return (

--- a/apps/crew/src/server-fns/crew-staffing-fns.server.ts
+++ b/apps/crew/src/server-fns/crew-staffing-fns.server.ts
@@ -26,17 +26,20 @@ import {
   filterCrewDepartmentLeadRoster,
 } from "../lib/crew/department-leads"
 import {
-  buildCrewStaffingMatrix,
-  buildCrewStaffingReport,
-  type CrewStaffingConfirmationInput,
-  type CrewStaffingMatrix,
-  type CrewStaffingMatrixInput,
-  type CrewStaffingReport,
-} from "../lib/crew/staffing"
-import {
   getCrewRosterAssigneeId,
   isCrewRosterVolunteerStaffable,
 } from "../lib/crew/roster-shifts"
+import {
+  buildCrewStaffingMatrix,
+  buildCrewStaffingReport,
+  type CrewStaffingConfirmationInput,
+  type CrewStaffingCoverageRow,
+  type CrewStaffingMatrix,
+  type CrewStaffingMatrixInput,
+  type CrewStaffingReport,
+  type CrewStaffingRoleSummary,
+  type CrewStaffingTimeBlock,
+} from "../lib/crew/staffing"
 import { filterCrewStaffingInputForDepartmentLead } from "../lib/crew/staffing/department-lead-scope"
 import { resolveCrewDepartmentLeadAccess } from "../server/crew-department-lead.server"
 import {
@@ -60,16 +63,23 @@ export interface CrewStaffingReportEvent {
 
 export interface CrewStaffingReportPageData {
   event: CrewStaffingReportEvent
+  timeBlocks: CrewStaffingTimeBlock[]
+  summary: Pick<
+    CrewStaffingMatrix["summary"],
+    "totalNeeded" | "totalFilled" | "openCapacity"
+  >
+  roleSummaries: CrewStaffingRoleSummary[]
+  underfilledRows: CrewStaffingCoverageRow[]
+}
+
+export interface CrewStaffingReportForDayOfData {
+  event: CrewStaffingReportEvent
+  matrixInput: CrewStaffingMatrixInput
   matrix: CrewStaffingMatrix
   report: CrewStaffingReport
   sources: CrewStaffingReport["sourceCounts"] & {
     activeJudgeVersions: number
   }
-}
-
-export interface CrewStaffingReportForDayOfData
-  extends CrewStaffingReportPageData {
-  matrixInput: CrewStaffingMatrixInput
 }
 
 export async function getCrewStaffingReportPage(
@@ -79,9 +89,14 @@ export async function getCrewStaffingReportPage(
 
   return {
     event: staffing.event,
-    matrix: staffing.matrix,
-    report: staffing.report,
-    sources: staffing.sources,
+    timeBlocks: staffing.matrix.timeBlocks,
+    summary: {
+      totalNeeded: staffing.matrix.summary.totalNeeded,
+      totalFilled: staffing.matrix.summary.totalFilled,
+      openCapacity: staffing.matrix.summary.openCapacity,
+    },
+    roleSummaries: staffing.report.roleSummaries,
+    underfilledRows: staffing.report.underfilledRows,
   }
 }
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -280,15 +280,15 @@ The CSV import modal uses [[apps/crew/src/components/crew/volunteer-import-flow.
 
 ## Staffing Page Gap Report
 
-Crew staffing pages expose the matrix core as a read-only event operations report.
+The Crew staffing page answers a single question — "what volunteer gaps do I still have?" — as a read-only view over the matrix core.
 
 [[apps/crew/src/server-fns/crew-staffing-fns.ts]] exposes a lightweight route-safe server-function wrapper.
 
 [[apps/crew/src/server-fns/crew-staffing-fns.server.ts]] hydrates the matrix from existing event, venue, heat, lane, roster, shift, active judge assignment, and confirmation data.
 
-[[apps/crew/src/routes/events/$eventId/staffing.tsx]] renders coverage, open capacity, judge lane gaps, conflicts, availability warnings, role warnings, confirmation gaps, and source counts without mutating schema or assignments.
+[[apps/crew/src/routes/events/$eventId/staffing.tsx]] renders a gaps-only view: a single verdict (open slots needed, fully staffed, or nothing to staff yet) plus two complementary cuts of the open slots — "who you need" (by role) and "when they're needed" (by time block). Judge lane gaps surface as judge-role coverage rows, so they need no separate list. Confirmation, conflict, availability, and credential signals live on the Confirmations and Event Day pages, not here. The page never mutates schema or assignments.
 
-[[apps/crew/src/lib/crew/staffing/report.ts]] owns the deterministic event-level status and report summaries used by the page.
+[[apps/crew/src/lib/crew/staffing/report.ts]] owns the deterministic event-level status and report summaries used by the page; its `roleSummaries` and `underfilledRows` drive the role and time-block gap cuts.
 
 ## Staffing Calculator
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -286,7 +286,7 @@ The Crew staffing page answers a single question — "what volunteer gaps do I s
 
 [[apps/crew/src/server-fns/crew-staffing-fns.server.ts]] hydrates the matrix from existing event, venue, heat, lane, roster, shift, active judge assignment, and confirmation data.
 
-[[apps/crew/src/routes/events/$eventId/staffing.tsx]] renders a gaps-only view: a single verdict (open slots needed, fully staffed, or nothing to staff yet) plus two complementary cuts of the open slots — "who you need" (by role) and "when they're needed" (by time block). Judge lane gaps surface as judge-role coverage rows, so they need no separate list. Confirmation, conflict, availability, and credential signals live on the Confirmations and Event Day pages, not here. The page never mutates schema or assignments.
+[[apps/crew/src/routes/events/$eventId/staffing.tsx]] renders a gaps-only view: a single verdict (open slots needed, fully staffed, or nothing to staff yet) plus two complementary cuts of the open slots — "who you need" (by role) and "when they're needed" (by distinct time block). Judge lane gaps surface as judge-role coverage rows, so the role action links operators to the Judges page for judge gaps and the Shifts page for shift gaps. Confirmation, conflict, availability, and credential signals live on the Confirmations and Event Day pages, not here. The page never mutates schema or assignments.
 
 [[apps/crew/src/lib/crew/staffing/report.ts]] owns the deterministic event-level status and report summaries used by the page; its `roleSummaries` and `underfilledRows` drive the role and time-block gap cuts.
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -284,7 +284,7 @@ The Crew staffing page answers a single question — "what volunteer gaps do I s
 
 [[apps/crew/src/server-fns/crew-staffing-fns.ts]] exposes a lightweight route-safe server-function wrapper.
 
-[[apps/crew/src/server-fns/crew-staffing-fns.server.ts]] hydrates the matrix from existing event, venue, heat, lane, roster, shift, active judge assignment, and confirmation data.
+[[apps/crew/src/server-fns/crew-staffing-fns.server.ts]] hydrates the matrix from existing event, venue, heat, lane, roster, shift, active judge assignment, and confirmation data. `getCrewStaffingReportForDayOf` keeps the full matrix and report for the Event Day surface, while `getCrewStaffingReportPage` trims the loader payload to just the gap data the page renders: event, time blocks, the needed/filled/open summary, role summaries, and underfilled rows.
 
 [[apps/crew/src/routes/events/$eventId/staffing.tsx]] renders a gaps-only view: a single verdict (open slots needed, fully staffed, or nothing to staff yet) plus two complementary cuts of the open slots — "who you need" (by role) and "when they're needed" (by distinct time block). Judge lane gaps surface as judge-role coverage rows, so the role action links operators to the Judges page for judge gaps and the Shifts page for shift gaps. Confirmation, conflict, availability, and credential signals live on the Confirmations and Event Day pages, not here. The page never mutates schema or assignments.
 


### PR DESCRIPTION
## What changed

Simplifies the Crew event staffing page into a gaps-only report focused on the operator question: what volunteer slots are still open?

The page now shows:

- a single verdict for no staffing blocks, fully staffed, or open slots remaining
- role-based gaps under "Who you need"
- time-block gaps under "When they're needed"
- setup links for adding shifts or scheduled heats when there is nothing to staff yet

The Crew `lat.md` documentation was updated to describe the narrower staffing-page responsibility and to clarify that confirmation, conflict, availability, and credential signals live on other Crew operations pages.

## Impact

Operators get a shorter staffing page focused on filling open volunteer and judge capacity. This removes duplicated issue/source panels from the staffing page without changing the underlying staffing matrix or assignment data.

## Validation

- `lat check`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm --filter crew type-check`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm --filter crew test src/lib/crew/staffing/report.test.ts`
- `PATH="$HOME/.nvm/versions/node/v24.15.0/bin:$PATH" corepack pnpm exec biome check 'src/routes/events/$eventId/staffing.tsx'`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the Crew event staffing page with a gaps-only report focused on open volunteer slots, and trims the loader payload to only what the page renders. Matrix logic stays the same, with faster loads and clearer actions.

- **New Features**
  - Single verdict: nothing to staff, fully staffed, or N people needed.
  - “Who you need” by role (from `roleSummaries`) with quick links to Judges or Shifts.
  - “When they’re needed” by time block (from `underfilledRows`) with event-local time windows.
  - Setup links to add shifts or schedule heats when nothing is staffable.

- **Refactors**
  - Trimmed `getCrewStaffingReportPage` to return event, time blocks, summary (needed/filled/open), `roleSummaries`, and `underfilledRows`.
  - Removed issue panels, source counts, and confirmation/conflict/availability/credential lists from this page.
  - Judge lane gaps roll up into judge-role coverage; action links route to Judges or Shifts.
  - Updated `lat.md/crew.md`; no schema or assignment mutations.

<sup>Written for commit a4451920e7bc65fd9cc15f93dbf915a193ad8ade. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified the crew staffing page into a gaps-focused view.
  * Added a clear staffing verdict, plus two breakdowns showing open roles and when coverage is needed.
  * Improved time display for staffing gaps using the event’s local timezone.

* **Documentation**
  * Updated the crew staffing page docs to match the new read-only, gaps-only experience.
  * Clarified that other staffing signals are now shown on separate pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->