### PR TITLE
[codex] polish Crew print packet output

### DIFF
--- a/apps/crew/src/components/crew-event-sidebar.tsx
+++ b/apps/crew/src/components/crew-event-sidebar.tsx
@@ -243,16 +243,16 @@ export function CrewEventSidebarShell({
       </Sidebar>
 
       <SidebarInset>
-        <header className="fixed top-0 right-0 left-0 z-40 flex h-14 items-center gap-2 border-b bg-background px-3 md:hidden">
+        <header className="fixed top-0 right-0 left-0 z-40 flex h-14 items-center gap-2 border-b bg-background px-3 md:hidden print:hidden">
           <SidebarTrigger className="-ml-1">
             <Menu className="size-5" />
           </SidebarTrigger>
           <CrewBrandLink variant={variant} compact />
         </header>
-        <div className="h-14 md:hidden" />
+        <div className="h-14 md:hidden print:hidden" />
 
-        <div className="flex flex-1 flex-col gap-4 p-4 sm:gap-6 sm:p-6">
-          <header className="flex flex-col gap-2 border-b pb-5">
+        <div className="flex flex-1 flex-col gap-4 p-4 sm:gap-6 sm:p-6 print:gap-0 print:p-0">
+          <header className="flex flex-col gap-2 border-b pb-5 print:hidden">
             <p className="text-sm font-medium uppercase text-muted-foreground">
               {eyebrow}
             </p>

--- a/apps/crew/src/components/ui/sidebar.tsx
+++ b/apps/crew/src/components/ui/sidebar.tsx
@@ -205,7 +205,7 @@ const Sidebar = React.forwardRef<
     return (
       <div
         ref={ref}
-        className="group peer hidden text-sidebar-foreground md:block"
+        className="group peer hidden text-sidebar-foreground md:block print:hidden"
         data-state={state}
         data-collapsible={state === "collapsed" ? collapsible : ""}
         data-variant={variant}

--- a/apps/crew/src/routes/events/$eventId/exports.tsx
+++ b/apps/crew/src/routes/events/$eventId/exports.tsx
@@ -136,27 +136,47 @@ export function EventPilotExportsView({
         ))}
       </div>
 
-      <PrintHeader
-        eventName={event.name}
-        subtitle={PACKET_TABS.find((tab) => tab.id === activeTab)?.label ?? ""}
-        generatedAt={formatExportDate(exports.generatedAt, timezone)}
-      />
-
-      {activeTab === "schedule" ? (
-        <ScheduleTab
-          daySections={exports.masterScheduleDaySections}
-          timezone={timezone}
-        />
-      ) : null}
-      {activeTab === "judges" ? (
-        <JudgesTab
-          eventSections={exports.judgeEventSections}
-          timezone={timezone}
-        />
-      ) : null}
-      {activeTab === "shifts" ? (
-        <ShiftsTab shiftSheets={exports.shiftSheets} timezone={timezone} />
-      ) : null}
+      {/* The thead repeats on every printed page, giving each page a compact
+          branded header without any screen-layout impact. */}
+      <table className="w-full">
+        <thead className="hidden print:table-header-group">
+          <tr>
+            <td className="pb-4">
+              <PrintPageHeader
+                eventName={event.name}
+                subtitle={
+                  PACKET_TABS.find((tab) => tab.id === activeTab)?.label ?? ""
+                }
+                generatedAt={formatExportDate(exports.generatedAt, timezone)}
+              />
+            </td>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              {activeTab === "schedule" ? (
+                <ScheduleTab
+                  daySections={exports.masterScheduleDaySections}
+                  timezone={timezone}
+                />
+              ) : null}
+              {activeTab === "judges" ? (
+                <JudgesTab
+                  eventSections={exports.judgeEventSections}
+                  timezone={timezone}
+                />
+              ) : null}
+              {activeTab === "shifts" ? (
+                <ShiftsTab
+                  shiftSheets={exports.shiftSheets}
+                  timezone={timezone}
+                />
+              ) : null}
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </section>
   )
 }
@@ -299,7 +319,7 @@ function ShiftsTab({
   )
 }
 
-function PrintHeader({
+function PrintPageHeader({
   eventName,
   subtitle,
   generatedAt,
@@ -309,12 +329,24 @@ function PrintHeader({
   generatedAt: string
 }) {
   return (
-    <header className="hidden border-b pb-4 print:block">
-      <h1 className="text-2xl font-semibold">{eventName}</h1>
-      <p className="text-sm">
-        {subtitle} / {generatedAt}
+    <div className="flex items-center justify-between gap-4 border-b pb-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <img
+          src="/wodsmith-logo-no-text.png"
+          alt=""
+          width={20}
+          height={20}
+          className="size-5 shrink-0"
+        />
+        <span className="whitespace-nowrap text-sm">
+          <span className="font-black uppercase">wod</span>smith{" "}
+          <span className="font-medium">Crew</span>
+        </span>
+      </div>
+      <p className="truncate text-xs">
+        {eventName} / {subtitle} / {generatedAt}
       </p>
-    </header>
+    </div>
   )
 }
 

--- a/lat.md/crew.md
+++ b/lat.md/crew.md
@@ -500,6 +500,8 @@ The event-day packet renders [[crew#Pilot Exports]] as three printable tabs at [
 
 The tabs are **Master Schedule** (shifts and heats combined, day-sectioned, with a Master CSV download), **Judges** (per event/workout, a clear heat × lane × judge table), and **Shifts** (each shift as its own section listing who is on and when).
 
+Print output hides all app chrome (sidebar, mobile top bar, and the event hero header get `print:hidden` in [[apps/crew/src/components/crew-event-sidebar.tsx]] and the sidebar UI primitive) and instead shows a compact WODsmith Crew brand header — logo, event name, packet name, generated time — repeated on every printed page via a `thead` set to `print:table-header-group` wrapping the packet content.
+
 The packet is full local-operator-only through [[apps/crew/src/server/crew-pilot-exports.server.ts]] and [[apps/crew/src/server-fns/crew-pilot-export-fns.ts]]. It deliberately omits station/floor cards, role sheets, the response/decline list, the packet index, and metric panels, and does not add PDF runtime infrastructure, schema, queue/email work, public tokens, department-lead subset export access, or assignment/judge-version mutations.
 
 ## Strategic Moat Privacy Model


### PR DESCRIPTION
## Summary

Polishes the Crew event-day print packet output so each printed page gets a compact branded header and the app chrome stays out of print views.

## Changes

- Replaces the screen-only print header with a print table header that repeats across printed pages.
- Adds the WODsmith Crew brand mark, event name, packet tab, and generated timestamp to the repeated print header.
- Hides sidebar, mobile top bar, spacing shim, and event hero chrome in print output.
- Updates `lat.md` with the print behavior note.

## Validation

- `lat check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Crew event-day print packets with a compact branded header that repeats on every printed page and hides app chrome in print. Screen layout stays unchanged.

- **New Features**
  - Added a print-only repeating header via table `thead` (`print:table-header-group`) with brand mark, event name, packet tab, and generated time.
  - In print, hides sidebar (including the shared sidebar primitive), mobile top bar, section header, spacing shim, and event hero, and strips extra padding/gaps (`print:hidden`, `print:gap-0`, `print:p-0`).
  - Documented the behavior in `lat.md/crew.md`.

<sup>Written for commit 50cb25313d815ce947ecde17d19e814b5bda0824. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/wodsmith/thewodapp/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Printed export packets now include a branded header on every page, showing the event name, packet title, and generation time.
  * Print layouts now hide on-screen navigation and headers for a cleaner exported document.

* **Bug Fixes**
  * Improved spacing and visibility in print mode so exported pages render more consistently.

* **Documentation**
  * Updated export packet documentation to match the new print behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->